### PR TITLE
Add Javadoc comment which specifies that Realm.deleteRealmFile(...) throws IllegalStateException if target Reealm file is not closed.

### DIFF
--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1643,6 +1643,8 @@ public final class Realm implements Closeable {
      * @param context an Android {@link android.content.Context}.
      * @return false if a file could not be deleted. The failing file will be logged.
      * @see io.realm.Realm#clear(Class)
+     *
+     * @throws java.lang.IllegalStateException if trying to delete a Realm that is already open.
      */
     public static boolean deleteRealmFile(Context context) {
         return deleteRealmFile(context, DEFAULT_REALM_NAME);
@@ -1655,6 +1657,8 @@ public final class Realm implements Closeable {
      * @param context  an Android {@link android.content.Context}.
      * @param fileName the name of the custom Realm (i.e. "myCustomRealm.realm").
      * @return false if a file could not be deleted. The failing file will be logged.
+     *
+     * @throws java.lang.IllegalStateException if trying to delete a Realm that is already open.
      */
     public static boolean deleteRealmFile(Context context, String fileName) {
         return deleteRealmFile(new File(context.getFilesDir(), fileName));
@@ -1666,6 +1670,8 @@ public final class Realm implements Closeable {
      *
      * @param realmFile The reference to the Realm file.
      * @return false if a file could not be deleted. The failing file will be logged.
+     *
+     * @throws java.lang.IllegalStateException if trying to delete a Realm that is already open.
      */
     public static synchronized boolean deleteRealmFile(File realmFile) {
         boolean result = true;


### PR DESCRIPTION
Fixes #1107 