### PR TITLE
Dynamic API

### DIFF
--- a/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -367,7 +367,11 @@ public class ClassMetaData {
      * model classes.
      */
     public boolean isModelClass() {
-        return (!classType.toString().endsWith(".RealmObject") && !classType.toString().endsWith("RealmProxy"));
+        String type = classType.toString();
+        if (type.equals("io.realm.dynamic.DynamicRealmObject")) {
+            return false;
+        }
+        return (!type.endsWith(".RealmObject") && !type.endsWith("RealmProxy"));
     }
 
     public String getFullyQualifiedClassName() {

--- a/realm-jni/src/io_realm_internal_CheckedRow.cpp
+++ b/realm-jni/src/io_realm_internal_CheckedRow.cpp
@@ -226,7 +226,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetString
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String))
         return;
 
-    Java_io_realm_internal_CheckedRow_nativeSetString(env, obj, nativeRowPtr, columnIndex, value);
+    Java_io_realm_internal_UncheckedRow_nativeSetString(env, obj, nativeRowPtr, columnIndex, value);
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetByteArray

--- a/realm-jni/src/io_realm_internal_CheckedRow.h
+++ b/realm-jni/src/io_realm_internal_CheckedRow.h
@@ -231,6 +231,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeClose
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeIsAttached
   (JNIEnv *, jobject, jlong);
 
+
 #ifdef __cplusplus
 }
 #endif

--- a/realm-jni/src/io_realm_internal_UncheckedRow.cpp
+++ b/realm-jni/src/io_realm_internal_UncheckedRow.cpp
@@ -288,3 +288,10 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsAttached
     TR_ENTER_PTR(nativeRowPtr)
     return ROW(nativeRowPtr)->is_attached();
 }
+
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeHasColumn
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jstring columnName)
+{
+    jlong ndx = Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(env, obj, nativeRowPtr, columnName);
+    return ndx != to_jlong_or_not_found(realm::not_found);
+}

