### PR TITLE
Fix a memory leak in RealmBaseAdapter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.81.0
  * Fixed bug where Realm.createOrUpdateWithJson() reset Date and Binary data to default values if not found in the JSON output.
+ * Fixed a memory leak when using RealmBaseAdapter.
  * RealmBaseAdapter now allow RealmResults to be null (thanks @zaki50).
 
 0.80.2

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -42,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
@@ -169,7 +171,7 @@ public final class Realm implements Closeable {
 
     // Maps classes to the name of the proxied class. Examples: Dog.class -> Dog, DogRealmProxy -> Dog
     private final Map<Class<?>, String> proxiedClassNames = new HashMap<Class<?>, String>();
-    private final List<RealmChangeListener> changeListeners = new ArrayList<RealmChangeListener>();
+    private final List<WeakReference<RealmChangeListener>> changeListeners = new ArrayList<WeakReference<RealmChangeListener>>();
     private final Map<Class<?>, Table> tables = new HashMap<Class<?>, Table>();
     private static final Set<Class<? extends RealmObject>> customSchema = new HashSet<Class<? extends RealmObject>>();
     private static final long UNVERSIONED = -1;
@@ -1308,7 +1310,7 @@ public final class Realm implements Closeable {
     public <E extends RealmObject> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldName1,
                                                                boolean sortAscending1, String fieldName2,
                                                                boolean sortAscending2) {
-        return allObjectsSorted(clazz, new String[] {fieldName1, fieldName2}, new boolean[] {sortAscending1,
+        return allObjectsSorted(clazz, new String[]{fieldName1, fieldName2}, new boolean[]{sortAscending1,
                 sortAscending2});
     }
 
@@ -1383,7 +1385,7 @@ public final class Realm implements Closeable {
      */
     public void addChangeListener(RealmChangeListener listener) {
         checkIfValid();
-        changeListeners.add(listener);
+        changeListeners.add(new WeakReference<RealmChangeListener>(listener));
     }
 
     /**
@@ -1394,7 +1396,7 @@ public final class Realm implements Closeable {
      */
     public void removeChangeListener(RealmChangeListener listener) {
         checkIfValid();
-        changeListeners.remove(listener);
+        changeListeners.remove(new WeakReference<RealmChangeListener>(listener));
     }
 
     /**
@@ -1408,9 +1410,14 @@ public final class Realm implements Closeable {
     }
 
     void sendNotifications() {
-        List<RealmChangeListener> defensiveCopy = new ArrayList<RealmChangeListener>(changeListeners);
-        for (RealmChangeListener listener : defensiveCopy) {
-            listener.onChange();
+        Iterator<WeakReference<RealmChangeListener>> iterator = changeListeners.iterator();
+        while (iterator.hasNext()) {
+            RealmChangeListener listener = iterator.next().get();
+            if (listener == null) {
+                iterator.remove();
+            } else {
+                listener.onChange();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1109
We now use WeakReferences to store the change listeners.
This allows the Garbage Collector to clean up the adapters.