### PR TITLE
Use java.io.IOException

### DIFF
--- a/tightdb_jni/src/util.cpp
+++ b/tightdb_jni/src/util.cpp
@@ -82,7 +82,7 @@ void ThrowException(JNIEnv* env, ExceptionKind exception, std::string classStr, 
             break;
 
         case IOFailed:
-            jExceptionClass = env->FindClass("java/lang/IOException");
+            jExceptionClass = env->FindClass("java/io/IOException");
             message = "Failed to open " + classStr;
             break;
 


### PR DESCRIPTION
The correct exception when I/O errors is java.io.IOException.
See http://docs.oracle.com/javase/6/docs/api/java/io/IOException.html

@bmunkholm 
