### PR TITLE
Querying RealmResults can crash

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
  * Realm will now throw a RealmError when Realm's underlying storage engine encounters an unrecoverable error.
  * @Index annotation can also be applied to byte/short/int/long/boolean/Date now.
  * Fields with annotation @PrimaryKey are indexed automatically now.
+ * Fixed a bug where RealmQuery objects are prematurely garbage collected.
 
 0.81.1
  * Fixed memory leak causing Realm to never release Realm objects.

--- a/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm-jni/src/io_realm_internal_tableview.cpp
@@ -962,9 +962,10 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeRowToString(
     return NULL;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeWhere
-  (JNIEnv *env, jobject, jlong nativeViewPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeWhere(
+    JNIEnv *env, jobject, jlong nativeViewPtr)
 {
+    TR_ENTER_PTR(nativeViewPtr)
     try {
         if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
             return 0;

--- a/realm/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -5,6 +5,7 @@ import android.test.AndroidTestCase;
 import java.util.Date;
 
 import io.realm.entities.AllTypes;
+import io.realm.entities.CatOwner;
 import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
@@ -457,6 +458,22 @@ public class RealmQueryTest extends AndroidTestCase{
         stringOnlies2.sort("chars");
         for (int i = 0; i < stringOnlies2.size(); i++) {
             assertEquals(sorted[i], stringOnlies2.get(i).getChars());
+        }
+    }
+
+    // If the RealmQuery is built on a TableView, it should not crash when used after GC.
+    // See issue #1161 for more details.
+    public void testBuildQueryFromResultsGC() {
+        // According to the testing, setting this to 10 can almost certainly trigger the GC.
+        // Use 30 here can ensure GC happen. (Tested with 4.3 1G Ram and 5.0 3G Ram)
+        final int count = 30;
+        RealmResults<CatOwner> results = testRealm.where(CatOwner.class).findAll();
+
+        for (int i=1; i<=count; i++) {
+            @SuppressWarnings({"unused"})
+            byte garbage[] = TestHelper.allocGarbage(0);
+            results = results.where().findAll();
+            System.gc(); // if a native resource has a reference count = 0, doing GC here might lead to a crash
         }
     }
 }

--- a/realm/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/src/androidTest/java/io/realm/TestHelper.java
@@ -94,4 +94,23 @@ public class TestHelper {
             return 0; // Stub implementation
         }
     }
+
+    // Alloc as much garbage as we can. Pass maxSize = 0 to use it.
+    public static byte[] allocGarbage(int garbageSize) {
+        if (garbageSize == 0) {
+            long maxMemory = Runtime.getRuntime().maxMemory();
+            long totalMemory = Runtime.getRuntime().totalMemory();
+            garbageSize = (int)(maxMemory - totalMemory)/10*9;
+        }
+        byte garbage[];
+        try {
+            garbage = new byte[garbageSize];
+            garbage[0] = 1;
+            garbage[garbage.length - 1] = 1;
+        } catch (OutOfMemoryError oom) {
+            return allocGarbage(garbageSize/10*9);
+        }
+
+        return garbage;
+    }
 }

--- a/realm/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/src/main/java/io/realm/internal/TableQuery.java
@@ -23,19 +23,36 @@ public class TableQuery implements Closeable {
     protected boolean DEBUG = false;
 
     protected long nativePtr;
-    protected final Table parent;
+    protected final Table table;
+    // Don't convert this into local variable and don't remove this.
+    // Core requests Query to hold the TableView reference which it is built from.
+    @SuppressWarnings({"unused"})
+    private final TableOrView origin; // Table or TableView which created this TableQuery
     private final Context context;
 
     private boolean queryValidated = true;
 
     // TODO: Can we protect this?
-    public TableQuery(Context context, Table parent, long nativeQueryPtr){
-        if (DEBUG)
+    public TableQuery(Context context, Table table, long nativeQueryPtr) {
+        if (DEBUG) {
             System.err.println("++++++ new TableQuery, ptr= " + nativeQueryPtr);
+        }
         this.context = context;
-        this.parent = parent;
+        this.table = table;
         this.nativePtr = nativeQueryPtr;
+        this.origin = null;
     }
+
+    public TableQuery(Context context, Table table, long nativeQueryPtr, TableOrView origin) {
+        if (DEBUG) {
+            System.err.println("++++++ new TableQuery, ptr= " + nativeQueryPtr);
+        }
+        this.context = context;
+        this.table = table;
+        this.nativePtr = nativeQueryPtr;
+        this.origin = origin;
+    }
+
 
     public void close() {
         synchronized (context) {
@@ -55,7 +72,7 @@ public class TableQuery implements Closeable {
     protected void finalize() {
         synchronized (context) {
             if (nativePtr != 0) {
-                context.asyncDisposeQuery(nativePtr); 
+                context.asyncDisposeQuery(nativePtr);
                 nativePtr = 0; // Set to 0 if finalize is called before close() for some reason
             }
         }
@@ -472,7 +489,7 @@ public class TableQuery implements Closeable {
         context.executeDelayedDisposal();
         long nativeViewPtr = nativeFindAll(nativePtr, start, end, limit);
         try {
-            return new TableView(this.context, this.parent, nativeViewPtr);
+            return new TableView(this.context, this.table, nativeViewPtr, this);
         } catch (RuntimeException e) {
             TableView.nativeClose(nativeViewPtr);
             throw e;
@@ -486,7 +503,7 @@ public class TableQuery implements Closeable {
         context.executeDelayedDisposal();
         long nativeViewPtr = nativeFindAll(nativePtr, 0, Table.INFINITE, Table.INFINITE);
         try {
-            return new TableView(this.context, this.parent, nativeViewPtr);
+            return new TableView(this.context, this.table, nativeViewPtr, this);
         } catch (RuntimeException e) {
             TableView.nativeClose(nativeViewPtr);
             throw e;
@@ -687,13 +704,13 @@ public class TableQuery implements Closeable {
     // Deletion.
     public long remove(long start, long end) {
         validateQuery();
-        if (parent.isImmutable()) throwImmutable();
+        if (table.isImmutable()) throwImmutable();
         return nativeRemove(nativePtr, start, end, Table.INFINITE);
     }
 
     public long remove() {
         validateQuery();
-        if (parent.isImmutable()) throwImmutable();
+        if (table.isImmutable()) throwImmutable();
         return nativeRemove(nativePtr, 0, Table.INFINITE, Table.INFINITE);
     }
 

--- a/realm/src/main/java/io/realm/internal/TableView.java
+++ b/realm/src/main/java/io/realm/internal/TableView.java
@@ -64,19 +64,40 @@ import java.util.List;
  */
 public class TableView implements TableOrView, Closeable {
     protected boolean DEBUG = false; //true;
+    // Don't convert this into local variable and don't remove this.
+    // Core requests TableView to hold the Query reference.
+    @SuppressWarnings({"unused"})
+    private final TableQuery query; // the query which created this TableView
 
-     /**
+    /**
+     * Creates a TableView. This constructor is used if the TableView is created from a table.
+     *
+     * @param context
+     * @param parent
+     * @param nativePtr
+     */
+    protected TableView(Context context, Table parent, long nativePtr) {
+        this.context = context;
+        this.parent = parent;
+        this.nativePtr = nativePtr;
+        this.query = null;
+    }
+
+    /**
      * Creates a TableView with already created Java TableView Object and a
      * native native TableView object reference. The method is not supposed to
      * be called by the user of the db. The method is for internal use only.
      *
+     * @param context
      * @param parent A table.
-     * @param nativePtr pointer to table.
+     * @param nativePtr pointer to table view.
+     * @param query a reference to the query which the table view is based
      */
-    protected TableView(Context context, Table parent, long nativePtr){
+    protected TableView(Context context, Table parent, long nativePtr, TableQuery query) {
         this.context = context;
         this.parent = parent;
         this.nativePtr = nativePtr;
+        this.query = query;
     }
 
     @Override
@@ -85,7 +106,7 @@ public class TableView implements TableOrView, Closeable {
     }
 
     @Override
-    public void close(){
+    public void close() {
         synchronized (context) {
             if (nativePtr != 0) {
                 nativeClose(nativePtr);
@@ -910,7 +931,7 @@ public class TableView implements TableOrView, Closeable {
         this.context.executeDelayedDisposal();
         long nativeQueryPtr = nativeWhere(nativePtr);
         try {
-            return new TableQuery(this.context, this.parent, nativeQueryPtr);
+            return new TableQuery(this.context, this.parent, nativeQueryPtr, this);
         } catch (RuntimeException e) {
             TableQuery.nativeClose(nativeQueryPtr);
             throw e;


### PR DESCRIPTION
A reported in #1161, querying `RealmResults` might lead to a crash. The reason seems to be that a `TableQuery` might be finalised prematurely, and the native resource is freed. When the native resource is freed, accessing it will cause a segmentation fault.

This fixes #1161 by adding references to TableView and TableQuery in order to prevent premature garbage collection.

@emanuelez @cmelchior @beeender 