### PR TITLE
Fixed a bug in how RealmResults are created on the C++ level

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.70.3 ()
   * Upgrading to core 0.84.0
+  * Fixed bug in RealmResults: https://github.com/realm/realm-java/issues/453
 
 0.70.2 (03 Oct 2014)
   * Adding RealmQuery.count() method

--- a/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm-jni/src/io_realm_internal_tableview.cpp
@@ -999,7 +999,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeWhere
 
     try {
         TableView* tv = TV(nativeViewPtr);
-        Query query = tv->get_parent().where().tableview(*tv);
+        Query query = tv->get_parent().where(tv);
         TableQuery* queryPtr = new TableQuery(query);
         return reinterpret_cast<jlong>(queryPtr);
     } CATCH_STD()

--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -174,7 +174,14 @@ public class RealmResultsTest extends AndroidTestCase {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
         RealmResults<AllTypes> sortedList = resultList.sort("columnLong", RealmResults.SORT_ORDER_DECENDING);
         assertEquals("Should have same size", resultList.size(), sortedList.size());
+        assertEquals(TEST_DATA_SIZE, sortedList.size());
         assertEquals("First excepted to be last", resultList.first().getColumnString(), sortedList.last().getColumnString());
+
+        RealmResults<AllTypes> reverseList = sortedList.sort("columnLong", RealmResults.SORT_ORDER_ASCENDING);
+        assertEquals(TEST_DATA_SIZE, reverseList.size());
+
+        RealmResults<AllTypes> reserveSortedList = reverseList.sort("columnLong", RealmResults.SORT_ORDER_DECENDING);
+        assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
     }
 
     public void testCount() {


### PR DESCRIPTION
Issue #453 reports a bug on sorting a sorted `RealmResults` list. The bug was triggered because result sets were created in a wrong way on the C++ level.

@bmunkholm @emanuelez  
