### PR TITLE
Shrink Android JNI library by using `-flto -fvisibility=hidden`

### DIFF
--- a/tightdb_jni/project.mk
+++ b/tightdb_jni/project.mk
@@ -51,8 +51,8 @@ ifeq ($(TIGHTDB_ANDROID),)
     endif
   endif
 else
-  PROJECT_CFLAGS += -DANDROID
-  CFLAGS_OPTIM = -Os -DNDEBUG
+  PROJECT_CFLAGS += -fvisibility=hidden -DANDROID
+  CFLAGS_OPTIM = -Os -flto -DNDEBUG
 endif
 
 PROJECT_CFLAGS_OPTIM  += $(TIGHTDB_CFLAGS)


### PR DESCRIPTION
Depends on: https://github.com/Tightdb/tightdb/pull/378

The theory is, that in the case of JNI, it is ok to set global visibility to hidden (`-fvisibility=hidden`) and then explicitly declare the native method implementations to be visible `__attribute__((visibility("hidden")))`. This generally has great impact on both library size and speed (speed because internal calls to internal functions can be optimized much more than internal calls to external functions).

Note that this scheme is particularly well suited for JNI, because the number of JNI entry points is relatively small, and no types, that we define, need to be declared visible. Further more, in the headers generated by `javah`, the native method implementations are already declared using the `JNIEXPRT` macro which contains an explicit visibility declaration.

This scheme works only when the core library is statically linked into the binding (such as it is for Android). And it requires that `-fvisibility=hidden` is applied to both the core library and the to the binding sources.

I have not been able to test whether the resulting libraries work. I hope we can do this tomorrow.

Simple inspection suggest that it definitely has a huge effect:

```
                                    ARM     ARM-V7    MIPS     I386
---------------------------------------------------------------------
(-Os)                             1230196  1213816  2518820  2090932
(-Os -flto)                       1078644  1070456  2268660  1877980
(-Os -fvisibility=hidden)          980340   963960  2322100  1836980
(-Os -flto -fvisibility=hidden)    918896   910708  2203032  1640348  (THIS PULL REQUEST!!)
```

Interestingly, we can compare this to "the theoretical minimum" which is achieved with concattenated source files and using "whole program" optimization (`-fwhole-program`). With the current state of the core and build system, this requires a number "dirty tricks". For Android/ARM, the number comes out as "894320".

The following table shows that the effect of concatenated sources without `-fwhole-program` is limited:

```
                                 individually   concatenated
                                   compiled       sources
Android/ARM                        sources      (core + JNI)
----------------------------------------------------------------
(-Os)                              1230196        1230252
(-Os -flto)                        1078644        1078700
(-Os -fvisibility=hidden)           980340         972204
(-Os -flto -fvisibility=hidden)     918896         910704
```

Note: In all cases above the numbers are the stripped sizes.

@emanuelez @hovoere @bmunkholm @astigsen 
