### PR TITLE
Properly check for key equality while using a cached Realm instance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 0.80
 * Queries on relationships can be case sensitive.
 * Fixed bug crashing annotation processor when using "name" in model classes for RealmObject references
+* Fixed problem occurring when opening an encrypted Realm with two different instances of the same key.
 
 0.79.1
  * copyToRealm() no longer crashes on cyclic data structures.

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -1316,6 +1316,39 @@ public class RealmTest extends AndroidTestCase {
         outStream.close();
     }
 
+    public void testOpeningOfEncryptedRealmWithDifferentKeyInstances() throws Exception {
+        byte[] key1 = new byte[64];
+        byte[] key2 = new byte[64];
+        new Random(42).nextBytes(key1);
+        new Random(42).nextBytes(key2);
+
+        // Make sure the key is the same, but in two different instances
+        assertArrayEquals(key1, key2);
+        assertTrue(key1 != key2);
+
+        final String ENCRYPTED_REALM = "differentKeys.realm";
+
+        Realm realm1 = null;
+        Realm realm2 = null;
+        try {
+            realm1 = Realm.getInstance(getContext(), ENCRYPTED_REALM, key1);
+            try {
+                realm2 = Realm.getInstance(getContext(), ENCRYPTED_REALM, key2);
+            } catch (Exception e) {
+                fail();
+            } finally {
+                if (realm2 != null) {
+                    realm2.close();
+                }
+            }
+        } finally {
+            if (realm1 != null) {
+                realm1.close();
+            }
+        }
+
+    }
+
     // TODO Enable once copy to encrypted Realm works again
     public void disableTestWriteEncryptedCopy() throws Exception {
         populateTestRealm();

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -1316,7 +1316,7 @@ public class RealmTest extends AndroidTestCase {
         outStream.close();
     }
 
-    public void testOpeningOfEncryptedRealmWithDifferentKeyInstances() throws Exception {
+    public void testOpeningOfEncryptedRealmWithDifferentKeyInstances() {
         byte[] key1 = new byte[64];
         byte[] key2 = new byte[64];
         new Random(42).nextBytes(key1);
@@ -1346,7 +1346,6 @@ public class RealmTest extends AndroidTestCase {
                 realm1.close();
             }
         }
-
     }
 
     // TODO Enable once copy to encrypted Realm works again

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -504,7 +504,7 @@ public final class Realm implements Closeable {
         Realm realm = realms.get(absolutePath.hashCode());
 
         if (realm != null) {
-            if (realm.key != key) {
+            if (!Arrays.equals(realm.key, key)) {
                 throw new IllegalStateException(DIFFERENT_KEY_MESSAGE);
             }
             localRefCount.put(id, references + 1);


### PR DESCRIPTION
Fixes #901 