### PR TITLE
Updating to Realm Core 0.89.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -215,11 +215,11 @@ This software contains components with separate copyright and license terms.
 Your use of these components is subject to the terms and conditions of the
 following licenses.
 
-For the Realm Core (TightDB) component
+For the Realm Core component
 
-  Realm Core (TightDB) Binary License
+  Realm Core Binary License
 
-  Copyright (c) 2011-2014 Realm Inc All rights reserved
+  Copyright (c) 2011-2015 Realm Inc All rights reserved
 
   Redistribution and use in binary form, with or without modification, is
   permitted provided that the following conditions are met:

--- a/realm-jni/build.gradle
+++ b/realm-jni/build.gradle
@@ -1,4 +1,4 @@
-ext.coreVersion = '0.88.6'
+ext.coreVersion = '0.89.0'
 ext.clang = false // gcc is default for the NDK. It also produces smaller binaries
 
 def commonCflags = [ '-std=c++11', '-ffunction-sections', '-fdata-sections', '-flto' ]
@@ -148,25 +148,25 @@ targets.each { target ->
         environment PATH: "${buildDir}/standalone-toolchains/${target.toolchain.name}/bin:${System.env.PATH}"
         environment CC: "${target.toolchain.commandPrefix}-${clang?'clang':'gcc'}"
         environment STRIP: "${target.toolchain.commandPrefix}-strip"
-        environment TIGHTDB_ANDROID: '1'
+        environment REALM_ANDROID: '1'
         commandLine = [
             'make',
             '-C', "${projectDir}/src",
             "CC_IS=${clang?'clang':'gcc'}",
-            "TIGHTDB_CFLAGS=-Wno-variadic-macros -DTIGHTDB_HAVE_CONFIG -DPIC -I${projectDir}/../core-${project.coreVersion}/include",
+            "REALM_CFLAGS=-Wno-variadic-macros -DREALM_HAVE_CONFIG -DPIC -I${projectDir}/../core-${project.coreVersion}/include",
             "CFLAGS_ARCH=${(commonCflags + target.cflags).join(' ')}",
             "BASE_DENOM=${target.name}",
-            "TIGHTDB_LDFLAGS=-ltightdb-android-${target.name} -lstdc++ -lsupc++ -llog -L${projectDir}/../core-${project.coreVersion} -Wl,--gc-sections -flto",
+            "REALM_LDFLAGS=-lrealm-android-${target.name} -lstdc++ -lsupc++ -llog -L${projectDir}/../core-${project.coreVersion} -Wl,--gc-sections -flto",
             'LIB_SUFFIX_SHARED=.so',
-            "libtightdb-jni-${target.name}.so"
+            "librealm-jni-${target.name}.so"
         ]
     }
 
     task "copyAndroidJni${target.name.capitalize()}"(type: Copy) {
         dependsOn "buildAndroidJni${target.name.capitalize()}"
-        from "${projectDir}/src/libtightdb-jni-${target.name}.so"
+        from "${projectDir}/src/librealm-jni-${target.name}.so"
         into "${projectDir}/../realm/src/main/jniLibs/${target.jniFolder}"
-        rename "libtightdb-jni-${target.name}.so", 'libtightdb-jni.so'
+        rename "librealm-jni-${target.name}.so", 'librealm-jni.so'
     }
 }
 

--- a/realm-jni/project.mk
+++ b/realm-jni/project.mk
@@ -1,7 +1,7 @@
 ENABLE_INSTALL_DEBUG_LIBS = 1
 
 # Construct fat binaries on Darwin when using Clang
-ifneq ($(TIGHTDB_ENABLE_FAT_BINARIES),)
+ifneq ($(REALM_ENABLE_FAT_BINARIES),)
   ifeq ($(OS),Darwin)
     ifeq ($(COMPILER_IS),clang)
       CFLAGS_ARCH += -arch i386 -arch x86_64
@@ -13,7 +13,7 @@ ifeq ($(OS),Darwin)
   CFLAGS_ARCH += -mmacosx-version-min=10.8 -stdlib=libc++
 endif
 
-# FIXME: '-fno-elide-constructors' currently causes TightDB to fail
+# FIXME: '-fno-elide-constructors' currently causes Realm to fail
 #CFLAGS_DEBUG += -fno-elide-constructors
 CFLAGS_PTHREADS += -pthread
 CFLAGS_GENERAL += -Wextra -ansi -pedantic -Wno-long-long
@@ -37,11 +37,11 @@ endif
   #jnidir = $(JNI_INSTALL_DIR)
 #endif
 
-ifeq ($(TIGHTDB_ANDROID),)
-  TIGHTDB_LDFLAGS += -llog
+ifeq ($(REALM_ANDROID),)
+  REALM_LDFLAGS += -llog
   CFLAGS_INCLUDE += $(JAVA_CFLAGS)
-  ifneq ($(TIGHTDB_ENABLE_MEM_USAGE),)
-    PROJECT_CFLAGS += -DTIGHTDB_ENABLE_MEM_USAGE
+  ifneq ($(REALM_ENABLE_MEM_USAGE),)
+    PROJECT_CFLAGS += -DREALM_ENABLE_MEM_USAGE
     ifeq ($(shell pkg-config libprocps --exists 2>/dev/null && echo yes),yes)
       PROCPS_CFLAGS  := $(shell pkg-config libprocps --cflags)
       PROCPS_LDFLAGS := $(shell pkg-config libprocps --libs)
@@ -56,9 +56,9 @@ else
   CFLAGS_OPTIM = -Os -DNDEBUG
 endif
 
-PROJECT_CFLAGS_OPTIM  += $(TIGHTDB_CFLAGS)
-PROJECT_CFLAGS_DEBUG  += $(TIGHTDB_CFLAGS_DBG)
-PROJECT_CFLAGS_COVER  += $(TIGHTDB_CFLAGS_DBG)
-PROJECT_LDFLAGS_OPTIM += $(TIGHTDB_LDFLAGS)
-PROJECT_LDFLAGS_DEBUG += $(TIGHTDB_LDFLAGS_DBG)
-PROJECT_LDFLAGS_COVER += $(TIGHTDB_LDFLAGS_DBG)
+PROJECT_CFLAGS_OPTIM  += $(REALM_CFLAGS)
+PROJECT_CFLAGS_DEBUG  += $(REALM_CFLAGS_DBG)
+PROJECT_CFLAGS_COVER  += $(REALM_CFLAGS_DBG)
+PROJECT_LDFLAGS_OPTIM += $(REALM_LDFLAGS)
+PROJECT_LDFLAGS_DEBUG += $(REALM_LDFLAGS_DBG)
+PROJECT_LDFLAGS_COVER += $(REALM_LDFLAGS_DBG)

--- a/realm-jni/src/Makefile
+++ b/realm-jni/src/Makefile
@@ -1,10 +1,10 @@
-lib_LIBRARIES = libtightdb-jni.a
+lib_LIBRARIES = librealm-jni.a
 
 JNI_SOURCES := $(wildcard *.cpp)
-libtightdb_jni_a_SOURCES = $(JNI_SOURCES)
+librealm_jni_a_SOURCES = $(JNI_SOURCES)
 
 # Used by ../../build.sh
 get-inst-libraries:
