### PR TITLE
Throw exception if using copyToRealmOrUpdate with a null primary key value

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.81
+ * Trying to using Realm.copyToRealmOrUpdate() with a an object with a null primary key now throws a proper exception.
+
 0.80.1
  * Realm.createOrUpdateWithJson() no longer resets fields to their default value if they are not found in the JSON input.
  * Realm.compactRealmFile() now uses Realm Core's compact() method which is more failure resilient.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -523,7 +523,11 @@ public class RealmProxyClassGenerator {
                     .emitStatement("long pkColumnIndex = table.getPrimaryKey()");
 
             if (Utils.isString(metadata.getPrimaryKey())) {
-                writer.emitStatement("long rowIndex = table.findFirstString(pkColumnIndex, object.%s())", metadata.getPrimaryKeyGetter());
+                writer
+                    .beginControlFlow("if (object.%s() == null)", metadata.getPrimaryKeyGetter())
+                        .emitStatement("throw new IllegalArgumentException(\"Primary key value must not be null.\")")
+                    .endControlFlow()
+                    .emitStatement("long rowIndex = table.findFirstString(pkColumnIndex, object.%s())", metadata.getPrimaryKeyGetter());
             } else {
                 writer.emitStatement("long rowIndex = table.findFirstLong(pkColumnIndex, object.%s())", metadata.getPrimaryKeyGetter());
             }

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -414,6 +414,9 @@ public class AllTypesRealmProxy extends AllTypes {
         if (canUpdate) {
             Table table = realm.getTable(AllTypes.class);
             long pkColumnIndex = table.getPrimaryKey();
+            if (object.getColumnString() == null) {
+                throw new IllegalArgumentException("Primary key value must not be null.");
+            }
             long rowIndex = table.findFirstString(pkColumnIndex, object.getColumnString());
             if (rowIndex != TableOrView.NO_MATCH) {
                 realmObject = new AllTypesRealmProxy();

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -1179,6 +1179,15 @@ public class RealmTest extends AndroidTestCase {
         fail();
     }
 
+    public void testCopyToRealmOrUpdateNullPrimaryKeyThrows() {
+        testRealm.beginTransaction();
+        try {
+            testRealm.copyToRealmOrUpdate(new PrimaryKeyAsString());
+            fail();
+        } catch (RealmException expected) {
+        }
+    }
+
     public void testCopyOrUpdateNoPrimaryKeyThrows() {
         try {
             testRealm.copyToRealmOrUpdate(new AllTypes());

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1596,7 +1596,7 @@ public final class Realm implements Closeable {
         } catch (IllegalAccessException e) {
             throw new RealmException("Could not execute the copyToRealm method : " + APT_NOT_EXECUTED_MESSAGE, e);
         } catch (InvocationTargetException e) {
-            throw new RealmException("An exception was thrown in the copyToRealm method in the proxy class  " + proxyClass.getName() + ": " + APT_NOT_EXECUTED_MESSAGE, e);
+            throw new RealmException("An exception was thrown in the copyToRealm method in the proxy class " + proxyClass.getName(), e);
         }
     }
 


### PR DESCRIPTION
Fixes #1051 

We now throw a proper exception instead of crashing core.

@emanuelez @bmunkholm @kneth 
