### PR TITLE
Prefixing table names

### DIFF
--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmSourceCodeGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmSourceCodeGenerator.java
@@ -39,7 +39,7 @@ public class RealmSourceCodeGenerator {
     private List<VariableElement> fields;
     private static final String realmPackageName = "io.realm";
 
-    private static final String table_prefix = "class_";
+    private static final String tablePrefix = "class_";
 
     public RealmSourceCodeGenerator(ProcessingEnvironment processingEnvironment, String className, String packageName, List<VariableElement> fields) {
         this.processingEnvironment = processingEnvironment;
@@ -311,8 +311,8 @@ public class RealmSourceCodeGenerator {
                 EnumSet.of(Modifier.PUBLIC, Modifier.STATIC), // Modifiers
                 "ImplicitTransaction", "transaction"); // Argument type & argument name
 
-        writer.beginControlFlow("if(!transaction.hasTable(\"" + table_prefix + this.className + "\"))");
-        writer.emitStatement("Table table = transaction.getTable(\"%s%s\")", table_prefix, this.className);
+        writer.beginControlFlow("if(!transaction.hasTable(\"" + tablePrefix + this.className + "\"))");
+        writer.emitStatement("Table table = transaction.getTable(\"%s%s\")", tablePrefix, this.className);
 
         // For each field generate corresponding table index constant
         for (VariableElement field : fields) {
@@ -330,11 +330,11 @@ public class RealmSourceCodeGenerator {
                         JAVA_TO_COLUMN_TYPES.get(fieldTypeCanonicalName),
                         fieldName.toLowerCase(Locale.getDefault()));
             } else if (typeUtils.isAssignable(field.asType(), realmObject)) {
-                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", table_prefix, fieldTypeName);
+                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", tablePrefix, fieldTypeName);
                 writer.emitStatement("%sRealmProxy.initTable(transaction)", fieldTypeName);
                 writer.endControlFlow();
                 writer.emitStatement("table.addColumnLink(ColumnType.LINK, \"%s\", transaction.getTable(\"%s%s\"))",
-                        fieldName.toLowerCase(Locale.getDefault()), table_prefix, fieldTypeName);
+                        fieldName.toLowerCase(Locale.getDefault()), tablePrefix, fieldTypeName);
             } else if (typeUtils.isAssignable(field.asType(), realmList)) {
                 String genericCanonicalType = ((DeclaredType) field.asType()).getTypeArguments().get(0).toString();
                 String genericType;
@@ -343,16 +343,16 @@ public class RealmSourceCodeGenerator {
                 } else {
                     genericType = genericCanonicalType;
                 }
-                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", table_prefix, genericType);
+                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", tablePrefix, genericType);
                 writer.emitStatement("%sRealmProxy.initTable(transaction)", genericType);
                 writer.endControlFlow();
                 writer.emitStatement("table.addColumnLink(ColumnType.LINK_LIST, \"%s\", transaction.getTable(\"%s%s\"))",
-                        fieldName.toLowerCase(Locale.getDefault()), table_prefix, genericType);
+                        fieldName.toLowerCase(Locale.getDefault()), tablePrefix, genericType);
             }
         }
         writer.emitStatement("return table");
         writer.endControlFlow();
-        writer.emitStatement("return transaction.getTable(\"%s%s\")", table_prefix, this.className);
+        writer.emitStatement("return transaction.getTable(\"%s%s\")", tablePrefix, this.className);
         writer.endMethod();
         writer.emitEmptyLine();
 


### PR DESCRIPTION
The class names as prefixed by "class_" in the Cocoa binding, and there is no translation to lower or upper case.

Left-out in this PR:
- A table called "metadata" (using by migrations)
- Support for primary keys

The two items above should be implemented in other PRs.

@bmunkholm @emanuelez 
