### PR TITLE
Linebreaks in version.txt no longer breaks build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
   apply plugin: 'android-sdk-manager'
 
   group = 'io.realm'
-  version = new File("${rootDir}/version.txt").text
+  version = new File("${rootDir}/version.txt").text.replaceAll("\\r|\\n","")
 
   repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,7 @@ allprojects {
   apply plugin: 'android-sdk-manager'
 
   group = 'io.realm'
-  version = new File("${rootDir}/version.txt").text.replaceAll("\\r|\\n","")
-
+  version = new File("${rootDir}/version.txt").text.trim();
   repositories {
     jcenter()
   }

--- a/realm-annotations-processor/build.gradle
+++ b/realm-annotations-processor/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-version = new File("${projectDir}/../version.txt").text
+version = new File("${projectDir}/../version.txt").text.replaceAll("\\r|\\n","")
 sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 

--- a/realm-annotations-processor/build.gradle
+++ b/realm-annotations-processor/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-version = new File("${projectDir}/../version.txt").text.replaceAll("\\r|\\n","")
+version = new File("${projectDir}/../version.txt").text.trim();
 sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 

--- a/realm-annotations/build.gradle
+++ b/realm-annotations/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-version = new File("${projectDir}/../version.txt").text.replaceAll("\\r|\\n","")
+version = new File("${projectDir}/../version.txt").text.trim()
 sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 

--- a/realm-annotations/build.gradle
+++ b/realm-annotations/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-version = new File("${projectDir}/../version.txt").text
+version = new File("${projectDir}/../version.txt").text.replaceAll("\\r|\\n","")
 sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 


### PR DESCRIPTION
We can now edit the version.txt from GitHub. Yay

@emanuelez @kneth 