### PR TITLE
Fix Date and byte[] being reset when using createOrUpdateFromJson

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.81.0
+ * Fixed bug where Realm.createOrUpdateWithJson() reset Date and Binary data to default values if not found in the JSON output.
+
 0.80.2
  * Trying to use Realm.copyToRealmOrUpdate() with an object with a null primary key now throws a proper exception.
  * RealmMigrationNeedException can now return the path to the Realm that needs to be migrated.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
@@ -56,8 +56,6 @@ public class RealmJsonTypeHelper {
                         .nextControlFlow("else")
                             .emitStatement("obj.%s(new Date(json.getLong(\"%s\")))", setter, fieldName)
                         .endControlFlow()
-                    .nextControlFlow("else")
-                        .emitStatement("obj.%s(new Date(0))", setter)
                     .endControlFlow();
             }
 
@@ -77,7 +75,10 @@ public class RealmJsonTypeHelper {
         JAVA_TO_JSON_TYPES.put("byte[]", new JsonToRealmTypeConverter() {
             @Override
             public void emitTypeConversion(String setter, String fieldName, String fieldType, JavaWriter writer) throws IOException {
-                writer.emitStatement("obj.%s(JsonUtils.stringToBytes(json.isNull(\"%s\") ? null : json.getString(\"%s\")))", setter, fieldName, fieldName);
+                writer
+                    .beginControlFlow("if (!json.isNull(\"%s\"))", fieldName)
+                        .emitStatement("obj.%s(JsonUtils.stringToBytes(json.getString(\"%s\")))", setter, fieldName)
+                    .endControlFlow();
             }
 
             @Override

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -341,10 +341,10 @@ public class AllTypesRealmProxy extends AllTypes {
             } else {
                 obj.setColumnDate(new Date(json.getLong("columnDate")));
             }
-        } else {
-            obj.setColumnDate(new Date(0));
         }
-        obj.setColumnBinary(JsonUtils.stringToBytes(json.isNull("columnBinary") ? null : json.getString("columnBinary")));
+        if (!json.isNull("columnBinary")) {
+            obj.setColumnBinary(JsonUtils.stringToBytes(json.getString("columnBinary")));
+        }
         if (!json.isNull("columnObject")) {
             some.test.AllTypes columnObjectObj = AllTypesRealmProxy.createOrUpdateUsingJsonObject(realm, json.getJSONObject("columnObject"), update);
             obj.setColumnObject(columnObjectObj);

--- a/realm/src/androidTest/assets/list_alltypes_primarykey.json
+++ b/realm/src/androidTest/assets/list_alltypes_primarykey.json
@@ -4,7 +4,7 @@
         "columnLong" : 1,
         "columnFloat" : 1.23,
         "columnDouble" : 1.234,
-        "columnBoolean" : true,
+        "columnBoolean" : false,
         "columnBinary" : "AQID",
         "columnDate" : 1000,
         "columnRealmObject" : {
@@ -27,7 +27,7 @@
         "columnLong" : 1,
         "columnFloat" : 2.23,
         "columnDouble" : 2.234,
-        "columnBoolean" : false,
+        "columnBoolean" : true,
         "columnBinary" : "AQID",
         "columnDate" : 2000,
         "columnRealmObject" : {

--- a/realm/src/androidTest/java/io/realm/RealmJsonTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmJsonTest.java
@@ -493,35 +493,31 @@ public class RealmJsonTest extends AndroidTestCase {
         assertEquals("bar", newObj.getColumnString());
     }
 
-    public void testCreateOrUpdateJsonObject_ignoreUnsetProperties() {
+    public void testCreateOrUpdateJsonObject_ignoreUnsetProperties() throws IOException {
+        String json = TestHelper.streamToString(loadJsonFromAssets("list_alltypes_primarykey.json"));
         testRealm.beginTransaction();
-        AllTypesPrimaryKey obj = testRealm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, "{ \"columnLong\":1, \"columnString\": \"foo\" }");
-        obj.setColumnBoolean(true);
+        testRealm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, json);
         testRealm.commitTransaction();
 
+        // No-op as no properties should be updated
         testRealm.beginTransaction();
-        obj = testRealm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, "{ \"columnLong\":1, \"columnString\": \"bar\" }");
+        testRealm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, "{ \"columnLong\":1 }");
         testRealm.commitTransaction();
 
-        assertTrue(obj.isColumnBoolean());
+        assertAllTypesPrimaryKeyUpdated();
     }
 
     public void testCreateOrUpdateJsonStream_ignoreUnsetProperties() throws IOException {
         testRealm.beginTransaction();
-        AllTypesPrimaryKey obj = testRealm.createOrUpdateObjectFromJson(
-                AllTypesPrimaryKey.class, strToStream("{ \"columnLong\":1, \"columnString\": \"foo\" }")
-        );
-        obj.setColumnBoolean(true);
+        testRealm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, loadJsonFromAssets("list_alltypes_primarykey.json"));
         testRealm.commitTransaction();
 
+        // No-op as no properties should be updated
         testRealm.beginTransaction();
-        obj = testRealm.createOrUpdateObjectFromJson(
-                AllTypesPrimaryKey.class, strToStream("{ \"columnLong\":1, \"columnString\": \"bar\" }")
-        );
+        testRealm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, strToStream("{ \"columnLong\":1 }"));
         testRealm.commitTransaction();
 
-        assertTrue(obj.isColumnBoolean());
-        assertEquals("bar", obj.getColumnString());
+        assertAllTypesPrimaryKeyUpdated();
     }
 
     public void testCreateOrUpdateInputStream() throws IOException {
@@ -624,7 +620,7 @@ public class RealmJsonTest extends AndroidTestCase {
         assertEquals("Bar", obj.getColumnString());
         assertEquals(2.23F, obj.getColumnFloat());
         assertEquals(2.234D, obj.getColumnDouble());
-        assertEquals(false, obj.isColumnBoolean());
+        assertEquals(true, obj.isColumnBoolean());
         assertArrayEquals(new byte[] {1,2,3}, obj.getColumnBinary());
         assertEquals(new Date(2000), obj.getColumnDate());
         assertEquals("Dog4", obj.getColumnRealmObject().getName());


### PR DESCRIPTION
Fixes #1095 

Date and byte[] fields where incorrectly reset even though this bug was fixed in the last release.
Lesson learned: Remember to unit test all types :(

@emanuelez @kneth 