### PR TITLE
RealmConfiguration used as cache key

### DIFF
--- a/realm/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/src/androidTest/java/io/realm/NotificationsTest.java
@@ -135,7 +135,7 @@ public class NotificationsTest extends AndroidTestCase {
         assertEquals(1, counter.get());
     }
 
-    public void testNotificationsNumber () throws InterruptedException, ExecutionException {
+    public void testNotificationsNumber() throws InterruptedException, ExecutionException {
         final AtomicInteger counter = new AtomicInteger(0);
         final AtomicBoolean isReady = new AtomicBoolean(false);
         final Looper[] looper = new Looper[1];
@@ -173,10 +173,10 @@ public class NotificationsTest extends AndroidTestCase {
         while (!isReady.get()) {
             Thread.sleep(5);
         }
-        Thread.sleep(100); 
+        Thread.sleep(100);
 
         // Trigger OnRealmChanged on background thread
-        Realm realm = Realm.getInstance(getContext());
+        realm = Realm.getInstance(getContext());
         realm.beginTransaction();
         Dog dog = realm.createObject(Dog.class);
         dog.setName("Rex");

--- a/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
@@ -23,6 +23,7 @@ import java.util.Random;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
+import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.Owner;
 import io.realm.exceptions.RealmMigrationNeededException;
@@ -275,6 +276,71 @@ public class RealmConfigurationTest extends AndroidTestCase {
             realm = Realm.getInstance(new RealmConfiguration.Builder(getContext()).schemaVersion(42).build());
             fail();
         } catch (RealmMigrationNeededException expected) {
+        }
+    }
+
+    public void testEquals() {
+        RealmConfiguration config1 = new RealmConfiguration.Builder(getContext()).build();
+        RealmConfiguration config2 = new RealmConfiguration.Builder(getContext()).build();
+        assertTrue(config1.equals(config2));
+    }
+
+    public void testHashCode() {
+        RealmConfiguration config1 = new RealmConfiguration.Builder(getContext()).build();
+        RealmConfiguration config2 = new RealmConfiguration.Builder(getContext()).build();
+        assertEquals(config1.hashCode(), config2.hashCode());
+    }
+
+    public void testEqualConfigurationsReturnCachedRealm() {
+        Realm realm1 = Realm.getInstance(getContext());
+        Realm realm2 = Realm.getInstance(getContext());
+        try {
+            assertEquals(realm1, realm2);
+        } finally {
+            realm1.close();
+            realm2.close();
+        }
+    }
+
+    public void testDifferentVersionsThrows() {
+        RealmConfiguration config1 = new RealmConfiguration.Builder(getContext()).schemaVersion(1).build();
+        RealmConfiguration config2 = new RealmConfiguration.Builder(getContext()).schemaVersion(2).build();
+
+        Realm realm1 = Realm.getInstance(config1);
+        try {
+            Realm.getInstance(config2);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        } finally {
+            realm1.close();
+        }
+    }
+
+    public void testDifferentEncryptionKeysThrows() {
+        RealmConfiguration config1 = new RealmConfiguration.Builder(getContext()).encryptionKey(TestHelper.getRandomKey()).build();
+        RealmConfiguration config2 = new RealmConfiguration.Builder(getContext()).encryptionKey(TestHelper.getRandomKey()).build();
+
+        Realm realm1 = Realm.getInstance(config1);
+        try {
+            Realm.getInstance(config2);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        } finally {
+            realm1.close();
+        }
+    }
+
+    public void testDifferentSchemasThrows() {
+        RealmConfiguration config1 = new RealmConfiguration.Builder(getContext()).schema(AllTypes.class).build();
+        RealmConfiguration config2 = new RealmConfiguration.Builder(getContext()).schema(CyclicType.class).build();
+
+        Realm realm1 = Realm.getInstance(config1);
+        try {
+            Realm.getInstance(config2);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        } finally {
+            realm1.close();
         }
     }
 }

--- a/realm/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/src/androidTest/java/io/realm/TestHelper.java
@@ -78,10 +78,16 @@ public class TestHelper {
     // Returns a random key used by encrypted Realms.
     public static byte[] getRandomKey() {
         byte[] key = new byte[64];
-        new Random(42).nextBytes(key);
+        new Random().nextBytes(key);
         return key;
     }
 
+    // Returns a random key from the given seed. Used by encrypted Realms.
+    public static byte[] getRandomKey(long seed) {
+        byte[] key = new byte[64];
+        new Random(seed).nextBytes(key);
+        return key;
+    }
 
     public static class StubInputStream extends InputStream {
         @Override

--- a/realm/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/src/main/java/io/realm/RealmConfiguration.java
@@ -19,11 +19,15 @@ package io.realm;
 import android.content.Context;
 
 import java.io.File;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.realm.annotations.RealmModule;
 import io.realm.exceptions.RealmException;
@@ -116,6 +120,36 @@ public class RealmConfiguration {
         return canonicalPath;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        RealmConfiguration that = (RealmConfiguration) obj;
+
+        if (schemaVersion != that.schemaVersion) return false;
+        if (deleteRealmIfMigrationNeeded != that.deleteRealmIfMigrationNeeded) return false;
+        if (!realmFolder.equals(that.realmFolder)) return false;
+        if (!realmFileName.equals(that.realmFileName)) return false;
+        if (!canonicalPath.equals(that.canonicalPath)) return false;
+        if (!Arrays.equals(key, that.key)) return false;
+        if (migration != null ? !migration.equals(that.migration) : that.migration != null) return false;
+        return schemaMediator.equals(that.schemaMediator);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = realmFolder.hashCode();
+        result = 31 * result + realmFileName.hashCode();
+        result = 31 * result + canonicalPath.hashCode();
+        result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
+        result = 31 * result + schemaVersion;
+        result = 31 * result + (migration != null ? migration.hashCode() : 0);
+        result = 31 * result + (deleteRealmIfMigrationNeeded ? 1 : 0);
+        result = 31 * result + schemaMediator.hashCode();
+        return result;
+    }
+
     // Creates the mediator that defines the current schema
     private RealmProxyMediator createSchemaMediator(Builder builder) {
 
@@ -172,7 +206,6 @@ public class RealmConfiguration {
         private int schemaVersion;
         private RealmMigration migration;
         private boolean deleteRealmIfMigrationNeeded;
-        private boolean resetRealmBeforeOpening;
         private HashSet<Object> modules = new HashSet<Object>();
         private HashSet<Class<? extends RealmObject>> debugSchema = new HashSet<Class<? extends RealmObject>>();
 
@@ -220,7 +253,6 @@ public class RealmConfiguration {
             this.schemaVersion = 0;
             this.migration = null;
             this.deleteRealmIfMigrationNeeded = false;
-            this.resetRealmBeforeOpening = false;
             if (DEFAULT_MODULE != null) {
                 this.modules.add(DEFAULT_MODULE);
             }

--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -183,7 +183,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
 
     // Transparently copies a standalone object or managed object from another Realm to the Realm backing this RealmList.
     private E copyToRealmIfNeeded(E object) {
-        if (object.row != null && object.realm.canonicalPath.equals(realm.canonicalPath)) {
+        if (object.row != null && object.realm.getPath().equals(realm.getPath())) {
             return object;
         }
         if (realm.getTable(object.getClass()).hasPrimaryKey()) {

--- a/realm/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -130,6 +130,20 @@ public abstract class RealmProxyMediator {
      */
     public abstract <E extends RealmObject> E createUsingJsonStream(Class<E> clazz, Realm realm, JsonReader reader) throws java.io.IOException;
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof RealmProxyMediator)) {
+            return false;
+        }
+        RealmProxyMediator other = (RealmProxyMediator) o;
+        return getModelClasses().equals(other.getModelClasses());
+    }
+
+    @Override
+    public int hashCode() {
+        return getModelClasses().hashCode();
+    }
+
     protected static void checkClass(Class<? extends RealmObject> clazz) {
         if (clazz == null) {
             throw new NullPointerException("A class extending RealmObject must be provided");


### PR DESCRIPTION
This changes the Realm caching to work on RealmConfiguration instead of path alone. This is needed to catch subtle errors that path alone cannot, eg. different schema versions in the configuration and different configured schemas.

This means that an IllegalArgumentException will be thrown if:
- Encryption key in two different configurations pointing to the same file are used
- Schema version is different in two different configurations pointing to the same file
- The configured schema is different in two different configurations pointing to the same file.
