### PR TITLE
Adding light HTML markup to JavaDoc so documentation website looks better

### DIFF
--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -65,29 +65,29 @@ import io.realm.internal.log.RealmLog;
  * is in charge of creating instances of your RealmObjects. Objects within a Realm can be queried
  * and read at any time. Creating, modifying, and deleting objects must be done while inside a
  * transaction. See {@link #beginTransaction()}
- *
+ * <p>
  * The transactions ensure that multiple instances (on multiple threads) can access the same
  * objects in a consistent state with full ACID guarantees.
- *
+ * <p>
  * It is important to remember to call the {@link #close()} method when done with a Realm
  * instance. Failing to do so can lead to {@link java.lang.OutOfMemoryError} as the native
  * resources cannot be freed.
- *
+ * <p>
  * Realm instances cannot be used across different threads. This means that you have to open an
  * instance on each thread you want to use Realm. Realm instances are cached automatically per
  * thread using reference counting, so as long as the reference count doesn't reach zero, calling
  * {@link #getInstance(android.content.Context)} will just return the cached Realm and should be
  * considered a lightweight operation.
- *
+ * <p>
  * For the UI thread this means that opening and closing Realms should occur in either
  * onCreate/onDestroy or onStart/onStop.
- *
+ * <p>
  * Realm instances coordinate their state across threads using the {@link android.os.Handler}
  * mechanism. This also means that Realm instances on threads without a {@link android.os.Looper}
  * cannot receive updates unless {@link #refresh()} is manually called.
- *
+ * <p>
  * A standard pattern for working with Realm in Android activities can be seen below:
- *
+ * <p>
  * <pre>
  * public class RealmActivity extends Activity {
  *
@@ -107,9 +107,9 @@ import io.realm.internal.log.RealmLog;
  *   }
  * }
  * </pre>
- *
+ * <p>
  * Realm supports String and byte fields containing up to 16 MB.
- *
+ * <p>
  * @see <a href="http://en.wikipedia.org/wiki/ACID">ACID</a>
  * @see <a href="https://github.com/realm/realm-java/tree/master/examples">Examples using Realm</a>
  */
@@ -212,7 +212,7 @@ public final class Realm implements Closeable {
 
     /**
      * Closes the Realm instance and all its resources.
-     * 
+     * <p>
      * It's important to always remember to close Realm instances when you're done with it in order 
      * not to leak memory, file descriptors or grow the size of Realm file out of measure.
      */
@@ -268,7 +268,7 @@ public final class Realm implements Closeable {
 
     /**
      * Set the auto-refresh status of the Realm instance.
-     *
+     * <p>
      * Auto-refresh is a feature that enables automatic update of the current realm instance and all its derived objects
      * (RealmResults and RealmObjects instances) when a commit is performed on a Realm acting on the same file in another thread.
      * This feature is only available if the realm instance lives is a {@link android.os.Looper} enabled thread.
@@ -303,7 +303,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor for the default realm "default.realm".
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param context an Android {@link android.content.Context}
@@ -320,7 +320,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor.
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param context  an Android {@link android.content.Context}
@@ -339,7 +339,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor.
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param context an Android {@link android.content.Context}
@@ -358,7 +358,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor.
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param context an Android {@link android.content.Context}
@@ -377,7 +377,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor.
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param writeableFolder a File object representing a writeable folder
@@ -395,7 +395,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor.
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param writeableFolder a File object representing a writeable folder
@@ -414,7 +414,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor.
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param writeableFolder a File object representing a writeable folder
@@ -433,7 +433,7 @@ public final class Realm implements Closeable {
     /**
      * Realm static constructor.
      * {link io.realm.close} must be called when you are done using the Realm instance.
-     *
+     * <p>
      * It sets auto-refresh on if the current thread has a Looper, off otherwise.
      *
      * @param writeableFolder a File object representing a writeable folder
@@ -782,9 +782,9 @@ public final class Realm implements Closeable {
 
     /**
      * Write a compacted copy of the Realm to the given destination File.
-     *
+     * <p>
      * The destination file cannot already exist.
-     *
+     * <p>
      * Note that if this is called from within a write transaction it writes the
      * current data, and not the data as it was when the last write transaction was committed.
      *
@@ -797,12 +797,12 @@ public final class Realm implements Closeable {
 
     /**
      * Write a compacted and encrypted copy of the Realm to the given destination File.
-     *
+     * <p>
      * The destination file cannot already exist.
-     *
+     * <p>
      * Note that if this is called from within a write transaction it writes the
      * current data, and not the data as it was when the last write transaction was committed.
-     *
+     * <p>
      * @param destination File to save the Realm to
      * @throws java.io.IOException if any write operation fails
      */
@@ -1426,10 +1426,10 @@ public final class Realm implements Closeable {
      * Compact a realm file. A realm file usually contain free/unused space.
      * This method removes this free space and the file size is thereby reduced.
      * Objects within the realm files are untouched.
-     * 
-     * The file must be closed before this method is called.
-     * The file system should have free space for at least a copy of the realm file.
-     * The realm file is left untouched if any file operation fails. 
+     * <p>
+     * The file must be closed before this method is called.<br>
+     * The file system should have free space for at least a copy of the realm file.<br>
+     * The realm file is left untouched if any file operation fails.<br>
      *
      * @param context an Android {@link android.content.Context}
      * @param fileName the name of the file to compact
@@ -1465,10 +1465,10 @@ public final class Realm implements Closeable {
      * Compact a realm file. A realm file usually contain free/unused space.
      * This method removes this free space and the file size is thereby reduced.
      * Objects within the realm files are untouched.
-     * 
-     * The file must be closed before this method is called.
-     * The file system should have free space for at least a copy of the realm file.
-     * The realm file is left untouched if any file operation fails. 
+     * <p>
+     * The file must be closed before this method is called.<br>
+     * The file system should have free space for at least a copy of the realm file.<br>
+     * The realm file is left untouched if any file operation fails.<br>
      *
      * @param context an Android {@link android.content.Context}
      * @return true if successful, false if any file operation failed
@@ -1488,7 +1488,7 @@ public final class Realm implements Closeable {
 
     /**
      * Encapsulates a Realm transaction.
-     *
+     * <p>
      * Using this class will automatically handle {@link #beginTransaction()} and {@link #commitTransaction()}
      * If any exception is thrown during the transaction {@link #cancelTransaction()} will be called
      * instead of {@link #commitTransaction()}.

--- a/realm/src/main/java/io/realm/RealmBaseAdapter.java
+++ b/realm/src/main/java/io/realm/RealmBaseAdapter.java
@@ -23,10 +23,10 @@ import android.widget.BaseAdapter;
 /**
  * The RealmBaseAdapter class is an abstract utility class for binding UI elements to Realm data,
  * much like an {@link android.widget.CursorAdapter}.
- *
+ * <p>
  * This adapter will automatically handle any updates to its data and call
  * {@link #notifyDataSetChanged()} as appropriate.
- *
+ * <p>
  * The RealmAdapter will stop receiving updates if the Realm instance providing the
  * {@link io.realm.RealmResults} is closed. Trying to access read objects, will at this point also
  * result in a {@link io.realm.exceptions.RealmException}.

--- a/realm/src/main/java/io/realm/RealmChangeListener.java
+++ b/realm/src/main/java/io/realm/RealmChangeListener.java
@@ -18,11 +18,11 @@ package io.realm;
 
 /**
  * Using RealmChangeListener, it is possible to be notified when a Realm instance has been updated.
- *
- * Realm instances on a thread without a {@link android.os.Looper} (almost all background threads)
- * don't get updated automatically, but have to call {@link Realm#refresh()} manually. This will
+ * <p>
+ * Realm instances on a thread without an {@link android.os.Looper} (almost all background threads)
+ * doesn't get updated automatically, but have to call {@link Realm#refresh()} manually. This will
  * in turn trigger the RealmChangeListener for that background thread.
- *
+ * <p>
  * All {@link io.realm.RealmObject} and {@link io.realm.RealmResults} will automatically contain
  * their new values when the {@link #onChange()} method is called. Normally this means that it
  * isn't necessary to query again for those objects, but just invalidate any UI elements that are

--- a/realm/src/main/java/io/realm/RealmChangeListener.java
+++ b/realm/src/main/java/io/realm/RealmChangeListener.java
@@ -20,7 +20,7 @@ package io.realm;
  * Using RealmChangeListener, it is possible to be notified when a Realm instance has been updated.
  * <p>
  * Realm instances on a thread without an {@link android.os.Looper} (almost all background threads)
- * doesn't get updated automatically, but have to call {@link Realm#refresh()} manually. This will
+ * don't get updated automatically, but have to call {@link Realm#refresh()} manually. This will
  * in turn trigger the RealmChangeListener for that background thread.
  * <p>
  * All {@link io.realm.RealmObject} and {@link io.realm.RealmResults} will automatically contain

--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -27,16 +27,16 @@ import io.realm.internal.LinkView;
  * RealmList is used to model one-to-many relationships in a {@link io.realm.RealmObject}.
  * RealmList has two modes: A managed and non-managed mode. In managed mode all objects are persisted
  * inside a Realm, in non-managed mode it works as a normal ArrayList.
- *
- * Only Realm can create managed RealmLists. Managed RealmLists will automatically update their
+ * <p>
+ * Only Realm can create managed RealmLists. Managed RealmLists will automatically update the
  * content whenever the underlying Realm is updated, and can only be accessed using the getter
- * from a {@link io.realm.RealmObject}.
- *
+ * of a {@link io.realm.RealmObject}.
+ * <p>
  * Non-managed RealmLists can be created by the user and can contain both managed and non-managed
- * RealmObjects. This is useful eg. when dealing with JSON deserializers like GSON or other
+ * RealmObjects. This is useful when dealing with JSON deserializers like GSON or other
  * frameworks that inject values into a class. Non-managed elements in this list can be added to a
  * Realm using the {@link Realm#copyToRealm(Iterable)} method.
- *
+ * <p>
  * @param <E> The class of objects in list.
  */
 
@@ -56,7 +56,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * Create a RealmList in non-managed mode, where the elements are not controlled by a Realm.
      * This effectively makes the RealmList function as a {@link java.util.ArrayList} and it is not possible
      * to query the objects in this state.
-     *
+     * <p>
      * Use {@link io.realm.Realm#copyToRealm(Iterable)}  to properly persist it's elements in
      * Realm.
      */

--- a/realm/src/main/java/io/realm/RealmObject.java
+++ b/realm/src/main/java/io/realm/RealmObject.java
@@ -22,7 +22,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 import io.realm.annotations.RealmClass;
 import io.realm.internal.Row;
@@ -31,41 +30,48 @@ import io.realm.internal.Row;
  * In Realm you define your model classes by sub-classing RealmObject and adding fields to be
  * persisted. You then create your objects within a Realm, and use your custom subclasses instead
  * of using the RealmObject class directly.
- *
+ * <p>
  * An annotation processor will create a proxy class for your RealmObject subclass. The getters and
  * setters should not contain any custom code of logic as they are overridden as part of the annotation
  * process.
- *
+ * <p>
  * A RealmObject is currently limited to the following:
  *
- * - Private fields.
- * - Getter and setters for these fields.
- * - Static methods.
- *
- * The following field data types are supported (No boxed types):
- * - boolean
- * - short
- * - int
- * - long
- * - float
- * - double
- * - byte[]
- * - String
- * - Date
- * - Any RealmObject subclass
- * - RealmList
- *
+ * <ul>
+ *   <li>Private fields.</li>
+ *   <li>Getter and setters for these fields.</li>
+ *   <li>Static methods.</li>
+ * </ul>
+ * <p>
+ * The following field data types are supported (no boxed types):
+ * <ul>
+ *   <li>boolean</li>
+ *   <li>short</li>
+ *   <li>int</li>
+ *   <li>long</li>
+ *   <li>float</li>
+ *   <li>double</li>
+ *   <li>byte[]</li>
+ *   <li>String</li>
+ *   <li>Date</li>
+ *   <li>Any RealmObject subclass</li>
+ *   <li>RealmList</li>
+ * </ul>
+ * <p>
+ * The types <code>short</code>, <code>int</code>, and <code>long</code> are mapped to <code>long</code>
+ * when storing within a Realm.
+ * <p>
  * Getter and setter names must have the name {@code getXXX} or {@code setXXX} if
  * the field name is {@code XXX}. Getters for fields of type boolean can be called {@code isXXX} as
  * well. Fields with a m-prefix must have getters and setters named setmXXX and getmXXX which is
  * the default behavior when Android Studio automatically generates the getters and setters.
- *
+ * <p>
  * Fields annotated with {@link io.realm.annotations.Ignore} don't have these restrictions and
  * don't require either a getter or setter.
- *
+ * <p>
  * Realm will create indexes for fields annotated with {@link io.realm.annotations.Index}. This
  * will speedup queries but will have a negative impact on inserts and updates.
- * *
+ * * <p>
  * A RealmObject cannot be passed between different threads.
  *
  * @see Realm#createObject(Class)
@@ -80,7 +86,7 @@ public abstract class RealmObject {
 
     /**
      * Removes the object from the Realm it is currently associated to.
-     *
+     * <p>
      * After this method is called the object will be invalid and any operation (read or write)
      * performed on it will fail with an IllegalStateException
      */

--- a/realm/src/main/java/io/realm/RealmQuery.java
+++ b/realm/src/main/java/io/realm/RealmQuery.java
@@ -33,14 +33,14 @@ import io.realm.internal.TableView;
  * A RealmQuery encapsulates a query on a {@link io.realm.Realm} or a {@link io.realm.RealmResults}
  * using the Builder pattern. The query is executed using either {@link #findAll()} or
  * {@link #findFirst()}
- *
+ * <p>
  * The input to many of the query functions take a field name as String. Note that this is not
  * type safe. If a model class is refactored care has to be taken to not break any queries.
- *
+ * <p>
  * A {@link io.realm.Realm} is unordered, which means that there is no guarantee that querying a
  * Realm will return the objects in the order they where inserted. Use
  * {@link #findAllSorted(String)} and similar methods if a specific order is required.
- *
+ * <p>
  * A RealmQuery cannot be passed between different threads.
  *
  * @param <E> The class of the objects to be queried.

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -31,30 +31,21 @@ import io.realm.internal.TableOrView;
 import io.realm.internal.TableView;
 
 /**
-<<<<<<< HEAD
- * A RealmResults list contains a list of objects of a given type that matches the query.
- * The objects are not copied from the Realm to the RealmResults list, but just references the original objects.
- * This preserves memory and increase speed.
- * It also implies that any modification to any object in a RealmResults is reflected in the objects in the 
- * Realm that was queried.
- * Updates to objects must be done within a transaction and the modified object is persisted to the backing
- * Realm file during the commit of the transaction.
- * Notice that a RealmResults is never null not even in the case where it contains no objects. You
- * should always use the size() method to check if a RealmResults is empty or not.
-=======
  * This class holds all the matches of a {@link io.realm.RealmQuery} for a given Realm. The objects
  * are not copied from the Realm to the RealmResults list, but are just referenced from the
  * RealmResult instead. This saves memory and increases speed.
- *
- * RealmResults are live views, which means that if it is on a {@link android.os.Looper} thread,
+ * <p>
+ * RealmResults are live views, which means that if it is on an {@link android.os.Looper} thread,
  * it will automatically update its query results after a transaction has been committed. If on a
  * non-looper thread, {@link Realm#refresh()} must be called to update the results.
- *
+ * <p>
  * Updates to RealmObjects from a RealmResults list must be done from within a transaction and the
  * modified objects are persisted to the Realm file during the commit of the transaction.
- *
+ * <p>
  * A RealmResults object cannot be passed between different threads.
->>>>>>> 0eaba7e0c7bc84d9905274c062fa8f1b1c257055
+ * <p>
+ * Notice that a RealmResults is never null not even in the case where it contains no objects. You
+ * should always use the size() method to check if a RealmResults is empty or not.
  *
  * @param <E> The class of objects in this list
  * @see RealmQuery#findAll()


### PR DESCRIPTION
In general JavaDoc isn't like markdown, and some HTML formatting must be added in order to generate some better formatted HTML for the website. In particular, this includes empty line (should be `<p>`) and unordered list.

@emanuelez @cmelchior 