### PR TITLE
Extending unit tests for sort

### DIFF
--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -29,6 +29,15 @@ public class RealmResultsTest extends AndroidTestCase {
 
     protected Realm testRealm;
 
+    private final static String FIELD_STRING = "columnString";
+    private final static String FIELD_LONG = "columnLong";
+    private final static String FIELD_FLOAT = "columnFloat";
+    private final static String FIELD_DOUBLE = "columnDouble";
+    private final static String FIELD_BOOLEAN = "columnBoolean";
+    private final static String FIELD_DATE = "columnDate";
+    private final static String FIELD_BYTE = "columnBinary";
+    private final static String FIELD_DOG = "columnRealmObject";
+
     @Override
     protected void setUp() throws InterruptedException {
         Realm.deleteRealmFile(getContext());
@@ -42,7 +51,7 @@ public class RealmResultsTest extends AndroidTestCase {
             AllTypes allTypes = testRealm.createObject(AllTypes.class);
             allTypes.setColumnBoolean((i % 3) == 0);
             allTypes.setColumnBinary(new byte[]{1, 2, 3});
-            allTypes.setColumnDate(new Date());
+            allTypes.setColumnDate(new Date((long)i));
             allTypes.setColumnDouble(3.1415 + i);
             allTypes.setColumnFloat(1.234567f + i);
             allTypes.setColumnString("test data " + i);
@@ -104,21 +113,21 @@ public class RealmResultsTest extends AndroidTestCase {
     public void testMinValueIsMinValue() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
 
-        Number minimum = resultList.min("columnLong");
+        Number minimum = resultList.min(FIELD_LONG);
         assertEquals("ResultList.min returned wrong value", 0, minimum.intValue());
     }
 
     public void testMaxValueIsMaxValue() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
 
-        Number maximum = resultList.max("columnLong");
-        assertEquals("ResultList.max returned wrong value", TEST_DATA_SIZE -1, maximum.intValue());
+        Number maximum = resultList.max(FIELD_LONG);
+        assertEquals("ResultList.max returned wrong value", TEST_DATA_SIZE-1, maximum.intValue());
     }
 
     public void testSumGivesCorrectValue() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
 
-        Number sum = resultList.sum("columnLong");
+        Number sum = resultList.sum(FIELD_LONG);
 
         int checkSum = 0;
         for (int i = 0; i < TEST_DATA_SIZE; ++i) {
@@ -130,9 +139,9 @@ public class RealmResultsTest extends AndroidTestCase {
     public void testAvgGivesCorrectValue() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
 
-        Double avg = Math.round(resultList.average("columnDouble")*10000.0)/10000.0;
+        Double avg = Math.round(resultList.average(FIELD_DOUBLE)*10000.0)/10000.0;
 
-        assertEquals("ResultList.sum returned wrong sum", 260.6415 ,avg);
+        assertEquals("ResultList.sum returned wrong sum", 260.6415, avg);
     }
 
 
@@ -174,41 +183,41 @@ public class RealmResultsTest extends AndroidTestCase {
     public void testSortByLong() {
 
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.sort("columnLong", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> sortedList = resultList.sort(FIELD_LONG, RealmResults.SORT_ORDER_DECENDING);
         assertEquals("Should have same size", resultList.size(), sortedList.size());
         assertEquals(TEST_DATA_SIZE, sortedList.size());
         assertEquals("First excepted to be last", resultList.first().getColumnLong(), sortedList.last().getColumnLong());
 
-        RealmResults<AllTypes> reverseList = sortedList.sort("columnLong", RealmResults.SORT_ORDER_ASCENDING);
+        RealmResults<AllTypes> reverseList = sortedList.sort(FIELD_LONG, RealmResults.SORT_ORDER_ASCENDING);
         assertEquals(TEST_DATA_SIZE, reverseList.size());
         assertEquals("First excepted to be first", resultList.first().getColumnLong(), reverseList.first().getColumnLong());
         assertEquals("Last excepted to be last", resultList.last().getColumnLong(), reverseList.last().getColumnLong());
 
-        RealmResults<AllTypes> reserveSortedList = reverseList.sort("columnLong", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> reserveSortedList = reverseList.sort(FIELD_LONG, RealmResults.SORT_ORDER_DECENDING);
         assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
     }
 
     public void testSortByDate() {
 
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.sort("columnDate", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> sortedList = resultList.sort(FIELD_DATE, RealmResults.SORT_ORDER_DECENDING);
         assertEquals("Should have same size", resultList.size(), sortedList.size());
         assertEquals(TEST_DATA_SIZE, sortedList.size());
         assertEquals("First excepted to be last", resultList.first().getColumnDate(), sortedList.last().getColumnDate());
 
-        RealmResults<AllTypes> reverseList = sortedList.sort("columnDate", RealmResults.SORT_ORDER_ASCENDING);
+        RealmResults<AllTypes> reverseList = sortedList.sort(FIELD_DATE, RealmResults.SORT_ORDER_ASCENDING);
         assertEquals(TEST_DATA_SIZE, reverseList.size());
         assertEquals("First excepted to be first", resultList.first().getColumnDate(), reverseList.first().getColumnDate());
         assertEquals("Last excepted to be last", resultList.last().getColumnDate(), reverseList.last().getColumnDate());
 
-        RealmResults<AllTypes> reserveSortedList = reverseList.sort("columnDate", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> reserveSortedList = reverseList.sort(FIELD_DATE, RealmResults.SORT_ORDER_DECENDING);
         assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
     }
 
     public void testSortByBoolean(){
 
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.sort("columnBoolean", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> sortedList = resultList.sort(FIELD_BOOLEAN, RealmResults.SORT_ORDER_DECENDING);
         assertEquals("Should have same size", resultList.size(), sortedList.size());
         assertEquals(TEST_DATA_SIZE, sortedList.size());
         assertEquals("Last expected to be false", false, sortedList.last().isColumnBoolean());
@@ -216,14 +225,14 @@ public class RealmResultsTest extends AndroidTestCase {
         assertEquals("Expected to be true", true, sortedList.get(147).isColumnBoolean());
         assertEquals("Expected to be false", false, sortedList.get(368).isColumnBoolean());
 
-        RealmResults<AllTypes> reverseList = sortedList.sort("columnBoolean", RealmResults.SORT_ORDER_ASCENDING);
+        RealmResults<AllTypes> reverseList = sortedList.sort(FIELD_BOOLEAN, RealmResults.SORT_ORDER_ASCENDING);
         assertEquals(TEST_DATA_SIZE, reverseList.size());
         assertEquals("Last expected to be true", true, reverseList.last().isColumnBoolean());
         assertEquals("First expected to be false", false, reverseList.first().isColumnBoolean());
         assertEquals("Expected to be false", false, reverseList.get(147).isColumnBoolean());
         assertEquals("Expected to be true", true, reverseList.get(368).isColumnBoolean());
 
-        RealmResults<AllTypes> reserveSortedList = reverseList.sort("columnBoolean", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> reserveSortedList = reverseList.sort(FIELD_BOOLEAN, RealmResults.SORT_ORDER_DECENDING);
         assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
         assertEquals(reserveSortedList.first(), sortedList.first());
     }
@@ -239,46 +248,46 @@ public class RealmResultsTest extends AndroidTestCase {
         assertEquals(TEST_DATA_SIZE, sortedList.size());
         assertEquals("First excepted to be last", resultList.first().getColumnString(), sortedList.last().getColumnString());
 
-        RealmResults<AllTypes> reverseList = sortedList.sort("columnString", RealmResults.SORT_ORDER_ASCENDING);
+        RealmResults<AllTypes> reverseList = sortedList.sort(FIELD_STRING, RealmResults.SORT_ORDER_ASCENDING);
         assertEquals(TEST_DATA_SIZE, reverseList.size());
         assertEquals("First excepted to be first", resultList.first().getColumnString(), reverseList.first().getColumnString());
         assertEquals("Last excepted to be last", resultList.get(99).getColumnString(), reverseList.last().getColumnString());
 
-        RealmResults<AllTypes> reserveSortedList = reverseList.sort("columnString", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> reserveSortedList = reverseList.sort(FIELD_STRING, RealmResults.SORT_ORDER_DECENDING);
         assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
     }
 
 
     public void testSortByDouble() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.sort("columnDouble", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> sortedList = resultList.sort(FIELD_DOUBLE, RealmResults.SORT_ORDER_DECENDING);
         assertEquals("Should have same size", resultList.size(), sortedList.size());
         assertEquals(TEST_DATA_SIZE, sortedList.size());
         assertEquals("First excepted to be last", resultList.first().getColumnDouble(), sortedList.last().getColumnDouble());
 
-        RealmResults<AllTypes> reverseList = sortedList.sort("columnDouble", RealmResults.SORT_ORDER_ASCENDING);
+        RealmResults<AllTypes> reverseList = sortedList.sort(FIELD_DOUBLE, RealmResults.SORT_ORDER_ASCENDING);
         assertEquals(TEST_DATA_SIZE, reverseList.size());
         assertEquals("First excepted to be first", resultList.first().getColumnDouble(), reverseList.first().getColumnDouble());
         assertEquals("Last excepted to be last", resultList.last().getColumnDouble(), reverseList.last().getColumnDouble());
 
-        RealmResults<AllTypes> reserveSortedList = reverseList.sort("columnDouble", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> reserveSortedList = reverseList.sort(FIELD_DOUBLE, RealmResults.SORT_ORDER_DECENDING);
         assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
     }
 
 
     public void testSortByFloat() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.sort("columnFloat", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> sortedList = resultList.sort(FIELD_FLOAT, RealmResults.SORT_ORDER_DECENDING);
         assertEquals("Should have same size", resultList.size(), sortedList.size());
         assertEquals(TEST_DATA_SIZE, sortedList.size());
         assertEquals("First excepted to be last", resultList.first().getColumnFloat(), sortedList.last().getColumnFloat());
 
-        RealmResults<AllTypes> reverseList = sortedList.sort("columnFloat", RealmResults.SORT_ORDER_ASCENDING);
+        RealmResults<AllTypes> reverseList = sortedList.sort(FIELD_FLOAT, RealmResults.SORT_ORDER_ASCENDING);
         assertEquals(TEST_DATA_SIZE, reverseList.size());
         assertEquals("First excepted to be first", resultList.first().getColumnFloat(), reverseList.first().getColumnFloat());
         assertEquals("Last excepted to be last", resultList.last().getColumnFloat(), reverseList.last().getColumnFloat());
 
-        RealmResults<AllTypes> reserveSortedList = reverseList.sort("columnFloat", RealmResults.SORT_ORDER_DECENDING);
+        RealmResults<AllTypes> reserveSortedList = reverseList.sort(FIELD_FLOAT, RealmResults.SORT_ORDER_DECENDING);
         assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
     }
 


### PR DESCRIPTION
Extending unit tests for `RealmResults.sort` so all supported field types are tested.

@benjaminprakash88 @emanuelez 
