### PR TITLE
Cleanup of the Realm.java file

### DIFF
--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -507,7 +507,7 @@ public class Realm {
     }
 
     /**
-     * Starts a write transaction, this must be closed with either commitTransaction()
+     * Starts a write transaction, this must be closed with commitTransaction()
      */
     public void beginTransaction() {
         // If we are moving the transaction forward, send local notifications


### PR DESCRIPTION
Contains:
- removal of useless cache lookups (resulting in a minor speedup)
- made some methods package protected instead of public
- fix for a missed cache population
- small Javadoc improvements
