### PR TITLE
Fix crash when using copyToRealmOrUpdate with complex object graph

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.79.1
+ * Fixed potential crash when using copyToRealmOrUpdate with an object graph containing a mix of elements with and without primary keys.
+
 0.79
  * Added support for ARM64.
  * Added RealmQuery.not() to negate a query condition.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -481,7 +481,7 @@ public class RealmProxyClassGenerator {
         );
 
         if (primaryKey == null) {
-            writer.emitStatement("return copy(realm, object, false)");
+            writer.emitStatement("return copy(realm, object, update)");
         } else {
             writer
                 .emitStatement("%s realmObject = null", className)
@@ -587,7 +587,7 @@ public class RealmProxyClassGenerator {
                 writer
                     .emitStatement("%s %s = newObject.%s()", Utils.getFieldTypeSimpleName(field), fieldName, getters.get(fieldName))
                     .beginControlFlow("if (%s != null)", fieldName)
-                        .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %s, realm.getTable(%s.class).hasPrimaryKey()))",
+                        .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %s, true))",
                                 setters.get(fieldName),
                                 Utils.getProxyClassSimpleName(field),
                                 fieldName,

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -250,7 +250,7 @@ public class AllTypesRealmProxy extends AllTypes {
     }
 
     public static AllTypes copyOrUpdate(Realm realm, AllTypes object, boolean update) {
-        return copy(realm, object, false);
+        return copy(realm, object, update);
     }
 
     public static AllTypes copy(Realm realm, AllTypes newObject, boolean update) {

--- a/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -141,7 +141,7 @@ public class BooleansRealmProxy extends Booleans {
     }
 
     public static Booleans copyOrUpdate(Realm realm, Booleans object, boolean update) {
-        return copy(realm, object, false);
+        return copy(realm, object, update);
     }
 
     public static Booleans copy(Realm realm, Booleans newObject, boolean update) {

--- a/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -117,7 +117,7 @@ public class SimpleRealmProxy extends Simple {
     }
 
     public static Simple copyOrUpdate(Realm realm, Simple object, boolean update) {
-        return copy(realm, object, false);
+        return copy(realm, object, update);
     }
 
     public static Simple copy(Realm realm, Simple newObject, boolean update) {

--- a/realm/src/androidTest/java/io/realm/entities/Cat.java
+++ b/realm/src/androidTest/java/io/realm/entities/Cat.java
@@ -28,6 +28,7 @@ public class Cat extends RealmObject {
     private boolean hasTail;
     private Date birthday;
     private Owner owner;
+    private DogPrimaryKey scaredOfDog;
 
     public Owner getOwner() {
         return owner;
@@ -84,5 +85,13 @@ public class Cat extends RealmObject {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public DogPrimaryKey getScaredOfDog() {
+        return scaredOfDog;
+    }
+
+    public void setScaredOfDog(DogPrimaryKey scaredOfDog) {
+        this.scaredOfDog = scaredOfDog;
     }
 }

--- a/realm/src/androidTest/java/io/realm/entities/OwnerPrimaryKey.java
+++ b/realm/src/androidTest/java/io/realm/entities/OwnerPrimaryKey.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class OwnerPrimaryKey extends RealmObject {
+
+    @PrimaryKey
+    private long id;
+
+    private String name;
+    private DogPrimaryKey dog;
+
+    public OwnerPrimaryKey() {
+    }
+
+    public OwnerPrimaryKey(long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public DogPrimaryKey getDog() {
+        return dog;
+    }
+
+    public void setDog(DogPrimaryKey dog) {
+        this.dog = dog;
+    }
+}

--- a/realm/src/androidTest/java/io/realm/entities/PrimaryKeyMix.java
+++ b/realm/src/androidTest/java/io/realm/entities/PrimaryKeyMix.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class PrimaryKeyMix extends RealmObject {
+
+    @PrimaryKey
+    private long id;
+
+    private OwnerPrimaryKey dogOwner;
+    private Cat cat;
+
+    public PrimaryKeyMix() {
+
+    }
+
+    public PrimaryKeyMix(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public OwnerPrimaryKey getDogOwner() {
+        return dogOwner;
+    }
+
+    public void setDogOwner(OwnerPrimaryKey dogOwner) {
+        this.dogOwner = dogOwner;
+    }
+
+    public Cat getCat() {
+        return cat;
+    }
+
+    public void setCat(Cat cat) {
+        this.cat = cat;
+    }
+}


### PR DESCRIPTION
This PR fixes: https://github.com/realm/realm-java/issues/864

Before, the update flag was cleared if an class didn't contain a primary key. This could cause duplicate entry errors if that object contained references to objects with primary keys as they where only copied.

@emanuelez @kneth @bmunkholm 