### PR TITLE
Adding objects using a RealmLists now properly clears any previous data.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
  * Fixed a memory leak when using RealmBaseAdapter.
  * RealmBaseAdapter now allow RealmResults to be null (thanks @zaki50).
  * Fixed a bug where a change to a model class (RealmList<A> to RealmList<B>) would not throw a RealmMigrationNeededException.
+ * Fixed a bug where where setting multiple RealmLists didn't remove the previously added objects.
 
 0.80.2
  * Trying to use Realm.copyToRealmOrUpdate() with an object with a null primary key now throws a proper exception.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -308,6 +308,7 @@ public class RealmProxyClassGenerator {
                 writer.beginControlFlow("if (value == null)");
                 writer.emitStatement("return"); // TODO: delete all the links instead
                 writer.endControlFlow();
+                writer.emitStatement("links.clear()");
                 writer.beginControlFlow("for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value)");
                 writer.emitStatement("links.add(linkedObject.row.getIndex())");
                 writer.endControlFlow();

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -166,6 +166,7 @@ public class AllTypesRealmProxy extends AllTypes
         if (value == null) {
             return;
         }
+        links.clear();
         for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value) {
             links.add(linkedObject.row.getIndex());
         }

--- a/realm/src/androidTest/java/io/realm/RealmListTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmListTest.java
@@ -18,9 +18,10 @@ package io.realm;
 
 import android.test.AndroidTestCase;
 
+import io.realm.entities.AllTypes;
+import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.Owner;
-import io.realm.entities.AllTypes;
 import io.realm.exceptions.RealmException;
 
 public class RealmListTest extends AndroidTestCase {
@@ -452,5 +453,16 @@ public class RealmListTest extends AndroidTestCase {
         try { list.move(0, 1);  fail(); } catch (IllegalStateException expected) {}
         try { list.remove(0);   fail(); } catch (IllegalStateException expected) {}
         try { list.set(0, dog); fail(); } catch (IllegalStateException expected) {}
+    }
+
+    public void testSettingListClearsOldItems() {
+        testRealm.beginTransaction();
+        CyclicType one = testRealm.copyToRealm(new CyclicType());
+        CyclicType two = testRealm.copyToRealm(new CyclicType());
+        two.setObjects(new RealmList<CyclicType>(one));
+        two.setObjects(new RealmList<CyclicType>(one));
+        testRealm.commitTransaction();
+
+        assertEquals(1, two.getObjects().size());
     }
 }


### PR DESCRIPTION
Fixes #1143 

@emanuelez @kneth 