### PR TITLE
Throw exception when close called on a diff thread.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.81.2
+ * Closing realm on another thread different from which it was created on throws an exception.
+
 0.81.1
  * Fixed memory leak causing Realm to never release Realm objects.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 0.81.2
- * Closing realm on another thread different from which it was created on throws an exception.
+ * Closing realm on another thread different from where it was created now throws an exception.
 
 0.81.1
  * Fixed memory leak causing Realm to never release Realm objects.


### PR DESCRIPTION
Without checking the thread in close, some weird logic could be
triggered which is really hard to think about.


I was thinking maybe this would cause #1241 , but according to the feedback, this might not the root cause. But anyway, it is something worth to fix.