### PR TITLE
Isolate the Android build system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 allprojects {
   group = 'io.realm'
   version = '0.1.0'
-  ext.coreVersion = '0.82.2'
 
   repositories {
     mavenCentral()

--- a/examples/performance/build.gradle
+++ b/examples/performance/build.gradle
@@ -29,7 +29,16 @@ android {
     }
 }
 
+task buildApt(type: GradleBuild) {
+    dir = file('../../realm-annotations-processor')
+    tasks = ['build']
+}
+
+tasks.preBuild {
+    dependsOn buildApt
+}
+
 dependencies {
-    apt project(':realm-annotations-processor')
+    apt files('../../realm-annotations-processor/build/libs/realm-annotations-processor.jar')
     compile project(':realm')
 }

--- a/realm-annotations-processor/build.gradle
+++ b/realm-annotations-processor/build.gradle
@@ -1,15 +1,18 @@
 apply plugin: 'java'
 
+repositories {
+    mavenCentral()
+}
+
 sourceSets {
     main {
         java {
-            srcDirs =  ['src/main/java', "${rootDir}/realm/src/main/java/"]
+            srcDirs =  ['src/main/java', "../realm/src/main/java/io/realm/annotations"]
         }
     }
 }
 
 dependencies {
-    compile project(':realm')
     compile group:'com.squareup', name:'javawriter', version:'2.5.0'
 }
 

--- a/realm-jni/build.gradle
+++ b/realm-jni/build.gradle
@@ -1,7 +1,18 @@
+ext.coreVersion = '0.82.2'
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'de.undercouch:gradle-download-task:1.0'
+    }
+}
+
 apply plugin: 'download-task'
 
 Properties localProperties = new Properties()
-localProperties.load(new FileInputStream("${rootDir}/local.properties"))
+localProperties.load(new FileInputStream("${projectDir}/../local.properties"))
 localProperties.entrySet().each() { entry ->
     project.ext[entry.getKey()] = localProperties.setProperty(entry.getKey(), entry.getValue())
 }
@@ -19,7 +30,7 @@ task checkProperties(group: 'check', description: 'Check the user provided gradl
 }
 
 task downloadCore(group: 'build setup', description: 'Download the latest version of realm core', dependsOn: checkProperties) {
-    outputs.dir "${rootDir}/core-${project.coreVersion}"
+    outputs.dir "../core-${project.coreVersion}"
     doLast {
         download {
             src "http://static.realm.io/downloads/core/realm-core-android-${project.coreVersion}.tar.gz"
@@ -28,7 +39,7 @@ task downloadCore(group: 'build setup', description: 'Download the latest versio
         }
         copy {
             from tarTree(new File(buildDir, "core-android-${project.coreVersion}.tar.gz"))
-            into "${rootDir}/core-${project.coreVersion}"
+            into "../core-${project.coreVersion}"
         }
     }
 }
@@ -63,10 +74,10 @@ task buildAndroidJniArm {
                 'make',
                 '-C', "${projectDir}/src",
                 'CC_IS=gcc',
-                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${rootDir}/core-${project.coreVersion}/include",
+                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${projectDir}/../core-${project.coreVersion}/include",
                 'CFLAGS_ARCH=-mthumb',
                 'BASE_DENOM=arm',
-                "TIGHTDB_LDFLAGS=-ltightdb-android-arm -lstdc++ -lsupc++ -L${rootDir}/core-${project.coreVersion}",
+                "TIGHTDB_LDFLAGS=-ltightdb-android-arm -lstdc++ -lsupc++ -L${projectDir}/../core-${project.coreVersion}",
                 'LIB_SUFFIX_SHARED=.so',
                 'libtightdb-jni-arm.so'
             ]
@@ -93,10 +104,10 @@ task buildAndroidJniArmv7a {
                 'make',
                 '-C', "${projectDir}/src",
                 'CC_IS=gcc',
-                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${rootDir}/core-${project.coreVersion}/include",
+                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${projectDir}/../core-${project.coreVersion}/include",
                 'CFLAGS_ARCH=-mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16',
                 'BASE_DENOM=arm-v7a',
-                "TIGHTDB_LDFLAGS=-ltightdb-android-arm-v7a -lstdc++ -lsupc++ -L${rootDir}/core-${project.coreVersion}",
+                "TIGHTDB_LDFLAGS=-ltightdb-android-arm-v7a -lstdc++ -lsupc++ -L${projectDir}/../core-${project.coreVersion}",
                 'LIB_SUFFIX_SHARED=.so',
                 'libtightdb-jni-arm-v7a.so'
             ]
@@ -123,10 +134,10 @@ task buildAndroidJniMips {
                 'make',
                 '-C', "${projectDir}/src",
                 'CC_IS=gcc',
-                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${rootDir}/core-${project.coreVersion}/include",
+                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${projectDir}/../core-${project.coreVersion}/include",
                 'CFLAGS_ARCH=',
                 'BASE_DENOM=mips',
-                "TIGHTDB_LDFLAGS=-ltightdb-android-mips -lstdc++ -lsupc++ -L${rootDir}/core-${project.coreVersion}",
+                "TIGHTDB_LDFLAGS=-ltightdb-android-mips -lstdc++ -lsupc++ -L${projectDir}/../core-${project.coreVersion}",
                 'LIB_SUFFIX_SHARED=.so',
                 'libtightdb-jni-mips.so'
             ]
@@ -153,10 +164,10 @@ task buildAndroidJniIntel {
                 'make',
                 '-C', "${projectDir}/src",
                 'CC_IS=gcc',
-                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${rootDir}/core-${project.coreVersion}/include",
+                "TIGHTDB_CFLAGS=-DTIGHTDB_HAVE_CONFIG -DPIC -I${projectDir}/../core-${project.coreVersion}/include",
                 'CFLAGS_ARCH=',
                 'BASE_DENOM=x86',
-                "TIGHTDB_LDFLAGS=-ltightdb-android-x86 -lstdc++ -lsupc++ -L${rootDir}/core-${project.coreVersion}",
+                "TIGHTDB_LDFLAGS=-ltightdb-android-x86 -lstdc++ -lsupc++ -L${projectDir}/../core-${project.coreVersion}",
                 'LIB_SUFFIX_SHARED=.so',
                 'libtightdb-jni-x86.so'
             ]

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -32,6 +32,11 @@ android.libraryVariants.all { variant ->
     }
 }
 
+task compileJni(type: GradleBuild) {
+    dir = file('../realm-jni')
+    tasks = ['buildAndroidJni']
+}
+
 tasks.preBuild {
-    dependsOn ':realm-jni:buildAndroidJni'
+    dependsOn compileJni
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,4 @@
-include 'realm-jni'
 include 'realm'
-include 'realm-annotations-processor'
 include ':performance'
 project(':performance').projectDir = new File('examples/performance')
 


### PR DESCRIPTION
The Android Gradle plugin does not like to play along with sibling projects of other types (Java for example). This was preventing being able to use Android specific classes in the realm project.
