### PR TITLE
Allow all names in model classes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.80
 * Queries on relationships can be case sensitive.
+* Fixed bug crashing annotation processor when using "name" in model classes for RealmObject references
 
 0.79.1
  * copyToRealm() no longer crashes on cyclic data structures.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
@@ -133,9 +133,9 @@ public class RealmJsonTypeHelper {
 
     public static void emitFillRealmObjectFromStream(String setter, String fieldName, String fieldTypeCanonicalName, String proxyClass, JavaWriter writer) throws IOException {
         writer
-            .emitStatement("%s %s = standalone ? new %s() : obj.realm.createObject(%s.class)", fieldTypeCanonicalName, fieldName, fieldTypeCanonicalName, fieldTypeCanonicalName)
-            .emitStatement("%s.populateUsingJsonStream(%s, reader)", proxyClass, fieldName)
-            .emitStatement("obj.%s(%s)", setter, fieldName);
+            .emitStatement("%s %sObj = standalone ? new %s() : obj.realm.createObject(%s.class)", fieldTypeCanonicalName, fieldName, fieldTypeCanonicalName, fieldTypeCanonicalName)
+            .emitStatement("%s.populateUsingJsonStream(%sObj, reader)", proxyClass, fieldName)
+            .emitStatement("obj.%s(%sObj)", setter, fieldName);
     }
 
     public static void emitFillRealmListFromStream(String getter, String setter, String fieldTypeCanonicalName, String proxyClass, JavaWriter writer) throws IOException {

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -538,13 +538,13 @@ public class RealmProxyClassGenerator {
             if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 writer
                     .emitEmptyLine()
-                    .emitStatement("%s %s = newObject.%s()", fieldType, fieldName, getters.get(fieldName))
-                    .beginControlFlow("if (%s != null)", fieldName)
-                        .emitStatement("%s cache%s = (%s) cache.get(%s)", fieldType, fieldName, fieldType, fieldName)
+                    .emitStatement("%s %sObj = newObject.%s()", fieldType, fieldName, getters.get(fieldName))
+                    .beginControlFlow("if (%sObj != null)", fieldName)
+                        .emitStatement("%s cache%s = (%s) cache.get(%sObj)", fieldType, fieldName, fieldType, fieldName)
                         .beginControlFlow("if (cache%s != null)", fieldName)
                             .emitStatement("realmObject.%s(cache%s)", setters.get(fieldName), fieldName)
                         .nextControlFlow("else")
-                            .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %s, update, cache))",
+                            .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %sObj, update, cache))",
                                     setters.get(fieldName),
                                     Utils.getProxyClassSimpleName(field),
                                     fieldName)
@@ -598,13 +598,13 @@ public class RealmProxyClassGenerator {
             String fieldName = field.getSimpleName().toString();
             if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 writer
-                    .emitStatement("%s %s = newObject.%s()", Utils.getFieldTypeSimpleName(field), fieldName, getters.get(fieldName))
-                    .beginControlFlow("if (%s != null)", fieldName)
-                        .emitStatement("%s cache%s = (%s) cache.get(%s)", Utils.getFieldTypeSimpleName(field), fieldName, Utils.getFieldTypeSimpleName(field), fieldName)
+                    .emitStatement("%s %sObj = newObject.%s()", Utils.getFieldTypeSimpleName(field), fieldName, getters.get(fieldName))
+                    .beginControlFlow("if (%sObj != null)", fieldName)
+                        .emitStatement("%s cache%s = (%s) cache.get(%sObj)", Utils.getFieldTypeSimpleName(field), fieldName, Utils.getFieldTypeSimpleName(field), fieldName)
                         .beginControlFlow("if (cache%s != null)", fieldName)
                             .emitStatement("realmObject.%s(cache%s)", setters.get(fieldName), fieldName)
                         .nextControlFlow("else")
-                            .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %s, true, cache))",
+                            .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %sObj, true, cache))",
                                     setters.get(fieldName),
                                     Utils.getProxyClassSimpleName(field),
                                     fieldName,

