### PR TITLE
Fix findFirst() for queried RealmList

### DIFF
--- a/realm/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -365,4 +365,34 @@ public class RealmQueryTest extends AndroidTestCase{
         RealmResults<AllTypes> subQueryResult = result.where().greaterThan("columnLong", 3).findAll();
         assertEquals(1, subQueryResult.size());
     }
+
+    public void testFindFirst() {
+        testRealm.beginTransaction();
+        Owner owner1 = testRealm.createObject(Owner.class);
+        owner1.setName("Owner 1");
+        Dog dog1 = testRealm.createObject(Dog.class);
+        dog1.setName("Dog 1");
+        dog1.setWeight(1);
+        Dog dog2 = testRealm.createObject(Dog.class);
+        dog2.setName("Dog 2");
+        dog2.setWeight(2);
+        owner1.getDogs().add(dog1);
+        owner1.getDogs().add(dog2);
+
+        Owner owner2 = testRealm.createObject(Owner.class);
+        owner2.setName("Owner 2");
+        Dog dog3 = testRealm.createObject(Dog.class);
+        dog3.setName("Dog 3");
+        dog3.setWeight(1);
+        Dog dog4 = testRealm.createObject(Dog.class);
+        dog4.setName("Dog 4");
+        dog4.setWeight(2);
+        owner2.getDogs().add(dog3);
+        owner2.getDogs().add(dog4);
+        testRealm.commitTransaction();
+
+        RealmList<Dog> dogs = testRealm.where(Owner.class).equalTo("name", "Owner 2").findFirst().getDogs();
+        Dog dog = dogs.where().equalTo("name", "Dog 4").findFirst();
+        assertEquals(dog4, dog);
+    }
 }

--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import io.realm.exceptions.RealmException;
 import io.realm.internal.LinkView;
-import io.realm.internal.TableQuery;
+import io.realm.internal.TableOrView;
 
 /**
  * RealmList is used to model one-to-many relationships in a {@link io.realm.RealmObject}.
@@ -236,8 +236,8 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      */
     public RealmQuery<E> where() {
         if (managedMode) {
-            TableQuery query = this.view.where();
-            return new RealmQuery<E>(this.realm, query, clazz);
+            TableOrView table = this.view.where().findAll();
+            return new RealmQuery<E>(this.realm, table, clazz);
         } else {
             throw new RealmException(ONLY_IN_MANAGED_MODE_MESSAGE);
         }

--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import io.realm.exceptions.RealmException;
 import io.realm.internal.LinkView;
-import io.realm.internal.TableOrView;
 
 /**
  * RealmList is used to model one-to-many relationships in a {@link io.realm.RealmObject}.
@@ -236,8 +235,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      */
     public RealmQuery<E> where() {
         if (managedMode) {
-            TableOrView table = this.view.where().findAll();
-            return new RealmQuery<E>(this.realm, table, clazz);
+            return new RealmQuery<E>(this.realm, view, clazz);
         } else {
             throw new RealmException(ONLY_IN_MANAGED_MODE_MESSAGE);
         }


### PR DESCRIPTION
I found the bug of RealmQuery#findFirst() for queried ReamList.
FindFirst() may return different result of FindAll().get(0).

Code to reproduce:

```Java
public class Book extends RealmObject {
    private String id;
    private RealmList<Page> pages;
}
public class Page extends RealmObject {
    private String id;
}

String book = "book_city";
String page = "city_japan";
RealmList<Page> pages = realm.where(Book.class)
                             .equalTo("id", book)
                             .findFirst()
                             .getPages();

RealmList<Page> page1 = pages.where()
                             .equalTo("id", page)
                             .findAll()
                             .get(0);

RealmList<Page> page2 = pages.where()
                             .equalTo("id", page)
                             .findFirst();
```

Data:

```
[book]      [page]
book_food   food_fast
book_food   food_chinese
book_food   food_japanese
book_city   city_america
book_city   city_japan
```

Results:

```
page1 -> city_japan   -- Expected
page2 -> food_chinese -- Not expected
```

I don't know whether my PR is best way.
But RealmQuery#findFirst() should look queried table or view because returned rowIndex is not source row index.

