### PR TITLE
size() now respect the Collection.size() contract.

### DIFF
--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -291,7 +291,8 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     @Override
     public int size() {
         if (managedMode) {
-            return ((Long)view.size()).intValue();
+            long size = view.size();
+            return size < Integer.MAX_VALUE ? (int) size : Integer.MAX_VALUE;
         } else {
             return nonManagedList.size();
         }


### PR DESCRIPTION
Small fix for an issue that crept up when reviewing DynamicObject. 

Realm theoretically support collections larger that Integer.MAX_VALUE. Collections.size() has a return type of int and right now we just cast the size potentially overflowing the value. 

For reference: http://docs.oracle.com/javase/7/docs/api/java/util/Collection.html#size()

@emanuelez @nhachicha @kneth 

No changelog, because....really?