### PR TITLE
Core library changes in Group::OpenMode

### DIFF
--- a/tightdb_jni/src/com_tightdb_Group.cpp
+++ b/tightdb_jni/src/com_tightdb_Group.cpp
@@ -21,7 +21,7 @@ JNIEXPORT jlong JNICALL Java_com_tightdb_Group_createNative__Ljava_lang_String_2
 
     Group* pGroup = 0;
     try {
-        pGroup = new Group(fileNameCharPtr, readOnly != 0 ? Group::mode_ReadOnly : Group::mode_Normal);
+        pGroup = new Group(fileNameCharPtr, readOnly != 0 ? Group::mode_ReadOnly : Group::mode_ReadWrite);
     }
     catch (...) {
         // FIXME: Diffrent exception types mean different things. More


### PR DESCRIPTION
Group::mode_Normal has been renamed to Group::mode_ReadWrite in the core library.

Also, the default open mode of a group has been changed from ReadWrite to ReadOnly.

Brian, what is the current default in Java? If it is not readOnly, it must be changed.

For all other languages, this change happens automatically when the core library changes (https://github.com/Tightdb/tightdb/pull/109) are merged.

\cc @bmunkholm 
