### PR TITLE
Made Thread example more resilient to monkey test events.

### DIFF
--- a/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
@@ -18,6 +18,7 @@ package io.realm.examples.threads;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -140,11 +141,7 @@ public class ThreadFragment extends Fragment {
                     backgroundThreadRealm.commitTransaction();
 
                     // Wait 0.5 sec. before adding the next dot.
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException e) {
-                        break;
-                    }
+                    SystemClock.sleep(500);
                 }
 
                 // Also close Realm instances used in background threads.

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
@@ -127,6 +127,7 @@ public class ThreadFragment extends Fragment {
             public void run() {
                 // Realm instances cannot be shared between threads, so we need to create a new
                 // instance on the background thread.
+                int redColor = getResources().getColor(R.color.realm_red);
                 Realm backgroundThreadRealm = Realm.getInstance(getActivity());
                 while (!backgroundThread.isInterrupted()) {
                     backgroundThreadRealm.beginTransaction();
@@ -135,14 +136,14 @@ public class ThreadFragment extends Fragment {
                     Dot dot = backgroundThreadRealm.createObject(Dot.class);
                     dot.setX(random.nextInt(100));
                     dot.setY(random.nextInt(100));
-                    dot.setColor(getResources().getColor(R.color.realm_red));
+                    dot.setColor(redColor);
                     backgroundThreadRealm.commitTransaction();
 
                     // Wait 0.5 sec. before adding the next dot.
                     try {
                         Thread.sleep(500);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        break;
                     }
                 }
 


### PR DESCRIPTION
This fixes the Thread example which tried to access resources after fragment was detached.
It also now properly kills the background thread.

@emanuelez @kneth @bmunkholm 