### PR TITLE
Fixed Realm cache not working

### DIFF
--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -74,9 +74,10 @@ public class RealmTest extends AndroidTestCase {
     private final static int BACKGROUND_COMMIT_TEST_DATA_SET_SIZE = 5;
 
 
-    // Test io.realm.Realm API
+    public void testRealmCache() {
+        assertEquals(testRealm, Realm.getInstance(getContext()));
+    }
 
-    // Realm Constructors
     public void testShouldCreateRealm() {
         Realm realm = Realm.getInstance(getContext());
         assertNotNull("Realm.getInstance unexpectedly returns null", realm);

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -365,7 +365,7 @@ public class Realm {
 
     private static Realm createAndValidate(String absolutePath, byte[] key, boolean validateSchema, boolean autoRefresh) {
         Map<Integer, Realm> realms = realmsCache.get();
-        Realm realm = realms.get(absolutePath);
+        Realm realm = realms.get(absolutePath.hashCode());
 
         if (realm != null) {
             return realm;


### PR DESCRIPTION
I have added a unit test for this case as well. 
The error was introduced after last release, so changelog shouldn't need to be updated.  

@kneth @bmunkholm 
