### PR TITLE
Use to_jstring() everywhere at the JNI layer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
   * Adding case sensitive versions of string comparison operators equalTo and notEqualTo
   * Adding new method distinct() to Realm
   * Updated core to 0.86.0, fixing a bug in cancelling an empty transaction, and major query speedups with floats/doubles
+  * Consistent handling of UTF-8 strings
 
 0.73.1 (05 Nov 2014)
   * Fixed a bug that would send infinite notifications in some instances

--- a/realm-jni/src/io_realm_internal_Group.cpp
+++ b/realm-jni/src/io_realm_internal_Group.cpp
@@ -255,7 +255,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Group_nativeToJson(
         ss.sync_with_stdio(false); // for performance
         grp->to_json(ss);
         const std::string str = ss.str();
-        return env->NewStringUTF(str.c_str());
+        return to_jstring(env, str);
     } CATCH_STD()
     return 0;
 }
@@ -270,7 +270,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Group_nativeToString(
         ss.sync_with_stdio(false); // for performance
         grp->to_string(ss);
         const std::string str = ss.str();
-        return env->NewStringUTF(str.c_str());
+        return to_jstring(env, str);
     } CATCH_STD()
     return 0;
 }

--- a/realm-jni/src/io_realm_internal_SharedGroup.cpp
+++ b/realm-jni/src/io_realm_internal_SharedGroup.cpp
@@ -269,7 +269,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_SharedGroup_nativeGetDefaultRep
     ThrowException(env, UnsupportedOperation,
                    "Replication is not currently supported by the Java language binding.");
     return 0;
-//    return env->NewStringUTF(Replication::get_path_to_database_file());
+//    return to_jstring(env, Replication::get_path_to_database_file());
 #else
     ThrowException(env, UnsupportedOperation,
                    "Replication was disable in the native library at compile time");

--- a/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm-jni/src/io_realm_internal_tableview.cpp
@@ -955,7 +955,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeToJson(
         ss.sync_with_stdio(false); // for performance
         tv->to_json(ss);
         const std::string str = ss.str();
-        return env->NewStringUTF(str.c_str());
+        return to_jstring(env, str);
     } CATCH_STD()
     return NULL;
 }
@@ -973,7 +973,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeToString(
        ss.sync_with_stdio(false); // for performance
        tv->to_string(ss, S(maxRows));
        const std::string str = ss.str();
-       return env->NewStringUTF(str.c_str());
+       return to_jstring(env, str);
     } CATCH_STD()
     return NULL;
 }
@@ -990,7 +990,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeRowToString(
         std::ostringstream ss;
         tv->row_to_string(S(rowIndex), ss);
         const std::string str = ss.str();
-        return env->NewStringUTF(str.c_str());
+        return to_jstring(env, str);
     } CATCH_STD()
     return NULL;
 }

--- a/realm-jni/src/util.cpp
+++ b/realm-jni/src/util.cpp
@@ -137,7 +137,7 @@ void jprint(JNIEnv *env, char *txt)
     static jclass myClass = GetClass(env, "io/realm/internal/util");
     static jmethodID myMethod = env->GetStaticMethodID(myClass, "javaPrint", "(Ljava/lang/String;)V");
     if (myMethod)
-        env->CallStaticVoidMethod(myClass, myMethod, env->NewStringUTF(txt));
+        env->CallStaticVoidMethod(myClass, myMethod, to_jstring(env, txt);
 #endif
 }
 

--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -374,6 +374,35 @@ public class RealmResultsTest extends AndroidTestCase {
         }
     }
 
+    public void testSortNonLatin() {
+        testRealm.beginTransaction();
+        testRealm.clear(AllTypes.class);
+        AllTypes at1 = testRealm.createObject(AllTypes.class);
+        at1.setColumnString("Санкт-Петербург");
+        AllTypes at2 = testRealm.createObject(AllTypes.class);
+        at2.setColumnString("Москва");
+        AllTypes at3 = testRealm.createObject(AllTypes.class);
+        at3.setColumnString("Новороссийск");
+        testRealm.commitTransaction();
+
+        RealmResults<AllTypes> result = testRealm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> sortedResult = result.sort(FIELD_STRING);
+
+        assertEquals(3, sortedResult.size());
+        assertEquals("Москва", sortedResult.first().getColumnString());
+        assertEquals("Москва", sortedResult.get(0).getColumnString());
+        assertEquals("Новороссийск", sortedResult.get(1).getColumnString());
+        assertEquals("Санкт-Петербург", sortedResult.get(2).getColumnString());
+
+        RealmResults<AllTypes> reverseResult = result.sort(FIELD_STRING, RealmResults.SORT_ORDER_DECENDING);
+        assertEquals(3, reverseResult.size());
+        assertEquals("Москва", reverseResult.last().getColumnString());
+
+        RealmResults<AllTypes> reverseSortedResult = sortedResult.sort(FIELD_STRING, RealmResults.SORT_ORDER_DECENDING);
+        assertEquals(3, reverseSortedResult.size());
+        assertEquals("Москва", reverseSortedResult.last().getColumnString());
+    }
+
     public void testCount() {
         assertEquals(TEST_DATA_SIZE, testRealm.where(AllTypes.class).count());
     }


### PR DESCRIPTION
We have seen a ugly crash in `sort()` which might related to Russian letters (see issue #529). As @kspangsege mentioned recently, `to_jstring()` must be used when strings are returned from the core to the JVM.

@cmelchior @bmunkholm 
