### PR TITLE
Use s3cmd to perform the deployment of releases

### DIFF
--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -250,33 +250,31 @@ examples.each() { src, dest ->
     }
 }
 
-apply plugin: 's3'
+task uploadDistributionPackage(type: Exec) {
+    examples.each { src, dest ->
+        dependsOn "distributionMonkey${dest}"
+    }
+    commandLine 's3cmd', 'put', "${rootDir}/realm-java-${version}.zip", 's3://static.realm.io/downloads/java/'
+}
 
-import com.github.skhatri.s3aws.plugin.S3UploadTask
+task createEmptyFile(type: Exec) {
+    dependsOn uploadDistributionPackage
+    commandLine 'touch', 'latest'
+}
 
-// This is an ugly hack because we have two links to the latest version.
-// The right solution here would be to contribute a change to the S3 Gradle plugin
-// to allow link to be a list of strings.
 ['java', 'android'].each() { link ->
-    task "upload${link.capitalize()}DistributionPackage"(type: S3UploadTask) {
-        examples.each { src, dest ->
-            dependsOn "distributionMonkey${dest}"
-        }
-        bucket = 'static.realm.io'
-        file = "${rootDir}/realm-java-${version}.zip"
-        key = 'downloads/java/realm-java-${version}.zip'
-        link = "downloads/${link}/latest"
+    task "upload${link.capitalize()}LatestLink"(type: Exec) {
+        dependsOn createEmptyFile
+        commandLine 's3cmd', 'put', 'latest', "--add-header=x-amz-website-redirect-location:/downloads/java/realm-java-${version}.zip", "s3://static.realm.io/downloads/${link}/latest"
     }
 }
 
-task uploadUpdateVersion(type: S3UploadTask) {
+
+task uploadUpdateVersion(type: Exec) {
     ['java', 'android'].each() { link ->
-        dependsOn "upload${link.capitalize()}DistributionPackage"
+        dependsOn "upload${link.capitalize()}LatestLink"
     }
-    bucket = 'static.realm.io'
-    file = "${rootDir}/version.txt"
-    key = 'update/java'
-    link = 'downloads/temp/update-java'
+    commandLine 's3cmd', 'put', "${rootDir}/version.txt", 's3://static.realm.io/update/java'
 }
 
 task tagRepo(type: Exec) {


### PR DESCRIPTION
Fixes #893 

This assumes that the S3 credentials have already been setup with s3cmd --configure on the hosting machine