### PR TITLE
Automatically test examples and distribution

### DIFF
--- a/monkey-distribution.sh
+++ b/monkey-distribution.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Runs Android monkey tool on all distribution projects. Using this script before using
 # build-distribution.sh will fail.
@@ -14,8 +14,8 @@ echo "Testing distribution examples"
 echo ""
 for dist in distribution/Realm*/ ; do
 
-    applicationId=`grep applicationId "${dist}app/build.gradle" | cut -d \" -f 2 | cut -d \' -f 2`
-    project=`basename ${dist}`
+    applicationId=$(grep applicationId "${dist}app/build.gradle" | cut -d \" -f 2 | cut -d \' -f 2)
+    project=$(basename ${dist})
 
     echo "Building ${dist}"
     adb uninstall ${applicationId} > /dev/null
@@ -25,7 +25,7 @@ for dist in distribution/Realm*/ ; do
 
     echo "Letting monkey loose in $dist"
     adb shell "monkey -p ${applicationId} -v ${TEST_EVENTS} ; echo \"\$?\\c\" > /data/local/tmp/${applicationId}.exitcode"
-    rc=`adb shell cat /data/local/tmp/${applicationId}.exitcode`
+    rc=$(adb shell cat /data/local/tmp/${applicationId}.exitcode)
     echo ""
     if [ "${rc}" != "0" ] ; then
         echo ""

--- a/monkey-examples.sh
+++ b/monkey-examples.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Runs Android monkey tool on all example projects.
 #
@@ -13,8 +13,8 @@ echo "TESTING EXAMPLES"
 echo ""
 for example in examples/*/ ; do
 
-    applicationId=`grep applicationId "${example}build.gradle" | cut -d \" -f 2 | cut -d \' -f 2`
-    project=`basename ${example}`
+    applicationId=$(grep applicationId "${example}build.gradle" | cut -d \" -f 2 | cut -d \' -f 2)
+    project=$(basename ${example})
 
     if [ ${project} == "encryptionExample" ] ; then
         echo "Skipping ${example}"
@@ -28,7 +28,7 @@ for example in examples/*/ ; do
 
     echo "Letting monkey loose in $example"
     adb shell "monkey -p ${applicationId} -v ${TEST_EVENTS} ; echo \"\$?\\c\" > /data/local/tmp/${applicationId}.exitcode"
-    rc=`adb shell cat /data/local/tmp/${applicationId}.exitcode`
+    rc=$(adb shell cat /data/local/tmp/${applicationId}.exitcode)
     if [ "${rc}" != "0" ] ; then
         echo ""
         echo "Monkey found an error, stopping tests."


### PR DESCRIPTION
Added two shellscripts that automatically install and test example and distribution projects by using the Android monkey tool. Any failure will result in the scripts to exit with an error code.
