### PR TITLE
Disabling indexOf()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
  * Lenient UTF-8 to UTF-16 transcoding by inserting replacement characters.
  * Adding more logging capabilities at the JNI level.
  * Added proper encryption support. NOTE: The key has been increased from 32 bytes to 64 bytes (see example).
- * Throw NoSuchMethodError when RealmResults.indexOf() is called.
+ * Throw NoSuchMethodError when RealmResults.indexOf() is called, since it's not implemented yet.
 
 0.76.0
  * RealmObjects can now be imported using JSON.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
  * Lenient UTF-8 to UTF-16 transcoding by inserting replacement characters.
  * Adding more logging capabilities at the JNI level.
  * Added proper encryption support. NOTE: The key has been increased from 32 bytes to 64 bytes (see example).
+ * Throw NoSuchMethodError when RealmResults.indexOf() is called.
 
 0.76.0
  * RealmObjects can now be imported using JSON.

--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Future;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.Cat;
-import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
 
@@ -663,5 +662,12 @@ public class RealmResultsTest extends AndroidTestCase {
         assertEquals(1, all.size());
     }
 
+    public void testIndexOf() {
+        try {
+            RealmResults<AllTypes> all = testRealm.allObjects(AllTypes.class);
+            int index = all.indexOf(all.first());
+            fail();
+        } catch (NoSuchMethodError e) {}
+    }
     // TODO: More extended tests of querying all types must be done.
 }

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -109,7 +109,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
      */
     @Override
     public int indexOf(Object o) {
-        throw new NoSuchMethodError();
+        throw new NoSuchMethodError("indexOf is not supported on RealmResults");
     }
 
     /**

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -105,6 +105,14 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int indexOf(Object o) {
+        throw new NoSuchMethodError();
+    }
+
+    /**
      * Get the first object from the list.
      * @return The first object.
      */


### PR DESCRIPTION
`RealmResults` inherits from `AbtractList`. This implies that `indexOf` will return 0 if not implemented. As we haven't yet implemented the method, it is safer to throw `NoSuchMethodError` when it is called.

@emanuelez @cmelchior @bmunkholm 