### PR TITLE
Allow the Realm Gradle plugin to modify the bytecode

### DIFF
--- a/gradle-plugin/buildSrc/build.gradle
+++ b/gradle-plugin/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 rootProject.dependencies {

--- a/gradle-plugin/plugin/build.gradle
+++ b/gradle-plugin/plugin/build.gradle
@@ -1,6 +1,12 @@
 apply plugin: 'groovy'
 
+repositories {
+    jcenter()
+}
+
 dependencies {
     compile gradleApi()
     compile localGroovy()
+    compile 'com.android.tools.build:gradle:1.2.3'
+    compile 'org.javassist:javassist:3.18.2-GA'
 }

--- a/gradle-plugin/plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -1,13 +1,126 @@
 package io.realm.gradle
-
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryPlugin
+import javassist.*
+import javassist.expr.ExprEditor
+import javassist.expr.FieldAccess
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.compile.JavaCompile
 
 class Realm implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-    	project.repositories.add(project.repositories.jcenter())
+        // Make sure the project is either an Android application or library
+        def isAndroidApp = project.plugins.withType(AppPlugin)
+        def isAndroidLib = project.plugins.withType(LibraryPlugin)
+        if (!isAndroidApp && !isAndroidLib) {
+            throw new GradleException("'android' or 'android-library' plugin required.")
+        }
+
+        // Configure the project
+        project.repositories.add(project.repositories.jcenter())
         project.dependencies.add('compile', 'io.realm:realm-android:0.82.0') // TODO: make version dynamic
+
+        // Find all the variants
+        final def variants
+        if (isAndroidApp) {
+            variants = project.android.applicationVariants
+        } else {
+            variants = project.android.libraryVariants
+        }
+
+        // Do the bytecode manipulation
+        variants.all { variant ->
+            variant.dex.doFirst() {// Get the jar files of the imported libraries
+                JavaCompile javaCompile = variant.javaCompile
+                FileCollection classpathFileCollection = project.files(project.android.bootClasspath)
+                classpathFileCollection += javaCompile.classpath
+
+                // Initialize the class container for Javassist
+                ClassPool classPool = new ClassPool();
+
+                // Add the classpath jar files
+                classpathFileCollection.each {
+                    classPool.appendClassPath(it.toString())
+                }
+
+                // Append the folder containing the .class files for the project
+                classPool.appendClassPath(javaCompile.destinationDir.path)
+
+                // Find the class files
+                ConfigurableFileTree classFiles = project.fileTree(javaCompile.destinationDir);
+                classFiles.include("**/*.class");
+
+
+                def classCache = [:]
+
+                // Add custom accessors to the model classes
+                classFiles.each { classFile ->
+                    CtClass clazz = openClass(classFile, classPool)
+                    classCache[classFile] = clazz
+                    addRealmAccessors(clazz)
+                }
+
+                // Replace access fields with using the custom accessors
+                classFiles.each { classFile ->
+                    def clazz = classCache[classFile]
+                    useRealmAccessors(clazz as CtClass)
+                    (clazz as CtClass).writeFile(javaCompile.destinationDir.absolutePath)
+                }
+            }
+        }
+    }
+
+    private static void useRealmAccessors(CtClass clazz) {
+        clazz.getDeclaredBehaviors().each { behavior ->
+            if (!behavior.name.startsWith('realmGetter$') && !behavior.name.startsWith('realmSetter$')) {
+                behavior.instrument(new ExprEditor() {
+                    @Override
+                    void edit(FieldAccess fieldAccess) throws CannotCompileException {
+                        if (fieldAccess.field?.declaringClass?.superclass?.name?.equals("io.realm.RealmObject")) {
+                            println("Realm: Manipulating ${clazz.simpleName}.${behavior.name}(): ${fieldAccess.fieldName}")
+                            def fieldName = fieldAccess.fieldName
+                            if (fieldAccess.isReader()) {
+                                fieldAccess.replace('$_ = $0.realmGetter$' + fieldName + '();')
+                            } else if (fieldAccess.isWriter()) {
+                                fieldAccess.replace('$0.realmSetter$' + fieldName + '($1);')
+                            }
+                        }
+                    }
+                })
+            }
+        }
+    }
+
+    private static void addRealmAccessors(CtClass clazz) {
+        if (clazz.superclass.name.equals("io.realm.RealmObject")) {
+            println("Realm: Adding accessors to ${clazz.simpleName}")
+            clazz.declaredFields.each { field ->
+                // TODO: eventually filter out ignored fields. This would add a dependency on the annotations project
+                clazz.addMethod(CtNewMethod.getter("realmGetter\$${field.name}", field))
+                clazz.addMethod(CtNewMethod.setter("realmSetter\$${field.name}", field))
+            }
+        }
+    }
+
+    private static CtClass openClass(File classFile, ClassPool classPool) {
+        InputStream stream = null
+        CtClass clazz = null
+        try {
+            stream = new DataInputStream(new BufferedInputStream(new FileInputStream(classFile)))
+            clazz = classPool.makeClass(stream);
+        } catch (Exception ignored) {
+            throw new GradleException("Could not load a class for modification")
+        } finally {
+            if (stream != null) {
+                stream.close()
+            }
+        }
+        clazz
     }
 }

