### PR TITLE
Eliminate warnings relating to `MAX_JLONG`.

### DIFF
--- a/tightdb_jni/src/com_tightdb_Group.cpp
+++ b/tightdb_jni/src/com_tightdb_Group.cpp
@@ -1,3 +1,5 @@
+#include <tightdb/util/safe_int_ops.hpp>
+
 #include "util.hpp"
 #include "com_tightdb_Group.h"
 
@@ -199,14 +201,7 @@ JNIEXPORT jobject JNICALL Java_com_tightdb_Group_nativeWriteToByteBuffer(
     BinaryData buffer;
     try {
         buffer = G(nativeGroupPtr)->write_to_mem();
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wtautological-constant-out-of-range-compare"
-#endif
-        if (buffer.size() <= MAX_JLONG) {
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+        if (util::int_less_than_or_equal(buffer.size(), MAX_JLONG)) {
             return env->NewDirectByteBuffer(const_cast<char*>(buffer.data()), static_cast<jlong>(buffer.size()));
             // Data is now owned by the Java DirectByteBuffer - so we must not free it.
         }

--- a/tightdb_jni/src/util.hpp
+++ b/tightdb_jni/src/util.hpp
@@ -65,9 +65,9 @@ std::string num_to_string(T pNumber)
 }
 
 
-#define MAX_JLONG  9223372036854775807
-#define MIN_JLONG -9223372036854775808
-#define MAX_JINT   2147483647
+#define MAX_JLONG  0x7FFFFFFFFFFFFFFFLL
+#define MIN_JLONG -0x8000000000000000LL
+#define MAX_JINT   0x7FFFFFFFL
 #define MAX_JSIZE  MAX_JINT
 
 // Helper macros for better readability


### PR DESCRIPTION
First warning was eliminated by adding suffix `LL` to the constant. This is necessary because `long long` is the smallest (and only type) that ANSI guarantees is 64 bits.
Likewise, `MAX_JINT` must have an `L` suffix, because `long` is the smallest type that ANSI guarantees is 32 bits.
The second and last warning was removed by deploying `util::int_less_than_or_equal()` (a utility function created precisely for this purpose).

@bmunkholm 
