### PR TITLE
Reenable RealmResults remove methods + document behavior

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 0.79
- * RealmResults.remove(index) and RealmResults.removeLast() are now working again.
+ * Re-enabled RealmResults.remove(index) and RealmResults.removeLast().
 
 0.78
  * Added proper support for encryption. Encryption support is now included by default. Keys are now 64 bytes long.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.79
+ * RealmResults.remove(index) and RealmResults.removeLast() are now working again.
+
 0.78
  * Added proper support for encryption. Encryption support is now included by default. Keys are now 64 bytes long.
  * Added support to write an encrypted copy of a Realm.

--- a/realm/src/androidTest/java/io/realm/RealmAdapterTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmAdapterTest.java
@@ -102,13 +102,12 @@ public class RealmAdapterTest extends AndroidTestCase {
         RealmAdapter realmAdapter = new RealmAdapter(getContext(), resultList, automaticUpdate);
 
         testRealm.beginTransaction();
-        try {
-            realmAdapter.getRealmResults().remove(0);
-            fail("Remove should be disabled for now");
-        } catch (RealmException ignore) {
-        } finally {
-            testRealm.cancelTransaction();
-        }
+        realmAdapter.getRealmResults().remove(0);
+        testRealm.commitTransaction();
+        assertEquals(TEST_DATA_SIZE - 1, realmAdapter.getCount());
+
+        resultList = testRealm.where(AllTypes.class).equalTo(FIELD_STRING, "test data 0").findAll();
+        assertEquals(0, resultList.size());
     }
 
     public void testSortWithAdapter() {

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -441,18 +441,18 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
      * {@link io.realm.RealmResults.RealmResultsIterator#remove()} instead.
      *
      * @param index      The array index identifying the object to be removed.
-     * @return           Object that was removed.
+     * @return           Always return null.
      */
     @Override
     public E remove(int index) {
-        E obj = get(index);
         TableOrView table = getTable();
         table.remove(index);
-        return obj;
+        return null; // Returning the object doesn't make sense, since it could no longer access any data.
     }
 
     /**
-     * Removes the last object in the list. This also deletes the object from the underlying Realm.
+     * Removes and returns the last object in the list. This also deletes the object from the
+     * underlying Realm.
      *
      * Using this method while iterating the list can result in a undefined behavior. Use
      * {@link io.realm.RealmResults.RealmResultsListIterator#removeLast()} instead.

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -437,31 +437,29 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     /**
      * Removes an object at a given index. This also deletes the object from the underlying Realm.
      *
-     * WARNING: This method is currently disabled and will always throw an
-     * {@link io.realm.exceptions.RealmException}
+     * Using this method while iterating the list, can result in a undefined behavior. Use
+     * {@link io.realm.RealmResults.RealmResultsIterator#remove()} instead.
      *
      * @param index      The array index identifying the object to be removed.
-     * @return           Always return null.
+     * @return           Object that was removed.
      */
     @Override
     public E remove(int index) {
-        throw new RealmException("Removing object is not supported.");
-/*        TableOrView table = getTable();
+        E obj = get(index);
+        TableOrView table = getTable();
         table.remove(index);
-        return null;*/
+        return obj;
     }
 
     /**
      * Removes the last object in the list. This also deletes the object from the underlying Realm.
      *
-     * WARNING: This method is currently disabled and will always throw an
-     * {@link io.realm.exceptions.RealmException}
+     * Using this method while iterating the list, can result in a undefined behavior. Use
+     * {@link io.realm.RealmResults.RealmResultsListIterator#removeLast()} instead.
      */
     public void removeLast() {
-        throw new RealmException("Removing object is not supported.");
-        /*
         TableOrView table = getTable();
-        table.removeLast();*/
+        table.removeLast();
     }
 
     /**

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -435,7 +435,10 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     // Deleting
 
     /**
-     * Removes an object at a given index.
+     * Removes an object at a given index. This also deletes the object from the underlying Realm.
+     *
+     * WARNING: This method is currently disabled and will always throw an
+     * {@link io.realm.exceptions.RealmException}
      *
      * @param index      The array index identifying the object to be removed.
      * @return           Always return null.
@@ -449,8 +452,10 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
-     * Removes the last object in the list.
+     * Removes the last object in the list. This also deletes the object from the underlying Realm.
      *
+     * WARNING: This method is currently disabled and will always throw an
+     * {@link io.realm.exceptions.RealmException}
      */
     public void removeLast() {
         throw new RealmException("Removing object is not supported.");
@@ -460,8 +465,8 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
-     * Removes all objects from the list.
-     *
+     * Removes all objects from the list. This also deletes the objects from the
+     * underlying Realm.
      */
     public void clear() {
         TableOrView table = getTable();
@@ -526,6 +531,12 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
             return get(pos);
         }
 
+        /**
+         * Removes the RealmObject at the position from both the list and the underlying Realm.
+         *
+         * WARNING: This method is currently disabled and will always throw an
+         * {@link io.realm.exceptions.RealmException}
+         */
         public void remove() {
             throw new RealmException("Removing is not supported.");
     /*        assertRealmIsStable();
@@ -592,6 +603,13 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
             throw new RealmException("Replacing elements not supported.");
         }
 
+
+        /**
+         * Removes the RealmObject at the position from both the list and the underlying Realm.
+         *
+         * WARNING: This method is currently disabled and will always throw an
+         * {@link io.realm.exceptions.RealmException}
+         */
         @Override
         public void remove() { throw new RealmException("Removing elements not supported."); }
     }

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -437,7 +437,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     /**
      * Removes an object at a given index. This also deletes the object from the underlying Realm.
      *
-     * Using this method while iterating the list, can result in a undefined behavior. Use
+     * Using this method while iterating the list can result in a undefined behavior. Use
      * {@link io.realm.RealmResults.RealmResultsIterator#remove()} instead.
      *
      * @param index      The array index identifying the object to be removed.
@@ -454,7 +454,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     /**
      * Removes the last object in the list. This also deletes the object from the underlying Realm.
      *
-     * Using this method while iterating the list, can result in a undefined behavior. Use
+     * Using this method while iterating the list can result in a undefined behavior. Use
      * {@link io.realm.RealmResults.RealmResultsListIterator#removeLast()} instead.
      */
     public void removeLast() {

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -532,7 +532,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
         }
 
         /**
-         * Removes the RealmObject at the position from both the list and the underlying Realm.
+         * Removes the RealmObject at the current position from both the list and the underlying Realm.
          *
          * WARNING: This method is currently disabled and will always throw an
          * {@link io.realm.exceptions.RealmException}
@@ -605,7 +605,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
 
 
         /**
-         * Removes the RealmObject at the position from both the list and the underlying Realm.
+         * Removes the RealmObject at the current position from both the list and the underlying Realm.
          *
          * WARNING: This method is currently disabled and will always throw an
          * {@link io.realm.exceptions.RealmException}


### PR DESCRIPTION
Reenabled remove methods and documented their behaviour if called while inside loops.

@bmunkholm @kneth @emanuelez 