### PR TITLE
Added Realm.executeTransaction() method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
  * Fixed bug when doing queries on the elements of a RealmList, ie. like Realm.where(Foo.class).getBars().where().equalTo("name").
  * Throw NoSuchMethodError when RealmResults.indexOf() is called, since it's not implemented yet.
  * Adding more precise imports in proxy classes to avoid ambiguous references.
+ * Added support for executing a transaction a closure using Realm.executeTransaction().
 
 0.76.0
  * RealmObjects can now be imported using JSON.

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -38,6 +38,7 @@ import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
 import io.realm.entities.StringOnly;
+import io.realm.exceptions.RealmException;
 import io.realm.internal.Table;
 
 
@@ -73,8 +74,9 @@ public class RealmTest extends AndroidTestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        if (testRealm != null)
+        if (testRealm != null) {
             testRealm.close();
+        }
     }
 
     private void populateTestRealm(int objects) {
@@ -441,6 +443,42 @@ public class RealmTest extends AndroidTestCase {
         } catch (IllegalStateException ignored) {
         }
     }
+
+
+    public void testExecuteTransactionNull() {
+        testRealm.executeTransaction(null); // Nothing happens
+        assertFalse(testRealm.hasChanged());
+    }
+
+    public void testExecuteTransactionCommit() {
+        assertEquals(0, testRealm.allObjects(Owner.class).size());
+        testRealm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                Owner owner = realm.createObject(Owner.class);
+                owner.setName("Owner");
+            }
+        });
+        assertEquals(1, testRealm.allObjects(Owner.class).size());
+    }
+
+    public void testExecuteTransactionCancel() {
+        assertEquals(0, testRealm.allObjects(Owner.class).size());
+        try {
+            testRealm.executeTransaction(new Realm.Transaction() {
+                @Override
+                public void execute(Realm realm) {
+                    Owner owner = realm.createObject(Owner.class);
+                    owner.setName("Owner");
+                    throw new RuntimeException("Boom");
+                }
+            });
+        } catch (RealmException ignore) {
+        }
+        assertEquals(0, testRealm.allObjects(Owner.class).size());
+    }
+
+
 
     // void clear(Class<?> classSpec)
     public void testClear() {

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1078,6 +1078,29 @@ public final class Realm implements Closeable {
      }
 
     /**
+     * Executes a given transaction on the Realm. {@link #beginTransaction()} and
+     * {@link #commitTransaction()} will be called automatically. If any exception is thrown
+     * during the transaction {@link #cancelTransaction()} will be called instead.
+     *
+     * @param transaction Transaction to execute.
+     * @throws RealmException if any error happened during the transaction.
+     */
+    public void executeTransaction(Transaction transaction) {
+        if (transaction == null) return;
+        beginTransaction();
+        try {
+            transaction.execute(this);
+            commitTransaction();
+        } catch (RuntimeException e) {
+            cancelTransaction();
+            throw new RealmException("Error during transaction.", e);
+        } catch (Error e) {
+            cancelTransaction();
+            throw e;
+        }
+    }
+
+    /**
      * Remove all objects of the specified class.
      *
      * @param classSpec The class which objects should be removed
@@ -1231,6 +1254,16 @@ public final class Realm implements Closeable {
      */
     public String getPath() {
         return path;
+    }
+
+    /**
+     * Encapsulates a Realm transaction.
+     *
+     * Using this class will automatically handle {@link #beginTransaction()} and {@link #commitTransaction()}
+     * If any exception is thrown while inside the transaction {@link #cancelTransaction()} will be called instead.
+     */
+    public interface Transaction {
+        public void execute(Realm realm);
     }
 }
 

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1080,9 +1080,9 @@ public final class Realm implements Closeable {
     /**
      * Executes a given transaction on the Realm. {@link #beginTransaction()} and
      * {@link #commitTransaction()} will be called automatically. If any exception is thrown
-     * during the transaction {@link #cancelTransaction()} will be called instead.
+     * during the transaction {@link #cancelTransaction()} will be called instead of {@link #commitTransaction()}.
      *
-     * @param transaction Transaction to execute.
+     * @param transaction {@link io.realm.Realm.Transaction} to execute.
      * @throws RealmException if any error happened during the transaction.
      */
     public void executeTransaction(Transaction transaction) {
@@ -1260,7 +1260,8 @@ public final class Realm implements Closeable {
      * Encapsulates a Realm transaction.
      *
      * Using this class will automatically handle {@link #beginTransaction()} and {@link #commitTransaction()}
-     * If any exception is thrown while inside the transaction {@link #cancelTransaction()} will be called instead.
+     * If any exception is thrown during the transaction {@link #cancelTransaction()} will be called
+     * instead of {@link #commitTransaction()}.
      */
     public interface Transaction {
         public void execute(Realm realm);


### PR DESCRIPTION
Added convenience method for using the begin/commit/cancel pattern for transactions. It also mirrors the functionality for RLMRealm.transactionWithBlock on Cocoa.

Note that while it actually looks like it is more difficult to write, IntelliJ folding + autocomplete means it actually require fewer keypresses plus folds nicely.

I added it as a inner public class in order to keep the global number of classes low.

@emanuelez @kneth @bmunkholm 