### PR TITLE
Remove deprecated sorting methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
  * Fixed error when instantiating a Realm with the wrong key.
  * Throw an exception if deleteRealmFile() is called when there is an open instance of the Realm.
  * Made migrations and compression methods synchronised.
+ * Removed methods deprecated in 0.76. Now Realm.allObjectsSorted() and RealmQuery.findAllSorted() need to be used instead.
 
 0.78
  * Added proper support for encryption. Encryption support is now included by default. Keys are now 64 bytes long.

--- a/realm/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -359,11 +359,12 @@ public class RealmQueryTest extends AndroidTestCase{
 
         // null is not allowed
         try {
-            RealmResults<AllTypes> results = testRealm.where(AllTypes.class).findAll(null, null);
+            RealmResults<AllTypes> results = testRealm.where(AllTypes.class).findAllSorted(null, null);
             fail();
         } catch (IllegalArgumentException ignored) {}
         try {
-            RealmResults<AllTypes> results = testRealm.where(AllTypes.class).findAll(new String[]{FIELD_STRING}, null);
+            RealmResults<AllTypes> results = testRealm.where(AllTypes.class).findAllSorted(new String[]{FIELD_STRING},
+                    null);
             fail();
         } catch (IllegalArgumentException ignored) {}
 

--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -715,18 +715,21 @@ public class RealmResultsTest extends AndroidTestCase {
     }
 
     public void testFindAllSorted() {
-        RealmResults<AllTypes> allTypes = testRealm.where(AllTypes.class).findAll(FIELD_LONG, RealmResults.SORT_ORDER_ASCENDING);
+        RealmResults<AllTypes> allTypes = testRealm.where(AllTypes.class).findAllSorted(FIELD_LONG,
+                RealmResults.SORT_ORDER_ASCENDING);
         assertEquals(TEST_DATA_SIZE, allTypes.size());
         assertEquals(0, allTypes.first().getColumnLong());
         assertEquals(TEST_DATA_SIZE - 1, allTypes.last().getColumnLong());
 
-        RealmResults<AllTypes> reverseList = testRealm.where(AllTypes.class).findAll(FIELD_LONG, RealmResults.SORT_ORDER_DESCENDING);
+        RealmResults<AllTypes> reverseList = testRealm.where(AllTypes.class).findAllSorted(FIELD_LONG,
+                RealmResults.SORT_ORDER_DESCENDING);
         assertEquals(TEST_DATA_SIZE, reverseList.size());
         assertEquals(0, reverseList.last().getColumnLong());
         assertEquals(TEST_DATA_SIZE - 1, reverseList.first().getColumnLong());
 
         try {
-            RealmResults<AllTypes> none = testRealm.where(AllTypes.class).findAll("invalid", RealmResults.SORT_ORDER_DESCENDING);
+            RealmResults<AllTypes> none = testRealm.where(AllTypes.class).findAllSorted("invalid",
+                    RealmResults.SORT_ORDER_DESCENDING);
             fail();
         } catch (IllegalArgumentException ignored) {}
     }

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1066,29 +1066,6 @@ public final class Realm implements Closeable {
      * @return A sorted RealmResults containing the objects.
      * @throws java.lang.IllegalArgumentException if field name does not exist.
      */
-    @Deprecated
-    public <E extends RealmObject> RealmResults<E> allObjects(Class<E> clazz, String fieldName, boolean sortAscending) {
-        checkIfValid();
-        Table table = getTable(clazz);
-        TableView.Order order = sortAscending ? TableView.Order.ascending : TableView.Order.descending;
-        Long columnIndex = columnIndices.get(simpleClassNames.get(clazz)).get(fieldName);
-        if (columnIndex == null || columnIndex < 0) {
-            throw new IllegalArgumentException(String.format("Field name '%s' does not exist.", fieldName));
-        }
-
-        TableView tableView = table.getSortedView(columnIndex, order);
-        return new RealmResults<E>(this, tableView, clazz);
-    }
-
-    /**
-     * Get all objects of a specific Class sorted by a field.
-     *
-     * @param clazz the Class to get objects of.
-     * @param fieldName the field name to sort by.
-     * @param sortAscending sort ascending if SORT_ORDER_ASCENDING, sort descending if SORT_ORDER_DESCENDING.
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if field name does not exist.
-     */
     public <E extends RealmObject> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldName,
                                                                boolean sortAscending) {
         checkIfValid();
@@ -1114,47 +1091,11 @@ public final class Realm implements Closeable {
      * @return A sorted RealmResults containing the objects.
      * @throws java.lang.IllegalArgumentException if a field name does not exist.
      */
-    @Deprecated
-    public <E extends RealmObject> RealmResults<E> allObjects(Class<E> clazz, String fieldName1, boolean sortAscending1,
-                                                              String fieldName2, boolean sortAscending2) {
-        return allObjects(clazz, new String[] {fieldName1, fieldName2}, new boolean[] {sortAscending1, sortAscending2});
-    }
-
-    /**
-     * Get all objects of a specific class sorted by two field names.
-     *
-     * @param clazz the class ti get objects of.
-     * @param fieldName1 first field name to sort by.
-     * @param sortAscending1 sort order for first field.
-     * @param fieldName2 second field name to sort by.
-     * @param sortAscending2 sort order for second field.
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if a field name does not exist.
-     */
     public <E extends RealmObject> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldName1,
                                                                boolean sortAscending1, String fieldName2,
                                                                boolean sortAscending2) {
-        return allObjects(clazz, new String[] {fieldName1, fieldName2}, new boolean[] {sortAscending1, sortAscending2});
-    }
-
-    /**
-     * Get all objects of a specific class sorted by two specific field names.
-     *
-     * @param clazz the class ti get objects of.
-     * @param fieldName1 first field name to sort by.
-     * @param sortAscending1 sort order for first field.
-     * @param fieldName2 second field name to sort by.
-     * @param sortAscending2 sort order for second field.
-     * @param fieldName3 third field name to sort by.
-     * @param sortAscending3 sort order for third field.
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if a field name does not exist.
-     */
-    @Deprecated
-    public <E extends RealmObject> RealmResults<E> allObjects(Class<E> clazz, String fieldName1, boolean sortAscending1,
-                                                              String fieldName2, boolean sortAscending2,
-                                                              String fieldName3, boolean sortAscending3) {
-        return allObjects(clazz, new String[] {fieldName1, fieldName2, fieldName3}, new boolean[] {sortAscending1, sortAscending2, sortAscending3});
+        return allObjectsSorted(clazz, new String[] {fieldName1, fieldName2}, new boolean[] {sortAscending1,
+                sortAscending2});
     }
 
     /**
@@ -1174,26 +1115,8 @@ public final class Realm implements Closeable {
                                                                boolean sortAscending1,
                                                               String fieldName2, boolean sortAscending2,
                                                               String fieldName3, boolean sortAscending3) {
-        return allObjects(clazz, new String[] {fieldName1, fieldName2, fieldName3}, new boolean[] {sortAscending1, sortAscending2, sortAscending3});
-    }
-
-    /**
-     * Get all objects of a specific Class sorted by multiple fields.
-     *
-     * @param clazz the Class to get objects of.
-     * @param sortAscending sort ascending if SORT_ORDER_ASCENDING, sort descending if SORT_ORDER_DESCENDING.
-     * @param fieldNames an array of fieldnames to sort objects by.
-     *        The objects are first sorted by fieldNames[0], then by fieldNames[1] and so forth.  
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if a field name does not exist.
-     */
-    @Deprecated
-    public <E extends RealmObject> RealmResults<E> allObjects(Class<E> clazz, String fieldNames[], boolean sortAscending[]) {
-        // FIXME: This is not an optimal implementation. When core's Table::get_sorted_view() supports
-        // FIXME: multi-column sorting, we can rewrite this method to a far better implementation.
-        RealmResults<E> results = this.allObjects(clazz);
-        results.sort(fieldNames, sortAscending);
-        return results;
+        return allObjectsSorted(clazz, new String[] {fieldName1, fieldName2, fieldName3},
+                new boolean[] {sortAscending1, sortAscending2, sortAscending3});
     }
 
     /**

--- a/realm/src/main/java/io/realm/RealmQuery.java
+++ b/realm/src/main/java/io/realm/RealmQuery.java
@@ -1127,26 +1127,6 @@ public class RealmQuery<E extends RealmObject> {
      * @return A sorted RealmResults containing the objects.
      * @throws java.lang.IllegalArgumentException if field name does not exist.
      */
-    @Deprecated
-    public RealmResults<E> findAll(String fieldName, boolean sortAscending) {
-        TableView tableView = query.findAll();
-        TableView.Order order = sortAscending ? TableView.Order.ascending : TableView.Order.descending;
-        Long columnIndex = columns.get(fieldName);
-        if (columnIndex == null || columnIndex < 0) {
-            throw new IllegalArgumentException(String.format("Field name '%s' does not exist.", fieldName));
-        }
-        tableView.sort(columnIndex, order);
-        return new RealmResults<E>(realm, tableView, clazz);
-    }
-
-    /**
-     * Find all objects that fulfill the query conditions and sorted by specific field name.
-     *
-     * @param fieldName the field name to sort by.
-     * @param sortAscending sort ascending if SORT_ORDER_ASCENDING, sort descending if SORT_ORDER_DESCENDING.
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if field name does not exist.
-     */
     public RealmResults<E> findAllSorted(String fieldName, boolean sortAscending) {
         TableView tableView = query.findAll();
         TableView.Order order = sortAscending ? TableView.Order.ascending : TableView.Order.descending;
@@ -1166,61 +1146,8 @@ public class RealmQuery<E extends RealmObject> {
      * @return A sorted RealmResults containing the objects.
      * @throws java.lang.IllegalArgumentException if field name does not exist.
      */
-    @Deprecated
-    public RealmResults<E> findAll(String fieldName) {
-        return findAll(fieldName, true);
-    }
-
-    /**
-     * Find all objects that fulfill the query conditions and sorted by specific field name in
-     * ascending order.
-     *
-     * @param fieldName the field name to sort by.
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if field name does not exist.
-     */
     public RealmResults<E> findAllSorted(String fieldName) {
-        return findAll(fieldName, true);
-    }
-
-    /**
-     * Find all objects that fulfill the query conditions and sorted by specific field names.
-     *
-     * @param fieldNames an array of field names to sort by.
-     * @param sortAscending sort ascending if SORT_ORDER_ASCENDING, sort descending if SORT_ORDER_DESCENDING.
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if a field name does not exist.
-     */
-    @Deprecated
-    public RealmResults<E> findAll(String fieldNames[], boolean sortAscending[]) {
-        if (fieldNames == null) {
-            throw new IllegalArgumentException("fieldNames cannot be 'null'.");
-        } else if (sortAscending == null) {
-            throw new IllegalArgumentException("sortAscending cannot be 'null'.");
-        } else if (fieldNames.length == 0) {
-            throw new IllegalArgumentException("At least one field name must be specified.");
-        } else if (fieldNames.length != sortAscending.length) {
-            throw new IllegalArgumentException(String.format("Number of field names (%d) and sort orders (%d) does not match.", fieldNames.length, sortAscending.length));
-        }
-
-        if (fieldNames.length == 1) {
-            return findAll(fieldNames[0], sortAscending[0]);
-        } else {
-            TableView tableView = query.findAll();
-            List<Long> columnIndices = new ArrayList<Long>();
-            List<TableView.Order> orders = new ArrayList<TableView.Order>();
-            for (int i = 0; i < fieldNames.length; i++) {
-                String fieldName = fieldNames[i];
-                Long columnIndex = columns.get(fieldName);
-                if (columnIndex == null || columnIndex < 0) {
-                    throw new IllegalArgumentException(String.format("Field name '%s' does not exist.", fieldName));
-                }
-                columnIndices.add(columnIndex);
-                orders.add(sortAscending[i] ? TableView.Order.ascending : TableView.Order.descending);
-            }
-            tableView.sort(columnIndices, orders);
-            return new RealmResults<E>(realm, tableView, clazz);
-        }
+        return findAllSorted(fieldName, true);
     }
 
     /**
@@ -1243,7 +1170,7 @@ public class RealmQuery<E extends RealmObject> {
         }
 
         if (fieldNames.length == 1) {
-            return findAll(fieldNames[0], sortAscending[0]);
+            return findAllSorted(fieldNames[0], sortAscending[0]);
         } else {
             TableView tableView = query.findAll();
             List<Long> columnIndices = new ArrayList<Long>();
@@ -1273,47 +1200,9 @@ public class RealmQuery<E extends RealmObject> {
      * @return A sorted RealmResults containing the objects.
      * @throws java.lang.IllegalArgumentException if a field name does not exist.
      */
-    @Deprecated
-    public RealmResults<E> findAll(String fieldName1, boolean sortAscending1,
-                                   String fieldName2, boolean sortAscending2) {
-        return findAll(new String[] {fieldName1, fieldName2}, new boolean[] {sortAscending1, sortAscending2});
-    }
-
-    /**
-     * Find all objects that fulfill the query conditions and sorted by specific field names in
-     * ascending order.
-     *
-     * @param fieldName1 first field name
-     * @param sortAscending1 sort order for first field
-     * @param fieldName2 second field name
-     * @param sortAscending2 sort order for second field
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if a field name does not exist.
-     */
     public RealmResults<E> findAllSorted(String fieldName1, boolean sortAscending1,
                                    String fieldName2, boolean sortAscending2) {
-        return findAll(new String[] {fieldName1, fieldName2}, new boolean[] {sortAscending1, sortAscending2});
-    }
-
-    /**
-     * Find all objects that fulfill the query conditions and sorted by specific field names in
-     * ascending order.
-     *
-     * @param fieldName1 first field name
-     * @param sortAscending1 sort order for first field
-     * @param fieldName2 second field name
-     * @param sortAscending2 sort order for second field
-     * @param fieldName3 third field name
-     * @param sortAscending3 sort order for third field
-     * @return A sorted RealmResults containing the objects.
-     * @throws java.lang.IllegalArgumentException if a field name does not exist.
-     */
-    @Deprecated
-    public RealmResults<E> findAll(String fieldName1, boolean sortAscending1,
-                                   String fieldName2, boolean sortAscending2,
-                                   String fieldName3, boolean sortAscending3) {
-        return findAll(new String[] {fieldName1, fieldName2, fieldName3},
-                new boolean[] {sortAscending1, sortAscending2, sortAscending3});
+        return findAllSorted(new String[] {fieldName1, fieldName2}, new boolean[] {sortAscending1, sortAscending2});
     }
 
     /**
@@ -1332,7 +1221,7 @@ public class RealmQuery<E extends RealmObject> {
     public RealmResults<E> findAllSorted(String fieldName1, boolean sortAscending1,
                                    String fieldName2, boolean sortAscending2,
                                    String fieldName3, boolean sortAscending3) {
-        return findAll(new String[] {fieldName1, fieldName2, fieldName3},
+        return findAllSorted(new String[] {fieldName1, fieldName2, fieldName3},
                 new boolean[] {sortAscending1, sortAscending2, sortAscending3});
     }
 


### PR DESCRIPTION
Changelog:
 * Removed methods deprecated in 0.76. Now Realm.allObjectsSorted() and RealmQuery.findAllSorted() need to be used instead.