--- a/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
+++ b/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
@@ -34,6 +34,7 @@ public class RealmProcessorTest {
     private JavaFileObject booleansProxy = JavaFileObjects.forResource("io/realm/BooleansRealmProxy.java");
     private JavaFileObject emptyModel = JavaFileObjects.forResource("some/test/Empty.java");
     private JavaFileObject noAccessorsModel = JavaFileObjects.forResource("some/test/NoAccessors.java");
+    private JavaFileObject fieldNamesModel = JavaFileObjects.forResource("some/test/FieldNames.java");
 
     @Test
     public void compileSimpleFile() {
@@ -152,5 +153,13 @@ public class RealmProcessorTest {
                 .that(noAccessorsModel)
                 .processedWith(new RealmProcessor())
                 .failsToCompile();
+    }
+
+    @Test
+    public void compileFieldNamesFiles() {
+        ASSERT.about(javaSource())
+                .that(fieldNamesModel)
+                .processedWith(new RealmProcessor())
+                .compilesWithoutError();
     }
 }

--- a/realm-annotations-processor/src/test/resources/some/test/AllTypes.java
+++ b/realm-annotations-processor/src/test/resources/some/test/AllTypes.java
@@ -18,9 +18,12 @@ package some.test;
 
 import java.util.Date;
 
+import io.realm.RealmList;
 import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
 
 public class AllTypes extends RealmObject {
+    @PrimaryKey
     private String columnString;
     private long columnLong;
     private float columnFloat;
@@ -28,6 +31,8 @@ public class AllTypes extends RealmObject {
     private boolean columnBoolean;
     private Date columnDate;
     private byte[] columnBinary;
+    private AllTypes columnObject;
+    private RealmList<AllTypes> columnRealmList;
 
     public String getColumnString() {
         return columnString;
@@ -83,5 +88,21 @@ public class AllTypes extends RealmObject {
 
     public void setColumnBinary(byte[] columnBinary) {
         this.columnBinary = columnBinary;
+    }
+
+    public AllTypes getColumnObject() {
+        return columnObject;
+    }
+
+    public void setColumnObject(AllTypes columnObject) {
+        this.columnObject = columnObject;
+    }
+
+    public RealmList<AllTypes> getColumnRealmList() {
+        return columnRealmList;
+    }
+
+    public void setColumnRealmList(RealmList<AllTypes> columnRealmList) {
+        this.columnRealmList = columnRealmList;
     }
 }

--- a/realm-annotations-processor/src/test/resources/some/test/FieldNames.java
+++ b/realm-annotations-processor/src/test/resources/some/test/FieldNames.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package some.test;
+
+import io.realm.RealmObject;
+import some.test.Simple;
+
+/**
+ * All field names should be allowed. This means that annnotation processor
+ * should add a suffix to all fieldNames to avoid naming conflict with
+ * internal processor variabels.
+ *
+ * This class list field names that has caused problems.
+ */
+public class FieldNames extends RealmObject {
+
+    private Simple name;
+
+    public Simple getName() {
+        return name;
+    }
+
+    public void setName(Simple name) {
+        this.name = name;
+    }
+}

--- a/realm-annotations-processor/src/test/resources/some/test/FieldNames.java
+++ b/realm-annotations-processor/src/test/resources/some/test/FieldNames.java
@@ -29,6 +29,7 @@ import some.test.Simple;
 public class FieldNames extends RealmObject {
 
     private Simple name;
+    private Simple cache;
 
     public Simple getName() {
         return name;
@@ -36,5 +37,13 @@ public class FieldNames extends RealmObject {
 
     public void setName(Simple name) {
         this.name = name;
+    }
+
+    public Simple getCache() {
+        return cache;
+    }
+
+    public void setCache(Simple cache) {
+        this.cache = cache;
     }
 }


### PR DESCRIPTION
This PR fixes this issue: https://github.com/realm/realm-java/issues/881

It makes sure that object references are properly suffixed so they don't conflict with internal variabel names (This only happened in one JSON import function).

@emanuelez @kneth @bmunkholm 