### PR TITLE
Refactored RealmProcessor to make it easier to add changes.

### DIFF
--- a/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -269,6 +269,12 @@ public class ClassMetaData {
             if (elementKind.equals(ElementKind.FIELD)) {
                 VariableElement variableElement = (VariableElement) element;
                 String fieldName = variableElement.getSimpleName().toString();
+
+                Set<Modifier> modifiers = variableElement.getModifiers();
+                if (modifiers.contains(Modifier.STATIC)) {
+                    continue; // completely ignore any static fields
+                }
+
                 if (variableElement.getAnnotation(Ignore.class) != null) {
                     // The field has the @Ignore annotation. No need to go any further.
                     String ignoredFieldName = variableElement.getSimpleName().toString();

--- a/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.processor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+
+import io.realm.annotations.Ignore;
+import io.realm.annotations.Index;
+import io.realm.annotations.PrimaryKey;
+
+/**
+ * Utility class for holding metadata for RealmProxy classes.
+ */
+public class ClassMetaData {
+
+    private final TypeElement classType;
+    private String className;
+    private String packageName;
+    private boolean hasDefaultConstructor = false;
+    private VariableElement primaryKey = null;
+    private List<VariableElement> fields = new ArrayList<VariableElement>();
+    private List<VariableElement> indexedFields = new ArrayList<VariableElement>();
+    private Set<VariableElement> ignoredFields = new HashSet<VariableElement>();
+    private Set<String> expectedGetters = new HashSet<String>();
+    private Set<String> expectedSetters = new HashSet<String>();
+    private Set<ExecutableElement> methods = new HashSet<ExecutableElement>();
+    private Map<String, String> getters = new HashMap<String, String>();
+    private Map<String, String> setters = new HashMap<String, String>();
+    private final List<TypeMirror> validPrimaryKeyTypes;
+    private final Types typeUtils;
+
+    public ClassMetaData(ProcessingEnvironment env, TypeElement clazz) {
+        this.classType = clazz;
+        this.className = clazz.getSimpleName().toString();
+        typeUtils = env.getTypeUtils();
+        TypeMirror stringType = env.getElementUtils().getTypeElement("java.lang.String").asType();
+        validPrimaryKeyTypes = Arrays.asList(
+                stringType,
+                typeUtils.getPrimitiveType(TypeKind.SHORT),
+                typeUtils.getPrimitiveType(TypeKind.INT),
+                typeUtils.getPrimitiveType(TypeKind.LONG)
+        );
+    }
+
+    /**
+     * Build the meta data structures for this class. Any errors or messages will be
+     * posted on the provided Messager.
+     *
+     * @return True if processing should continue, false otherwise. Note that true might be returned for smaller errors,
+     * which will enable the annotation processor to output error messages for multiple classes before exiting.
+     */
+    public boolean generateMetaData(Messager messager) {
+        // Get the package of the class
+        Element enclosingElement = classType.getEnclosingElement();
+        if (!enclosingElement.getKind().equals(ElementKind.PACKAGE)) {
+            Utils.error("The RealmClass annotation does not support nested classes", classType);
+        }
+
+        TypeElement parentElement = (TypeElement) Utils.getSuperClass(classType);
+        if (!parentElement.toString().endsWith(".RealmObject")) {
+            Utils.error("A RealmClass annotated object must be derived from RealmObject", classType);
+        }
+
+        PackageElement packageElement = (PackageElement) enclosingElement;
+        packageName = packageElement.getQualifiedName().toString();
+
+        for (Element element : classType.getEnclosedElements()) {
+            ElementKind elementKind = element.getKind();
+
+            if (elementKind.equals(ElementKind.FIELD)) {
+                VariableElement variableElement = (VariableElement) element;
+                String fieldName = variableElement.getSimpleName().toString();
+                if (variableElement.getAnnotation(Ignore.class) != null) {
+                    // The field has the @Ignore annotation. No need to go any further.
+                    ignoredFields.add(variableElement);
+                    continue;
+                }
+
+                if (variableElement.getAnnotation(Index.class) != null) {
+                    // The field has the @Index annotation. It's only valid for:
+                    // * String
+                    String elementTypeCanonicalName = variableElement.asType().toString();
+                    if (elementTypeCanonicalName.equals("java.lang.String")) {
+                        indexedFields.add(variableElement);
+                    } else {
+                        Utils.error("@Index is only applicable to String fields - got " + element);
+                        return false;
+                    }
+                }
+
+                if (variableElement.getAnnotation(PrimaryKey.class) != null) {
+                    // The field has the @PrimaryKey annotation. It is only valid for
+                    // String, short, int, long and must only be present one time
+                    if (primaryKey != null) {
+                        Utils.error(String.format("@PrimaryKey cannot be defined more than once. It was found here \"%s\" and here \"%s\"",
+                                primaryKey.getSimpleName().toString(),
+                                variableElement.getSimpleName().toString()));
+                        return false;
+                    }
+
+                    TypeMirror fieldType = variableElement.asType();
+                    if (!isValidPrimaryKeyType(fieldType)) {
+                        Utils.error("\"" + variableElement.getSimpleName().toString() + "\" is not allowed as primary key. See @PrimaryKey for allowed types.");
+                        return false;
+                    }
+
+                    primaryKey = variableElement;
+
+                    // Also add as index if the primary key is a string
+                    if (Utils.isString(variableElement) && !indexedFields.contains(variableElement)) {
+                        indexedFields.add(variableElement);
+                    }
+                }
+
+                if (!variableElement.getModifiers().contains(Modifier.PRIVATE)) {
+                    Utils.error("The fields of the model must be private", variableElement);
+                }
+
+                fields.add(variableElement);
+                expectedGetters.add(fieldName);
+                expectedSetters.add(fieldName);
+            } else if (elementKind.equals(ElementKind.CONSTRUCTOR)) {
+                hasDefaultConstructor =  hasDefaultConstructor || Utils.isDefaultConstructor(element);
+
+            } else if (elementKind.equals(ElementKind.METHOD)) {
+                ExecutableElement executableElement = (ExecutableElement) element;
+                methods.add(executableElement);
+            }
+        }
+
+        List<String> fieldNames = new ArrayList<String>();
+        List<String> ignoreFieldNames = new ArrayList<String>();
+        for (VariableElement field : fields) {
+            fieldNames.add(field.getSimpleName().toString());
+        }
+        for (VariableElement ignoredField : ignoredFields) {
+            fieldNames.add(ignoredField.getSimpleName().toString());
+            ignoreFieldNames.add(ignoredField.getSimpleName().toString());
+        }
+
+        for (ExecutableElement executableElement : methods) {
+
+            String methodName = executableElement.getSimpleName().toString();
+
+            // Check the modifiers of the method
+            Set<Modifier> modifiers = executableElement.getModifiers();
+            if (modifiers.contains(Modifier.STATIC)) {
+                continue; // We're cool with static methods. Move along!
+            } else if (!modifiers.contains(Modifier.PUBLIC)) {
+                Utils.error("The methods of the model must be public", executableElement);
+            }
+
+            if (methodName.startsWith("get") || methodName.startsWith("is")) {
+                boolean found = false;
+
+                if (methodName.startsWith("is")) {
+                    String methodMinusIs = methodName.substring(2);
+                    String methodMinusIsCapitalised = Utils.lowerFirstChar(methodMinusIs);
+                    if (fieldNames.contains(methodName)) { // isDone -> isDone
+                        expectedGetters.remove(methodName);
+                        if (!ignoreFieldNames.contains(methodName)) {
+                            getters.put(methodName, methodName);
+                        }
+                        found = true;
+                    } else if (fieldNames.contains(methodMinusIs)) {  // mDone -> ismDone
+                        expectedGetters.remove(methodMinusIs);
+                        if (!ignoreFieldNames.contains(methodMinusIs)) {
+                            getters.put(methodMinusIs, methodName);
+                        }
+                        found = true;
+                    } else if (fieldNames.contains(methodMinusIsCapitalised)) { // done -> isDone
+                        expectedGetters.remove(methodMinusIsCapitalised);
+                        if (!ignoreFieldNames.contains(methodMinusIsCapitalised)) {
+                            getters.put(methodMinusIsCapitalised, methodName);
+                        }
+                        found = true;
+                    }
+                }
+
+                if (!found && methodName.startsWith("get")) {
+                    String methodMinusGet = methodName.substring(3);
+                    String methodMinusGetCapitalised = Utils.lowerFirstChar(methodMinusGet);
+                    if (fieldNames.contains(methodMinusGet)) { // mPerson -> getmPerson
+                        expectedGetters.remove(methodMinusGet);
+                        if (!ignoreFieldNames.contains(methodMinusGet)) {
+                            getters.put(methodMinusGet, methodName);
+                        }
+                        found = true;
+                    } else if (fieldNames.contains(methodMinusGetCapitalised)) { // person -> getPerson
+                        expectedGetters.remove(methodMinusGetCapitalised);
+                        if (!ignoreFieldNames.contains(methodMinusGetCapitalised)) {
+                            getters.put(methodMinusGetCapitalised, methodName);
+                        }
+                        found = true;
+                    }
+                }
+
+                if (!found) {
+                    Utils.note(String.format("Getter %s is not associated to any field", methodName));
+                }
+            } else if (methodName.startsWith("set")) {
+                boolean found = false;
+
+                String methodMinusSet = methodName.substring(3);
+                String methodMinusSetCapitalised = Utils.lowerFirstChar(methodMinusSet);
+                String methodMenusSetPlusIs = "is" + methodMinusSet;
+
+                if (fieldNames.contains(methodMinusSet)) { // mPerson -> setmPerson
+                    expectedSetters.remove(methodMinusSet);
+                    if (!ignoreFieldNames.contains(methodMinusSet)) {
+                        setters.put(methodMinusSet, methodName);
+                    }
+                    found = true;
+                } else if (fieldNames.contains(methodMinusSetCapitalised)) { // person -> setPerson
+                    expectedSetters.remove(methodMinusSetCapitalised);
+                    if (!ignoreFieldNames.contains(methodMinusSetCapitalised)) {
+                        setters.put(methodMinusSetCapitalised, methodName);
+                    }
+                    found = true;
+                } else if (fieldNames.contains(methodMenusSetPlusIs)) { // isReady -> setReady
+                    expectedSetters.remove(methodMenusSetPlusIs);
+                    if (!ignoreFieldNames.contains(methodMenusSetPlusIs)) {
+                        setters.put(methodMenusSetPlusIs, methodName);
+                    }
+                    found = true;
+                }
+
+                if (!found) {
+                    Utils.note(String.format("Setter %s is not associated to any field", methodName));
+                }
+            } else {
+                Utils.error("Only getters and setters should be defined in model classes", executableElement);
+            }
+        }
+
+        if (!hasDefaultConstructor) {
+            Utils.error("A default public constructor with no argument must be declared if a custom constructor is declared.");
+        }
+
+        for (String expectedGetter : expectedGetters) {
+            Utils.error("No getter found for field " + expectedGetter);
+            getters.put(expectedGetter, ""); // Prevent null pointers later
+        }
+
+        for (String expectedSetter : expectedSetters) {
+            Utils.error("No setter found for field " + expectedSetter);
+            setters.put(expectedSetter, ""); // Prevent null pointers later
+        }
+
+        return true;
+    }
+
+    public String getSimpleClassName() {
+        return className;
+    }
+
+    /**
+     * Returns true if the model class is considered to be a true model class.
+     * RealmObject and Proxy classes also has the the @RealmClass annotation but is not considered true
+     * model classes.
+     */
+    public boolean isModelClass() {
+        return (!classType.toString().endsWith(".RealmObject") && !classType.toString().endsWith("RealmProxy"));
+    }
+
+    public String getFullyQualifiedClassName() {
+        return packageName + "." + className;
+    }
+
+    public List<VariableElement> getFields() {
+        return fields;
+    }
+
+    public String getGetter(String fieldName) {
+        return getters.get(fieldName);
+    }
+
+    public String getSetter(String fieldName) {
+        return setters.get(fieldName);
+    }
+
+    public List<VariableElement> getIndexedFields() {
+        return indexedFields;
+    }
+
+    public boolean hasPrimaryKey() {
+        return primaryKey != null;
+    }
+
+    public VariableElement getPrimaryKey() {
+        return primaryKey;
+    }
+
+    public String getPrimaryKeyGetter() {
+        return getters.get(primaryKey.getSimpleName().toString());
+    }
+
+    private boolean isValidPrimaryKeyType(TypeMirror type) {
+        for (TypeMirror validType : validPrimaryKeyTypes) {
+            if (typeUtils.isAssignable(type, validType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.processor;
+
+public class Constants {
+    public static final String REALM_PACKAGE_NAME = "io.realm";
+    public static final String PROXY_SUFFIX = "RealmProxy";
+    public static final String TABLE_PREFIX = "class_";
+}

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmJSonImplGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmJSonImplGenerator.java
@@ -30,13 +30,12 @@ public class RealmJSonImplGenerator {
     private static final String CLASS_NAME = "RealmJsonImpl";
     private static final String EXCEPTION_MSG = "\"Could not find the generated proxy class for \" + classQualifiedName";
 
-    public RealmJSonImplGenerator(ProcessingEnvironment processingEnv, Set<String> classesToValidate) {
+    public RealmJSonImplGenerator(ProcessingEnvironment processingEnv, Set<ClassMetaData> classesToValidate) {
         this.processingEnvironment = processingEnv;
-        for (String clazz : classesToValidate) {
-            String simpleName = Utils.stripPackage(clazz);
-            qualifiedModelClasses.add(clazz);
-            simpleModelClasses.add(simpleName);
-            proxyClasses.add(Utils.getProxyClassName(simpleName));
+        for (ClassMetaData metadata: classesToValidate) {
+            qualifiedModelClasses.add(metadata.getFullyQualifiedClassName());
+            simpleModelClasses.add(metadata.getSimpleClassName());
+            proxyClasses.add(Utils.getProxyClassName(metadata.getSimpleClassName()));
         }
     }
 

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -63,7 +63,8 @@ public class RealmProcessor extends AbstractProcessor {
             Utils.note("Processing class " + metadata.getSimpleClassName());
             boolean success = metadata.generateMetaData(processingEnv.getMessager());
             if (!success) {
-                return true;
+                done = true;
+                return true; // Abort processing by claiming all annotations
             }
             classesToValidate.add(metadata);
 

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -16,24 +16,19 @@
 
 package io.realm.processor;
 
-
-import io.realm.annotations.Ignore;
-import io.realm.annotations.Index;
-import io.realm.annotations.PrimaryKey;
-import io.realm.annotations.RealmClass;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.*;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Types;
-import javax.tools.Diagnostic;
-import java.io.IOException;
-import java.util.*;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
 
+import io.realm.annotations.RealmClass;
 
 @SupportedAnnotationTypes({
         "io.realm.annotations.RealmClass",
@@ -42,7 +37,7 @@ import java.util.*;
         "io.realm.annotations.PrimaryKey"
 })
 public class RealmProcessor extends AbstractProcessor {
-    Set<String> classesToValidate = new HashSet<String>();
+    Set<ClassMetaData> classesToValidate = new HashSet<ClassMetaData>();
     boolean done = false;
 
     @Override public SourceVersion getSupportedSourceVersion() {
@@ -55,249 +50,30 @@ public class RealmProcessor extends AbstractProcessor {
         updateChecker.executeRealmVersionUpdate();
         Utils.initialize(processingEnv);
 
-        Types typeUtils = processingEnv.getTypeUtils();
-        TypeMirror stringType = processingEnv.getElementUtils().getTypeElement("java.lang.String").asType();
-        List<TypeMirror> validPrimaryKeyTypes = Arrays.asList(
-                stringType,
-                typeUtils.getPrimitiveType(TypeKind.SHORT),
-                typeUtils.getPrimitiveType(TypeKind.INT),
-                typeUtils.getPrimitiveType(TypeKind.LONG)
-        );
-
         for (Element classElement : roundEnv.getElementsAnnotatedWith(RealmClass.class)) {
-            String className;
-            String packageName;
-            boolean hasDefaultConstructor = false;
-            List<VariableElement> fields = new ArrayList<VariableElement>();
-            List<VariableElement> indexedFields = new ArrayList<VariableElement>();
-            Set<VariableElement> ignoredFields = new HashSet<VariableElement>();
-            Set<String> expectedGetters = new HashSet<String>();
-            Set<String> expectedSetters = new HashSet<String>();
-            Set<ExecutableElement> methods = new HashSet<ExecutableElement>();
-            Map<String, String> getters = new HashMap<String, String>();
-            Map<String, String> setters = new HashMap<String, String>();
 
             // Check the annotation was applied to a Class
             if (!classElement.getKind().equals(ElementKind.CLASS)) {
-                error("The RealmClass annotation can only be applied to classes", classElement);
+                Utils.error("The RealmClass annotation can only be applied to classes", classElement);
             }
-            TypeElement typeElement = (TypeElement) classElement;
-            className = typeElement.getSimpleName().toString();
-
-            if (typeElement.toString().endsWith(".RealmObject") || typeElement.toString().endsWith("RealmProxy")) {
+            ClassMetaData metadata = new ClassMetaData(processingEnv, (TypeElement) classElement);
+            if (!metadata.isModelClass()) {
                 continue;
             }
-
-            note("Processing class " + className);
-
-            classesToValidate.add(typeElement.toString());
-
-            // Get the package of the class
-            Element enclosingElement = typeElement.getEnclosingElement();
-            if (!enclosingElement.getKind().equals(ElementKind.PACKAGE)) {
-                error("The RealmClass annotation does not support nested classes", classElement);
+            Utils.note("Processing class " + metadata.getSimpleClassName());
+            boolean success = metadata.generateMetaData(processingEnv.getMessager());
+            if (!success) {
+                return true;
             }
+            classesToValidate.add(metadata);
 
-            TypeElement parentElement = (TypeElement) processingEnv.getTypeUtils().asElement(typeElement.getSuperclass());
-            if (!parentElement.toString().endsWith(".RealmObject")) {
-                error("A RealmClass annotated object must be derived from RealmObject", classElement);
-            }
-
-            PackageElement packageElement = (PackageElement) enclosingElement;
-            packageName = packageElement.getQualifiedName().toString();
-            VariableElement primaryKey = null;
-
-            for (Element element : typeElement.getEnclosedElements()) {
-                ElementKind elementKind = element.getKind();
-
-                if (elementKind.equals(ElementKind.FIELD)) {
-                    VariableElement variableElement = (VariableElement) element;
-                    String fieldName = variableElement.getSimpleName().toString();
-                    if (variableElement.getAnnotation(Ignore.class) != null) {
-                        // The field has the @Ignore annotation. No need to go any further.
-                        ignoredFields.add(variableElement);
-                        continue;
-                    }
-
-                    if (variableElement.getAnnotation(Index.class) != null) {
-                        // The field has the @Index annotation. It's only valid for:
-                        // * String
-                        String elementTypeCanonicalName = variableElement.asType().toString();
-                        if (elementTypeCanonicalName.equals("java.lang.String")) {
-                            indexedFields.add(variableElement);
-                        } else {
-                            error("@Index is only applicable to String fields - got " + element);
-                            return true;
-                        }
-                    }
-
-                    if (variableElement.getAnnotation(PrimaryKey.class) != null) {
-                        // The field has the @PrimaryKey annotation. It is only valid for
-                        // String, short, int, long and must only be present one time
-                        if (primaryKey != null) {
-                            error(String.format("@PrimaryKey cannot be defined more than once. It was found here \"%s\" and here \"%s\"",
-                                    primaryKey.getSimpleName().toString(),
-                                    variableElement.getSimpleName().toString()));
-                            return true;
-                        }
-
-                        TypeMirror fieldType = variableElement.asType();
-                        if (!Utils.isValidType(typeUtils, fieldType, validPrimaryKeyTypes)) {
-                            error("\"" + variableElement.getSimpleName().toString() + "\" is not allowed as primary key. See @PrimaryKey for allowed types.");
-                            return true;
-                        }
-
-                        primaryKey = variableElement;
-
-                        // Also add as index if the primary key is a string
-                        if (Utils.isString(variableElement) && !indexedFields.contains(variableElement)) {
-                            indexedFields.add(variableElement);
-                        }
-                    }
-
-                    if (!variableElement.getModifiers().contains(Modifier.PRIVATE)) {
-                        error("The fields of the model must be private", variableElement);
-                    }
-
-                    fields.add(variableElement);
-                    expectedGetters.add(fieldName);
-                    expectedSetters.add(fieldName);
-                } else if (elementKind.equals(ElementKind.CONSTRUCTOR)) {
-                    hasDefaultConstructor = hasDefaultConstructor || Utils.isDefaultConstructor(element);
-
-                } else if (elementKind.equals(ElementKind.METHOD)) {
-                    ExecutableElement executableElement = (ExecutableElement) element;
-                    methods.add(executableElement);
-                }
-            }
-
-            List<String> fieldNames = new ArrayList<String>();
-            List<String> ignoreFieldNames = new ArrayList<String>();
-            for (VariableElement field : fields) {
-                fieldNames.add(field.getSimpleName().toString());
-            }
-            for (VariableElement ignoredField : ignoredFields) {
-                fieldNames.add(ignoredField.getSimpleName().toString());
-                ignoreFieldNames.add(ignoredField.getSimpleName().toString());
-            }
-
-            for (ExecutableElement executableElement : methods) {
-
-                String methodName = executableElement.getSimpleName().toString();
-
-                // Check the modifiers of the method
-                Set<Modifier> modifiers = executableElement.getModifiers();
-                if (modifiers.contains(Modifier.STATIC)) {
-                    continue; // We're cool with static methods. Move along!
-                } else if (!modifiers.contains(Modifier.PUBLIC)) {
-                    error("The methods of the model must be public", executableElement);
-                }
-
-                if (methodName.startsWith("get") || methodName.startsWith("is")) {
-                    boolean found = false;
-
-                    if (methodName.startsWith("is")) {
-                        String methodMinusIs = methodName.substring(2);
-                        String methodMinusIsCapitalised = Utils.lowerFirstChar(methodMinusIs);
-                        if (fieldNames.contains(methodName)) { // isDone -> isDone
-                            expectedGetters.remove(methodName);
-                            if (!ignoreFieldNames.contains(methodName)) {
-                                getters.put(methodName, methodName);
-                            }
-                            found = true;
-                        } else if (fieldNames.contains(methodMinusIs)) {  // mDone -> ismDone
-                            expectedGetters.remove(methodMinusIs);
-                            if (!ignoreFieldNames.contains(methodMinusIs)) {
-                                getters.put(methodMinusIs, methodName);
-                            }
-                            found = true;
-                        } else if (fieldNames.contains(methodMinusIsCapitalised)) { // done -> isDone
-                            expectedGetters.remove(methodMinusIsCapitalised);
-                            if (!ignoreFieldNames.contains(methodMinusIsCapitalised)) {
-                                getters.put(methodMinusIsCapitalised, methodName);
-                            }
-                            found = true;
-                        }
-                    }
-
-                    if (!found && methodName.startsWith("get")) {
-                        String methodMinusGet = methodName.substring(3);
-                        String methodMinusGetCapitalised = Utils.lowerFirstChar(methodMinusGet);
-                        if (fieldNames.contains(methodMinusGet)) { // mPerson -> getmPerson
-                            expectedGetters.remove(methodMinusGet);
-                            if (!ignoreFieldNames.contains(methodMinusGet)) {
-                                getters.put(methodMinusGet, methodName);
-                            }
-                            found = true;
-                        } else if (fieldNames.contains(methodMinusGetCapitalised)) { // person -> getPerson
-                            expectedGetters.remove(methodMinusGetCapitalised);
-                            if (!ignoreFieldNames.contains(methodMinusGetCapitalised)) {
-                                getters.put(methodMinusGetCapitalised, methodName);
-                            }
-                            found = true;
-                        }
-                    }
-
-                    if (!found) {
-                        note(String.format("Getter %s is not associated to any field", methodName));
-                    }
-                } else if (methodName.startsWith("set")) {
-                    boolean found = false;
-
-                    String methodMinusSet = methodName.substring(3);
-                    String methodMinusSetCapitalised = Utils.lowerFirstChar(methodMinusSet);
-                    String methodMenusSetPlusIs = "is" + methodMinusSet;
-
-                    if (fieldNames.contains(methodMinusSet)) { // mPerson -> setmPerson
-                        expectedSetters.remove(methodMinusSet);
-                        if (!ignoreFieldNames.contains(methodMinusSet)) {
-                            setters.put(methodMinusSet, methodName);
-                        }
-                        found = true;
-                    } else if (fieldNames.contains(methodMinusSetCapitalised)) { // person -> setPerson
-                        expectedSetters.remove(methodMinusSetCapitalised);
-                        if (!ignoreFieldNames.contains(methodMinusSetCapitalised)) {
-                            setters.put(methodMinusSetCapitalised, methodName);
-                        }
-                        found = true;
-                    } else if (fieldNames.contains(methodMenusSetPlusIs)) { // isReady -> setReady
-                        expectedSetters.remove(methodMenusSetPlusIs);
-                        if (!ignoreFieldNames.contains(methodMenusSetPlusIs)) {
-                            setters.put(methodMenusSetPlusIs, methodName);
-                        }
-                        found = true;
-                    }
-
-                    if (!found) {
-                        note(String.format("Setter %s is not associated to any field", methodName));
-                    }
-                } else {
-                    error("Only getters and setters should be defined in model classes", executableElement);
-                }
-            }
-
-            if (!hasDefaultConstructor) {
-                error("A default public constructor with no argument must be declared if a custom constructor is declared.");
-            }
-
-            for (String expectedGetter : expectedGetters) {
-                error("No getter found for field " + expectedGetter);
-                getters.put(expectedGetter, "");
-            }
-
-            for (String expectedSetter : expectedSetters) {
-                error("No setter found for field " + expectedSetter);
-                setters.put(expectedSetter, "");
-            }
-
-            RealmProxyClassGenerator sourceCodeGenerator =
-                    new RealmProxyClassGenerator(processingEnv, className, packageName, fields, getters, setters, indexedFields, primaryKey);
+            RealmProxyClassGenerator sourceCodeGenerator = new RealmProxyClassGenerator(processingEnv, metadata);
             try {
                 sourceCodeGenerator.generate();
             } catch (IOException e) {
-                error(e.getMessage(), classElement);
+                Utils.error(e.getMessage(), classElement);
             } catch (UnsupportedOperationException e) {
-                error(e.getMessage(), classElement);
+                Utils.error(e.getMessage(), classElement);
             }
         }
 
@@ -309,22 +85,10 @@ public class RealmProcessor extends AbstractProcessor {
                 jsonGenerator.generate();
                 done = true;
             } catch (IOException e) {
-                error(e.getMessage());
+                Utils.error(e.getMessage());
             }
         }
 
         return true;
-    }
-
-    private void error(String message, Element element) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, element);
-    }
-
-    private void error(String message) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message);
-    }
-
-    private void note(String message) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, message);
     }
 }

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -32,16 +32,8 @@ import java.util.*;
 
 public class RealmProxyClassGenerator {
     private ProcessingEnvironment processingEnvironment;
-    private String className;
-    private String packageName;
-    private List<VariableElement> fields = new ArrayList<VariableElement>();
-    private Map<String, String> getters = new HashMap<String, String>();
-    private Map<String, String> setters = new HashMap<String, String>();
-    private List<VariableElement> fieldsToIndex;
-    private VariableElement primaryKey;
-    private static final String REALM_PACKAGE_NAME = "io.realm";
-    private static final String TABLE_PREFIX = "class_";
-    public static final String PROXY_SUFFIX = "RealmProxy";
+    private ClassMetaData metadata;
+    private final String className;
 
     // Class metadata for generating proxy classes
     private Elements elementUtils;
@@ -49,24 +41,13 @@ public class RealmProxyClassGenerator {
     private TypeMirror realmObject;
     private DeclaredType realmList;
 
-    public RealmProxyClassGenerator(ProcessingEnvironment processingEnvironment,
-                                    String className, String packageName,
-                                    List<VariableElement> fields,
-                                    Map<String, String> getters, Map<String, String> setters,
-                                    List<VariableElement> fieldsToIndex,
-                                    VariableElement primaryKey) {
+    public RealmProxyClassGenerator(ProcessingEnvironment processingEnvironment, ClassMetaData metadata) {
         this.processingEnvironment = processingEnvironment;
-        this.className = className;
-        this.packageName = packageName;
-        this.fields = fields;
-        this.getters = getters;
-        this.setters = setters;
-        this.fieldsToIndex = fieldsToIndex;
-        this.primaryKey = primaryKey;
+        this.metadata = metadata;
+        this.className = metadata.getSimpleClassName();
     }
 
     private static final Map<String, String> JAVA_TO_REALM_TYPES;
-
     static {
         JAVA_TO_REALM_TYPES = new HashMap<String, String>();
         JAVA_TO_REALM_TYPES.put("byte", "Long");
@@ -91,7 +72,6 @@ public class RealmProxyClassGenerator {
 
     // Types in this array are guarded by if != null and use default value if trying to insert null
     private static final Map<String, String> NULLABLE_JAVA_TYPES;
-
     static {
         NULLABLE_JAVA_TYPES = new HashMap<String, String>();
         NULLABLE_JAVA_TYPES.put("java.util.Date", "new Date(0)");
@@ -100,7 +80,6 @@ public class RealmProxyClassGenerator {
     }
 
     private static final Map<String, String> JAVA_TO_COLUMN_TYPES;
-
     static {
         JAVA_TO_COLUMN_TYPES = new HashMap<String, String>();
         JAVA_TO_COLUMN_TYPES.put("byte", "ColumnType.INTEGER");
@@ -123,7 +102,6 @@ public class RealmProxyClassGenerator {
     }
 
     private static final Map<String, String> CASTING_TYPES;
-
     static {
         CASTING_TYPES = new HashMap<String, String>();
         CASTING_TYPES.put("byte", "long");
@@ -151,14 +129,14 @@ public class RealmProxyClassGenerator {
         realmObject = elementUtils.getTypeElement("io.realm.RealmObject").asType();
         realmList = typeUtils.getDeclaredType(elementUtils.getTypeElement("io.realm.RealmList"), typeUtils.getWildcardType(null, null));
 
-        String qualifiedGeneratedClassName = String.format("%s.%s", REALM_PACKAGE_NAME, Utils.getProxyClassName(className));
+        String qualifiedGeneratedClassName = String.format("%s.%s", Constants.REALM_PACKAGE_NAME, Utils.getProxyClassName(className));
         JavaFileObject sourceFile = processingEnvironment.getFiler().createSourceFile(qualifiedGeneratedClassName);
         JavaWriter writer = new JavaWriter(new BufferedWriter(sourceFile.openWriter()));
 
         // Set source code indent to 4 spaces
         writer.setIndent("    ");
 
-        writer.emitPackage(REALM_PACKAGE_NAME)
+        writer.emitPackage(Constants.REALM_PACKAGE_NAME)
                 .emitEmptyLine();
 
         ArrayList<String> imports = new ArrayList<String>();
@@ -181,9 +159,9 @@ public class RealmProxyClassGenerator {
         imports.add("org.json.JSONObject");
         imports.add("org.json.JSONException");
         imports.add("org.json.JSONArray");
-        imports.add(String.format("%s.%s", packageName, className));
+        imports.add(metadata.getFullyQualifiedClassName());
 
-        for (VariableElement field : fields) {
+        for (VariableElement field : metadata.getFields()) {
             String fieldTypeName = "";
             if (typeUtils.isAssignable(field.asType(), realmObject)) { // Links
                 fieldTypeName = field.asType().toString();
@@ -225,7 +203,7 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitAccessors(JavaWriter writer) throws IOException {
-        for (VariableElement field : fields) {
+        for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             String fieldTypeCanonicalName = field.asType().toString();
 
@@ -238,7 +216,7 @@ public class RealmProxyClassGenerator {
 
                 // Getter
                 writer.emitAnnotation("Override");
-                writer.beginMethod(fieldTypeCanonicalName, getters.get(fieldName), EnumSet.of(Modifier.PUBLIC));
+                writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
                 writer.emitStatement(
                         "realm.checkIfValid()"
                 );
@@ -250,7 +228,7 @@ public class RealmProxyClassGenerator {
 
                 // Setter
                 writer.emitAnnotation("Override");
-                writer.beginMethod("void", setters.get(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
+                writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
                 writer.emitStatement(
                         "realm.checkIfValid()"
                 );
@@ -265,7 +243,7 @@ public class RealmProxyClassGenerator {
 
                 // Getter
                 writer.emitAnnotation("Override");
-                writer.beginMethod(fieldTypeCanonicalName, getters.get(fieldName), EnumSet.of(Modifier.PUBLIC));
+                writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
                 writer.beginControlFlow("if (row.isNullLink(Realm.columnIndices.get(\"%s\").get(\"%s\")))", className, fieldName);
                 writer.emitStatement("return null");
                 writer.endControlFlow();
@@ -277,7 +255,7 @@ public class RealmProxyClassGenerator {
 
                 // Setter
                 writer.emitAnnotation("Override");
-                writer.beginMethod("void", setters.get(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
+                writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
                 writer.beginControlFlow("if (value == null)");
                 writer.emitStatement("row.nullifyLink(Realm.columnIndices.get(\"%s\").get(\"%s\"))", className, fieldName);
                 writer.emitStatement("return");
@@ -292,7 +270,7 @@ public class RealmProxyClassGenerator {
 
                 // Getter
                 writer.emitAnnotation("Override");
-                writer.beginMethod(fieldTypeCanonicalName, getters.get(fieldName), EnumSet.of(Modifier.PUBLIC));
+                writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
                 writer.emitStatement(
                         "return new RealmList<%s>(%s.class, row.getLinkList(Realm.columnIndices.get(\"%s\").get(\"%s\")), realm)",
                         genericType, genericType, className, fieldName);
@@ -301,7 +279,7 @@ public class RealmProxyClassGenerator {
 
                 // Setter
                 writer.emitAnnotation("Override");
-                writer.beginMethod("void", setters.get(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
+                writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
                 writer.emitStatement("LinkView links = row.getLinkList(Realm.columnIndices.get(\"%s\").get(\"%s\"))", className, fieldName);
                 writer.beginControlFlow("if (value == null)");
                 writer.emitStatement("return"); // TODO: delete all the links instead
@@ -325,11 +303,11 @@ public class RealmProxyClassGenerator {
                 EnumSet.of(Modifier.PUBLIC, Modifier.STATIC), // Modifiers
                 "ImplicitTransaction", "transaction"); // Argument type & argument name
 
-        writer.beginControlFlow("if(!transaction.hasTable(\"" + TABLE_PREFIX + this.className + "\"))");
-        writer.emitStatement("Table table = transaction.getTable(\"%s%s\")", TABLE_PREFIX, this.className);
+        writer.beginControlFlow("if(!transaction.hasTable(\"" + Constants.TABLE_PREFIX + this.className + "\"))");
+        writer.emitStatement("Table table = transaction.getTable(\"%s%s\")", Constants.TABLE_PREFIX, this.className);
 
         // For each field generate corresponding table index constant
-        for (VariableElement field : fields) {
+        for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             String fieldTypeCanonicalName = field.asType().toString();
             String fieldTypeSimpleName = Utils.getFieldTypeSimpleName(field);
@@ -339,28 +317,28 @@ public class RealmProxyClassGenerator {
                         JAVA_TO_COLUMN_TYPES.get(fieldTypeCanonicalName),
                         fieldName);
             } else if (typeUtils.isAssignable(field.asType(), realmObject)) {
-                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", TABLE_PREFIX, fieldTypeSimpleName);
-                writer.emitStatement("%s%s.initTable(transaction)", fieldTypeSimpleName, PROXY_SUFFIX);
+                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", Constants.TABLE_PREFIX, fieldTypeSimpleName);
+                writer.emitStatement("%s%s.initTable(transaction)", fieldTypeSimpleName, Constants.PROXY_SUFFIX);
                 writer.endControlFlow();
                 writer.emitStatement("table.addColumnLink(ColumnType.LINK, \"%s\", transaction.getTable(\"%s%s\"))",
-                        fieldName, TABLE_PREFIX, fieldTypeSimpleName);
+                        fieldName, Constants.TABLE_PREFIX, fieldTypeSimpleName);
             } else if (typeUtils.isAssignable(field.asType(), realmList)) {
                 String genericType = Utils.getGenericType(field);
-                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", TABLE_PREFIX, genericType);
-                writer.emitStatement("%s%s.initTable(transaction)", genericType, PROXY_SUFFIX);
+                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", Constants.TABLE_PREFIX, genericType);
+                writer.emitStatement("%s%s.initTable(transaction)", genericType, Constants.PROXY_SUFFIX);
                 writer.endControlFlow();
                 writer.emitStatement("table.addColumnLink(ColumnType.LINK_LIST, \"%s\", transaction.getTable(\"%s%s\"))",
-                        fieldName, TABLE_PREFIX, genericType);
+                        fieldName, Constants.TABLE_PREFIX, genericType);
             }
         }
 
-        for (VariableElement field : fieldsToIndex) {
+        for (VariableElement field : metadata.getIndexedFields()) {
             String fieldName = field.getSimpleName().toString();
             writer.emitStatement("table.setIndex(table.getColumnIndex(\"%s\"))", fieldName);
         }
 
-        if (primaryKey != null) {
-            String fieldName = primaryKey.getSimpleName().toString();
+        if (metadata.hasPrimaryKey()) {
+            String fieldName = metadata.getPrimaryKey().getSimpleName().toString();
             writer.emitStatement("table.setPrimaryKey(\"%s\")", fieldName);
         } else {
             writer.emitStatement("table.setPrimaryKey(\"\")");
@@ -368,7 +346,7 @@ public class RealmProxyClassGenerator {
 
         writer.emitStatement("return table");
         writer.endControlFlow();
-        writer.emitStatement("return transaction.getTable(\"%s%s\")", TABLE_PREFIX, this.className);
+        writer.emitStatement("return transaction.getTable(\"%s%s\")", Constants.TABLE_PREFIX, this.className);
         writer.endMethod();
         writer.emitEmptyLine();
     }
@@ -380,22 +358,22 @@ public class RealmProxyClassGenerator {
                 EnumSet.of(Modifier.PUBLIC, Modifier.STATIC), // Modifiers
                 "ImplicitTransaction", "transaction"); // Argument type & argument name
 
-        writer.beginControlFlow("if(transaction.hasTable(\"" + TABLE_PREFIX + this.className + "\"))");
-        writer.emitStatement("Table table = transaction.getTable(\"%s%s\")", TABLE_PREFIX, this.className);
+        writer.beginControlFlow("if(transaction.hasTable(\"" + Constants.TABLE_PREFIX + this.className + "\"))");
+        writer.emitStatement("Table table = transaction.getTable(\"%s%s\")", Constants.TABLE_PREFIX, this.className);
 
         // verify number of columns
-        writer.beginControlFlow("if(table.getColumnCount() != " + fields.size() + ")");
+        writer.beginControlFlow("if(table.getColumnCount() != " + metadata.getFields().size() + ")");
         writer.emitStatement("throw new IllegalStateException(\"Column count does not match\")");
         writer.endControlFlow();
 
         // create type dictionary for lookup
         writer.emitStatement("Map<String, ColumnType> columnTypes = new HashMap<String, ColumnType>()");
-        writer.beginControlFlow("for(long i = 0; i < " + fields.size() + "; i++)");
+        writer.beginControlFlow("for(long i = 0; i < " + metadata.getFields().size() + "; i++)");
         writer.emitStatement("columnTypes.put(table.getColumnName(i), table.getColumnType(i))");
         writer.endControlFlow();
 
         // For each field verify there is a corresponding column
-        for (VariableElement field : fields) {
+        for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             String fieldTypeCanonicalName = field.asType().toString();
             String fieldTypeSimpleName = Utils.getFieldTypeSimpleName(field);
@@ -417,9 +395,9 @@ public class RealmProxyClassGenerator {
                 writer.emitStatement("throw new IllegalStateException(\"Invalid type '%s' for column '%s'\")",
                         fieldTypeSimpleName, fieldName);
                 writer.endControlFlow();
-                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", TABLE_PREFIX, fieldTypeSimpleName);
+                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", Constants.TABLE_PREFIX, fieldTypeSimpleName);
                 writer.emitStatement("throw new IllegalStateException(\"Missing table '%s%s' for column '%s'\")",
-                        TABLE_PREFIX, fieldTypeSimpleName, fieldName);
+                        Constants.TABLE_PREFIX, fieldTypeSimpleName, fieldName);
                 writer.endControlFlow();
                 // TODO: Replace with a proper comparison
 //                writer.emitStatement("Table table_%d = transaction.getTable(\"%s%s\")", columnNumber, TABLE_PREFIX, fieldTypeName);
@@ -436,9 +414,9 @@ public class RealmProxyClassGenerator {
                 writer.emitStatement("throw new IllegalStateException(\"Invalid type '%s' for column '%s'\")",
                         genericType, fieldName);
                 writer.endControlFlow();
-                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", TABLE_PREFIX, genericType);
+                writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", Constants.TABLE_PREFIX, genericType);
                 writer.emitStatement("throw new IllegalStateException(\"Missing table '%s%s' for column '%s'\")",
-                        TABLE_PREFIX, genericType, fieldName);
+                        Constants.TABLE_PREFIX, genericType, fieldName);
                 writer.endControlFlow();
                 // TODO: Replace with a proper comparison
 //                writer.emitStatement("Table table_%d = transaction.getTable(\"%s%s\")", columnNumber, TABLE_PREFIX, genericType);
@@ -456,7 +434,7 @@ public class RealmProxyClassGenerator {
     private void emitGetFieldNamesMethod(JavaWriter writer) throws IOException {
         writer.beginMethod("List<String>", "getFieldNames", EnumSet.of(Modifier.PUBLIC, Modifier.STATIC));
         StringBuilder stringBuilder = new StringBuilder();
-        Iterator<VariableElement> iterator = fields.iterator();
+        Iterator<VariableElement> iterator = metadata.getFields().iterator();
         while (iterator.hasNext()) {
             String fieldName = iterator.next().getSimpleName().toString();
             stringBuilder.append("\"");
@@ -480,7 +458,7 @@ public class RealmProxyClassGenerator {
                 "Realm", "realm", className, "object", "boolean", "update", "Map<RealmObject,RealmObject>", "cache" // Argument type & argument name
         );
 
-        if (primaryKey == null) {
+        if (!metadata.hasPrimaryKey()) {
             writer.emitStatement("return copy(realm, object, update, cache)");
         } else {
             writer
@@ -490,12 +468,10 @@ public class RealmProxyClassGenerator {
                     .emitStatement("Table table = realm.getTable(%s.class)", className)
                     .emitStatement("long pkColumnIndex = table.getPrimaryKey()");
 
-            if (primaryKey == null) {
-                writer.emitStatement("long rowIndex = TableOrView.NO_MATCH");
-            } else if (Utils.isString(primaryKey)) {
-                writer.emitStatement("long rowIndex = table.findFirstString(pkColumnIndex, object.%s())", getters.get(primaryKey.getSimpleName().toString()));
+            if (Utils.isString(metadata.getPrimaryKey())) {
+                writer.emitStatement("long rowIndex = table.findFirstString(pkColumnIndex, object.%s())", metadata.getPrimaryKeyGetter());
             } else {
-                writer.emitStatement("long rowIndex = table.findFirstLong(pkColumnIndex, object.%s())", getters.get(primaryKey.getSimpleName().toString()));
+                writer.emitStatement("long rowIndex = table.findFirstLong(pkColumnIndex, object.%s())", metadata.getPrimaryKeyGetter());
             }
 
             writer
@@ -532,20 +508,20 @@ public class RealmProxyClassGenerator {
 
         writer.emitStatement("%s realmObject = realm.createObject(%s.class)", className, className);
         writer.emitStatement("cache.put(newObject, realmObject)");
-        for (VariableElement field : fields) {
+        for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             String fieldType = field.asType().toString();
             if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 writer
                     .emitEmptyLine()
-                    .emitStatement("%s %sObj = newObject.%s()", fieldType, fieldName, getters.get(fieldName))
+                    .emitStatement("%s %sObj = newObject.%s()", fieldType, fieldName, metadata.getGetter(fieldName))
                     .beginControlFlow("if (%sObj != null)", fieldName)
                         .emitStatement("%s cache%s = (%s) cache.get(%sObj)", fieldType, fieldName, fieldType, fieldName)
                         .beginControlFlow("if (cache%s != null)", fieldName)
-                            .emitStatement("realmObject.%s(cache%s)", setters.get(fieldName), fieldName)
+                            .emitStatement("realmObject.%s(cache%s)", metadata.getSetter(fieldName), fieldName)
                         .nextControlFlow("else")
                             .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %sObj, update, cache))",
-                                    setters.get(fieldName),
+                                    metadata.getSetter(fieldName),
                                     Utils.getProxyClassSimpleName(field),
                                     fieldName)
                         .endControlFlow()
@@ -553,9 +529,9 @@ public class RealmProxyClassGenerator {
             } else if (typeUtils.isAssignable(field.asType(), realmList)) {
                 writer
                     .emitEmptyLine()
-                    .emitStatement("RealmList<%s> %sList = newObject.%s()", Utils.getGenericType(field), fieldName, getters.get(fieldName))
+                    .emitStatement("RealmList<%s> %sList = newObject.%s()", Utils.getGenericType(field), fieldName, metadata.getGetter(fieldName))
                     .beginControlFlow("if (%sList != null)", fieldName)
-                        .emitStatement("RealmList<%s> %sRealmList = realmObject.%s()", Utils.getGenericType(field), fieldName, getters.get(fieldName))
+                        .emitStatement("RealmList<%s> %sRealmList = realmObject.%s()", Utils.getGenericType(field), fieldName, metadata.getGetter(fieldName))
                         .beginControlFlow("for (int i = 0; i < %sList.size(); i++)", fieldName)
                                 .emitStatement("%s %sItem = %sList.get(i)", Utils.getGenericType(field), fieldName, fieldName)
                                 .emitStatement("%s cache%s = (%s) cache.get(%sItem)", Utils.getGenericType(field), fieldName, Utils.getGenericType(field), fieldName)
@@ -571,12 +547,12 @@ public class RealmProxyClassGenerator {
             } else {
                 if (NULLABLE_JAVA_TYPES.containsKey(fieldType)) {
                     writer.emitStatement("realmObject.%s(newObject.%s() != null ? newObject.%s() : %s)",
-                            setters.get(fieldName),
-                            getters.get(fieldName),
-                            getters.get(fieldName),
+                            metadata.getSetter(fieldName),
+                            metadata.getGetter(fieldName),
+                            metadata.getGetter(fieldName),
                             NULLABLE_JAVA_TYPES.get(fieldType));
                 } else {
-                    writer.emitStatement("realmObject.%s(newObject.%s())", setters.get(fieldName), getters.get(fieldName));
+                    writer.emitStatement("realmObject.%s(newObject.%s())", metadata.getSetter(fieldName), metadata.getGetter(fieldName));
                 }
             }
         }
@@ -594,30 +570,30 @@ public class RealmProxyClassGenerator {
                 EnumSet.of(Modifier.STATIC), // Modifiers
                 "Realm", "realm", className, "realmObject", className, "newObject", "Map<RealmObject, RealmObject>", "cache"); // Argument type & argument name
 
-        for (VariableElement field : fields) {
+        for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 writer
-                    .emitStatement("%s %sObj = newObject.%s()", Utils.getFieldTypeSimpleName(field), fieldName, getters.get(fieldName))
+                    .emitStatement("%s %sObj = newObject.%s()", Utils.getFieldTypeSimpleName(field), fieldName, metadata.getGetter(fieldName))
                     .beginControlFlow("if (%sObj != null)", fieldName)
                         .emitStatement("%s cache%s = (%s) cache.get(%sObj)", Utils.getFieldTypeSimpleName(field), fieldName, Utils.getFieldTypeSimpleName(field), fieldName)
                         .beginControlFlow("if (cache%s != null)", fieldName)
-                            .emitStatement("realmObject.%s(cache%s)", setters.get(fieldName), fieldName)
+                            .emitStatement("realmObject.%s(cache%s)", metadata.getSetter(fieldName), fieldName)
                         .nextControlFlow("else")
                             .emitStatement("realmObject.%s(%s.copyOrUpdate(realm, %sObj, true, cache))",
-                                    setters.get(fieldName),
+                                    metadata.getSetter(fieldName),
                                     Utils.getProxyClassSimpleName(field),
                                     fieldName,
                                     Utils.getFieldTypeSimpleName(field)
                             )
                         .endControlFlow()
                     .nextControlFlow("else")
-                        .emitStatement("realmObject.%s(null)", setters.get(fieldName))
+                        .emitStatement("realmObject.%s(null)", metadata.getSetter(fieldName))
                     .endControlFlow();
             } else if (typeUtils.isAssignable(field.asType(), realmList)) {
                 writer
-                    .emitStatement("RealmList<%s> %sList = newObject.%s()", Utils.getGenericType(field), fieldName, getters.get(fieldName))
-                    .emitStatement("RealmList<%s> %sRealmList = realmObject.%s()", Utils.getGenericType(field), fieldName, getters.get(fieldName))
+                    .emitStatement("RealmList<%s> %sList = newObject.%s()", Utils.getGenericType(field), fieldName, metadata.getGetter(fieldName))
+                    .emitStatement("RealmList<%s> %sRealmList = realmObject.%s()", Utils.getGenericType(field), fieldName, metadata.getGetter(fieldName))
                     .emitStatement("%sRealmList.clear()", fieldName)
                     .beginControlFlow("if (%sList != null)", fieldName)
                         .beginControlFlow("for (int i = 0; i < %sList.size(); i++)", fieldName)
@@ -632,19 +608,19 @@ public class RealmProxyClassGenerator {
                     .endControlFlow();
 
             } else {
-                if (field == primaryKey) {
+                if (field == metadata.getPrimaryKey()) {
                     continue;
                 }
 
                 String fieldType = field.asType().toString();
                 if (NULLABLE_JAVA_TYPES.containsKey(fieldType)) {
                     writer.emitStatement("realmObject.%s(newObject.%s() != null ? newObject.%s() : %s)",
-                            setters.get(fieldName),
-                            getters.get(fieldName),
-                            getters.get(fieldName),
+                            metadata.getSetter(fieldName),
+                            metadata.getGetter(fieldName),
+                            metadata.getGetter(fieldName),
                             NULLABLE_JAVA_TYPES.get(fieldType));
                 } else {
-                    writer.emitStatement("realmObject.%s(newObject.%s())", setters.get(fieldName), getters.get(fieldName));
+                    writer.emitStatement("realmObject.%s(newObject.%s())", metadata.getSetter(fieldName), metadata.getGetter(fieldName));
                 }
             }
         }
@@ -661,6 +637,7 @@ public class RealmProxyClassGenerator {
         writer.emitStatement("return \"Invalid object\"");
         writer.endControlFlow();
         writer.emitStatement("StringBuilder stringBuilder = new StringBuilder(\"%s = [\")", className);
+        List<VariableElement> fields = metadata.getFields();
         for (int i = 0; i < fields.size(); i++) {
             VariableElement field = fields.get(i);
             String fieldName = field.getSimpleName().toString();
@@ -670,16 +647,16 @@ public class RealmProxyClassGenerator {
                 String fieldTypeSimpleName = Utils.getFieldTypeSimpleName(field);
                 writer.emitStatement(
                         "stringBuilder.append(%s() != null ? \"%s\" : \"null\")",
-                        getters.get(fieldName),
+                        metadata.getGetter(fieldName),
                         fieldTypeSimpleName
                 );
             } else if (typeUtils.isAssignable(field.asType(), realmList)) {
                 String genericType = Utils.getGenericType(field);
                 writer.emitStatement("stringBuilder.append(\"RealmList<%s>[\").append(%s().size()).append(\"]\")",
                         genericType,
-                        getters.get(fieldName));
+                        metadata.getGetter(fieldName));
             } else {
-                writer.emitStatement("stringBuilder.append(%s())", getters.get(fieldName));
+                writer.emitStatement("stringBuilder.append(%s())", metadata.getGetter(fieldName));
             }
             writer.emitStatement("stringBuilder.append(\"}\")");
 
@@ -711,7 +688,7 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitEqualsMethod(JavaWriter writer) throws IOException {
-        String proxyClassName = className + PROXY_SUFFIX;
+        String proxyClassName = className + Constants.PROXY_SUFFIX;
         writer.emitAnnotation("Override");
         writer.beginMethod("boolean", "equals", EnumSet.of(Modifier.PUBLIC), "Object", "o");
         writer.emitStatement("if (this == o) return true");
@@ -742,12 +719,12 @@ public class RealmProxyClassGenerator {
                 Arrays.asList("JSONException"));
 
         writer.emitStatement("boolean standalone = obj.realm == null");
-        for (VariableElement field : fields) {
+        for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             String qualifiedFieldType = field.asType().toString();
             if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 RealmJsonTypeHelper.emitFillRealmObjectWithJsonValue(
-                        setters.get(fieldName),
+                        metadata.getSetter(fieldName),
                         fieldName,
                         qualifiedFieldType,
                         Utils.getProxyClassSimpleName(field),
@@ -755,8 +732,8 @@ public class RealmProxyClassGenerator {
 
             } else if (typeUtils.isAssignable(field.asType(), realmList)) {
                 RealmJsonTypeHelper.emitFillRealmListWithJsonValue(
-                        getters.get(fieldName),
-                        setters.get(fieldName),
+                        metadata.getGetter(fieldName),
+                        metadata.getSetter(fieldName),
                         fieldName,
                         ((DeclaredType) field.asType()).getTypeArguments().get(0).toString(),
                         Utils.getProxyClassSimpleName(field),
@@ -764,7 +741,7 @@ public class RealmProxyClassGenerator {
 
             } else {
                 RealmJsonTypeHelper.emitFillJavaTypeWithJsonValue(
-                        setters.get(fieldName),
+                        metadata.getSetter(fieldName),
                         fieldName,
                         qualifiedFieldType,
                         writer);
@@ -788,6 +765,7 @@ public class RealmProxyClassGenerator {
         writer.beginControlFlow("while (reader.hasNext())");
         writer.emitStatement("String name = reader.nextName()");
 
+        List<VariableElement> fields = metadata.getFields();
         for (int i = 0; i < fields.size(); i++) {
             VariableElement field = fields.get(i);
             String fieldName = field.getSimpleName().toString();
@@ -800,7 +778,7 @@ public class RealmProxyClassGenerator {
             }
             if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 RealmJsonTypeHelper.emitFillRealmObjectFromStream(
-                        setters.get(fieldName),
+                        metadata.getSetter(fieldName),
                         fieldName,
                         qualifiedFieldType,
                         Utils.getProxyClassSimpleName(field),
@@ -808,15 +786,15 @@ public class RealmProxyClassGenerator {
 
             } else if (typeUtils.isAssignable(field.asType(), realmList)) {
                 RealmJsonTypeHelper.emitFillRealmListFromStream(
-                        getters.get(fieldName),
-                        setters.get(fieldName),
+                        metadata.getGetter(fieldName),
+                        metadata.getSetter(fieldName),
                         ((DeclaredType) field.asType()).getTypeArguments().get(0).toString(),
                         Utils.getProxyClassSimpleName(field),
                         writer);
 
             } else {
                 RealmJsonTypeHelper.emitFillJavaTypeFromStream(
-                        setters.get(fieldName),
+                        metadata.getSetter(fieldName),
                         fieldName,
                         qualifiedFieldType,
                         writer);

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmValidationListGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmValidationListGenerator.java
@@ -27,25 +27,22 @@ import java.util.*;
 
 public class RealmValidationListGenerator {
     private ProcessingEnvironment processingEnvironment;
-    private Set<String> classesToValidate = new HashSet<String>();
+    private Set<ClassMetaData> classesToValidate = new HashSet<ClassMetaData>();
 
-    private static final String REALM_PACKAGE_NAME = "io.realm";
     private static final String CLASS_NAME = "ValidationList";
-    private static final String PROXY_CLASS_SUFFIX = "RealmProxy";
 
-
-    public RealmValidationListGenerator(ProcessingEnvironment processingEnvironment, Set<String> classesToValidate) {
+    public RealmValidationListGenerator(ProcessingEnvironment processingEnvironment, Set<ClassMetaData> classesToValidate) {
         this.processingEnvironment = processingEnvironment;
         this.classesToValidate = classesToValidate;
     }
 
     public void generate() throws IOException {
-        String qualifiedGeneratedClassName = String.format("%s.%s", REALM_PACKAGE_NAME, CLASS_NAME);
+        String qualifiedGeneratedClassName = String.format("%s.%s", Constants.REALM_PACKAGE_NAME, CLASS_NAME);
         JavaFileObject sourceFile = processingEnvironment.getFiler().createSourceFile(qualifiedGeneratedClassName);
         JavaWriter writer = new JavaWriter(new BufferedWriter(sourceFile.openWriter()));
         writer.setIndent("    ");
 
-        writer.emitPackage(REALM_PACKAGE_NAME);
+        writer.emitPackage(Constants.REALM_PACKAGE_NAME);
         writer.emitEmptyLine();
 
         writer.emitImports("java.util.Arrays", "java.util.List");
@@ -61,8 +58,8 @@ public class RealmValidationListGenerator {
 
         writer.beginMethod("List<String>", "getProxyClasses", EnumSet.of(Modifier.PUBLIC, Modifier.STATIC));
         List<String> entries = new ArrayList<String>();
-        for (String classToValidate : classesToValidate) {
-            entries.add(String.format("\"%s\"", classToValidate));
+        for (ClassMetaData classToValidate : classesToValidate) {
+            entries.add(String.format("\"%s\"", classToValidate.getSimpleClassName()));
         }
         String statementSection = joinStringList(entries, ", ");
         writer.emitStatement("return Arrays.asList(%s)", statementSection);

--- a/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
@@ -1,16 +1,15 @@
 package io.realm.processor;
 
-import java.util.List;
-import java.util.ListIterator;
-
+import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
 
 /**
  * Utility methods working with the Realm processor.
@@ -18,23 +17,13 @@ import javax.lang.model.util.Types;
 public class Utils {
 
     public static Types typeUtils;
+    private static Messager messager;
     private static DeclaredType realmList;
 
     public static void initialize(ProcessingEnvironment env) {
         typeUtils = env.getTypeUtils();
+        messager = env.getMessager();
         realmList = typeUtils.getDeclaredType(env.getElementUtils().getTypeElement("io.realm.RealmList"), typeUtils.getWildcardType(null, null));
-    }
-
-    /**
-     * Checks if a given type is either on a list of valid types or is a subclass of such a type
-     */
-    public static boolean isValidType(Types typeUtils, TypeMirror type, List<TypeMirror> validTypes) {
-        for (TypeMirror validType : validTypes) {
-            if (typeUtils.isAssignable(type, validType)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**
@@ -63,19 +52,7 @@ public class Utils {
      * Return the proxy class name for a given clazz
      */
     public static String getProxyClassName(String clazz) {
-        return clazz + RealmProxyClassGenerator.PROXY_SUFFIX;
-    }
-
-    /**
-     * Returns the simple name of a class by stripping its package name.
-     */
-    public static String stripPackage(String clazz) {
-        String[] parts = clazz.split("\\.");
-        if (parts.length > 0) {
-            return parts[parts.length - 1];
-        } else {
-            return clazz;
-        }
+        return clazz + Constants.PROXY_SUFFIX;
     }
 
     /**
@@ -114,5 +91,22 @@ public class Utils {
             genericType = genericCanonicalType;
         }
         return genericType;
+    }
+
+
+    public static void error(String message, Element element) {
+        messager.printMessage(Diagnostic.Kind.ERROR, message, element);
+    }
+
+    public static void error(String message) {
+        messager.printMessage(Diagnostic.Kind.ERROR, message);
+    }
+
+    public static void note(String message) {
+        messager.printMessage(Diagnostic.Kind.NOTE, message);
+    }
+
+    public static Element getSuperClass(TypeElement classType) {
+        return typeUtils.asElement(classType.getSuperclass());
     }
 }

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -1327,7 +1327,7 @@ public class RealmTest extends AndroidTestCase {
         assertTrue(key1 != key2);
 
         final String ENCRYPTED_REALM = "differentKeys.realm";
-
+        Realm.deleteRealmFile(getContext(), ENCRYPTED_REALM);
         Realm realm1 = null;
         Realm realm2 = null;
         try {


### PR DESCRIPTION
Part of #880 

This PR refactors RealmProcessor so all information about a ProxyClass is now generated and encapsulated inside ClassMetaData. This makes it easier to move information about the proxy classes around as well as making the responsibility of the RealmProcessor class much cleaner.