### PR TITLE
Suggestion nr. 2: refactored jnitransaction test class. Pause for 100 ms

### DIFF
--- a/tightdb-java-test/src/test/java/com/tightdb/JNITransactions.java
+++ b/tightdb-java-test/src/test/java/com/tightdb/JNITransactions.java
@@ -22,6 +22,13 @@ public class JNITransactions {
         f = new File(filename + ".lock");
         if (f.exists())
             f.delete();
+        
+        // Pause to wait for async daemon to finish
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @BeforeMethod


### PR DESCRIPTION
inserted a pause for 100 ms after deleting tightdb-file and .lcok
