### PR TITLE
[WIP] Include version in exceptions

### DIFF
--- a/realm-jni/src/io_realm_internal_Util.cpp
+++ b/realm-jni/src/io_realm_internal_Util.cpp
@@ -17,6 +17,7 @@
 #include "util.hpp"
 #include "mem_usage.hpp"
 #include "io_realm_internal_Util.h"
+#include "io_realm_internal_Version.h"
 
 using std::string;
 
@@ -50,7 +51,6 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeTestcase(
     JNIEnv *env, jclass, jint testcase, jboolean dotest, jlong)
 {
     string expect;
-
     switch (ExceptionKind(testcase)) {
         case ClassNotFound:
             expect = "java.lang.ClassNotFoundException: Class 'parm1' could not be located.";
@@ -127,6 +127,9 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeTestcase(
     if (dotest) {
         return NULL;
     }
-    return to_jstring(env, expect);
+    string version = "Realm version " + num_to_string<int>(io_realm_internal_Version_REALM_JAVA_MAJOR) + "."
+        + num_to_string<int>(io_realm_internal_Version_REALM_JAVA_MINOR) + "."
+        + num_to_string<int>(io_realm_internal_Version_REALM_JAVA_PATCH);
+    return to_jstring(env, expect + " (" + version + ")");
 }
 

--- a/realm-jni/src/io_realm_internal_Version.h
+++ b/realm-jni/src/io_realm_internal_Version.h
@@ -7,6 +7,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#undef io_realm_internal_Version_REALM_JAVA_MAJOR
+#define io_realm_internal_Version_REALM_JAVA_MAJOR 0L
+#undef io_realm_internal_Version_REALM_JAVA_MINOR
+#define io_realm_internal_Version_REALM_JAVA_MINOR 78L
+#undef io_realm_internal_Version_REALM_JAVA_PATCH
+#define io_realm_internal_Version_REALM_JAVA_PATCH 0L
 #undef io_realm_internal_Version_CORE_MIN_MAJOR
 #define io_realm_internal_Version_CORE_MIN_MAJOR 0L
 #undef io_realm_internal_Version_CORE_MIN_MINOR

--- a/realm-jni/src/util.cpp
+++ b/realm-jni/src/util.cpp
@@ -22,6 +22,7 @@
 
 #include "util.hpp"
 #include "io_realm_internal_Util.h"
+#include "io_realm_internal_Version.h"
 
 using namespace std;
 using namespace tightdb;
@@ -132,8 +133,13 @@ void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& cla
             message = "Illegal State: " + classStr;
             break;
     }
-    if (jExceptionClass != NULL)
-        env->ThrowNew(jExceptionClass, message.c_str());
+    if (jExceptionClass != NULL) {
+        // Get binding version
+        string version = "Realm version " + num_to_string<int>(io_realm_internal_Version_REALM_JAVA_MAJOR) + "."
+            + num_to_string<int>(io_realm_internal_Version_REALM_JAVA_MINOR) + "."
+            + num_to_string<int>(io_realm_internal_Version_REALM_JAVA_PATCH);
+        env->ThrowNew(jExceptionClass, (message + " (" + version + ")").c_str());
+    }
     else {
         TR_ERR("ERROR: Couldn't throw exception.")
     }

--- a/realm/src/main/java/io/realm/internal/Version.java
+++ b/realm/src/main/java/io/realm/internal/Version.java
@@ -18,6 +18,11 @@ package io.realm.internal;
 
 public class Version {
 
+    // Set by tools/set-version.sh
+    static final int REALM_JAVA_MAJOR = 0;
+    static final int REALM_JAVA_MINOR = 77;
+    static final int REALM_JAVA_PATCH = 0;
+
     static final int CORE_MIN_MAJOR = 0;
     static final int CORE_MIN_MINOR = 1;
     static final int CORE_MIN_PATCH = 6;
@@ -41,8 +46,7 @@ public class Version {
     }
 
     public static String getVersion() {
-        // Currently Core version and Java version is the same
-        return getCoreVersion();
+        return String.format("%d.%d.%d", REALM_JAVA_MAJOR, REALM_JAVA_MINOR, REALM_JAVA_PATCH);
     }
 
     public static boolean hasFeature(Feature feature) {

--- a/tools/set-version.sh
+++ b/tools/set-version.sh
@@ -16,8 +16,12 @@ printf ",s/int REALM_JAVA_MAJOR .*/int REALM_JAVA_MAJOR = $realm_java_ver_major\
 printf ",s/int REALM_JAVA_MINOR .*/int REALM_JAVA_MINOR = $realm_java_ver_minor\;/\nw\nq" | ed -s "$realm_java_version_file" || exit 1
 printf ",s/int REALM_JAVA_PATCH .*/int REALM_JAVA_PATCH = $realm_java_ver_patch\;/\nw\nq" | ed -s "$realm_java_version_file" || exit 1
 
+# update annotations processor
+realm_apt_file="realm-annotations-processor/src/main/java/io/realm/processor/RealmVersionChecker.java"
+printf ",s/String REALM_VERSION .*/String REALM_VERSION = \"$realm_java_version\"\;/\nw\nq" | ed -s "$realm_apt_file" || exit 1
+
 # update version.text
 echo -n "$realm_java_ver_major.$realm_java_ver_minor.$realm_java_ver_patch" > version.text || exit 1
 
-echo "Remember to update JNI headers by running realm-jni/generate-headers.sh"
+echo "Remember to update JNI headers by running realm-jni/generate-jni-headers.sh"
 exit 0

--- a/tools/set-version.sh
+++ b/tools/set-version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "You must supply a version number"
+    exit 1
+fi
+
+realm_java_version="$1"
+realm_java_version_file="realm/src/main/java/io/realm/internal/Version.java"
+realm_java_ver_major="$(echo "$realm_java_version" | cut -f1 -d.)" || exit 1
+realm_java_ver_minor="$(echo "$realm_java_version" | cut -f2 -d.)" || exit 1
+realm_java_ver_patch="$(echo "$realm_java_version" | cut -f3 -d.)" || exit 1
+
+# update Version.java
+printf ",s/int REALM_JAVA_MAJOR .*/int REALM_JAVA_MAJOR = $realm_java_ver_major\;/\nw\nq" | ed -s "$realm_java_version_file" || exit 1
+printf ",s/int REALM_JAVA_MINOR .*/int REALM_JAVA_MINOR = $realm_java_ver_minor\;/\nw\nq" | ed -s "$realm_java_version_file" || exit 1
+printf ",s/int REALM_JAVA_PATCH .*/int REALM_JAVA_PATCH = $realm_java_ver_patch\;/\nw\nq" | ed -s "$realm_java_version_file" || exit 1
+
+# update version.text
+echo -n "$realm_java_ver_major.$realm_java_ver_minor.$realm_java_ver_patch" > version.text || exit 1
+
+echo "Remember to update JNI headers by running realm-jni/generate-headers.sh"
+exit 0


### PR DESCRIPTION
This pull request introduces two things:

* Version to exception thrown at JNI level. 
* A utility to set version (`tools/set-version.sh`)

Setting the version for a new release requires that `tools/set-version.sh` and `realm-jni/generate-jni-headers.sh` to be run.

@emanuelez @cmelchior @bmunkholm 