### PR TITLE
Strip Android JNI libraries to reduce their sizes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -790,8 +790,8 @@ EOF
             PATH="$path" CC="$cc" $MAKE -C "tightdb_jni/src" CC_IS="gcc" BASE_DENOM="$denom" CFLAGS_OPTIM="-Os -DNDEBUG" CFLAGS_ARCH="$extra_cflags" TIGHTDB_LDFLAGS="$android_ldflags" TIGHTDB_LDFLAGS_DBG="$android_ldflags" LIB_SUFFIX_SHARED=".so" "libtightdb-jni-$denom.so" || exit 1
             mkdir -p "$ANDROID_DIR/$subfolder" || exit 1
             cp "tightdb_jni/src/libtightdb-jni-$denom.so" "$ANDROID_DIR/$subfolder/libtightdb-jni.so" || exit 1
-#            strip="$(cd "$temp_dir/bin" && echo $android_prefix-linux-*-strip)" || exit 1
-#            PATH="$path" $strip --strip-unneeded "$ANDROID_DIR/$subfolder/libtightdb-jni.so" || exit 1
+            strip="$(cd "$temp_dir/bin" && echo $android_prefix-linux-*-strip)" || exit 1
+            PATH="$path" $strip --strip-all "$ANDROID_DIR/$subfolder/libtightdb-jni.so" || exit 1
             rm -rf "$temp_dir" || exit 1
         done
         sh build.sh build-jars || exit 1


### PR DESCRIPTION
This reduces sizes as follows:

From:

```
-rwxr-xr-x 1 kristian kristian 1943808 Mar 17 23:32 android-lib/armeabi/libtightdb-jni.so
-rwxr-xr-x 1 kristian kristian 1886108 Mar 17 23:32 android-lib/armeabi-v7a/libtightdb-jni.so
-rwxr-xr-x 1 kristian kristian 3058451 Mar 17 23:32 android-lib/mips/libtightdb-jni.so
-rwxr-xr-x 1 kristian kristian 2646420 Mar 17 23:32 android-lib/x86/libtightdb-jni.so
```

To:

```
-rwxr-xr-x 1 kristian kristian 1226100 Mar 18 00:25 android-lib/armeabi/libtightdb-jni.so
-rwxr-xr-x 1 kristian kristian 1213816 Mar 18 00:25 android-lib/armeabi-v7a/libtightdb-jni.so
-rwxr-xr-x 1 kristian kristian 2518684 Mar 18 00:25 android-lib/mips/libtightdb-jni.so
-rwxr-xr-x 1 kristian kristian 2090932 Mar 18 00:25 android-lib/x86/libtightdb-jni.so
```

@emanuelez @hovoere @bmunkholm
