### PR TITLE
Annotation processor now fails if a RealmObject contains no fields.

### DIFF
--- a/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -334,6 +334,10 @@ public class ClassMetaData {
             fieldNames.add(field.getSimpleName().toString());
         }
 
+        if (fields.size() == 0) {
+            Utils.error(className + " must contain at least 1 persistable field");
+        }
+
         return true;
     }
 

--- a/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
+++ b/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
@@ -53,18 +53,11 @@ public class RealmProcessorTest {
     }
 
     @Test
-    public void compileEmptyFile() {
-        ASSERT.about(javaSource())
-                .that(emptyModel)
-                .compilesWithoutError();
-    }
-
-    @Test
     public void compileProcessedEmptyFile() throws Exception {
         ASSERT.about(javaSource())
                 .that(emptyModel)
                 .processedWith(new RealmProcessor())
-                .compilesWithoutError();
+                .failsToCompile();
     }
 
     @Test

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -254,7 +254,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddEmptyRow(
     if (!TABLE_VALID(env, pTable))
         return 0;
     if (pTable->get_column_count() < 1){
-        ThrowException(env, IndexOutOfBounds, "Table has no columns");
+        ThrowException(env, IndexOutOfBounds, std::string("Table has no columns: ") + pTable->get_name().data());
         return 0;
     }
     try {

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -254,7 +254,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddEmptyRow(
     if (!TABLE_VALID(env, pTable))
         return 0;
     if (pTable->get_column_count() < 1){
-        ThrowException(env, IndexOutOfBounds, std::string("Table has no columns: ") + pTable->get_name().data());
+        ThrowException(env, IndexOutOfBounds, concat_stringdata("Table has no columns: ", pTable->get_name()));
         return 0;
     }
     try {

--- a/realm-jni/src/util.cpp
+++ b/realm-jni/src/util.cpp
@@ -271,6 +271,11 @@ string string_to_hex(const string& message, const jchar *str, size_t size, size_
     return ret.str();
 }
 
+string concat_stringdata(const char *message, StringData strData)
+{
+    return std::string(message) + (strData != NULL ? strData.data() : "");
+}
+
 jstring to_jstring(JNIEnv* env, StringData str)
 {
     // For efficiency, if the incoming UTF-8 string is sufficiently

--- a/realm-jni/src/util.hpp
+++ b/realm-jni/src/util.hpp
@@ -434,6 +434,10 @@ inline bool TblIndexAndTypeInsertValid(JNIEnv* env, T* pTable, jlong columnIndex
 bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, tightdb::BinaryData& data);
 
 
+// Utility function for appending StringData, which is returned
+// by a lot of core functions, and might potentially be NULL.
+std::string concat_stringdata(const char *message, StringData data);
+
 // Note: JNI offers methods to convert between modified UTF-8 and
 // UTF-16. Unfortunately these methods are not appropriate in this
 // context. The reason is that they use a modified version of


### PR DESCRIPTION
Fixes a bug where having no fields crashes Realm.

@kneth @emanuelez @bmunkholm 