### PR TITLE
RealmChangedListener now gets called on the same thread doing the commit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.81
+ * RealmChangedListener now also gets called on the same thread that did the commit.
+
 0.80.2
  * Trying to use Realm.copyToRealmOrUpdate() with an object with a null primary key now throws a proper exception.
  * RealmMigrationNeedException can now return the path to the Realm that needs to be migrated.

--- a/realm/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/src/androidTest/java/io/realm/NotificationsTest.java
@@ -32,13 +32,24 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.realm.entities.AllTypes;
 import io.realm.entities.Dog;
 
 public class NotificationsTest extends AndroidTestCase {
 
+    private Realm realm;
+
     @Override
     protected void setUp() throws Exception {
         Realm.deleteRealmFile(getContext());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        if (realm != null) {
+            realm.close();
+        }
     }
 
     public void testFailingSetAutoRefreshOnNonLooperThread() throws ExecutionException, InterruptedException {
@@ -116,12 +127,13 @@ public class NotificationsTest extends AndroidTestCase {
             }
         });
 
-        // Wait until the looper is started
+        // Wait until the looper in the background thread is started
         while (!isReady.get()) {
             Thread.sleep(5);
         }
         Thread.sleep(100); 
 
+        // Trigger OnRealmChanged on background thread
         Realm realm = Realm.getInstance(getContext());
         realm.beginTransaction();
         Dog dog = realm.createObject(Dog.class);
@@ -303,5 +315,34 @@ public class NotificationsTest extends AndroidTestCase {
         assertNotNull(instance1.getHandler());
         instance1.close();
         assertNull(instance1.getHandler());
+    }
+
+    public void testImmediateNotificationsOnSameThread() {
+        final AtomicBoolean success = new AtomicBoolean(false);
+        realm = Realm.getInstance(getContext());
+        realm.addChangeListener(new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                success.set(true);
+            }
+        });
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+        assertTrue(success.get());
+    }
+
+    public void testEmptyCommitTriggerOnChangeHandler() {
+        final AtomicBoolean success = new AtomicBoolean(false);
+        realm = Realm.getInstance(getContext());
+        realm.addChangeListener(new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                success.set(true);
+            }
+        });
+        realm.beginTransaction();
+        realm.commitTransaction();
+        assertTrue(success.get());
     }
 }

--- a/realm/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/src/androidTest/java/io/realm/NotificationsTest.java
@@ -332,7 +332,7 @@ public class NotificationsTest extends AndroidTestCase {
         assertTrue(success.get());
     }
 
-    public void testEmptyCommitTriggerOnChangeHandler() {
+    public void testEmptyCommitTriggerChangeListener() {
         final AtomicBoolean success = new AtomicBoolean(false);
         realm = Realm.getInstance(getContext());
         realm.addChangeListener(new RealmChangeListener() {

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1467,11 +1467,18 @@ public final class Realm implements Closeable {
         for (Map.Entry<Handler, String> handlerIntegerEntry : handlers.entrySet()) {
             Handler handler = handlerIntegerEntry.getKey();
             String realmPath = handlerIntegerEntry.getValue();
+
+            // Notify at once on thread doing the commit
+            if (handler.equals(this.handler)) {
+                sendNotifications();
+                continue;
+            }
+
+            // For all other threads, use the Handler
             if (
-                    realmPath.equals(canonicalPath)                       // It's the right realm
+                    realmPath.equals(canonicalPath)              // It's the right realm
                     && !handler.hasMessages(REALM_CHANGED)       // The right message
                     && handler.getLooper().getThread().isAlive() // The receiving thread is alive
-                    && !handler.equals(this.handler)             // Don't notify yourself
             ) {
                 handler.sendEmptyMessage(REALM_CHANGED);
             }


### PR DESCRIPTION
This PR makes the OnRealmChanged callback behave more as expected and puts it in line with Realm-Cocoa behaviour.

Previously, callbacks registered on the thread doing the commit was not triggered, this is now the case. In order avoid weird cases like be below. The OnRealmChangedListener is called immediately instead of using the Handler mechanism.

```
// If using Handler messages, the following would be possible. By calling listeners at once, this is avoided.
realm.beginTransaction();
...
realm.commitTransaction();
realm.addChangeListener(new RealmChangedListener() {
  // This would get triggered even though it was added after the commit.
});
```

@emanuelez @kneth @jpsim @bmunkholm 

