### PR TITLE
Thread handler no longer gets removed too soon.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
  * Remove deprecated static constructors.
  * Introduce new static constructors based on File instead of Context, allowing to save Realm files in custom locations.
  * RealmList.remove() now properly returns the removed object.
+ * Calling realm.close() no longer prevent updates to other open realm instances on the same thread.
 
 0.76.0
  * RealmObjects can now be imported using JSON.

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1283,12 +1283,11 @@ public final class Realm implements Closeable {
 
     // Returns the Handler for this Realm on the calling thread
     Handler getHandler() {
-        for (Handler handler : handlers.keySet()) {
-            if (handlers.get(handler) == id) {
-                return handler;
+        for (Map.Entry<Handler, Integer> entry : handlers.entrySet()) {
+            if (entry.getValue() == id) {
+                return entry.getKey();
             }
         }
-
         return null;
     }
 

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -195,7 +195,7 @@ public final class Realm implements Closeable {
         }
         localRefCount.put(id, Math.max(0, refCount));
 
-        if (handler != null) {
+        if (handler != null && refCount <= 0) {
             removeHandler(handler);
         }
     }
@@ -1275,6 +1275,21 @@ public final class Realm implements Closeable {
      */
     public void clear(Class<?> classSpec) {
         getTable(classSpec).clear();
+    }
+
+    int getId() {
+        return id;
+    }
+
+    // Returns the Handler for this Realm on the calling thread
+    Handler getHandler() {
+        for (Handler handler : handlers.keySet()) {
+            if (handlers.get(handler) == id) {
+                return handler;
+            }
+        }
+
+        return null;
     }
 
     // package protected so unit tests can access it


### PR DESCRIPTION
This PR fixes the case where close() method removed the Thread handler to soon even though open instances still existed.

@bmunkholm @kneth @emanuelez 