### PR TITLE
Child objects with PK are now updated/copied correctly

### DIFF
--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -250,10 +250,10 @@ public class AllTypesRealmProxy extends AllTypes {
     }
 
     public static AllTypes copyOrUpdate(Realm realm, AllTypes object, boolean update) {
-        return copy(realm, object);
+        return copy(realm, object, false);
     }
 
-    public static AllTypes copy(Realm realm, AllTypes newObject) {
+    public static AllTypes copy(Realm realm, AllTypes newObject, boolean update) {
         AllTypes realmObject = realm.createObject(AllTypes.class);
         realmObject.setColumnString(newObject.getColumnString() != null ? newObject.getColumnString() : "");
         realmObject.setColumnLong(newObject.getColumnLong());

--- a/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -141,10 +141,10 @@ public class BooleansRealmProxy extends Booleans {
     }
 
     public static Booleans copyOrUpdate(Realm realm, Booleans object, boolean update) {
-        return copy(realm, object);
+        return copy(realm, object, false);
     }
 
-    public static Booleans copy(Realm realm, Booleans newObject) {
+    public static Booleans copy(Realm realm, Booleans newObject, boolean update) {
         Booleans realmObject = realm.createObject(Booleans.class);
         realmObject.setDone(newObject.isDone());
         realmObject.setReady(newObject.isReady());

--- a/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -117,10 +117,10 @@ public class SimpleRealmProxy extends Simple {
     }
 
     public static Simple copyOrUpdate(Realm realm, Simple object, boolean update) {
-        return copy(realm, object);
+        return copy(realm, object, false);
     }
 
-    public static Simple copy(Realm realm, Simple newObject) {
+    public static Simple copy(Realm realm, Simple newObject, boolean update) {
         Simple realmObject = realm.createObject(Simple.class);
         realmObject.setName(newObject.getName() != null ? newObject.getName() : "");
         realmObject.setAge(newObject.getAge());

--- a/realm/src/androidTest/assets/list_alltypes_primarykey.json
+++ b/realm/src/androidTest/assets/list_alltypes_primarykey.json
@@ -8,13 +8,16 @@
         "columnBinary" : "AQID",
         "columnDate" : 1000,
         "columnRealmObject" : {
+            "id" : 1,
             "name" : "Dog1"
         },
         "columnRealmList" : [
             {
+                "id" : 2,
                 "name" : "Dog2"
             },
             {
+                "id" : 3,
                 "name" : "Dog3"
             }
         ]
@@ -28,13 +31,16 @@
         "columnBinary" : "AQID",
         "columnDate" : 2000,
         "columnRealmObject" : {
+            "id" : 4,
             "name" : "Dog4"
         },
         "columnRealmList" : [
             {
+                "id" : 5,
                 "name" : "Dog5"
             },
             {
+                "id" : 6,
                 "name" : "Dog6"
             }
         ]

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Future;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.Dog;
+import io.realm.entities.DogPrimaryKey;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
 import io.realm.entities.PrimaryKeyAsLong;
@@ -1077,8 +1078,8 @@ public class RealmTest extends AndroidTestCase {
                 obj.setColumnBoolean(false);
                 obj.setColumnBinary(new byte[]{1, 2, 3});
                 obj.setColumnDate(new Date(1000));
-                obj.setColumnRealmObject(new Dog("Dog1"));
-                obj.setColumnRealmList(new RealmList<Dog>(new Dog("Dog2")));
+                obj.setColumnRealmObject(new DogPrimaryKey(1, "Dog1"));
+                obj.setColumnRealmList(new RealmList<DogPrimaryKey>(new DogPrimaryKey(2, "Dog2")));
                 realm.copyToRealm(obj);
 
                 AllTypesPrimaryKey obj2 = new AllTypesPrimaryKey();
@@ -1089,8 +1090,8 @@ public class RealmTest extends AndroidTestCase {
                 obj2.setColumnBoolean(true);
                 obj2.setColumnBinary(new byte[] {2, 3, 4});
                 obj2.setColumnDate(new Date(2000));
-                obj2.setColumnRealmObject(new Dog("Dog2"));
-                obj2.setColumnRealmList(new RealmList<Dog>(new Dog("Dog3")));
+                obj2.setColumnRealmObject(new DogPrimaryKey(3, "Dog3"));
+                obj2.setColumnRealmList(new RealmList<DogPrimaryKey>(new DogPrimaryKey(4, "Dog4")));
                 realm.copyToRealmOrUpdate(obj2);
             }
         });
@@ -1106,9 +1107,9 @@ public class RealmTest extends AndroidTestCase {
         assertEquals(true, obj.isColumnBoolean());
         assertArrayEquals(new byte[]{2, 3, 4}, obj.getColumnBinary());
         assertEquals(new Date(2000), obj.getColumnDate());
-        assertEquals("Dog2", obj.getColumnRealmObject().getName());
+        assertEquals("Dog3", obj.getColumnRealmObject().getName());
         assertEquals(1, obj.getColumnRealmList().size());
-        assertEquals("Dog3", obj.getColumnRealmList().get(0).getName());
+        assertEquals("Dog4", obj.getColumnRealmList().get(0).getName());
     }
 
     // Checks that a standalone object with only default values can override data
@@ -1124,8 +1125,8 @@ public class RealmTest extends AndroidTestCase {
                 obj.setColumnBoolean(false);
                 obj.setColumnBinary(new byte[]{1, 2, 3});
                 obj.setColumnDate(new Date(1000));
-                obj.setColumnRealmObject(new Dog("Dog1"));
-                obj.setColumnRealmList(new RealmList<Dog>(new Dog("Dog2")));
+                obj.setColumnRealmObject(new DogPrimaryKey(1, "Dog1"));
+                obj.setColumnRealmList(new RealmList<DogPrimaryKey>(new DogPrimaryKey(2, "Dog2")));
                 realm.copyToRealm(obj);
 
                 AllTypesPrimaryKey obj2 = new AllTypesPrimaryKey();
@@ -1156,20 +1157,20 @@ public class RealmTest extends AndroidTestCase {
             public void execute(Realm realm) {
                 AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
                 obj.setColumnLong(1);
-                obj.setColumnRealmObject(new Dog("Dog1"));
-                obj.setColumnRealmList(new RealmList<Dog>(new Dog("Dog2")));
+                obj.setColumnRealmObject(new DogPrimaryKey(1, "Dog1"));
+                obj.setColumnRealmList(new RealmList<DogPrimaryKey>(new DogPrimaryKey(2, "Dog2")));
                 realm.copyToRealm(obj);
 
                 AllTypesPrimaryKey obj2 = new AllTypesPrimaryKey();
-                obj.setColumnLong(1);
-                obj2.setColumnRealmObject(new Dog("Dog3"));
-                obj2.setColumnRealmList(new RealmList<Dog>(new Dog("Dog4")));
-                realm.copyToRealmOrUpdate(obj);
+                obj2.setColumnLong(1);
+                obj2.setColumnRealmObject(new DogPrimaryKey(3, "Dog3"));
+                obj2.setColumnRealmList(new RealmList<DogPrimaryKey>(new DogPrimaryKey(4, "Dog4")));
+                realm.copyToRealmOrUpdate(obj2);
             }
         });
 
         assertEquals(1, testRealm.allObjects(AllTypesPrimaryKey.class).size());
-        assertEquals(4, testRealm.allObjects(Dog.class).size());
+        assertEquals(4, testRealm.allObjects(DogPrimaryKey.class).size());
     }
 
     public void testCopyOrUpdateIterable() {
@@ -1195,6 +1196,25 @@ public class RealmTest extends AndroidTestCase {
 
         assertEquals(1, testRealm.allObjects(PrimaryKeyAsLong.class).size());
         assertEquals("Baz", testRealm.allObjects(PrimaryKeyAsLong.class).first().getName());
+    }
+
+    public void testCopyOrUpdateIterableChildObjects() {
+        DogPrimaryKey dog = new DogPrimaryKey(1, "Snoop");
+
+        AllTypesPrimaryKey allTypes1 = new AllTypesPrimaryKey();
+        allTypes1.setColumnLong(1);
+        allTypes1.setColumnRealmObject(dog);
+
+        AllTypesPrimaryKey allTypes2 = new AllTypesPrimaryKey();
+        allTypes1.setColumnLong(2);
+        allTypes2.setColumnRealmObject(dog);
+
+        testRealm.beginTransaction();
+        testRealm.copyToRealmOrUpdate(Arrays.asList(allTypes1, allTypes2));
+        testRealm.commitTransaction();
+
+        assertEquals(2, testRealm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(1, testRealm.allObjects(DogPrimaryKey.class).size());
     }
 
     private void fileCopy(File src, File dst) throws IOException {

--- a/realm/src/androidTest/java/io/realm/entities/AllTypesPrimaryKey.java
+++ b/realm/src/androidTest/java/io/realm/entities/AllTypesPrimaryKey.java
@@ -31,8 +31,8 @@ public class AllTypesPrimaryKey extends RealmObject {
     private boolean columnBoolean;
     private Date columnDate;
     private byte[] columnBinary;
-    private Dog columnRealmObject;
-    private RealmList<Dog> columnRealmList;
+    private DogPrimaryKey columnRealmObject;
+    private RealmList<DogPrimaryKey> columnRealmList;
 
     public String getColumnString() {
         return columnString;
@@ -90,19 +90,19 @@ public class AllTypesPrimaryKey extends RealmObject {
         this.columnBinary = columnBinary;
     }
 
-    public Dog getColumnRealmObject() {
+    public DogPrimaryKey getColumnRealmObject() {
         return columnRealmObject;
     }
 
-    public void setColumnRealmObject(Dog columnRealmObject) {
+    public void setColumnRealmObject(DogPrimaryKey columnRealmObject) {
         this.columnRealmObject = columnRealmObject;
     }
 
-    public RealmList<Dog> getColumnRealmList() {
+    public RealmList<DogPrimaryKey> getColumnRealmList() {
         return columnRealmList;
     }
 
-    public void setColumnRealmList(RealmList<Dog> columnRealmList) {
+    public void setColumnRealmList(RealmList<DogPrimaryKey> columnRealmList) {
         this.columnRealmList = columnRealmList;
     }
 }

--- a/realm/src/androidTest/java/io/realm/entities/DogPrimaryKey.java
+++ b/realm/src/androidTest/java/io/realm/entities/DogPrimaryKey.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.realm.entities;
+
+import java.util.Date;
+
+import io.realm.RealmObject;
+import io.realm.annotations.Index;
+import io.realm.annotations.PrimaryKey;
+
+public class DogPrimaryKey extends RealmObject {
+
+    @PrimaryKey
+    private long id;
+    private String name;
+    private long age;
+    private float height;
+    private double weight;
+    private boolean hasTail;
+    private Date birthday;
+    private Owner owner;
+
+    public DogPrimaryKey() {
+
+    }
+
+    public DogPrimaryKey(long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public DogPrimaryKey(String name) {
+        this.name = name;
+    }
+
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Owner getOwner() {
+        return owner;
+    }
+
+    public void setOwner(Owner owner) {
+        this.owner = owner;
+    }
+
+    public Date getBirthday() {
+        return birthday;
+    }
+
+    public void setBirthday(Date birthday) {
+        this.birthday = birthday;
+    }
+
+    public boolean isHasTail() {
+        return hasTail;
+    }
+
+    public void setHasTail(boolean hasTail) {
+        this.hasTail = hasTail;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    public float getHeight() {
+        return height;
+    }
+
+    public void setHeight(float height) {
+        this.height = height;
+    }
+
+    public long getAge() {
+        return age;
+    }
+
+    public void setAge(long age) {
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
A bug was discovered when using copyToRealmOrUpdate on child elements with primary keys: https://groups.google.com/forum/#!topic/realm-java/V7AVHgU5Oo4 which caused child objects to always be copied.

It wasn't caught due to a bug in some unit tests *cough*.

This PR fixes both the bug and the unit tests.

@emanuelez @kneth 