### PR TITLE
Fixed bug in Realm.copyToRealm() with primary key values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.81
  * Fixed bug causing Realms to be cached even though they failed to open correctly.
+ * Fixed bug when using Realm.copyToRealm() with a primary key could crash if default value was already used in the Realm.
 
 0.80
 * Queries on relationships can be case sensitive.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -506,7 +506,11 @@ public class RealmProxyClassGenerator {
                 EnumSet.of(Modifier.PUBLIC, Modifier.STATIC), // Modifiers
                 "Realm", "realm", className, "newObject", "boolean", "update", "Map<RealmObject,RealmObject>", "cache"); // Argument type & argument name
 
-        writer.emitStatement("%s realmObject = realm.createObject(%s.class)", className, className);
+        if (metadata.hasPrimaryKey()) {
+            writer.emitStatement("%s realmObject = realm.createObject(%s.class, newObject.%s())", className, className, metadata.getPrimaryKeyGetter());
+        } else {
+            writer.emitStatement("%s realmObject = realm.createObject(%s.class)", className, className);
+        }
         writer.emitStatement("cache.put(newObject, realmObject)");
         for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -364,7 +364,7 @@ public class AllTypesRealmProxy extends AllTypes {
     }
 
     public static AllTypes copy(Realm realm, AllTypes newObject, boolean update, Map<RealmObject,RealmObject> cache) {
-        AllTypes realmObject = realm.createObject(AllTypes.class);
+        AllTypes realmObject = realm.createObject(AllTypes.class, newObject.getColumnString());
         cache.put(newObject, realmObject);
         realmObject.setColumnString(newObject.getColumnString() != null ? newObject.getColumnString() : "");
         realmObject.setColumnLong(newObject.getColumnLong());

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -46,6 +46,7 @@ import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
 import io.realm.entities.OwnerPrimaryKey;
 import io.realm.entities.PrimaryKeyAsLong;
+import io.realm.entities.PrimaryKeyAsString;
 import io.realm.entities.PrimaryKeyMix;
 import io.realm.entities.StringOnly;
 import io.realm.exceptions.RealmException;
@@ -1067,6 +1068,26 @@ public class RealmTest extends AndroidTestCase {
         assertArrayEquals(new byte[0], realmTypes.getColumnBinary());
     }
 
+    // Check that using copyToRealm will set the primary key directly instead of first setting
+    // it to the default value (which can fail)
+    public void testCopyToRealmWithPrimaryKeySetValueDirectly() {
+        testRealm.beginTransaction();
+        testRealm.createObject(OwnerPrimaryKey.class);
+        testRealm.copyToRealm(new OwnerPrimaryKey(1, "Foo"));
+        testRealm.commitTransaction();
+        assertEquals(2, testRealm.where(OwnerPrimaryKey.class).count());
+    }
+
+    public void testCopyToRealmWithPrimaryAsNullThrows() {
+        testRealm.beginTransaction();
+        try {
+            testRealm.copyToRealm(new PrimaryKeyAsString());
+            fail();
+        } catch (RealmException expected) {
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
 
     public void testCopyToRealmList() {
         Dog dog1 = new Dog();
@@ -1500,7 +1521,6 @@ public class RealmTest extends AndroidTestCase {
             fail();
         } catch (IllegalStateException ignored) {
         }
-
     }
 
     public void testUpdateObjectWithLinks() throws Exception {

--- a/realm/src/androidTest/java/io/realm/entities/PrimaryKeyAsString.java
+++ b/realm/src/androidTest/java/io/realm/entities/PrimaryKeyAsString.java
@@ -26,6 +26,13 @@ public class PrimaryKeyAsString extends RealmObject {
 
     private long id;
 
+    public PrimaryKeyAsString() {
+    }
+
+    public PrimaryKeyAsString(String name) {
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/realm/src/androidTest/java/io/realm/internal/JNITransactions.java
+++ b/realm/src/androidTest/java/io/realm/internal/JNITransactions.java
@@ -36,7 +36,24 @@ public class JNITransactions extends AndroidTestCase {
         }
     }
 
-    
+    private Table getTableWithStringPrimaryKey() {
+        SharedGroup db = new SharedGroup(testFile, SharedGroup.Durability.FULL, null);
+        WriteTransaction trans = db.beginWrite();
+        Table t = trans.getTable("TestTable");
+        t.addColumn(ColumnType.STRING, "colName");
+        t.setPrimaryKey("colName");
+        return t;
+    }
+
+    private Table getTableWithIntegerPrimaryKey() {
+        SharedGroup db = new SharedGroup(testFile, SharedGroup.Durability.FULL, null);
+        WriteTransaction trans = db.beginWrite();
+        Table t = trans.getTable("TestTable");
+        t.addColumn(ColumnType.INTEGER, "colName");
+        t.setPrimaryKey("colName");
+        return t;
+    }
+
     private void createDBFileName(){
         testFile = new File(
                 this.getContext().getFilesDir(),
@@ -319,24 +336,44 @@ public class JNITransactions extends AndroidTestCase {
         fail("Primary key not enforced.");
     }
 
-
-
-    /*  ARM Only works for Java 1.7 - NOT available in Android.
-
-    @Test(enabled=true)
-    public void mustReadARM() {
-        writeOneTransaction(1);
-
-        // Read from table
-        // System.out.println("mustReadARM.");
-        try (ReadTransaction t = new ReadTransaction(db)) {
-            EmployeeTable employees = new EmployeeTable(t);
-            assertEquals(true, employees.isValid());
-            assertEquals(1, employees.size());
-        }
-        catch (Throwable e) {
-
+    public void testAddEmptyRowWithPrimaryKeyWrongTypeStringThrows() {
+        Table t = getTableWithStringPrimaryKey();
+        try {
+            t.addEmptyRowWithPrimaryKey(42);
+            fail();
+        } catch (IllegalArgumentException expected) {
         }
     }
-     */
+
+    public void testAddEmptyRowWithPrimaryKeyNullStringThrows() {
+        Table t = getTableWithStringPrimaryKey();
+        try {
+            t.addEmptyRowWithPrimaryKey(null);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    public void testAddEmptyRowWithPrimaryKeyWrongTypeIntegerThrows() {
+        Table t = getTableWithIntegerPrimaryKey();
+        try {
+            t.addEmptyRowWithPrimaryKey("Foo");
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    public void testAddEmptyRowWithPrimaryKeyString() {
+        Table t = getTableWithStringPrimaryKey();
+        long rowIndex = t.addEmptyRowWithPrimaryKey("Foo");
+        assertEquals(1, t.size());
+        assertEquals("Foo", t.getRow(rowIndex).getString(0));
+    }
+
+    public void testAddEmptyRowWithPrimaryKeyLong() {
+        Table t = getTableWithIntegerPrimaryKey();
+        long rowIndex = t.addEmptyRowWithPrimaryKey(42);
+        assertEquals(1, t.size());
+        assertEquals(42, t.getRow(rowIndex).getLong(0));
+    }
 }

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1066,7 +1066,7 @@ public final class Realm implements Closeable {
 
     /**
      * Creates a new object inside the Realm with the Primary key value initially set.
-     * If the value violates the primary key constraint, no object will be added and and
+     * If the value violates the primary key constraint, no object will be added and a
      * {@link RealmException} will be thrown.
      *
      * @param clazz The Class of the object to create

--- a/realm/src/main/java/io/realm/internal/Table.java
+++ b/realm/src/main/java/io/realm/internal/Table.java
@@ -399,7 +399,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
             Row row;
 
             // Add with primary key initially set
-            switch(type) {
+            switch (type) {
                 case STRING:
                     if (!(primaryKeyValue instanceof String)) {
                         throw new IllegalArgumentException("Primary key value is not a String: " + primaryKeyValue);

--- a/realm/src/main/java/io/realm/internal/Table.java
+++ b/realm/src/main/java/io/realm/internal/Table.java
@@ -398,7 +398,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
             long rowIndex;
             Row row;
 
-            // Add with with primary key initially set
+            // Add with primary key initially set
             switch(type) {
                 case STRING:
                     if (!(primaryKeyValue instanceof String)) {

--- a/realm/src/main/java/io/realm/internal/Table.java
+++ b/realm/src/main/java/io/realm/internal/Table.java
@@ -370,7 +370,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
         if (hasPrimaryKey()) {
             long primaryKeyColumnIndex = getPrimaryKey();
             ColumnType type = getColumnType(primaryKeyColumnIndex);
-            switch(type) {
+            switch (type) {
                 case STRING:
                     if (findFirstString(primaryKeyColumnIndex, STRING_DEFAULT_VALUE) != NO_MATCH) {
                         throwDuplicatePrimaryKeyException(STRING_DEFAULT_VALUE);


### PR DESCRIPTION
Fixes https://github.com/realm/realm-java/issues/993

This PR adds a package protected method ```Realm.createObject(Class clazz, Object primaryKeyValue);```

This was needed to fix the above bug, and we have before talked about adding such a method as Cocoa has it. I am still not convinced we should make it public as using copyToRealm() is an acceptable workaround imho (See isse for details), but I am open for discussing it.

@emanuelez @kneth @bmunkholm 
