### PR TITLE
Optimised thread check.

### DIFF
--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -172,6 +172,7 @@ public final class Realm implements Closeable {
     private boolean autoRefresh;
     private Handler handler;
 
+    private long threadId;
     private RealmConfiguration configuration;
     private SharedGroup sharedGroup;
     private final ImplicitTransaction transaction;
@@ -194,14 +195,14 @@ public final class Realm implements Closeable {
         }
 
         // Check if we are in the right thread
-        Realm currentRealm = realmsCache.get().get(configuration);
-        if (currentRealm != this) {
+        if (threadId != Thread.currentThread().getId()) {
             throw new IllegalStateException(INCORRECT_THREAD_MESSAGE);
         }
     }
 
     // The constructor in private to enforce the use of the static one
     private Realm(RealmConfiguration configuration, boolean autoRefresh) {
+        this.threadId = Thread.currentThread().getId();
         this.configuration = configuration;
         this.sharedGroup = new SharedGroup(configuration.getPath(), true, configuration.getEncryptionKey());
         this.transaction = sharedGroup.beginImplicitTransaction();


### PR DESCRIPTION
Our current check for testing for the correct thread is stupidly expensive and it is executed for each accessor. It should be enough to just compare thread ID's.

An informal benchmark showed a ~20% speed increase when running RealmResultsTest.

@emanuelez @kneth @nhachicha @beeender 