### PR TITLE
Update RealmProxyClassGenerator.java

### DIFF
--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -252,6 +252,7 @@ public class RealmProxyClassGenerator {
                 writer.beginMethod("void", setters.get(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
                 writer.beginControlFlow("if (value == null)");
                 writer.emitStatement("row.nullifyLink(Realm.columnIndices.get(\"%s\").get(\"%s\"))", className, fieldName);
+                writer.emitStatement("return");
                 writer.endControlFlow();
                 writer.emitStatement("row.setLink(Realm.columnIndices.get(\"%s\").get(\"%s\"), value.row.getIndex())", className, fieldName);
                 writer.endMethod();

--- a/realm/src/androidTest/java/io/realm/RealmObjectTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmObjectTest.java
@@ -448,4 +448,24 @@ public class RealmObjectTest extends AndroidTestCase {
         }
 
     }
+
+    public void testSetNullLink() {
+        testRealm.beginTransaction();
+        CyclicType objA = testRealm.createObject(CyclicType.class);
+        objA.setName("Foo");
+        CyclicType objB = testRealm.createObject(CyclicType.class);
+        objB.setName("Bar");
+
+        objA.setObject(objB);
+
+        assertNotNull(objA.getObject());
+
+        try {
+            objA.setObject(null);
+        } catch (NullPointerException nullPointer) {
+            fail();
+        }
+        testRealm.commitTransaction();
+        assertNull(objA.getObject());
+    }
 }


### PR DESCRIPTION
Setting relationship to null throws NullPointerException, because setter method does not exit where it should, trying to access null value instead.