### PR TITLE
add/insert isn't supported

### DIFF
--- a/realm/src/main/java/io/realm/RealmTableOrViewList.java
+++ b/realm/src/main/java/io/realm/RealmTableOrViewList.java
@@ -58,6 +58,7 @@ public class RealmTableOrViewList<E extends RealmObject> extends AbstractList<E>
     }
 
     @Override
+    @Deprecated
     public void move(int oldPos, int newPos) {
         throw new UnsupportedOperationException();
     }
@@ -258,11 +259,13 @@ public class RealmTableOrViewList<E extends RealmObject> extends AbstractList<E>
     // Adding objects
 
     @Override
+    @Deprecated
     public boolean add(E element) {
         throw new UnsupportedOperationException();
     }
 
     @Override
+    @Deprecated
     public void add(int index, E element) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
For the same reason that `Realm` does support `add`, the `add` is disabled here: we cannot hand over objects to the object store, and `create` are the method we use in the Java binding.

@emanuelez @bmunkholm @rlwaldrop 