--- a/realm-jni/src/io_realm_internal_UncheckedRow.h
+++ b/realm-jni/src/io_realm_internal_UncheckedRow.h
@@ -239,6 +239,15 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeClose
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsAttached
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     io_realm_internal_UncheckedRow
+ * Method:    nativeHasField
+ * Signature: (JLjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeHasColumn
+  (JNIEnv *, jobject, jlong, jstring);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -46,6 +46,7 @@ android.libraryVariants.all { variant ->
         source "../realm-annotations/src/main/java"
         ext.androidJar = files(project.android.getBootClasspath())
         classpath = files(variant.javaCompile.classpath.files) + ext.androidJar
+        options.memberLevel = JavadocMemberLevel.PUBLIC
         exclude '**/internal/**'
         exclude '**/BuildConfig.java'
         exclude '**/R.java'

--- a/realm/src/androidTest/java/io/realm/DynamicRealmListTest.java
+++ b/realm/src/androidTest/java/io/realm/DynamicRealmListTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm;
+
+import android.test.AndroidTestCase;
+
+import java.util.Date;
+
+import io.realm.dynamic.DynamicRealmList;
+import io.realm.dynamic.DynamicRealmObject;
+import io.realm.entities.AllJavaTypes;
+import io.realm.entities.Dog;
+
+public class DynamicRealmListTest extends AndroidTestCase {
+
+    private Realm realm;
+    private DynamicRealmObject dynamicObject;
+    private DynamicRealmList dynamicList;
+
+    @Override
+    protected void setUp() throws Exception {
+        RealmConfiguration realmConfig = new RealmConfiguration.Builder(getContext()).schema(AllJavaTypes.class, Dog.class).build();
+        Realm.deleteRealm(realmConfig);
+        realm = Realm.getInstance(realmConfig);
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        obj.setFieldString("str");
+        obj.setFieldShort((short) 1);
+        obj.setFieldInt(1);
+        obj.setFieldLong(1);
+        obj.setFieldByte((byte) 4);
+        obj.setFieldFloat(1.23f);
+        obj.setFieldDouble(1.234d);
+        obj.setFieldBinary(new byte[]{1, 2, 3});
+        obj.setFieldBoolean(true);
+        obj.setFieldDate(new Date(1000));
+        obj.setFieldObject(obj);
+        obj.getFieldList().add(obj);
+        dynamicObject = new DynamicRealmObject(obj);
+        dynamicList = dynamicObject.getList(AllJavaTypes.FIELD_LIST);
+        realm.commitTransaction();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        realm.close();
+    }
+
+    public void testAddNullObjectThrows() {
+        realm.beginTransaction();
+        try {
+            dynamicList.add(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+
+    public void testAddWrongTableClassThrows() {
+        realm.beginTransaction();
+        Dog dog = realm.createObject(Dog.class);
+        try {
+            dynamicList.add(new DynamicRealmObject(dog));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+
+    public void testAddFromWrongRealmThrows() {
+        RealmConfiguration otherConfig = new RealmConfiguration.Builder(getContext()).name("realm2").build();
+        Realm.deleteRealm(otherConfig);
+        Realm realm2 = Realm.getInstance(otherConfig);
+        realm2.beginTransaction();
+        AllJavaTypes realm2Object = realm2.createObject(AllJavaTypes.class);
+        realm2.commitTransaction();
+
+        realm.beginTransaction();
+        try {
+            dynamicList.add(new DynamicRealmObject(realm2Object));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+            realm2.close();
+        }
+    }
+
+    public void testAddObject() {
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        assertEquals(1, dynamicList.size());
+        dynamicList.add(new DynamicRealmObject(obj));
+        realm.commitTransaction();
+
+        assertEquals(2, dynamicList.size());
+    }
+
+    public void testClear() {
+        realm.beginTransaction();
+        dynamicList.clear();
+        realm.commitTransaction();
+
+        assertEquals(0, dynamicList.size());
+    }
+
+    public void testGetIllegalIndexThrows() {
+        int[] indexes = new int[] { -1, 1 };
+        for (int i : indexes) {
+            try {
+                dynamicList.get(i);
+                fail("Could retrieve from index" + i);
+            } catch (IndexOutOfBoundsException ignored) {
+            }
+        }
+    }
+
+    public void testGet() {
+        DynamicRealmObject listObject = dynamicList.get(0);
+        assertEquals(dynamicObject, listObject);
+    }
+
+    public void testSetIllegalLocationThrows() {
+        int[] indexes = new int[] { -1, 1 };
+        for (int i : indexes) {
+            try {
+                realm.beginTransaction();
+                dynamicList.set(i, dynamicObject);
+                fail("Could set index out of bounds " + i);
+            } catch (IndexOutOfBoundsException ignored) {
+            } finally {
+                realm.cancelTransaction();
+            }
+        }
+    }
+
+    public void testSetNullThrows() {
+        realm.beginTransaction();
+        try {
+            dynamicList.set(0, null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+
+    public void testSetWrongTableClassThrows() {
+        realm.beginTransaction();
+        Dog dog = realm.createObject(Dog.class);
+        try {
+            dynamicList.set(0, new DynamicRealmObject(dog));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+
+    public void testSetWrongRealmThrows() {
+        RealmConfiguration otherConfig = new RealmConfiguration.Builder(getContext()).name("realm2").build();
+        Realm.deleteRealm(otherConfig);
+        Realm realm2 = Realm.getInstance(otherConfig);
+        realm2.beginTransaction();
+        AllJavaTypes realm2Object = realm2.createObject(AllJavaTypes.class);
+        realm2.commitTransaction();
+
+        realm.beginTransaction();
+        try {
+            dynamicList.set(0, new DynamicRealmObject(realm2Object));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+            realm2.close();
+        }
+    }
+
+    public void testSet() {
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        obj.setFieldLong(2);
+        dynamicList.set(0, new DynamicRealmObject(obj));
+        realm.commitTransaction();
+
+        assertEquals(1, dynamicList.size());
+        assertEquals(new DynamicRealmObject(obj), dynamicList.get(0));
+    }
+
+    public void testSize() {
+        assertEquals(1, dynamicList.size());
+    }
+}

--- a/realm/src/androidTest/java/io/realm/DynamicRealmObjectTest.java
+++ b/realm/src/androidTest/java/io/realm/DynamicRealmObjectTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm;
+
+import android.test.AndroidTestCase;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import io.realm.dynamic.DynamicRealmList;
+import io.realm.dynamic.DynamicRealmObject;
+import io.realm.entities.AllJavaTypes;
+import io.realm.entities.Dog;
+
+import static io.realm.internal.test.ExtraTests.assertArrayEquals;
+
+public class DynamicRealmObjectTest extends AndroidTestCase {
+
+    private Realm realm;
+    private DynamicRealmObject dObj;
+
+    @Override
+    protected void setUp() throws Exception {
+        RealmConfiguration realmConfig = new RealmConfiguration.Builder(getContext()).build();
+        Realm.deleteRealm(realmConfig);
+        realm = Realm.getInstance(realmConfig);
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        obj.setFieldString("str");
+        obj.setFieldShort((short) 1);
+        obj.setFieldInt(1);
+        obj.setFieldLong(1);
+        obj.setFieldByte((byte) 4);
+        obj.setFieldFloat(1.23f);
+        obj.setFieldDouble(1.234d);
+        obj.setFieldBinary(new byte[]{1, 2, 3});
+        obj.setFieldBoolean(true);
+        obj.setFieldDate(new Date(1000));
+        obj.setFieldObject(obj);
+        obj.getFieldList().add(obj);
+        dObj = new DynamicRealmObject(obj);
+        realm.commitTransaction();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        realm.close();
+    }
+
+    public enum SupportedType {
+        BOOLEAN, SHORT, INT, LONG, BYTE, FLOAT, DOUBLE, STRING, BINARY, DATE, OBJECT, LIST;
+    }
+
+    // Test that all getters fail if given invalid field name
+    public void testGetXXXIllegalFieldNameThrows() {
+
+        // Set arguments
+        String linkedField = AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_STRING;
+        List<String> arguments = Arrays.asList(null, "foo", AllJavaTypes.FIELD_STRING, linkedField);
+        List<String> stringArguments = Arrays.asList(null, "foo", AllJavaTypes.FIELD_BOOLEAN, linkedField);
+
+        // Test all getters
+        for (SupportedType type : SupportedType.values()) {
+            List<String> args = (type == SupportedType.STRING) ? stringArguments : arguments;
+            try {
+                callGetter(type, args);
+                fail();
+            } catch(IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    private void callGetter(SupportedType type, List<String> arguments) {
+        for (String fieldName : arguments) {
+            switch(type) {
+                case BOOLEAN: dObj.getBoolean(fieldName); break;
+                case SHORT: dObj.getShort(fieldName); break;
+                case INT: dObj.getInt(fieldName); break;
+                case LONG: dObj.getLong(fieldName); break;
+                case BYTE: dObj.getByte(fieldName); break;
+                case FLOAT: dObj.getFloat(fieldName); break;
+                case DOUBLE: dObj.getDouble(fieldName); break;
+                case STRING: dObj.getString(fieldName); break;
+                case BINARY: dObj.getBlob(fieldName); break;
+                case DATE: dObj.getDate(fieldName); break;
+                case OBJECT: dObj.getObject(fieldName); break;
+                case LIST: dObj.getList(fieldName); break;
+                default:
+                    fail();
+            }
+        }
+    }
+
+    // Test that all getters fail if given invalid field name
+    public void testSetXXXIllegalFieldnameThrows() {
+
+        // Set arguments
+        String linkedField = AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_STRING;
+        List<String> arguments = Arrays.asList(null, "foo", AllJavaTypes.FIELD_STRING, linkedField);
+        List<String> stringArguments = Arrays.asList(null, "foo", AllJavaTypes.FIELD_BOOLEAN, linkedField);
+
+        // Test all getters
+        for (SupportedType type : SupportedType.values()) {
+            List<String> args = (type == SupportedType.STRING) ? stringArguments : arguments;
+            try {
+                callSetter(type, args);
+                fail();
+            } catch(IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    private void callSetter(SupportedType type, List<String> arguments) {
+        for (String fieldName : arguments) {
+            switch(type) {
+                case BOOLEAN: dObj.setBoolean(fieldName, false); break;
+                case SHORT: dObj.setShort(fieldName, (short) 1); break;
+                case INT: dObj.setInt(fieldName, 1); break;
+                case LONG: dObj.setLong(fieldName, 1L); break;
+                case BYTE: dObj.setByte(fieldName, (byte) 4); break;
+                case FLOAT: dObj.setFloat(fieldName, 1.23f); break;
+                case DOUBLE: dObj.setDouble(fieldName, 1.23d); break;
+                case STRING: dObj.setString(fieldName, "foo"); break;
+                case BINARY: dObj.setBlob(fieldName, new byte[]{}); break;
+                case DATE: dObj.getDate(fieldName); break;
+                case OBJECT: dObj.setObject(fieldName, null); break;
+                case LIST: dObj.setList(fieldName, null); break;
+                default:
+                    fail();
+            }
+        }
+    }
+
+    // Test all simple setters/setters
+    public void testGetterSettersXXX() {
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        DynamicRealmObject dObj = new DynamicRealmObject(obj);
+        try {
+            for (SupportedType type : SupportedType.values()) {
+                switch (type) {
+                    case BOOLEAN:
+                        dObj.setBoolean(AllJavaTypes.FIELD_BOOLEAN, true);
+                        assertTrue(dObj.getBoolean(AllJavaTypes.FIELD_BOOLEAN));
+                        break;
+                    case SHORT:
+                        dObj.setShort(AllJavaTypes.FIELD_SHORT, (short) 42);
+                        assertEquals(42, dObj.getShort(AllJavaTypes.FIELD_SHORT));
+                        break;
+                    case INT:
+                        dObj.setInt(AllJavaTypes.FIELD_INT, 42);
+                        assertEquals(42, dObj.getInt(AllJavaTypes.FIELD_INT));
+                        break;
+                    case LONG:
+                        dObj.setLong(AllJavaTypes.FIELD_LONG, 42L);
+                        assertEquals(42, dObj.getLong(AllJavaTypes.FIELD_LONG));
+                        break;
+                    case BYTE:
+                        dObj.setByte(AllJavaTypes.FIELD_BYTE, (byte) 4);
+                        assertEquals(4, dObj.getByte(AllJavaTypes.FIELD_BYTE));
+                        break;
+                    case FLOAT:
+                        dObj.setFloat(AllJavaTypes.FIELD_FLOAT, 1.23f);
+                        assertEquals(1.23f, dObj.getFloat(AllJavaTypes.FIELD_FLOAT));
+                        break;
+                    case DOUBLE:
+                        dObj.setDouble(AllJavaTypes.FIELD_DOUBLE, 1.234d);
+                        assertEquals(1.234d, dObj.getDouble(AllJavaTypes.FIELD_DOUBLE));
+                        break;
+                    case STRING:
+                        dObj.setString(AllJavaTypes.FIELD_STRING, "str");
+                        assertEquals("str", dObj.getString(AllJavaTypes.FIELD_STRING));
+                        break;
+                    case BINARY:
+                        dObj.setBlob(AllJavaTypes.FIELD_BINARY, new byte[]{1, 2, 3});
+                        assertArrayEquals(new byte[]{1, 2, 3}, dObj.getBlob(AllJavaTypes.FIELD_BINARY));
+                        break;
+                    case DATE:
+                        dObj.setDate(AllJavaTypes.FIELD_DATE, new Date(1000));
+                        assertEquals(new Date(1000), dObj.getDate(AllJavaTypes.FIELD_DATE));
+                        break;
+                    case OBJECT:
+                        dObj.setObject(AllJavaTypes.FIELD_OBJECT, dObj);
+                        assertEquals(dObj, dObj.getObject(AllJavaTypes.FIELD_OBJECT));
+                        break;
+                    case LIST:
+                    /* ignore, see testGetList/testSetList */
+                        break;
+                    default:
+                        fail();
+                }
+            }
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+
+    public void testSetXXXNullValues() {
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        DynamicRealmObject dObj = new DynamicRealmObject(obj);
+        try {
+            for (SupportedType type : SupportedType.values()) {
+                switch (type) {
+                    case OBJECT:
+                        dObj.setObject(AllJavaTypes.FIELD_OBJECT, null);
+                        assertNull(dObj.getObject(AllJavaTypes.FIELD_OBJECT));
+                        break;
+                    case LIST:
+                    case BOOLEAN:
+                    case SHORT:
+                    case INT:
+                    case LONG:
+                    case FLOAT:
+                    case DOUBLE:
+                    case STRING:
+                    case BINARY:
+                    case DATE:
+                    default:
+                        continue; // Ignore other types for now
+                }
+            }
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+
+    public void testSetObjectWrongTypeThrows() {
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        Dog otherObj = realm.createObject(Dog.class);
+        DynamicRealmObject dynamicObj = new DynamicRealmObject(obj);
+        DynamicRealmObject dynamicWrongType = new DynamicRealmObject(otherObj);
+        try {
+            dynamicObj.setObject(AllJavaTypes.FIELD_OBJECT, dynamicWrongType);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    // List is not a simple getter, test separately.
+    public void testGetList() {
+        DynamicRealmList list = dObj.getList(AllJavaTypes.FIELD_LIST);
+        assertEquals(1, list.size());
+        assertEquals(dObj, list.get(0));
+    }
+
+    public void testIsNullWithNullNotSupportedField() {
+        assertFalse(dObj.isNull(AllJavaTypes.FIELD_INT));
+    }
+
+    public void testIsNullTrue() {
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        realm.commitTransaction();
+
+        assertTrue(new DynamicRealmObject(obj).isNull(AllJavaTypes.FIELD_OBJECT));
+    }
+
+    public void testIsNullFalse() {
+        assertFalse(dObj.isNull(AllJavaTypes.FIELD_OBJECT));
+    }
+
+    public void testGetFieldNames() {
+        String[] expectedKeys = { AllJavaTypes.FIELD_STRING, AllJavaTypes.FIELD_SHORT, AllJavaTypes.FIELD_INT,
+                AllJavaTypes.FIELD_LONG, AllJavaTypes.FIELD_BYTE, AllJavaTypes.FIELD_FLOAT, AllJavaTypes.FIELD_DOUBLE,
+                AllJavaTypes.FIELD_BOOLEAN, AllJavaTypes.FIELD_DATE, AllJavaTypes.FIELD_BINARY,
+                AllJavaTypes.FIELD_OBJECT, AllJavaTypes.FIELD_LIST };
+        String[] keys = dObj.getFieldNames();
+        assertArrayEquals(expectedKeys, keys);
+    }
+
+    public void testHasFieldFalse() {
+        assertFalse(dObj.hasField(null));
+        assertFalse(dObj.hasField(""));
+        assertFalse(dObj.hasField("foo"));
+        assertFalse(dObj.hasField("foo.bar"));
+    }
+
+    public void testHasFieldTrue() {
+        assertTrue(dObj.hasField(AllJavaTypes.FIELD_STRING));
+    }
+
+    public void testEquals() {
+        AllJavaTypes obj1 = realm.where(AllJavaTypes.class).findFirst();
+        AllJavaTypes obj2 = realm.where(AllJavaTypes.class).findFirst();
+        DynamicRealmObject dObj1 = new DynamicRealmObject(obj1);
+        DynamicRealmObject dObj2 = new DynamicRealmObject(obj2);
+        assertTrue(dObj1.equals(dObj2));
+    }
+
+    public void testStandardAndDynamicObjectsNotEqual() {
+        AllJavaTypes standardObj = realm.where(AllJavaTypes.class).findFirst();
+        assertFalse(dObj.equals(standardObj));
+    }
+
+    public void testHashcode() {
+        AllJavaTypes standardObj = realm.where(AllJavaTypes.class).findFirst();
+        DynamicRealmObject dObj1 = new DynamicRealmObject(standardObj);
+        assertEquals(standardObj.hashCode(), dObj1.hashCode());
+    }
+
+    public void testToString() {
+        // Check that toString() doesn't crash. And do simple formatting checks. We cannot compare to a set String as
+        // eg. the byte array will be allocated each time it is accessed.
+        String str = dObj.toString();
+        assertTrue(str.startsWith("class_AllJavaTypes = ["));
+        assertTrue(str.endsWith("}]"));
+    }
+}

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import io.realm.dynamic.DynamicRealmObject;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.Cat;
@@ -1720,6 +1721,15 @@ public class RealmTest extends AndroidTestCase {
         } else {
             android.util.Log.d(RealmTest.class.getName(), "FinalizerRunnable freed : "
                     + (totalNumberOfReferences - references.size()) + " out of " + totalNumberOfReferences);
+        }
+    }
+
+    public void testCannotCreateDynamicRealmObject() {
+        testRealm.beginTransaction();
+        try {
+            testRealm.createObject(DynamicRealmObject.class);
+            fail();
+        } catch (RealmException ignored) {
         }
     }
 

--- a/realm/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/src/androidTest/java/io/realm/TestHelper.java
@@ -19,16 +19,15 @@ package io.realm;
 import android.content.Context;
 import android.content.res.AssetManager;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-
 import java.io.InputStreamReader;
-import java.util.Random;
 import java.nio.charset.Charset;
+import java.util.Random;
 
 public class TestHelper {
 

--- a/realm/src/androidTest/java/io/realm/entities/AllJavaTypes.java
+++ b/realm/src/androidTest/java/io/realm/entities/AllJavaTypes.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import java.util.Date;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.Index;
+import io.realm.annotations.PrimaryKey;
+
+public class AllJavaTypes extends RealmObject{
+
+    public static String FIELD_IGNORED = "fieldIgnored";
+    public static String FIELD_STRING = "fieldString";
+    public static String FIELD_SHORT = "fieldShort";
+    public static String FIELD_INT = "fieldInt";
+    public static String FIELD_LONG = "fieldLong";
+    public static String FIELD_BYTE = "fieldByte";
+    public static String FIELD_FLOAT = "fieldFloat";
+    public static String FIELD_DOUBLE = "fieldDouble";
+    public static String FIELD_BOOLEAN = "fieldBoolean";
+    public static String FIELD_DATE = "fieldDate";
+    public static String FIELD_BINARY = "fieldBinary";
+    public static String FIELD_OBJECT = "fieldObject";
+    public static String FIELD_LIST = "fieldList";
+
+    @Ignore private String fieldIgnored;
+    @Index private String fieldString;
+    private short fieldShort;
+    private int fieldInt;
+    @PrimaryKey private long fieldLong;
+    private byte fieldByte;
+    private float fieldFloat;
+    private double fieldDouble;
+    private boolean fieldBoolean;
+    private Date fieldDate;
+    private byte[] fieldBinary;
+    private AllJavaTypes fieldObject;
+    private RealmList<AllJavaTypes> fieldList;
+
+    public String getFieldIgnored() {
+        return fieldIgnored;
+    }
+
+    public void setFieldIgnored(String fieldIgnored) {
+        this.fieldIgnored = fieldIgnored;
+    }
+
+    public String getFieldString() {
+        return fieldString;
+    }
+
+    public void setFieldString(String fieldString) {
+        this.fieldString = fieldString;
+    }
+
+    public short getFieldShort() {
+        return fieldShort;
+    }
+
+    public void setFieldShort(short fieldShort) {
+        this.fieldShort = fieldShort;
+    }
+
+    public int getFieldInt() {
+        return fieldInt;
+    }
+
+    public void setFieldInt(int fieldInt) {
+        this.fieldInt = fieldInt;
+    }
+
+    public long getFieldLong() {
+        return fieldLong;
+    }
+
+    public void setFieldLong(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public byte getFieldByte() {
+        return fieldByte;
+    }
+
+    public void setFieldByte(byte fieldByte) {
+        this.fieldByte = fieldByte;
+    }
+
+    public float getFieldFloat() {
+        return fieldFloat;
+    }
+
+    public void setFieldFloat(float fieldFloat) {
+        this.fieldFloat = fieldFloat;
+    }
+
+    public double getFieldDouble() {
+        return fieldDouble;
+    }
+
+    public void setFieldDouble(double fieldDouble) {
+        this.fieldDouble = fieldDouble;
+    }
+
+    public boolean isFieldBoolean() {
+        return fieldBoolean;
+    }
+
+    public void setFieldBoolean(boolean fieldBoolean) {
+        this.fieldBoolean = fieldBoolean;
+    }
+
+    public Date getFieldDate() {
+        return fieldDate;
+    }
+
+    public void setFieldDate(Date fieldDate) {
+        this.fieldDate = fieldDate;
+    }
+
+    public byte[] getFieldBinary() {
+        return fieldBinary;
+    }
+
+    public void setFieldBinary(byte[] fieldBinary) {
+        this.fieldBinary = fieldBinary;
+    }
+
+    public AllJavaTypes getFieldObject() {
+        return fieldObject;
+    }
+
+    public void setFieldObject(AllJavaTypes columnRealmObject) {
+        this.fieldObject = columnRealmObject;
+    }
+
+    public RealmList<AllJavaTypes> getFieldList() {
+        return fieldList;
+    }
+
+    public void setFieldList(RealmList<AllJavaTypes> columnRealmList) {
+        this.fieldList = columnRealmList;
+    }
+}

--- a/realm/src/main/java/io/realm/RealmObject.java
+++ b/realm/src/main/java/io/realm/RealmObject.java
@@ -106,4 +106,22 @@ public abstract class RealmObject {
     public boolean isValid() {
         return row != null && row.isAttached();
     }
+
+    /**
+     * Returns the Realm instance this object belongs to. Internal use only.
+     *
+     * @return The Realm this object belongs to or {@code null} if it is a standalone object.
+     */
+    protected static Realm getRealm(RealmObject obj) {
+        return obj.realm;
+    }
+
+    /**
+     * Returns the {@link Row} representing this object. Internal use only.
+     *
+     * @return The {@link Row} this object belongs to or {@code null} if it is a standalone object.
+     */
+    protected static Row getRow(RealmObject obj) {
+        return obj.row;
+    }
 }

--- a/realm/src/main/java/io/realm/dynamic/DynamicRealmList.java
+++ b/realm/src/main/java/io/realm/dynamic/DynamicRealmList.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.dynamic;
+
+import java.util.AbstractList;
+import java.util.List;
+
+import io.realm.Realm;
+import io.realm.internal.LinkView;
+
+/**
+ * {@link io.realm.RealmList} exposed using a dynamic API. All objects in the list must have the same schema even though
+ * they are accessed dynamically. Null values are not allowed in this list.
+ */
+public class DynamicRealmList extends AbstractList<DynamicRealmObject> {
+
+    private final LinkView linkView;
+    private final Realm realm;
+
+    DynamicRealmList(LinkView linkView, Realm realm) {
+        this.linkView = linkView;
+        this.realm = realm;
+    }
+
+    /**
+     * Adds the specified object at the end of this List.
+     *
+     * @param object the object to add.
+     * @return true
+     * @throws IllegalArgumentException if object is either {@code null} or has the wrong type.
+     */
+    @Override
+    public boolean add(DynamicRealmObject object) {
+        checkIsValidObject(object);
+        linkView.add(object.row.getIndex());
+        return true;
+    }
+
+    /**
+     * Removes all elements from this list, leaving it empty.
+     *
+     * @see List#isEmpty
+     * @see List#size
+     */
+    @Override
+    public void clear() {
+        linkView.clear();
+    }
+
+    /**
+     * Returns the element at the specified location in this list.
+     *
+     * @param location the index of the element to return.
+     * @return the element at the specified index.
+     * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
+     */
+    @Override
+    public DynamicRealmObject get(int location) {
+        checkValidIndex(location);
+        return new DynamicRealmObject(realm, linkView.getCheckedRow(location));
+    }
+
+    /**
+     * Removes the object at the specified location from this list.
+     *
+     * @param location the index of the object to remove.
+     * @return the removed object.
+     * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
+     */
+    @Override
+    public DynamicRealmObject remove(int location) {
+        DynamicRealmObject removedItem = get(location);
+        linkView.remove(location);
+        return removedItem;
+    }
+
+    /**
+     * Replaces the element at the specified location in this list with the
+     * specified object.
+     *
+     * @param location the index at which to put the specified object.
+     * @param object the object to add.
+     * @return the previous element at the index.
+     * @throws IllegalArgumentException if object is either {@code null} or has the wrong type.
+     * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
+     */
+    @Override
+    public DynamicRealmObject set(int location, DynamicRealmObject object) {
+        checkIsValidObject(object);
+        checkValidIndex(location);
+        linkView.set(location, object.row.getIndex());
+        return object;
+    }
+
+    /**
+     * Returns the number of elements in this list.
+     *
+     * @return the number of elements in this list.
+     */
+    @Override
+    public int size() {
+        long size = linkView.size();
+        return size < Integer.MAX_VALUE ? (int) size : Integer.MAX_VALUE;
+    }
+
+    private void checkIsValidObject(DynamicRealmObject object) {
+        if (object == null) {
+            throw new IllegalArgumentException("DynamicRealmList does not accept null values");
+        }
+        if (!realm.getConfiguration().equals(object.realm.getConfiguration())) {
+            throw new IllegalArgumentException("Cannot add an object belonging to another Realm");
+        }
+        if (!linkView.getTable().hasSameSchema(object.row.getTable())) {
+            String expectedClass = linkView.getTable().getName();
+            String objectClassName = object.row.getTable().getName();
+            throw new IllegalArgumentException("Object is of type " + objectClassName + ". Expected " + expectedClass);
+        }
+    }
+
+    private void checkValidIndex(int index) {
+        long size = linkView.size();
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException(String.format("Invalid index: %d. Valid range is [%d, %d]", index, 0, size - 1));
+        }
+    }
+}

--- a/realm/src/main/java/io/realm/dynamic/DynamicRealmObject.java
+++ b/realm/src/main/java/io/realm/dynamic/DynamicRealmObject.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.dynamic;
+
+import java.util.Date;
+
+import io.realm.Realm;
+import io.realm.RealmObject;
+import io.realm.internal.CheckedRow;
+import io.realm.internal.ColumnType;
+import io.realm.internal.InvalidRow;
+import io.realm.internal.LinkView;
+import io.realm.internal.Row;
+import io.realm.internal.Table;
+import io.realm.internal.UncheckedRow;
+
+/**
+ * Class that wraps a normal RealmObject in order to allow dynamic access instead of a typed interface.
+ * Using a DynamicRealmObject is slower than using the regular model class.
+ */
+public class DynamicRealmObject extends RealmObject {
+
+     Realm realm;
+     Row row;
+
+    /**
+     * Creates a dynamic Realm object based on a existing object.
+     *
+     * @param obj Realm object to convert to a dynamic object. Only objects managed by Realm can be used.
+     * @throws IllegalArgumentException if object isn't managed by a Realm.
+     */
+    public DynamicRealmObject(RealmObject obj) {
+        if (obj == null) {
+            throw new IllegalArgumentException("Non-null object must be provided.");
+        }
+        Row row = RealmObject.getRow(obj);
+        if (row == null) {
+            throw new IllegalArgumentException("A object managed by Realm must be provided. This is a standalone object.");
+        }
+        this.realm = RealmObject.getRealm(obj);
+        this.row = (row instanceof CheckedRow) ? (CheckedRow) row : ((UncheckedRow) row).convertToChecked();
+    }
+
+    // Create a dynamic object. Only used internally
+    DynamicRealmObject(Realm realm, CheckedRow row) {
+        this.realm = realm;
+        this.row = row;
+    }
+
+    /**
+     * Returns the {@code boolean} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The boolean value.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain booleans.
+     */
+    public boolean getBoolean(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return row.getBoolean(columnIndex);
+    }
+
+    /**
+     * Returns the {@code int} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The int value. Integer values exceeding {@code Integer.MAX_VALUE} will wrap.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain integers.
+     */
+    public int getInt(String fieldName) {
+        return (int) getLong(fieldName);
+    }
+
+    /**
+     * Returns the {@code short} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The short value. Integer values exceeding {@code Short.MAX_VALUE} will wrap.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain integers.
+     */
+    public short getShort(String fieldName) {
+        return (short) getLong(fieldName);
+    }
+
+    /**
+     * Returns the {@code long} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The long value. Integer values exceeding {@code Long.MAX_VALUE} will wrap.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain integers.
+     */
+    public long getLong(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return row.getLong(columnIndex);
+    }
+
+    /**
+     * Returns the {@code byte} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The byte value.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain integers.
+     */
+    public byte getByte(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return (byte) row.getLong(columnIndex);
+    }
+
+    /**
+     * Returns the {@code float} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The float value.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain floats.
+     */
+    public float getFloat(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return row.getFloat(columnIndex);
+    }
+
+    /**
+     * Returns the {@code double} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The double value.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain doubles.
+     */
+    public double getDouble(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return row.getDouble(columnIndex);
+    }
+
+    /**
+     * Returns the {@code byte[]} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The byte[] value.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain binary data.
+     */
+    public byte[] getBlob (String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return row.getBinaryByteArray(columnIndex);
+    }
+
+    /**
+     * Returns the {@code String} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The String value.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain Strings.
+     */
+    public String getString(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return row.getString(columnIndex);
+    }
+
+    /**
+     * Returns the {@code Date} value for a given field.
+     *
+     * @param fieldName Name of field.
+     * @return The Date value.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain Dates.
+     */
+    public Date getDate(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return row.getDate(columnIndex);
+    }
+
+    /**
+     * Returns the object being linked to from this field.
+     *
+     * @param fieldName Name of field.
+     * @return The {@link DynamicRealmObject} representation of the linked object or {@code null} if no object is linked.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain links to other objects.
+     */
+    public DynamicRealmObject getObject(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        if (row.isNullLink(columnIndex)) {
+            return null;
+        } else {
+            long linkRowIndex = row.getLink(columnIndex);
+            CheckedRow linkRow = row.getTable().getCheckedRow(linkRowIndex);
+            return new DynamicRealmObject(realm, linkRow);
+        }
+    }
+
+    /**
+     * Returns the {@link io.realm.RealmList} of objects being linked to from this field. This list is returned
+     * as a {@link DynamicRealmList}.
+     *
+     * @param fieldName Name of field.
+     * @return the {@link DynamicRealmList} representation of the RealmList.
+     * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain a list of links.
+     */
+    public DynamicRealmList getList(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        return new DynamicRealmList(row.getLinkList(columnIndex), realm);
+    }
+
+    /**
+     * Checks if the value of a given field is {@code null}.
+     *
+     * @param fieldName Name of field.
+     * @return {@code true} if field value is null, {@code false} otherwise.
+     * @throws IllegalArgumentException if field name doesn't exists.
+     */
+    public boolean isNull(String fieldName) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        ColumnType type = row.getColumnType(columnIndex);
+        switch (type) {
+            case LINK:
+            case LINK_LIST:
+                return row.isNullLink(columnIndex);
+            case BOOLEAN:
+            case INTEGER:
+            case FLOAT:
+            case DOUBLE:
+            case STRING:
+            case BINARY:
+            case DATE:
+            case TABLE:
+            case MIXED:
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Checks whether an object has the given field or not.
+     * @param fieldName Field name to check.
+     * @return {@code true} if the object has a field with the given name, {@code false} otherwise.
+     */
+    public boolean hasField(String fieldName) {
+        if (fieldName == null || fieldName.isEmpty()) {
+            return false;
+        }
+        return row.hasColumn(fieldName);
+    }
+
+    /**
+     * Returns the list of field names on this object.
+     *
+     * @return list of field names on this objects or the empty list if the object doesn't have any fields.
+     */
+    public String[] getFieldNames() {
+        String[] keys = new String[(int) row.getColumnCount()];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = row.getColumnName(i);
+        }
+        return keys;
+    }
+
+    /**
+     * Sets the {@code boolean} value of the given field.
+     *
+     * @param fieldName Field name to update.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't a boolean field.
+     */
+    public void setBoolean(String fieldName, boolean value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setBoolean(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code short} value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't an integer field.
+     */
+    public void setShort(String fieldName, short value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setLong(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code int} value of the given field.
+     *
+     * @param fieldName Field name to update.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't an integer field.
+     */
+    public void setInt(String fieldName, int value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setLong(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code long} value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't an integer field.
+     */
+    public void setLong(String fieldName, long value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setLong(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code byte} value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't an integer field.
+     */
+    public void setByte(String fieldName, byte value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setLong(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code float} value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't an integer field.
+     */
+    public void setFloat(String fieldName, float value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setFloat(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code double} value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't a double field.
+     */
+    public void setDouble(String fieldName, double value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setDouble(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code String} value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't a String field.
+     */
+    public void setString(String fieldName, String value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setString(columnIndex, value);
+    }
+
+    /**
+     * Sets the binary value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't a binary field.
+     */
+    public void setBlob(String fieldName, byte[] value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setBinaryByteArray(columnIndex, value);
+    }
+
+    /**
+     * Sets the {@code Date} value of the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Value to insert.
+     * @throws IllegalArgumentException if field name doesn't exists or isn't a Date field.
+     */
+    public void setDate(String fieldName, Date value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        row.setDate(columnIndex, value);
+    }
+
+    /**
+     * Sets a reference to another object on the given field.
+     *
+     * @param fieldName Field name.
+     * @param value Object to link to.
+     * @throws IllegalArgumentException if field name doesn't exists, it doesn't link to other Realm objects, or the type
+     * of DynamicRealmObject doesn't match.
+     */
+    public void setObject(String fieldName, DynamicRealmObject value) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        if (value == null) {
+            row.nullifyLink(columnIndex);
+        } else {
+            if (value.realm == null || value.row == null) {
+                throw new IllegalArgumentException("Cannot link to objects that are not part of the Realm.");
+            }
+            if (!realm.getConfiguration().equals(value.realm.getConfiguration())) {
+                throw new IllegalArgumentException("Cannot add an object from another Realm");
+            }
+            Table table = row.getTable();
+            Table inputTable = value.row.getTable();
+            if (!table.hasSameSchema(inputTable)) {
+                throw new IllegalArgumentException(String.format("Type of object is wrong. Was %s, expected %s",
+                        inputTable.getName(), table.getName()));
+            }
+            row.setLink(columnIndex, value.row.getIndex());
+        }
+    }
+
+    /**
+     * Sets the reference to a {@link DynamicRealmList} on the given field.
+     *
+     * @param fieldName Field name.
+     * @param list List of references.
+     * @throws IllegalArgumentException if field name doesn't exists, it doesn't contain a list of links or the type
+     * of the object represented by the DynamicRealmObject doesn't match.
+     */
+    public void setList(String fieldName, DynamicRealmList list) {
+        long columnIndex = row.getColumnIndex(fieldName);
+        LinkView links = row.getLinkList(columnIndex);
+        links.clear();
+        for (DynamicRealmObject obj : list) {
+            links.add(obj.row.getIndex());
+        }
+    }
+
+    /**
+     * Deletes this object from the Realm. Accessing any fields after removing the object will throw an
+     * {@link IllegalStateException}.
+     */
+    public void removeFromRealm() {
+        row.getTable().moveLastOver(row.getIndex());
+        row = InvalidRow.INSTANCE;
+    }
+
+    /**
+     * Return the type of object. This will normally correspond to the name of a model class that is extending
+     * {@link RealmObject}.
+     *
+     * @return This objects type.
+     */
+    public String getType() {
+        return row.getTable().getName().substring(Table.TABLE_PREFIX.length());
+    }
+
+    @Override
+    public int hashCode() {
+        String realmName = realm.getPath();
+        String tableName = row.getTable().getName();
+        long rowIndex = row.getIndex();
+
+        int result = 17;
+        result = 31 * result + ((realmName != null) ? realmName.hashCode() : 0);
+        result = 31 * result + ((tableName != null) ? tableName.hashCode() : 0);
+        result = 31 * result + (int) (rowIndex ^ (rowIndex >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DynamicRealmObject other = (DynamicRealmObject) o;
+
+        String path = realm.getPath();
+        String otherPath = other.realm.getPath();
+        if (path != null ? !path.equals(otherPath) : otherPath != null) {
+            return false;
+        }
+
+        String tableName = row.getTable().getName();
+        String otherTableName = other.row.getTable().getName();
+        if (tableName != null ? !tableName.equals(otherTableName) : otherTableName != null) {
+            return false;
+        }
+
+        return row.getIndex() == other.row.getIndex();
+    }
+
+    @Override
+    public String toString() {
+        if (row == null || !row.isAttached()) {
+            return "Invalid object";
+        }
+        StringBuilder sb = new StringBuilder(row.getTable().getName() + " = [");
+        String[] fields = getFieldNames();
+        for (String field : fields) {
+            long columnIndex = row.getColumnIndex(field);
+            ColumnType type = row.getColumnType(columnIndex);
+            sb.append("{");
+            switch (type) {
+                case BOOLEAN: sb.append(field + ": " + row.getBoolean(columnIndex)); break;
+                case INTEGER: sb.append(field + ": " + row.getLong(columnIndex)); break;
+                case FLOAT: sb.append(field + ": " + row.getFloat(columnIndex)); break;
+                case DOUBLE: sb.append(field + ": " + row.getDouble(columnIndex)); break;
+                case STRING: sb.append(field + ": " + row.getString(columnIndex)); break;
+                case BINARY: sb.append(field + ": " + row.getBinaryByteArray(columnIndex)); break;
+                case DATE: sb.append(field + ": " + row.getDate(columnIndex)); break;
+                case LINK:
+                    if (row.isNullLink(columnIndex)) {
+                        sb.append("null");
+                    } else {
+                        sb.append(field + ": " + row.getTable().getLinkTarget(columnIndex).getName());
+                    }
+                    break;
+                case LINK_LIST:
+                    String targetType = row.getTable().getLinkTarget(columnIndex).getName();
+                    sb.append(String.format("%s: RealmList<%s>[%s]", field, targetType, row.getLinkList(columnIndex).size()));
+                    break;
+                case TABLE:
+                case MIXED:
+                default:
+                    sb.append(field + ": ?");
+            }
+            sb.append("}, ");
+        }
+        sb.replace(sb.length() - 2, sb.length(), "");
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/realm/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/src/main/java/io/realm/internal/CheckedRow.java
@@ -82,7 +82,7 @@ public class CheckedRow extends UncheckedRow {
         if (columnType == ColumnType.LINK || columnType == ColumnType.LINK_LIST) {
             return super.isNullLink(columnIndex);
         } else {
-            return false; // Unsupported types are never null
+            return false; // Unsupported types always return false
         }
     }
 

--- a/realm/src/main/java/io/realm/internal/InvalidRow.java
+++ b/realm/src/main/java/io/realm/internal/InvalidRow.java
@@ -171,6 +171,11 @@ public enum InvalidRow implements Row {
         throw getStubException();
     }
 
+    @Override
+    public boolean hasColumn(String fieldName) {
+        throw getStubException();
+    }
+
     private RuntimeException getStubException() {
         return new IllegalStateException("Object is no longer managed by Realm. Has it been deleted?");
     }

--- a/realm/src/main/java/io/realm/internal/Row.java
+++ b/realm/src/main/java/io/realm/internal/Row.java
@@ -105,4 +105,11 @@ public interface Row {
      * data. {@code false} otherwise.
      */
     boolean isAttached();
+
+    /**
+     * Returns {@code true} if the field name exists.
+     * @param fieldName Field name to check.
+     * @return {@code true} if field name exists, {@code false} otherwise.
+     */
+    boolean hasColumn(String fieldName);
 }

--- a/realm/src/main/java/io/realm/internal/Table.java
+++ b/realm/src/main/java/io/realm/internal/Table.java
@@ -30,6 +30,7 @@ import io.realm.exceptions.RealmException;
  */
 public class Table implements TableOrView, TableSchema, Closeable {
 
+    public static final String TABLE_PREFIX = "class_";
     public static final long INFINITE = -1;
     public static final String STRING_DEFAULT_VALUE = "";
     public static final long INTEGER_DEFAULT_VALUE = 0;

--- a/realm/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/src/main/java/io/realm/internal/UncheckedRow.java
@@ -254,6 +254,11 @@ public class UncheckedRow extends NativeObject implements Row {
         return nativePointer != 0 && nativeIsAttached(nativePointer);
     }
 
+    @Override
+    public boolean hasColumn(String fieldName) {
+        return nativeHasColumn(nativePointer, fieldName);
+    }
+
     protected native long nativeGetColumnCount(long nativeTablePtr);
     protected native String nativeGetColumnName(long nativeTablePtr, long columnIndex);
     protected native long nativeGetColumnIndex(long nativeTablePtr, String columnName);
@@ -283,4 +288,5 @@ public class UncheckedRow extends NativeObject implements Row {
     protected native void nativeNullifyLink(long nativeRowPtr, long columnIndex);
     protected static native void nativeClose(long nativeRowPtr);
     protected native boolean nativeIsAttached(long nativeRowPtr);
+    protected native boolean nativeHasColumn(long nativeRowPtr, String columnName);
 }


### PR DESCRIPTION
This PR is a prerequisite for the new Migration API. It adds support for manipulating RealmObjects/RealmList using a Dynamic API instead of the current type safe one.

Implementation details:
DynamicRealmList currently only extends AbstractList instead of RealmList. This is to avoid also having to make a dynamic query API as well, which seemed a bit overkill for migration purposes. For a full blown dynamic API it will be needed, but for the purpose of Migrations I think it can be left out.

```
public interface DynamicRealmObjectInterface {
    boolean getBoolean(String fieldName);
    int getInt(String fieldName);
    short getShort(String fieldName);
    long getLong(String fieldName);
    byte getByte(String fieldName);
    float getFloat(String fieldName);
    double getDouble(String fieldName);
    byte[] getBlob(String fieldName);
    String getString(String fieldName);
    Date getDate(String fieldName);
    DynamicRealmObject getObject(String fieldName);
    DynamicRealmList getList(String fieldName);
    void setBoolean(String fieldName, boolean value);
    void setShort(String fieldName, short value);
    void setInt(String fieldName, int value);
    void setLong(String fieldName, long value);
    void setByte(String fieldName, byte value);
    void setFloat(String fieldName, float value);
    void setDouble(String fieldName, double value);
    void setString(String fieldName, String value);
    void setBlob(String fieldName, byte[] value);
    void setDate(String fieldName, Date value);
    void setObject(String fieldName, DynamicRealmObject value);
    void setList(String fieldName, DynamicRealmList list);
    boolean isNull(String fieldName);
    boolean hasField(String fieldName);
    String[] getFieldNames();
    void removeFromRealm();
}
```
 How to support the difference between null fields and not-nullable fields? Solution: add ```isNull``` for getters. Override setters: ```setInt(int)``` and ```setInt(Integer)```.