-	@echo $(filter-out libtightdb-jni-cov.%,$(TARGETS_LIB_SHARED_ALIASES))
+	@echo $(filter-out librealm-jni-cov.%,$(TARGETS_LIB_SHARED_ALIASES))
 
 include ../generic.mk

--- a/realm-jni/src/TableSpecUtil.cpp
+++ b/realm-jni/src/TableSpecUtil.cpp
@@ -19,7 +19,7 @@
 #include "columntypeutil.hpp"
 
 using namespace std;
-using namespace tightdb;
+using namespace realm;
 
 jclass GetClassTableSpec(JNIEnv* env)
 {

--- a/realm-jni/src/TableSpecUtil.hpp
+++ b/realm-jni/src/TableSpecUtil.hpp
@@ -20,7 +20,7 @@
 #include <cstddef>
 #include <vector>
 #include <jni.h>
-#include <tightdb/table.hpp>
+#include <realm/table.hpp>
 
 jlong Java_io_realm_TableSpec_getColumnCount(JNIEnv*, jobject jTableSpec);
 
@@ -32,8 +32,8 @@ jobject Java_io_realm_TableSpec_getTableSpec(JNIEnv*, jobject jTableSpec, jlong 
 
 jlong Java_io_realm_TableSpec_getColumnIndex(JNIEnv*, jobject jTableSpec, jstring columnName);
 
-void set_descriptor(JNIEnv*,       tightdb::Descriptor&, jobject jTableSpec);
-void get_descriptor(JNIEnv*, const tightdb::Descriptor&, jobject jTableSpec);
+void set_descriptor(JNIEnv*,       realm::Descriptor&, jobject jTableSpec);
+void get_descriptor(JNIEnv*, const realm::Descriptor&, jobject jTableSpec);
 
 jclass GetClassTableSpec(JNIEnv*);
 jmethodID GetTableSpecMethodID(JNIEnv*, const char* methodStr, const char* typeStr);

--- a/realm-jni/src/columntypeutil.hpp
+++ b/realm-jni/src/columntypeutil.hpp
@@ -18,11 +18,11 @@
 #define REALM_COLUMN_TYPE_UTIL_H
 
 #include <jni.h>
-#include <tightdb.hpp>
+#include <realm.hpp>
 
 #ifdef __cplusplus
 
-using tightdb::DataType;
+using realm::DataType;
 
 extern "C" {
 

--- a/realm-jni/src/io_realm_internal_Group.cpp
+++ b/realm-jni/src/io_realm_internal_Group.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include <tightdb/util/safe_int_ops.hpp>
+#include <realm/util/safe_int_ops.hpp>
 
 #include "util.hpp"
 #include "io_realm_internal_Group.h"
 
-using namespace tightdb;
+using namespace realm;
 using std::string;
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Group_createNative__(
@@ -53,7 +53,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Group_createNative__Ljava_lang_St
         }
 
         KeyBuffer key(env, keyArray);
-#ifdef TIGHTDB_ENABLE_ENCRYPTION
+#ifdef REALM_ENABLE_ENCRYPTION
         pGroup = new Group(file_name, key.data(), openmode);
 #else
         pGroup = new Group(file_name, NULL, openmode);
@@ -179,7 +179,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Group_nativeWriteToFile(
     try {
         JStringAccessor file_name_tmp(env, jFileName); // throws
         file_name = StringData(file_name_tmp);
-#ifdef TIGHTDB_ENABLE_ENCRYPTION
+#ifdef REALM_ENABLE_ENCRYPTION
         G(nativeGroupPtr)->write(file_name, key.data());
 #else
         G(nativeGroupPtr)->write(file_name);

--- a/realm-jni/src/io_realm_internal_LinkView.cpp
+++ b/realm-jni/src/io_realm_internal_LinkView.cpp
@@ -18,7 +18,7 @@
 #include "tablequery.hpp"
 #include "util.hpp"
 
-using namespace tightdb;
+using namespace realm;
 
 JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeClose
   (JNIEnv*, jclass, jlong nativeLinkViewPtr)

--- a/realm-jni/src/io_realm_internal_Row.cpp
+++ b/realm-jni/src/io_realm_internal_Row.cpp
@@ -19,7 +19,7 @@
 #include "mixedutil.hpp"
 #include "tablebase_tpl.hpp"
 
-using namespace tightdb;
+using namespace realm;
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Row_nativeGetColumnCount
   (JNIEnv *, jobject, jlong nativeRowPtr)

--- a/realm-jni/src/io_realm_internal_SharedGroup.cpp
+++ b/realm-jni/src/io_realm_internal_SharedGroup.cpp
@@ -111,11 +111,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedGroup_nativeCreateReplicati
         file_name = StringData(file_name_tmp);
         KeyBuffer key(env, keyArray);
 #ifdef REALM_ENABLE_ENCRYPTION
-        Replication* repl = makeWriteLogCollector(file_name, false, key.data()).get();
+        std::unique_ptr<Replication> repl = makeWriteLogCollector(file_name, false, key.data());
 #else
-        Replication* repl = makeWriteLogCollector(file_name).get();
+        std::unique_ptr<Replication> repl = makeWriteLogCollector(file_name);
 #endif
-        return reinterpret_cast<jlong>(repl);
+        return reinterpret_cast<jlong>(repl.release());
     }
     CATCH_FILE(file_name)
     CATCH_STD()

--- a/realm-jni/src/io_realm_internal_SharedGroup.cpp
+++ b/realm-jni/src/io_realm_internal_SharedGroup.cpp
@@ -18,15 +18,15 @@
 
 #include "util.hpp"
 
-#include <tightdb/group_shared.hpp>
-#include <tightdb/replication.hpp>
-#include <tightdb/commit_log.hpp>
+#include <realm/group_shared.hpp>
+#include <realm/replication.hpp>
+#include <realm/commit_log.hpp>
 
 #include "util.hpp"
 #include "io_realm_internal_SharedGroup.h"
 
 using namespace std;
-using namespace tightdb;
+using namespace realm;
 
 #define SG(ptr) reinterpret_cast<SharedGroup*>(ptr)
 
@@ -42,7 +42,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedGroup_nativeCreate(
         file_name = StringData(file_name_tmp);
 
         if (enable_replication) {
-#ifdef TIGHTDB_ENABLE_REPLICATION
+#ifdef REALM_ENABLE_REPLICATION
             ThrowException(env, UnsupportedOperation,
                            "Replication is not currently supported by the Java language binding.");
 //            db = new SharedGroup(SharedGroup::replication_tag(), *file_name_ptr ? file_name_ptr : 0);
@@ -69,7 +69,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedGroup_nativeCreate(
             }
 
             KeyBuffer key(env, keyArray);
-#ifdef TIGHTDB_ENABLE_ENCRYPTION
+#ifdef REALM_ENABLE_ENCRYPTION
             db = new SharedGroup(file_name, no_create!=0, level, key.data());
 #else
             db = new SharedGroup(file_name, no_create!=0, level);
@@ -88,10 +88,10 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedGroup_createNativeWithImpli
     TR_ENTER()
     try {
         KeyBuffer key(env, keyArray);
-#ifdef TIGHTDB_ENABLE_ENCRYPTION
-        SharedGroup* db = new SharedGroup(*reinterpret_cast<tightdb::Replication*>(native_replication_ptr), SharedGroup::durability_Full, key.data());
+#ifdef REALM_ENABLE_ENCRYPTION
+        SharedGroup* db = new SharedGroup(*reinterpret_cast<realm::Replication*>(native_replication_ptr), SharedGroup::durability_Full, key.data());
 #else
-        SharedGroup* db = new SharedGroup(*reinterpret_cast<tightdb::Replication*>(native_replication_ptr));
+        SharedGroup* db = new SharedGroup(*reinterpret_cast<realm::Replication*>(native_replication_ptr));
 #endif
 
         return reinterpret_cast<jlong>(db);
@@ -110,10 +110,10 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedGroup_nativeCreateReplicati
         JStringAccessor file_name_tmp(env, jfile_name); // throws
         file_name = StringData(file_name_tmp);
         KeyBuffer key(env, keyArray);
-#ifdef TIGHTDB_ENABLE_ENCRYPTION
-        Replication* repl = makeWriteLogCollector(file_name, false, key.data());
+#ifdef REALM_ENABLE_ENCRYPTION
+        Replication* repl = makeWriteLogCollector(file_name, false, key.data()).get();
 #else
-        Replication* repl = makeWriteLogCollector(file_name);
+        Replication* repl = makeWriteLogCollector(file_name).get();
 #endif
         return reinterpret_cast<jlong>(repl);
     }
@@ -257,7 +257,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_SharedGroup_nativeGetDefaultRep
     JNIEnv* env, jclass)
 {
     TR_ENTER()
-#ifdef TIGHTDB_ENABLE_REPLICATION
+#ifdef REALM_ENABLE_REPLICATION
     ThrowException(env, UnsupportedOperation,
                    "Replication is not currently supported by the Java language binding.");
     return 0;

--- a/realm-jni/src/io_realm_internal_SubtableSchema.cpp
+++ b/realm-jni/src/io_realm_internal_SubtableSchema.cpp
@@ -17,7 +17,7 @@
 #include "util.hpp"
 #include "io_realm_internal_SubtableSchema.h"
 
-using namespace tightdb;
+using namespace realm;
 using namespace std;
 
 void arrayToVector(JNIEnv* env, jlongArray path, vector<size_t>& nativePath)

--- a/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -18,7 +18,7 @@
 #include "io_realm_internal_TableQuery.h"
 #include "tablequery.hpp"
 
-using namespace tightdb;
+using namespace realm;
 
 #if 1
 #define COL_TYPE_VALID(env,ptr,col, type)           TBL_AND_COL_INDEX_AND_TYPE_VALID(env,ptr,col, type)

--- a/realm-jni/src/io_realm_internal_Version.cpp
+++ b/realm-jni/src/io_realm_internal_Version.cpp
@@ -19,16 +19,16 @@
 
 #include "util.hpp"
 #include "io_realm_internal_Version.h"
-#include <tightdb/version.hpp>
+#include <realm/version.hpp>
 
-static int tightdb_jni_version = 23;
+static int realm_jni_version = 23;
 
 
-using namespace tightdb;
+using namespace realm;
 
 JNIEXPORT jint JNICALL Java_io_realm_internal_Version_nativeGetAPIVersion(JNIEnv*, jclass)
 {
-    return tightdb_jni_version;
+    return realm_jni_version;
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_Version_nativeGetVersion(JNIEnv *env, jclass)

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -27,7 +27,7 @@
 #include "tablequery.hpp"
 
 using namespace std;
-using namespace tightdb;
+using namespace realm;
 
 // Note: Don't modify spec on a table which has a shared_spec.
 // A spec is shared on subtables that are not in Mixed columns.
@@ -1451,7 +1451,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(
         // I
         if (columnName == NULL || env->GetStringLength(columnName) == 0) {
             // No primary key set. Remove any previous set keys
-            if (row_index != tightdb::not_found) {
+            if (row_index != realm::not_found) {
                 pk_table->remove(row_index);
             }
             return jlong(io_realm_internal_Table_NO_PRIMARY_KEY);
@@ -1459,7 +1459,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(
         else {
             JStringAccessor columnName2(env, columnName);
             size_t primary_key_column_index = table->get_column_index(columnName2);
-            if (row_index == tightdb::not_found) {
+            if (row_index == realm::not_found) {
                 // No primary key is currently set
                 if (check_valid_primary_key_column(env, table, primary_key_column_index)) {
                     row_index = pk_table->add_empty_row();

--- a/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm-jni/src/io_realm_internal_tableview.cpp
@@ -21,7 +21,7 @@
 #include "tablequery.hpp"
 #include <ostream>
 
-using namespace tightdb;
+using namespace realm;
 
 // if you disable the validation, please remember to call sync_in_needed() 
 #define VIEW_VALID_AND_IN_SYNC(env, ptr) view_valid_and_in_sync(env, ptr)

--- a/realm-jni/src/mem_usage.cpp
+++ b/realm-jni/src/mem_usage.cpp
@@ -16,7 +16,7 @@
 
 #include "mem_usage.hpp"
 
-#ifndef TIGHTDB_ENABLE_MEM_USAGE
+#ifndef REALM_ENABLE_MEM_USAGE
 
 size_t GetMemUsage()
 {

--- a/realm-jni/src/mem_usage.hpp
+++ b/realm-jni/src/mem_usage.hpp
@@ -19,7 +19,7 @@
 
 #include <cstdlib> // size_t
 
-/// This function requires that TIGHTDB_ENABLE_MEM_USAGE is specified
+/// This function requires that REALM_ENABLE_MEM_USAGE is specified
 /// during building. Otherwise it always returns zero.
 size_t GetMemUsage();
 

--- a/realm-jni/src/mixedutil.cpp
+++ b/realm-jni/src/mixedutil.cpp
@@ -18,7 +18,7 @@
 #include "mixedutil.hpp"
 #include "columntypeutil.hpp"
 
-using namespace tightdb;
+using namespace realm;
 
 jclass GetClassMixed(JNIEnv* env)
 {

--- a/realm-jni/src/mixedutil.hpp
+++ b/realm-jni/src/mixedutil.hpp
@@ -18,9 +18,9 @@
 #define MIXED_UTIL_H
 
 #include <jni.h>
-#include <tightdb.hpp>
+#include <realm.hpp>
 
-using namespace tightdb;
+using namespace realm;
 
 DataType GetMixedObjectType(JNIEnv* env, jobject jMixed);
 jobject CreateJMixedFromMixed(JNIEnv* env, Mixed& mixed);

--- a/realm-jni/src/tablequery.hpp
+++ b/realm-jni/src/tablequery.hpp
@@ -19,16 +19,16 @@
 
 #include <vector>
 #include <assert.h>
-#include <tightdb.hpp>
+#include <realm.hpp>
 
-class TableQuery : public tightdb::Query {
+class TableQuery : public realm::Query {
     // 'subtables' is used to figure out which subtable the query
     // is currectly working on, so that we can lookup the correct
     // table and verify the parameters related to that table.
     std::vector<size_t> subtables;  // holds subtable column indeces 
 
 public:
-    TableQuery(const Query& copy) : tightdb::Query(copy, tightdb::Query::TCopyExpressionTag{}) {};
+    TableQuery(const Query& copy) : realm::Query(copy, realm::Query::TCopyExpressionTag{}) {};
  
     void push_subtable(size_t index) {
         subtables.push_back(index);
@@ -41,8 +41,8 @@ public:
         return true;
     }
     
-    tightdb::TableRef get_current_table() {
-        tightdb::TableRef table = get_table();
+    realm::TableRef get_current_table() {
+        realm::TableRef table = get_table();
 
         // Go through the stack of subtables to find current subtable (if any)
         size_t size = subtables.size(); 

--- a/realm-jni/src/utf8.hpp
+++ b/realm-jni/src/utf8.hpp
@@ -1,34 +1,34 @@
 /*************************************************************************
  *
- * TIGHTDB CONFIDENTIAL
+ * REALM CONFIDENTIAL
  * __________________
  *
- *  [2011] - [2012] TightDB Inc
+ *  [2011] - [2012] Realm Inc
  *  All Rights Reserved.
  *
  * NOTICE:  All information contained herein is, and remains
- * the property of TightDB Incorporated and its suppliers,
+ * the property of Realm Incorporated and its suppliers,
  * if any.  The intellectual and technical concepts contained
- * herein are proprietary to TightDB Incorporated
+ * herein are proprietary to Realm Incorporated
  * and its suppliers and may be covered by U.S. and Foreign Patents,
  * patents in process, and are protected by trade secret or copyright law.
  * Dissemination of this information or reproduction of this material
  * is strictly forbidden unless prior written permission is obtained
- * from TightDB Incorporated.
+ * from Realm Incorporated.
  *
  **************************************************************************/
-#ifndef TIGHTDB_UTIL_UTF8_HPP
-#define TIGHTDB_UTIL_UTF8_HPP
+#ifndef REALM_UTIL_UTF8_HPP
+#define REALM_UTIL_UTF8_HPP
 
 #include <stdint.h>
 #include <string>
 
-#include <tightdb/util/safe_int_ops.hpp>
-#include <tightdb/string_data.hpp>
-#include <tightdb/util/features.h>
-#include <tightdb/utilities.hpp>
+#include <realm/util/safe_int_ops.hpp>
+#include <realm/string_data.hpp>
+#include <realm/util/features.h>
+#include <realm/utilities.hpp>
 
-namespace tightdb {
+namespace realm {
 namespace util {
 
 
@@ -97,34 +97,34 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
     const char* in = in_begin;
     Char16* out = out_begin;
     while (in != in_end) {
-        if (TIGHTDB_UNLIKELY(out == out_end)) {
+        if (REALM_UNLIKELY(out == out_end)) {
             break; // Need space in output buffer
         }
         uint_fast16_t v1 = uint_fast16_t(traits8::to_int_type(in[0]));
-        if (TIGHTDB_LIKELY(v1 < 0x80)) { // One byte
+        if (REALM_LIKELY(v1 < 0x80)) { // One byte
             // UTF-8 layout: 0xxxxxxx
             *out++ = Traits16::to_char_type(v1);
             in += 1;
             continue;
         }
-        if (TIGHTDB_UNLIKELY(v1 < 0xC0)) {
+        if (REALM_UNLIKELY(v1 < 0xC0)) {
             invalid = true;
             break; // Invalid first byte of UTF-8 sequence
         }
-        if (TIGHTDB_LIKELY(v1 < 0xE0)) { // Two bytes
-            if (TIGHTDB_UNLIKELY(in_end - in < 2)) {
+        if (REALM_LIKELY(v1 < 0xE0)) { // Two bytes
+            if (REALM_UNLIKELY(in_end - in < 2)) {
                 invalid = 1;
                 break; // Incomplete UTF-8 sequence
             }
             uint_fast16_t v2 = uint_fast16_t(traits8::to_int_type(in[1]));
             // UTF-8 layout: 110xxxxx 10xxxxxx
-            if (TIGHTDB_UNLIKELY((v2 & 0xC0) != 0x80)) {
+            if (REALM_UNLIKELY((v2 & 0xC0) != 0x80)) {
                 invalid = 2;
                 break; // Invalid continuation byte
             }
             uint_fast16_t v = uint_fast16_t(((v1 & 0x1F) << 6) |
                                             ((v2 & 0x3F) << 0));
-            if (TIGHTDB_UNLIKELY(v < 0x80)) {
+            if (REALM_UNLIKELY(v < 0x80)) {
                 invalid = 3;
                 break; // Overlong encoding is invalid
             }
@@ -132,26 +132,26 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
             in += 2;
             continue;
         }
-        if (TIGHTDB_LIKELY(v1 < 0xF0)) { // Three bytes
-            if (TIGHTDB_UNLIKELY(in_end - in < 3)) {
+        if (REALM_LIKELY(v1 < 0xF0)) { // Three bytes
+            if (REALM_UNLIKELY(in_end - in < 3)) {
                 invalid = 4;
                 break; // Incomplete UTF-8 sequence
             }
             uint_fast16_t v2 = uint_fast16_t(traits8::to_int_type(in[1]));
             uint_fast16_t v3 = uint_fast16_t(traits8::to_int_type(in[2]));
             // UTF-8 layout: 1110xxxx 10xxxxxx 10xxxxxx
-            if (TIGHTDB_UNLIKELY((v2 & 0xC0) != 0x80 || (v3 & 0xC0) != 0x80)) {
+            if (REALM_UNLIKELY((v2 & 0xC0) != 0x80 || (v3 & 0xC0) != 0x80)) {
                 invalid = true;
                 break; // Invalid continuation byte
             }
             uint_fast16_t v = uint_fast16_t(((v1 & 0x0F) << 12) |
                                             ((v2 & 0x3F) <<  6) |
                                             ((v3 & 0x3F) <<  0));
-            if (TIGHTDB_UNLIKELY(v < 0x800)) {
+            if (REALM_UNLIKELY(v < 0x800)) {
                 invalid = 5;
                 break; // Overlong encoding is invalid
             }
-            if (TIGHTDB_UNLIKELY(0xD800 <= v && v < 0xE000)) {
+            if (REALM_UNLIKELY(0xD800 <= v && v < 0xE000)) {
                 invalid = 6;
                 break; // Illegal code point range (reserved for UTF-16 surrogate pairs)
             }
@@ -159,11 +159,11 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
             in += 3;
             continue;
         }
-        if (TIGHTDB_UNLIKELY(out + 1 == out_end)) {
+        if (REALM_UNLIKELY(out + 1 == out_end)) {
             break; // Need space in output buffer for surrogate pair
         }
-        if (TIGHTDB_LIKELY(v1 < 0xF8)) { // Four bytes
-            if (TIGHTDB_UNLIKELY(in_end - in < 4)) {
+        if (REALM_LIKELY(v1 < 0xF8)) { // Four bytes
+            if (REALM_UNLIKELY(in_end - in < 4)) {
                 invalid = 7;
                 break; // Incomplete UTF-8 sequence
             }
@@ -172,7 +172,7 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
             uint_fast16_t v3 = uint_fast16_t(traits8::to_int_type(in[2])); // 16 bit intended
             uint_fast16_t v4 = uint_fast16_t(traits8::to_int_type(in[3])); // 16 bit intended
             // UTF-8 layout: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-            if (TIGHTDB_UNLIKELY((v2 & 0xC0) != 0x80 || (v3 & 0xC0) != 0x80 ||
+            if (REALM_UNLIKELY((v2 & 0xC0) != 0x80 || (v3 & 0xC0) != 0x80 ||
                                  (v4 & 0xC0) != 0x80)) {
                 invalid = 8;
                 break; // Invalid continuation byte
@@ -182,11 +182,11 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
                               ((v2 & 0x3F) << 12) | // Parenthesis is 32 bit partial result
                               ((v3 & 0x3F) <<  6) | // Parenthesis is 16 bit partial result
                               ((v4 & 0x3F) <<  0)); // Parenthesis is 16 bit partial result
-            if (TIGHTDB_UNLIKELY(v < 0x10000)) {
+            if (REALM_UNLIKELY(v < 0x10000)) {
                 invalid = 9;
                 break; // Overlong encoding is invalid
             }
-            if (TIGHTDB_UNLIKELY(0x110000 <= v)) {
+            if (REALM_UNLIKELY(0x110000 <= v)) {
                 invalid = 19;
                 break; // Code point too big for UTF-16
             }
@@ -219,17 +219,17 @@ inline std::size_t Utf8x16<Char16, Traits16>::find_utf16_buf_size(const char*& i
     const char* in = in_begin;
     while (in != in_end) {
         uint_fast16_t v1 = uint_fast16_t(traits8::to_int_type(in[0]));
-        if (TIGHTDB_LIKELY(v1 < 0x80)) { // One byte
+        if (REALM_LIKELY(v1 < 0x80)) { // One byte
             num_out += 1;
             in += 1;
             continue;
         }
-        if (TIGHTDB_UNLIKELY(v1 < 0xC0)) {
+        if (REALM_UNLIKELY(v1 < 0xC0)) {
             error_code = 1;
             break; // Invalid first byte of UTF-8 sequence
         }
-        if (TIGHTDB_LIKELY(v1 < 0xE0)) { // Two bytes
-            if (TIGHTDB_UNLIKELY(in_end - in < 2)) {
+        if (REALM_LIKELY(v1 < 0xE0)) { // Two bytes
+            if (REALM_UNLIKELY(in_end - in < 2)) {
                 error_code = 2;
                 break; // Incomplete UTF-8 sequence
             }
@@ -237,8 +237,8 @@ inline std::size_t Utf8x16<Char16, Traits16>::find_utf16_buf_size(const char*& i
             in += 2;
             continue;
         }
-        if (TIGHTDB_LIKELY(v1 < 0xF0)) { // Three bytes
-            if (TIGHTDB_UNLIKELY(in_end - in < 3)) {
+        if (REALM_LIKELY(v1 < 0xF0)) { // Three bytes
+            if (REALM_UNLIKELY(in_end - in < 3)) {
                 error_code = 3;
                 break; // Incomplete UTF-8 sequence
             }
@@ -246,8 +246,8 @@ inline std::size_t Utf8x16<Char16, Traits16>::find_utf16_buf_size(const char*& i
             in += 3;
             continue;
         }
-        if (TIGHTDB_LIKELY(v1 < 0xF8)) { // Four bytes
-            if (TIGHTDB_UNLIKELY(in_end - in < 4)) {
+        if (REALM_LIKELY(v1 < 0xF8)) { // Four bytes
+            if (REALM_UNLIKELY(in_end - in < 4)) {
                 error_code = 4;
                 break; // Incomplete UTF-8 sequence
             }
@@ -282,8 +282,8 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf8(const Char16*& in_begin, const 
     char* out = out_begin;
     while (in != in_end) {
         uint_fast16_t v1 = uint_fast16_t(Traits16::to_int_type(in[0]));
-        if (TIGHTDB_LIKELY(v1 < 0x80)) {
-            if (TIGHTDB_UNLIKELY(out == out_end)) {
+        if (REALM_LIKELY(v1 < 0x80)) {
+            if (REALM_UNLIKELY(out == out_end)) {
                 error_code = 1;
                 break; // Not enough output buffer space
             }
@@ -292,8 +292,8 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf8(const Char16*& in_begin, const 
             in += 1;
             continue;
         }
-        if (TIGHTDB_LIKELY(v1 < 0x800)) {
-            if (TIGHTDB_UNLIKELY(out_end - out < 2)) {
+        if (REALM_LIKELY(v1 < 0x800)) {
+            if (REALM_UNLIKELY(out_end - out < 2)) {
                 error_code = 2;
                 break; // Not enough output buffer space
             }
@@ -303,8 +303,8 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf8(const Char16*& in_begin, const 
             in += 1;
             continue;
         }
-        if (TIGHTDB_LIKELY(v1 < 0xD800 || 0xE000 <= v1)) {
-            if (TIGHTDB_UNLIKELY(out_end - out < 3)) {
+        if (REALM_LIKELY(v1 < 0xD800 || 0xE000 <= v1)) {
+            if (REALM_UNLIKELY(out_end - out < 3)) {
                 error_code = 3;
                 break; // Not enough output buffer space
             }
@@ -317,22 +317,22 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf8(const Char16*& in_begin, const 
         }
 
         // Surrogate pair
-        if (TIGHTDB_UNLIKELY(out_end - out < 4)) {
+        if (REALM_UNLIKELY(out_end - out < 4)) {
             error_code = 4;
             break; // Not enough output buffer space
         }
-        if (TIGHTDB_UNLIKELY(0xDC00 <= v1)) {
+        if (REALM_UNLIKELY(0xDC00 <= v1)) {
             error_code = 5;
             invalid = true;
             break; // Invalid first half of surrogate pair
         }
-        if (TIGHTDB_UNLIKELY(in + 1 == in_end)) {
+        if (REALM_UNLIKELY(in + 1 == in_end)) {
             error_code = 6;
             invalid = true;
             break; // Incomplete surrogate pair
         }
         uint_fast16_t v2 = uint_fast16_t(Traits16::to_int_type(in[1]));
-        if (TIGHTDB_UNLIKELY(v2 < 0xDC00 || 0xE000 <= v2)) {
+        if (REALM_UNLIKELY(v2 < 0xDC00 || 0xE000 <= v2)) {
             error_code = 7;
             invalid = true;
             break; // Invalid second half of surrogate pair
@@ -363,33 +363,33 @@ inline std::size_t Utf8x16<Char16, Traits16>::find_utf8_buf_size(const Char16*& 
     const Char16* in = in_begin;
     while (in != in_end) {
         uint_fast16_t v = uint_fast16_t(Traits16::to_int_type(in[0]));
-        if (TIGHTDB_LIKELY(v < 0x80)) {
-            if (TIGHTDB_UNLIKELY(int_add_with_overflow_detect(num_out, 1))) {
+        if (REALM_LIKELY(v < 0x80)) {
+            if (REALM_UNLIKELY(int_add_with_overflow_detect(num_out, 1))) {
                 error_code = 1;
                 break; // Avoid overflow
             }
             in += 1;
         }
-        else if (TIGHTDB_LIKELY(v < 0x800)) {
-            if (TIGHTDB_UNLIKELY(int_add_with_overflow_detect(num_out, 2))) {
+        else if (REALM_LIKELY(v < 0x800)) {
+            if (REALM_UNLIKELY(int_add_with_overflow_detect(num_out, 2))) {
                 error_code = 2;
                 break; // Avoid overflow
             }
             in += 1;
         }
-        else if (TIGHTDB_LIKELY(v < 0xD800 || 0xE000 <= v)) {
-            if (TIGHTDB_UNLIKELY(int_add_with_overflow_detect(num_out, 3))) {
+        else if (REALM_LIKELY(v < 0xD800 || 0xE000 <= v)) {
+            if (REALM_UNLIKELY(int_add_with_overflow_detect(num_out, 3))) {
                 error_code = 3;
                 break; // Avoid overflow
             }
             in += 1;
         }
         else {
-            if (TIGHTDB_UNLIKELY(in + 1 == in_end)) {
+            if (REALM_UNLIKELY(in + 1 == in_end)) {
                 error_code = 4;
                 break; // Incomplete surrogate pair
             }
-            if (TIGHTDB_UNLIKELY(int_add_with_overflow_detect(num_out, 4))) {
+            if (REALM_UNLIKELY(int_add_with_overflow_detect(num_out, 4))) {
                 error_code = 5;
                 break; // Avoid overflow
             }
@@ -401,6 +401,6 @@ inline std::size_t Utf8x16<Char16, Traits16>::find_utf8_buf_size(const Char16*& 
     return num_out;
 }
 } // namespace util
-} // namespace tightdb
+} // namespace realm
 
-#endif // TIGHTDB_UTIL_UTF8_HPP
+#endif // REALM_UTIL_UTF8_HPP

--- a/realm-jni/src/util.cpp
+++ b/realm-jni/src/util.cpp
@@ -17,15 +17,15 @@
 #include <algorithm>
 #include <stdexcept>
 
-#include <tightdb/util/assert.hpp>
+#include <realm/util/assert.hpp>
 #include "utf8.hpp"
 
 #include "util.hpp"
 #include "io_realm_internal_Util.h"
 
 using namespace std;
-using namespace tightdb;
-using namespace tightdb::util;
+using namespace realm;
+using namespace realm::util;
 
 void ConvertException(JNIEnv* env, const char *file, int line)
 {
@@ -42,7 +42,7 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         ThrowException(env, Unspecified, ss.str());
     }
     catch (...) { \
-        TIGHTDB_ASSERT(false);
+        REALM_ASSERT(false);
         ss << "Exception in " << file << " line " << line;
         ThrowException(env, RuntimeError, ss.str());
     }
@@ -182,7 +182,7 @@ void jprintf(JNIEnv *env, const char *format, ...)
     va_end(argptr);
 }
 
-bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, tightdb::BinaryData& bin)
+bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, realm::BinaryData& bin)
 {
     const char* data = static_cast<char*>(env->GetDirectBufferAddress(jByteBuffer));
     if (!data) {
@@ -209,8 +209,8 @@ namespace {
 // non-sign value bits, that is, an unsigned 16-bit integer, or any
 // signed or unsigned integer with more than 16 bits.
 struct JcharTraits {
-    static jchar to_int_type(jchar c)  TIGHTDB_NOEXCEPT { return c; }
-    static jchar to_char_type(jchar i) TIGHTDB_NOEXCEPT { return i; }
+    static jchar to_int_type(jchar c)  REALM_NOEXCEPT { return c; }
+    static jchar to_char_type(jchar i) REALM_NOEXCEPT { return i; }
 };
 
 struct JStringCharsAccessor {
@@ -220,8 +220,8 @@ struct JStringCharsAccessor {
     {
         m_env->ReleaseStringChars(m_string, m_data);
     }
-    const jchar* data() const TIGHTDB_NOEXCEPT { return m_data; }
-    size_t size() const TIGHTDB_NOEXCEPT { return m_size; }
+    const jchar* data() const REALM_NOEXCEPT { return m_data; }
+    size_t size() const REALM_NOEXCEPT { return m_size; }
 
 private:
     JNIEnv* const m_env;
@@ -286,7 +286,7 @@ jstring to_jstring(JNIEnv* env, StringData str)
 
     const size_t stack_buf_size = 48;
     jchar stack_buf[stack_buf_size];
-    UniquePtr<jchar[]> dyn_buf;
+    std::unique_ptr<jchar[]> dyn_buf;
 
     const char* in_begin = str.data();
     const char* in_end   = str.data() + str.size();
@@ -319,7 +319,7 @@ jstring to_jstring(JNIEnv* env, StringData str)
         size_t retcode = Xcode::to_utf16(in_begin, in_end, out_curr, out_end);
         if (retcode != 0) 
             throw runtime_error(string_to_hex("Failure when converting long string to UTF-16", str, in_begin, in_end, out_curr, out_end, size_t(0), retcode));
-        TIGHTDB_ASSERT(in_begin == in_end);
+        REALM_ASSERT(in_begin == in_end);
     }
 
   transcode_complete:
@@ -346,7 +346,7 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
 
     typedef Utf8x16<jchar, JcharTraits> Xcode;
     size_t max_project_size = 48;
-    TIGHTDB_ASSERT(max_project_size <= numeric_limits<size_t>::max()/4);
+    REALM_ASSERT(max_project_size <= numeric_limits<size_t>::max()/4);
     size_t buf_size;
     if (chars.size() <= max_project_size) {
         buf_size = chars.size() * 4;

--- a/realm-jni/src/util.hpp
+++ b/realm-jni/src/util.hpp
@@ -444,7 +444,7 @@ std::string concat_stringdata(const char *message, StringData data);
 // UTF-8 where U+0000 is stored as 0xC0 0x80 instead of 0x00 and
 // where a character in the range U+10000 to U+10FFFF is stored as
 // two consecutive UTF-8 encodings of the corresponding UTF-16
-// surrogate pair. Because TightDB uses proper UTF-8, we need to
+// surrogate pair. Because Realm uses proper UTF-8, we need to
 // do the transcoding ourselves.
 //
 // See also http://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8

--- a/realm-jni/src/util.hpp
+++ b/realm-jni/src/util.hpp
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <sstream>
+#include <memory>
 
 #include <jni.h>
 
@@ -26,11 +27,10 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#include <tightdb.hpp>
-#include <tightdb/util/meta.hpp>
-#include <tightdb/util/unique_ptr.hpp>
-#include <tightdb/util/safe_int_ops.hpp>
-#include <tightdb/lang_bind_helper.hpp>
+#include <realm.hpp>
+#include <realm/util/meta.hpp>
+#include <realm/util/safe_int_ops.hpp>
+#include <realm/lang_bind_helper.hpp>
 
 #include "io_realm_internal_Util.h"
 
@@ -94,12 +94,12 @@ std::string num_to_string(T pNumber)
 #define S(x)    static_cast<size_t>(x)
 #define B(x)    static_cast<bool>(x)
 #define S64(x)  static_cast<int64_t>(x)
-#define TBL(x)  reinterpret_cast<tightdb::Table*>(x)
-#define TV(x)   reinterpret_cast<tightdb::TableView*>(x)
-#define LV(x)   reinterpret_cast<tightdb::LinkView*>(x)
-#define Q(x)    reinterpret_cast<tightdb::Query*>(x)
-#define G(x)    reinterpret_cast<tightdb::Group*>(x)
-#define ROW(x)  reinterpret_cast<tightdb::Row*>(x)
+#define TBL(x)  reinterpret_cast<realm::Table*>(x)
+#define TV(x)   reinterpret_cast<realm::TableView*>(x)
+#define LV(x)   reinterpret_cast<realm::LinkView*>(x)
+#define Q(x)    reinterpret_cast<realm::Query*>(x)
+#define G(x)    reinterpret_cast<realm::Group*>(x)
+#define ROW(x)  reinterpret_cast<realm::Row*>(x)
 
 // Exception handling
 
@@ -212,7 +212,7 @@ extern const char *log_tag;
 
 
 inline jlong to_jlong_or_not_found(size_t res) {
-    return (res == tightdb::not_found) ? jlong(-1) : jlong(res);
+    return (res == realm::not_found) ? jlong(-1) : jlong(res);
 }
 
 template <class T>
@@ -221,7 +221,7 @@ inline bool TableIsValid(JNIEnv* env, T* objPtr)
     bool valid = (objPtr != NULL);
     if (valid) {
         // Check if Table is valid
-        if (tightdb::util::SameType<tightdb::Table, T>::value) {
+        if (realm::util::SameType<realm::Table, T>::value) {
             valid = TBL(objPtr)->is_attached();
         }
         // TODO: Add check for TableView
@@ -256,13 +256,13 @@ bool RowIndexesValid(JNIEnv* env, T* pTable, jlong startIndex, jlong endIndex, j
         ThrowException(env, IndexOutOfBounds, "startIndex < 0.");
         return false;
     }
-    if (tightdb::util::int_greater_than(startIndex, maxIndex)) {
+    if (realm::util::int_greater_than(startIndex, maxIndex)) {
         TR_ERR("startIndex %" PRId64 " > %" PRId64 " - invalid!", S64(startIndex), S64(maxIndex))
         ThrowException(env, IndexOutOfBounds, "startIndex > available rows.");
         return false;
     }
 
-    if (tightdb::util::int_greater_than(endIndex, maxIndex)) {
+    if (realm::util::int_greater_than(endIndex, maxIndex)) {
         TR_ERR("endIndex %" PRId64 " > %" PRId64 " - invalid!", S64(endIndex), S64(maxIndex))
         ThrowException(env, IndexOutOfBounds, "endIndex > available rows.");
         return false;
@@ -292,7 +292,7 @@ inline bool RowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset=fa
     size_t size = pTable->size();
     if (size > 0 && offset)
         size -= 1;
-    bool rowErr = tightdb::util::int_greater_than_or_equal(rowIndex, size);
+    bool rowErr = realm::util::int_greater_than_or_equal(rowIndex, size);
     if (rowErr) {
         TR_ERR("rowIndex %" PRId64 " > %" PRId64 " - invalid!", S64(rowIndex), S64(size))
         ThrowException(env, IndexOutOfBounds,
@@ -305,7 +305,7 @@ inline bool RowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset=fa
 template <class T>
 inline bool TblRowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset=false)
 {
-    if (tightdb::util::SameType<tightdb::Table, T>::value) {
+    if (realm::util::SameType<realm::Table, T>::value) {
         if (!TableIsValid(env, TBL(pTable)))
             return false;
     }
@@ -319,7 +319,7 @@ inline bool ColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
         ThrowException(env, IndexOutOfBounds, "columnIndex is less than 0.");
         return false;
     }
-    bool colErr = tightdb::util::int_greater_than_or_equal(columnIndex, pTable->get_column_count());
+    bool colErr = realm::util::int_greater_than_or_equal(columnIndex, pTable->get_column_count());
     if (colErr) {
         TR_ERR("columnIndex %" PRId64 " > %" PRId64 " - invalid!", S64(columnIndex), S64(pTable->get_column_count()))
         ThrowException(env, IndexOutOfBounds, "columnIndex > available columns.");
@@ -330,7 +330,7 @@ inline bool ColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
 template <class T>
 inline bool TblColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
 {
-    if (tightdb::util::SameType<tightdb::Table, T>::value) {
+    if (realm::util::SameType<realm::Table, T>::value) {
         if (!TableIsValid(env, TBL(pTable)))
             return false;
     }
@@ -361,7 +361,7 @@ inline bool TblIndexInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong
 {
     if (!TblColIndexValid(env, pTable, columnIndex))
         return false;
-    bool rowErr = tightdb::util::int_greater_than(rowIndex, pTable->size()+1);
+    bool rowErr = realm::util::int_greater_than(rowIndex, pTable->size()+1);
     if (rowErr) {
         TR_ERR("rowIndex %" PRId64 " > %" PRId64 " - invalid!", S64(rowIndex), S64(pTable->size()))
         ThrowException(env, IndexOutOfBounds,
@@ -377,7 +377,7 @@ inline bool TypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex,
     size_t col = static_cast<size_t>(columnIndex);
     int colType = pTable->get_column_type(col);
     if (allowMixed) {
-        if (colType == tightdb::type_Mixed) {
+        if (colType == realm::type_Mixed) {
             size_t row = static_cast<size_t>(rowIndex);
             colType = pTable->get_mixed_type(col, row);
         }
@@ -431,7 +431,7 @@ inline bool TblIndexAndTypeInsertValid(JNIEnv* env, T* pTable, jlong columnIndex
         && TypeValid(env, pTable, columnIndex, rowIndex, expectColType, false);
 }
 
-bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, tightdb::BinaryData& data);
+bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, realm::BinaryData& data);
 
 
 // Utility function for appending StringData, which is returned
@@ -449,19 +449,19 @@ std::string concat_stringdata(const char *message, StringData data);
 //
 // See also http://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
 
-jstring to_jstring(JNIEnv*, tightdb::StringData);
+jstring to_jstring(JNIEnv*, realm::StringData);
 
 class JStringAccessor {
 public:
     JStringAccessor(JNIEnv*, jstring);  // throws
 
-    operator tightdb::StringData() const TIGHTDB_NOEXCEPT
+    operator realm::StringData() const REALM_NOEXCEPT
     {
-        return tightdb::StringData(m_data.get(), m_size);
+        return realm::StringData(m_data.get(), m_size);
     }
 
 private:
-    tightdb::util::UniquePtr<char[]> m_data;
+    std::unique_ptr<char[]> m_data;
     std::size_t m_size;
 };
 
@@ -472,7 +472,7 @@ public:
     , m_array(arr)
     , m_ptr(0)
     {
-#ifdef TIGHTDB_ENABLE_ENCRYPTION
+#ifdef REALM_ENABLE_ENCRYPTION
         if (arr) {
             if (env->GetArrayLength(m_array) != 64)
                 ThrowException(env, UnsupportedOperation, "Encryption key must be exactly 64 bytes.");

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -211,7 +211,7 @@ task copyLibrariesToEclipseFolder(dependsOn: 'androidJar') << {
     }
     abi.each() { abiName ->
         copy {
-            from "build/intermediates/eclipse/lib/${abiName}/libtightdb-jni.so"
+            from "build/intermediates/eclipse/lib/${abiName}/librealm-jni.so"
             into "../distribution/eclipse/lib/${abiName}"
         }
     }

--- a/realm/src/androidTest/java/io/realm/internal/JNIBinaryTypeTest.java
+++ b/realm/src/androidTest/java/io/realm/internal/JNIBinaryTypeTest.java
@@ -9,7 +9,7 @@ public class JNIBinaryTypeTest extends TestCase {
 
     @Override
     public void setUp() {
-        TightDB.loadLibrary();
+        RealmCore.loadLibrary();
         //util.setDebugLevel(0); //Set to 1 to see more JNI debug messages
 
         table = new Table();

--- a/realm/src/main/java/io/realm/internal/Context.java
+++ b/realm/src/main/java/io/realm/internal/Context.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 class Context {
 
-    // Each group of related TightDB objects will have a Context object in the root.
+    // Each group of related Realm objects will have a Context object in the root.
     // The root can be a table, a group, or a shared group.
     // The Context object is used to store a list of native pointers 
     // whose disposal need to be handed over from the garbage 

--- a/realm/src/main/java/io/realm/internal/Group.java
+++ b/realm/src/main/java/io/realm/internal/Group.java
@@ -32,7 +32,7 @@ public class Group implements Closeable {
     private final Context context;
 
     static {
-        TightDB.loadLibrary();
+        RealmCore.loadLibrary();
     }
 
     //

--- a/realm/src/main/java/io/realm/internal/RealmCore.java
+++ b/realm/src/main/java/io/realm/internal/RealmCore.java
@@ -47,11 +47,11 @@ public class RealmCore {
     {
         String os = System.getProperty("os.name").toLowerCase();
         if (os.indexOf("win") >= 0)
-            return "tightdb_jni32.dll or tightdb_jni64.dll";
+            return "realm_jni32.dll or tightdb_jni64.dll";
         if (os.indexOf("mac") >= 0)
-            return "libtightdb-jni.jnilib";
+            return "librealm-jni.jnilib";
         if (os.indexOf("nix") >= 0 || os.indexOf("nux") >= 0 || os.indexOf("sunos") >= 0)
-            return "libtightdb-jni.so";
+            return "librealm-jni.so";
         return "realm-jni";
     }
 */
@@ -117,7 +117,7 @@ public class RealmCore {
         });
     }
 
-    private static void initTightDB() {
+    private static void initRealm() {
         // Guarantee gc is done on JVM exit to clean up any native resources
         gcOnExit();
     }
@@ -127,19 +127,19 @@ public class RealmCore {
             // only load library once
             return;
 
-        initTightDB();
+        initRealm();
 
         String jnilib;
         if (osIsWindows()) {
             jnilib = loadLibraryWindows();
         }
         else {
-            String debug = System.getenv("TIGHTDB_JAVA_DEBUG");
+            String debug = System.getenv("REALM_JAVA_DEBUG");
             if (debug == null || debug.isEmpty()) {
-                jnilib = "tightdb-jni";
+                jnilib = "realm-jni";
             }
             else {
-                jnilib = "tightdb-jni-dbg";
+                jnilib = "realm-jni-dbg";
             }
             System.loadLibrary(jnilib);
         }
@@ -160,15 +160,15 @@ public class RealmCore {
 //*/
         // Load debug library first - if available
         String jnilib;
-        jnilib = loadCorrectLibrary("tightdb_jni32d", "tightdb_jni64d");
+        jnilib = loadCorrectLibrary("realm_jni32d", "realm_jni64d");
         if (jnilib != null) {
-            System.out.println("!!! TightDB debug version loaded. !!!\n");
+            System.out.println("!!! Realm debug version loaded. !!!\n");
         }
         else {
-            jnilib = loadCorrectLibrary("tightdb_jni32", "tightdb_jni64");
+            jnilib = loadCorrectLibrary("realm_jni32", "realm_jni64");
             if (jnilib == null) {
                 System.err.println("Searched java.library.path=" + System.getProperty("java.library.path"));
-                throw new RuntimeException("Couldn't load the TightDB JNI library 'tightdb_jni32.dll or tightdb_jni64.dll" +
+                throw new RuntimeException("Couldn't load the Realm JNI library 'realm_jni32.dll or realm_jni64.dll" +
                                            "'. Please include the directory to the library in java.library.path.");
             }
         }

--- a/realm/src/main/java/io/realm/internal/RealmCore.java
+++ b/realm/src/main/java/io/realm/internal/RealmCore.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Utility methods for TightDB.
+ * Utility methods for Realm Core.
  */
 public class RealmCore {
 
@@ -47,7 +47,7 @@ public class RealmCore {
     {
         String os = System.getProperty("os.name").toLowerCase();
         if (os.indexOf("win") >= 0)
-            return "realm_jni32.dll or tightdb_jni64.dll";
+            return "realm_jni32.dll or realm_jni64.dll";
         if (os.indexOf("mac") >= 0)
             return "librealm-jni.jnilib";
         if (os.indexOf("nix") >= 0 || os.indexOf("nux") >= 0 || os.indexOf("sunos") >= 0)
@@ -117,7 +117,7 @@ public class RealmCore {
         });
     }
 
-    private static void initRealm() {
+    private static void init() {
         // Guarantee gc is done on JVM exit to clean up any native resources
         gcOnExit();
     }
@@ -127,7 +127,7 @@ public class RealmCore {
             // only load library once
             return;
 
-        initRealm();
+        init();
 
         String jnilib;
         if (osIsWindows()) {

--- a/realm/src/main/java/io/realm/internal/RealmCore.java
+++ b/realm/src/main/java/io/realm/internal/RealmCore.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Utility methods for TightDB.
  */
-public class TightDB {
+public class RealmCore {
 
 ///*
     private static final String FILE_SEP = File.separator;

--- a/realm/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/src/main/java/io/realm/internal/SharedGroup.java
@@ -31,7 +31,7 @@ public class SharedGroup implements Closeable {
     private final Context context;
 
     static {
-        TightDB.loadLibrary();
+        RealmCore.loadLibrary();
     }
 
     public enum Durability {

--- a/realm/src/main/java/io/realm/internal/SharedGroupWithReplication.java
+++ b/realm/src/main/java/io/realm/internal/SharedGroupWithReplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/*package com.tightdb;
+/*package io.realm.internal;
 
 public class SharedGroupWithReplication extends SharedGroup {
 

--- a/realm/src/main/java/io/realm/internal/Table.java
+++ b/realm/src/main/java/io/realm/internal/Table.java
@@ -52,7 +52,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
     protected static int TableCount = 0;
 
     static {
-        TightDB.loadLibrary();
+        RealmCore.loadLibrary();
     }
 
 

--- a/realm/src/main/java/io/realm/internal/TableView.java
+++ b/realm/src/main/java/io/realm/internal/TableView.java
@@ -49,7 +49,7 @@ import java.util.List;
  *      byte[] imageData;
  *  }
  *
- * Once this class is compiled along with TightDB annotation processor
+ * Once this class is compiled along with Realm annotation processor
  * this will produce following classes.
  *
  * 1. Employee

--- a/realm/src/main/java/io/realm/internal/Util.java
+++ b/realm/src/main/java/io/realm/internal/Util.java
@@ -21,7 +21,7 @@ import java.util.Scanner;
 public class Util {
 
     static {
-        TightDB.loadLibrary();
+        RealmCore.loadLibrary();
     }
 
     public static long getNativeMemUsage() {


### PR DESCRIPTION
Realm Core 0.89.0 is a bug fix and stability release, and has changed the namespace to `realm`. Moreover, to complete the renaming of the namespace, a number of Java files have been updated too.

The `CHANGELOG.md` is on purpose not updated. 

@cmelchior @emanuelez @bmunkholm 