### PR TITLE
Little refactor on RealmQuery

### DIFF
--- a/realm/src/main/java/io/realm/RealmQuery.java
+++ b/realm/src/main/java/io/realm/RealmQuery.java
@@ -808,7 +808,7 @@ public class RealmQuery<E extends RealmObject> {
      * @throws java.lang.RuntimeException Any other error
      */
     public RealmQuery<E> contains(String fieldName, String value) {
-        return contains(fieldName, value, true);
+        return contains(fieldName, value, CASE_SENSITIVE);
     }
 
     /**
@@ -840,7 +840,7 @@ public class RealmQuery<E extends RealmObject> {
      * @throws java.lang.RuntimeException Any other error
      */
     public RealmQuery<E> beginsWith(String fieldName, String value) {
-        return beginsWith(fieldName, value, true);
+        return beginsWith(fieldName, value, CASE_SENSITIVE);
     }
 
     /**
@@ -872,7 +872,7 @@ public class RealmQuery<E extends RealmObject> {
      * @throws java.lang.RuntimeException Any other error
      */
     public RealmQuery<E> endsWith(String fieldName, String value) {
-        return endsWith(fieldName, value, true);
+        return endsWith(fieldName, value, CASE_SENSITIVE);
     }
 
     /**


### PR DESCRIPTION
Looking into RealmQuery we have methods that just have same code...

And the native methods are caseSensitive by default.

Remove the same code from the methods and call the other passing true as default...