--- a/gradle-plugin/sample/build.gradle
+++ b/gradle-plugin/sample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
     }
 }
@@ -14,11 +14,11 @@ apply plugin: 'realm'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "22.0.0"
 
     defaultConfig {
         applicationId "io.realm.example.sample"
-        minSdkVersion 15
+        minSdkVersion 22
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
@@ -33,5 +33,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.0.0'
+    //compile 'com.android.support:appcompat-v7:22.0.0'
 }

--- a/gradle-plugin/sample/src/main/AndroidManifest.xml
+++ b/gradle-plugin/sample/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:label="@string/app_name">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name" >

--- a/gradle-plugin/sample/src/main/java/io/realm/example/sample/MainActivity.java
+++ b/gradle-plugin/sample/src/main/java/io/realm/example/sample/MainActivity.java
@@ -16,18 +16,16 @@
 
 package io.realm.example.sample;
 
-import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.widget.Toast;
 
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.Toast;
 import io.realm.Realm;
 import io.realm.RealmResults;
 import io.realm.example.sample.models.Person;
 
 
-public class MainActivity extends ActionBarActivity {
+public class MainActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -40,28 +38,10 @@ public class MainActivity extends ActionBarActivity {
             Toast toast = Toast.makeText(this, "No persons in the Realm file", Toast.LENGTH_SHORT);
             toast.show();
         }
+        realm.beginTransaction();
+        Person person  = realm.createObject(Person.class);
+        person.note = "Test";
+        realm.commitTransaction();
         realm.close();
-    }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_main, menu);
-        return true;
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
-
-        //noinspection SimplifiableIfStatement
-        if (id == R.id.action_settings) {
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
     }
 }

--- a/gradle-plugin/sample/src/main/java/io/realm/example/sample/models/Person.java
+++ b/gradle-plugin/sample/src/main/java/io/realm/example/sample/models/Person.java
@@ -16,10 +16,12 @@
 package io.realm.example.sample.models;
 
 import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
 
 public class Person extends RealmObject {
     private String name;
     private int age;
+    @Ignore public String note;
 
     public String getName() {
         return name;

--- a/gradle-plugin/sample/src/main/res/menu/menu_main.xml
+++ b/gradle-plugin/sample/src/main/res/menu/menu_main.xml
@@ -1,9 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".MainActivity">
-    <item android:id="@+id/action_settings"
-          android:title="@string/action_settings"
-          android:orderInCategory="100"
-          app:showAsAction="never"/>
-</menu>

--- a/gradle-plugin/sample/src/main/res/values/styles.xml
+++ b/gradle-plugin/sample/src/main/res/values/styles.xml
@@ -1,8 +1,0 @@
-<resources>
-
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
-    </style>
-
-</resources>


### PR DESCRIPTION
The bytecode is modified in two ways:
 * Custom accessors are added to model classes
    They are called .realm[GS]etter$<fieldName>
 * Such accessors are used instead of field accesses

This is part of making model classes feel like normal POJOs.