### PR TITLE
Repackage JavaWriter to avoid name conflicts with other libraries.

### DIFF
--- a/realm-annotations-processor/build.gradle
+++ b/realm-annotations-processor/build.gradle
@@ -1,4 +1,14 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.1'
+    }
+}
+
 apply plugin: 'java'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 version = new File("${projectDir}/../version.txt").text
 sourceCompatibility = '1.6'
@@ -26,6 +36,10 @@ dependencies {
 
 jar {
     from configurations.compile.findAll {it.name.contains('javawriter')}.collect { zipTree(it) }
+}
+
+shadowJar {
+    relocate 'com.squareup.javawriter', 'io.realm.processor.javawriter'
 }
 
 //for Ant filter

--- a/realm-annotations-processor/build.gradle
+++ b/realm-annotations-processor/build.gradle
@@ -40,6 +40,8 @@ jar {
 
 shadowJar {
     relocate 'com.squareup.javawriter', 'io.realm.processor.javawriter'
+    exclude 'io/realm/annotations/**'
+    classifier = ''
 }
 
 //for Ant filter

--- a/realm-annotations-processor/build.gradle
+++ b/realm-annotations-processor/build.gradle
@@ -74,7 +74,7 @@ task assembleRealm(type: GradleBuild) {
     tasks = ['assemble']
 }
 
-tasks.assemble {
+tasks.compileJava {
     dependsOn compileAnnotations
 }
 

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     compile 'com.intellij:annotations:+@jar'
     compile files("../realm-annotations/build/libs/realm-annotations-${version}.jar")
-    androidTestApt files("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}-all.jar")
+    androidTestApt files("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}.jar")
     androidTestApt files("../realm-annotations/build/libs/realm-annotations-${version}.jar")
 }
 
@@ -63,7 +63,7 @@ task androidJar(type: Jar, dependsOn: ['assemble']) {
     group 'Build'
     description 'Generates a jar file continaining Realm and its annotation processor'
     from zipTree('build/intermediates/bundles/release/classes.jar')
-    from zipTree("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}-all.jar")
+    from zipTree("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}.jar")
     from zipTree("../realm-annotations/build/libs/realm-annotations-${version}.jar")
     from(file('src/main/jniLibs')) {
         into 'lib'

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     compile 'com.intellij:annotations:+@jar'
     compile files("../realm-annotations/build/libs/realm-annotations-${version}.jar")
-    androidTestApt files("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}.jar")
+    androidTestApt files("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}-all.jar")
     androidTestApt files("../realm-annotations/build/libs/realm-annotations-${version}.jar")
 }
 
@@ -63,7 +63,7 @@ task androidJar(type: Jar, dependsOn: ['assemble']) {
     group 'Build'
     description 'Generates a jar file continaining Realm and its annotation processor'
     from zipTree('build/intermediates/bundles/release/classes.jar')
-    from zipTree("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}.jar")
+    from zipTree("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}-all.jar")
     from zipTree("../realm-annotations/build/libs/realm-annotations-${version}.jar")
     from(file('src/main/jniLibs')) {
         into 'lib'

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -143,7 +143,7 @@ if (version.endsWith('-SNAPSHOT')) { // Only publish if it's a snapshot version
 
 task buildApt(type: GradleBuild) {
     dir = file('../realm-annotations-processor')
-    tasks = ['assemble']
+    tasks = ['shadowJar']
 }
 
 task compileJni(type: GradleBuild) {


### PR DESCRIPTION
Fixes #950 

We inline JavaWriter to avoid version conflicts with other libraries, but don't repackage it which then causes class name conflicts. This PR repackages it as well to avoid these kinds of conflicts.

@emanuelez @kneth @bmunkholm 