### PR TITLE
Disable link time optimisations

### DIFF
--- a/realm-jni/project.mk
+++ b/realm-jni/project.mk
@@ -52,7 +52,7 @@ ifeq ($(TIGHTDB_ANDROID),)
   endif
 else
   PROJECT_CFLAGS += -fvisibility=hidden -DANDROID
-  CFLAGS_OPTIM = -Os -flto -DNDEBUG
+  CFLAGS_OPTIM = -Os -DNDEBUG
 endif
 
 PROJECT_CFLAGS_OPTIM  += $(TIGHTDB_CFLAGS)


### PR DESCRIPTION
They don’t seem to work with NDK version >=r9d
