### PR TITLE
Support search indexing for column int, bool, date

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
  * Trying to access a deleted Realm object throw throws a proper IllegalStateException.
  * Added in-memory Realm support.
  * Closing realm on another thread different from where it was created now throws an exception.
+ * @Index annotation can also be applied to byte/short/int/long/boolean/Date
+ now.
 
 0.81.1
  * Fixed memory leak causing Realm to never release Realm objects.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -294,13 +293,17 @@ public class ClassMetaData {
                 }
 
                 if (variableElement.getAnnotation(Index.class) != null) {
-                    // The field has the @Index annotation. It's only valid for:
-                    // * String
+                    // The field has the @Index annotation. It's only valid for column types:
+                    // STRING, DATE, INTEGER, BOOLEAN
                     String elementTypeCanonicalName = variableElement.asType().toString();
-                    if (elementTypeCanonicalName.equals("java.lang.String")) {
+                    String columnType = Constants.JAVA_TO_COLUMN_TYPES.get(elementTypeCanonicalName);
+                    if (columnType != null && (columnType.equals("ColumnType.STRING") ||
+                            columnType.equals("ColumnType.DATE") ||
+                            columnType.equals("ColumnType.INTEGER") ||
+                            columnType.equals("ColumnType.BOOLEAN"))) {
                         indexedFields.add(variableElement);
                     } else {
-                        Utils.error("@Index is only applicable to String fields - got " + element);
+                        Utils.error("@Index is not applicable to this field " + element + ".");
                         return false;
                     }
                 }

--- a/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
@@ -16,9 +16,88 @@
 
 package io.realm.processor;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class Constants {
     public static final String REALM_PACKAGE_NAME = "io.realm";
     public static final String PROXY_SUFFIX = "RealmProxy";
     public static final String TABLE_PREFIX = "class_";
     public static final String DEFAULT_MODULE_CLASS_NAME = "DefaultRealmModule";
+
+    static final Map<String, String> JAVA_TO_REALM_TYPES;
+    static {
+        JAVA_TO_REALM_TYPES = new HashMap<String, String>();
+        JAVA_TO_REALM_TYPES.put("byte", "Long");
+        JAVA_TO_REALM_TYPES.put("short", "Long");
+        JAVA_TO_REALM_TYPES.put("int", "Long");
+        JAVA_TO_REALM_TYPES.put("long", "Long");
+        JAVA_TO_REALM_TYPES.put("float", "Float");
+        JAVA_TO_REALM_TYPES.put("double", "Double");
+        JAVA_TO_REALM_TYPES.put("boolean", "Boolean");
+        JAVA_TO_REALM_TYPES.put("Byte", "Long");
+        JAVA_TO_REALM_TYPES.put("Short", "Long");
+        JAVA_TO_REALM_TYPES.put("Integer", "Long");
+        JAVA_TO_REALM_TYPES.put("Long", "Long");
+        JAVA_TO_REALM_TYPES.put("Float", "Float");
+        JAVA_TO_REALM_TYPES.put("Double", "Double");
+        JAVA_TO_REALM_TYPES.put("Boolean", "Boolean");
+        JAVA_TO_REALM_TYPES.put("java.lang.String", "String");
+        JAVA_TO_REALM_TYPES.put("java.util.Date", "Date");
+        JAVA_TO_REALM_TYPES.put("byte[]", "BinaryByteArray");
+        // TODO: add support for char and Char
+    }
+
+    // Types in this array are guarded by if != null and use default value if trying to insert null
+    static final Map<String, String> NULLABLE_JAVA_TYPES;
+    static {
+        NULLABLE_JAVA_TYPES = new HashMap<String, String>();
+        NULLABLE_JAVA_TYPES.put("java.util.Date", "new Date(0)");
+        NULLABLE_JAVA_TYPES.put("java.lang.String", "\"\"");
+        NULLABLE_JAVA_TYPES.put("byte[]", "new byte[0]");
+    }
+
+    static final Map<String, String> JAVA_TO_COLUMN_TYPES;
+    static {
+        JAVA_TO_COLUMN_TYPES = new HashMap<String, String>();
+        JAVA_TO_COLUMN_TYPES.put("byte", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("short", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("int", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("long", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("float", "ColumnType.FLOAT");
+        JAVA_TO_COLUMN_TYPES.put("double", "ColumnType.DOUBLE");
+        JAVA_TO_COLUMN_TYPES.put("boolean", "ColumnType.BOOLEAN");
+        JAVA_TO_COLUMN_TYPES.put("Byte", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("Short", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("Integer", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("Long", "ColumnType.INTEGER");
+        JAVA_TO_COLUMN_TYPES.put("Float", "ColumnType.FLOAT");
+        JAVA_TO_COLUMN_TYPES.put("Double", "ColumnType.DOUBLE");
+        JAVA_TO_COLUMN_TYPES.put("Boolean", "ColumnType.BOOLEAN");
+        JAVA_TO_COLUMN_TYPES.put("java.lang.String", "ColumnType.STRING");
+        JAVA_TO_COLUMN_TYPES.put("java.util.Date", "ColumnType.DATE");
+        JAVA_TO_COLUMN_TYPES.put("byte[]", "ColumnType.BINARY");
+    }
+
+    static final Map<String, String> CASTING_TYPES;
+    static {
+        CASTING_TYPES = new HashMap<String, String>();
+        CASTING_TYPES.put("byte", "long");
+        CASTING_TYPES.put("short", "long");
+        CASTING_TYPES.put("int", "long");
+        CASTING_TYPES.put("long", "long");
+        CASTING_TYPES.put("float", "float");
+        CASTING_TYPES.put("double", "double");
+        CASTING_TYPES.put("boolean", "boolean");
+        CASTING_TYPES.put("Byte", "long");
+        CASTING_TYPES.put("Short", "long");
+        CASTING_TYPES.put("Integer", "long");
+        CASTING_TYPES.put("Long", "long");
+        CASTING_TYPES.put("Float", "float");
+        CASTING_TYPES.put("Double", "double");
+        CASTING_TYPES.put("Boolean", "boolean");
+        CASTING_TYPES.put("java.lang.String", "String");
+        CASTING_TYPES.put("java.util.Date", "Date");
+        CASTING_TYPES.put("byte[]", "byte[]");
+    }
 }

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -18,6 +18,14 @@ package io.realm.processor;
 
 import com.squareup.javawriter.JavaWriter;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
@@ -26,9 +34,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.JavaFileObject;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.util.*;
 
 public class RealmProxyClassGenerator {
     private ProcessingEnvironment processingEnvironment;
@@ -45,82 +50,6 @@ public class RealmProxyClassGenerator {
         this.processingEnvironment = processingEnvironment;
         this.metadata = metadata;
         this.className = metadata.getSimpleClassName();
-    }
-
-    private static final Map<String, String> JAVA_TO_REALM_TYPES;
-    static {
-        JAVA_TO_REALM_TYPES = new HashMap<String, String>();
-        JAVA_TO_REALM_TYPES.put("byte", "Long");
-        JAVA_TO_REALM_TYPES.put("short", "Long");
-        JAVA_TO_REALM_TYPES.put("int", "Long");
-        JAVA_TO_REALM_TYPES.put("long", "Long");
-        JAVA_TO_REALM_TYPES.put("float", "Float");
-        JAVA_TO_REALM_TYPES.put("double", "Double");
-        JAVA_TO_REALM_TYPES.put("boolean", "Boolean");
-        JAVA_TO_REALM_TYPES.put("Byte", "Long");
-        JAVA_TO_REALM_TYPES.put("Short", "Long");
-        JAVA_TO_REALM_TYPES.put("Integer", "Long");
-        JAVA_TO_REALM_TYPES.put("Long", "Long");
-        JAVA_TO_REALM_TYPES.put("Float", "Float");
-        JAVA_TO_REALM_TYPES.put("Double", "Double");
-        JAVA_TO_REALM_TYPES.put("Boolean", "Boolean");
-        JAVA_TO_REALM_TYPES.put("java.lang.String", "String");
-        JAVA_TO_REALM_TYPES.put("java.util.Date", "Date");
-        JAVA_TO_REALM_TYPES.put("byte[]", "BinaryByteArray");
-        // TODO: add support for char and Char
-    }
-
-    // Types in this array are guarded by if != null and use default value if trying to insert null
-    private static final Map<String, String> NULLABLE_JAVA_TYPES;
-    static {
-        NULLABLE_JAVA_TYPES = new HashMap<String, String>();
-        NULLABLE_JAVA_TYPES.put("java.util.Date", "new Date(0)");
-        NULLABLE_JAVA_TYPES.put("java.lang.String", "\"\"");
-        NULLABLE_JAVA_TYPES.put("byte[]", "new byte[0]");
-    }
-
-    private static final Map<String, String> JAVA_TO_COLUMN_TYPES;
-    static {
-        JAVA_TO_COLUMN_TYPES = new HashMap<String, String>();
-        JAVA_TO_COLUMN_TYPES.put("byte", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("short", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("int", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("long", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("float", "ColumnType.FLOAT");
-        JAVA_TO_COLUMN_TYPES.put("double", "ColumnType.DOUBLE");
-        JAVA_TO_COLUMN_TYPES.put("boolean", "ColumnType.BOOLEAN");
-        JAVA_TO_COLUMN_TYPES.put("Byte", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("Short", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("Integer", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("Long", "ColumnType.INTEGER");
-        JAVA_TO_COLUMN_TYPES.put("Float", "ColumnType.FLOAT");
-        JAVA_TO_COLUMN_TYPES.put("Double", "ColumnType.DOUBLE");
-        JAVA_TO_COLUMN_TYPES.put("Boolean", "ColumnType.BOOLEAN");
-        JAVA_TO_COLUMN_TYPES.put("java.lang.String", "ColumnType.STRING");
-        JAVA_TO_COLUMN_TYPES.put("java.util.Date", "ColumnType.DATE");
-        JAVA_TO_COLUMN_TYPES.put("byte[]", "ColumnType.BINARY");
-    }
-
-    private static final Map<String, String> CASTING_TYPES;
-    static {
-        CASTING_TYPES = new HashMap<String, String>();
-        CASTING_TYPES.put("byte", "long");
-        CASTING_TYPES.put("short", "long");
-        CASTING_TYPES.put("int", "long");
-        CASTING_TYPES.put("long", "long");
-        CASTING_TYPES.put("float", "float");
-        CASTING_TYPES.put("double", "double");
-        CASTING_TYPES.put("boolean", "boolean");
-        CASTING_TYPES.put("Byte", "long");
-        CASTING_TYPES.put("Short", "long");
-        CASTING_TYPES.put("Integer", "long");
-        CASTING_TYPES.put("Long", "long");
-        CASTING_TYPES.put("Float", "float");
-        CASTING_TYPES.put("Double", "double");
-        CASTING_TYPES.put("Boolean", "boolean");
-        CASTING_TYPES.put("java.lang.String", "String");
-        CASTING_TYPES.put("java.util.Date", "Date");
-        CASTING_TYPES.put("byte[]", "byte[]");
     }
 
     public void generate() throws IOException, UnsupportedOperationException {
@@ -231,12 +160,12 @@ public class RealmProxyClassGenerator {
             String fieldName = field.getSimpleName().toString();
             String fieldTypeCanonicalName = field.asType().toString();
 
-            if (JAVA_TO_REALM_TYPES.containsKey(fieldTypeCanonicalName)) {
+            if (Constants.JAVA_TO_REALM_TYPES.containsKey(fieldTypeCanonicalName)) {
                 /**
                  * Primitives and boxed types
                  */
-                String realmType = JAVA_TO_REALM_TYPES.get(fieldTypeCanonicalName);
-                String castingType = CASTING_TYPES.get(fieldTypeCanonicalName);
+                String realmType = Constants.JAVA_TO_REALM_TYPES.get(fieldTypeCanonicalName);
+                String castingType = Constants.CASTING_TYPES.get(fieldTypeCanonicalName);
 
                 // Getter
                 writer.emitAnnotation("Override");
@@ -337,9 +266,9 @@ public class RealmProxyClassGenerator {
             String fieldTypeCanonicalName = field.asType().toString();
             String fieldTypeSimpleName = Utils.getFieldTypeSimpleName(field);
 
-            if (JAVA_TO_REALM_TYPES.containsKey(fieldTypeCanonicalName)) {
+            if (Constants.JAVA_TO_REALM_TYPES.containsKey(fieldTypeCanonicalName)) {
                 writer.emitStatement("table.addColumn(%s, \"%s\")",
-                        JAVA_TO_COLUMN_TYPES.get(fieldTypeCanonicalName),
+                        Constants.JAVA_TO_COLUMN_TYPES.get(fieldTypeCanonicalName),
                         fieldName);
             } else if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 writer.beginControlFlow("if (!transaction.hasTable(\"%s%s\"))", Constants.TABLE_PREFIX, fieldTypeSimpleName);
@@ -421,12 +350,13 @@ public class RealmProxyClassGenerator {
             String fieldTypeCanonicalName = field.asType().toString();
             String fieldTypeSimpleName = Utils.getFieldTypeSimpleName(field);
 
-            if (JAVA_TO_REALM_TYPES.containsKey(fieldTypeCanonicalName)) {
+            if (Constants.JAVA_TO_REALM_TYPES.containsKey(fieldTypeCanonicalName)) {
                 // make sure types align
                 writer.beginControlFlow("if (!columnTypes.containsKey(\"%s\"))", fieldName);
                 writer.emitStatement("throw new RealmMigrationNeededException(transaction.getPath(), \"Missing field '%s'\")", fieldName);
                 writer.endControlFlow();
-                writer.beginControlFlow("if (columnTypes.get(\"%s\") != %s)", fieldName, JAVA_TO_COLUMN_TYPES.get(fieldTypeCanonicalName));
+                writer.beginControlFlow("if (columnTypes.get(\"%s\") != %s)",
+                        fieldName, Constants.JAVA_TO_COLUMN_TYPES.get(fieldTypeCanonicalName));
                 writer.emitStatement("throw new RealmMigrationNeededException(transaction.getPath(), \"Invalid type '%s' for field '%s'\")",
                         fieldTypeSimpleName, fieldName);
                 writer.endControlFlow();
@@ -625,12 +555,12 @@ public class RealmProxyClassGenerator {
                     .emitEmptyLine();
 
             } else {
-                if (NULLABLE_JAVA_TYPES.containsKey(fieldType)) {
+                if (Constants.NULLABLE_JAVA_TYPES.containsKey(fieldType)) {
                     writer.emitStatement("realmObject.%s(newObject.%s() != null ? newObject.%s() : %s)",
                             metadata.getSetter(fieldName),
                             metadata.getGetter(fieldName),
                             metadata.getGetter(fieldName),
-                            NULLABLE_JAVA_TYPES.get(fieldType));
+                            Constants.NULLABLE_JAVA_TYPES.get(fieldType));
                 } else {
                     writer.emitStatement("realmObject.%s(newObject.%s())", metadata.getSetter(fieldName), metadata.getGetter(fieldName));
                 }
@@ -693,12 +623,12 @@ public class RealmProxyClassGenerator {
                 }
 
                 String fieldType = field.asType().toString();
-                if (NULLABLE_JAVA_TYPES.containsKey(fieldType)) {
+                if (Constants.NULLABLE_JAVA_TYPES.containsKey(fieldType)) {
                     writer.emitStatement("realmObject.%s(newObject.%s() != null ? newObject.%s() : %s)",
                             metadata.getSetter(fieldName),
                             metadata.getGetter(fieldName),
                             metadata.getGetter(fieldName),
-                            NULLABLE_JAVA_TYPES.get(fieldType));
+                            Constants.NULLABLE_JAVA_TYPES.get(fieldType));
                 } else {
                     writer.emitStatement("realmObject.%s(newObject.%s())", metadata.getSetter(fieldName), metadata.getGetter(fieldName));
                 }

--- a/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
+++ b/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
@@ -17,11 +17,13 @@
 package io.realm.processor;
 
 import com.google.testing.compile.JavaFileObjects;
+
 import org.junit.Test;
 
-import javax.tools.JavaFileObject;
-
+import java.io.IOException;
 import java.util.Arrays;
+
+import javax.tools.JavaFileObject;
 
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
@@ -241,5 +243,37 @@ public class RealmProcessorTest {
                 .that(customAccessorModel)
                 .processedWith(new RealmProcessor())
                 .failsToCompile();
+    }
+
+    // Supported "Index" annotation types
+    @Test
+    public void compileIndexTypes() throws IOException {
+        // TODO: Test "Byte", "Short", "Integer", "Long", "Boolean" when they are supported
+        final String validIndexFieldTypes[] = {"byte", "short", "int", "long", "boolean", "String", "java.util.Date"};
+
+        for (String fieldType : validIndexFieldTypes) {
+            TestRealmObjectFileObject javaFileObject =
+                    TestRealmObjectFileObject.getSingleFieldInstance("ValidIndexType", "Index", fieldType, "testField");
+            ASSERT.about(javaSource())
+                    .that(javaFileObject)
+                    .processedWith(new RealmProcessor())
+                    .compilesWithoutError();
+        }
+    }
+
+    // Unsupported "Index" annotation types
+    @Test
+    public void compileInvalidIndexTypes() throws IOException {
+        // TODO: Test "Float", "Double", when they are supported
+        final String invalidIndexFieldTypes[] = {"float", "double", "byte[]", "Simple", "RealmList"};
+
+        for (String fieldType : invalidIndexFieldTypes) {
+            TestRealmObjectFileObject javaFileObject =
+                    TestRealmObjectFileObject.getSingleFieldInstance("InvalidIndexType", "Index", fieldType, "testField");
+            ASSERT.about(javaSource())
+                    .that(javaFileObject)
+                    .processedWith(new RealmProcessor())
+                    .failsToCompile();
+        }
     }
 }

--- a/realm-annotations-processor/src/test/java/io/realm/processor/TestRealmObjectFileObject.java
+++ b/realm-annotations-processor/src/test/java/io/realm/processor/TestRealmObjectFileObject.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.processor;
+
+import com.squareup.javawriter.JavaWriter;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.EnumSet;
+
+import javax.lang.model.element.Modifier;
+import javax.tools.SimpleJavaFileObject;
+
+// Helper class for creating RealmObject java files
+public class TestRealmObjectFileObject extends SimpleJavaFileObject {
+    private StringWriter stringWriter;
+
+    private TestRealmObjectFileObject(String name, StringWriter stringWriter) {
+        super(URI.create(name + ".java"), Kind.SOURCE);
+        this.stringWriter = stringWriter;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+        return stringWriter.getBuffer();
+    }
+
+    // Helper function to create a Realm object java file with a single field.
+    public static TestRealmObjectFileObject getSingleFieldInstance(String className,
+                                                            String annotationToField,
+                                                            String fieldType,
+                                                            String fieldName) throws IOException {
+        String FieldName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1, fieldName.length());
+        StringWriter stringWriter = new StringWriter();
+        JavaWriter writer = new JavaWriter(stringWriter);
+
+        // Package name
+        writer.emitPackage("some.test");
+
+        // Import Realm classes
+        writer.emitImports("io.realm.*");
+        writer.emitImports("io.realm.annotations.*");
+
+        // Begin the class definition
+        writer.beginType(
+                className, // full qualified name of the item to generate
+                "class",                     // the type of the item
+                EnumSet.of(Modifier.PUBLIC), // modifiers to apply
+                "RealmObject")                   // class to extend
+                .emitEmptyLine();
+
+        // Declaration of field
+        writer.emitAnnotation(annotationToField);
+        writer.emitField(fieldType, fieldName, EnumSet.of(Modifier.PRIVATE));
+
+        // Getter
+        writer.beginMethod(
+                fieldType, // Return type
+                "get" + FieldName, // Method name
+                EnumSet.of(Modifier.PUBLIC)); // Modifiers
+        writer.emitStatement("return " +  fieldName);
+        writer.endMethod();
+
+        // Setter
+        writer.beginMethod(
+                "void", // Return type
+                "set"+ FieldName, // Method name
+                EnumSet.of(Modifier.PUBLIC),
+                fieldType, fieldName); // Modifiers
+        writer.emitStatement("this." + fieldName + "=" + fieldName);
+        writer.endMethod();
+
+        writer.endType();
+
+        return new TestRealmObjectFileObject(className, stringWriter);
+    }
+}

--- a/realm-annotations/src/main/java/io/realm/annotations/Index.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/Index.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 /**
  * This annotation will add a search index to the field. A search index will make the
  * Realm file larger and inserts slower but queries will be faster. 
- *
- * NOTICE: only String fields can be indexed.
+ * <p>
+ * NOTICE: Only String, int, byte, short, long, boolean and Date fields can be indexed.
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.FIELD)

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -29,6 +29,19 @@
 using namespace std;
 using namespace realm;
 
+inline static bool is_allowed_to_index(JNIEnv* env, DataType column_type) {
+    if (!(column_type == type_String ||
+                column_type == type_Int ||
+                column_type == type_Bool ||
+                column_type == type_DateTime)) {
+        ThrowException(env, IllegalArgument,
+                "This field cannot be indexed - "
+                "Only String/byte/short/int/long/boolean/Date fields are supported.");
+        return false;
+    }
+    return true;
+}
+
 // Note: Don't modify spec on a table which has a shared_spec.
 // A spec is shared on subtables that are not in Mixed columns.
 //
@@ -731,10 +744,12 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeAddSearchIndex(
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
         return;
-    if (pTable->get_column_type (S(columnIndex)) != type_String) {
-        ThrowException(env, IllegalArgument, "Invalid columntype - only string columns are supported at the moment.");
+
+    DataType column_type = pTable->get_column_type (S(columnIndex));
+    if (!is_allowed_to_index(env, column_type)) {
         return;
     }
+
     try {
         pTable->add_search_index( S(columnIndex));
     } CATCH_STD()
@@ -746,8 +761,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveSearchIndex(
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
         return;
-    if (pTable->get_column_type (S(columnIndex)) != type_String) {
-        ThrowException(env, IllegalArgument, "Invalid columntype - only string columns are supported at the moment.");
+    DataType column_type = pTable->get_column_type (S(columnIndex));
+    if (!is_allowed_to_index(env, column_type)) {
         return;
     }
     try {

--- a/realm/src/androidTest/java/io/realm/RealmAnnotationTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmAnnotationTest.java
@@ -18,6 +18,7 @@ package io.realm;
 
 import android.test.AndroidTestCase;
 
+import io.realm.entities.AnnotationIndexTypes;
 import io.realm.entities.AnnotationNameConventions;
 import io.realm.entities.AnnotationTypes;
 import io.realm.entities.PrimaryKeyAsLong;
@@ -50,10 +51,30 @@ public class RealmAnnotationTest extends AndroidTestCase {
         assertEquals(-1, table.getColumnIndex("ignoreString"));
     }
 
+    // Test if "index" annotation works with supported types
     public void testIndex() {
-        Table table = testRealm.getTable(AnnotationTypes.class);
+        Table table = testRealm.getTable(AnnotationIndexTypes.class);
+
         assertTrue(table.hasSearchIndex(table.getColumnIndex("indexString")));
         assertFalse(table.hasSearchIndex(table.getColumnIndex("notIndexString")));
+
+        assertTrue(table.hasSearchIndex(table.getColumnIndex("indexInt")));
+        assertFalse(table.hasSearchIndex(table.getColumnIndex("notIndexInt")));
+
+        assertTrue(table.hasSearchIndex(table.getColumnIndex("indexByte")));
+        assertFalse(table.hasSearchIndex(table.getColumnIndex("notIndexByte")));
+
+        assertTrue(table.hasSearchIndex(table.getColumnIndex("indexShort")));
+        assertFalse(table.hasSearchIndex(table.getColumnIndex("notIndexShort")));
+
+        assertTrue(table.hasSearchIndex(table.getColumnIndex("indexLong")));
+        assertFalse(table.hasSearchIndex(table.getColumnIndex("notIndexLong")));
+
+        assertTrue(table.hasSearchIndex(table.getColumnIndex("indexBoolean")));
+        assertFalse(table.hasSearchIndex(table.getColumnIndex("notIndexBoolean")));
+
+        assertTrue(table.hasSearchIndex(table.getColumnIndex("indexDate")));
+        assertFalse(table.hasSearchIndex(table.getColumnIndex("notIndexDate")));
     }
 
     public void testHasPrimaryKeyNoIntIndex() {

--- a/realm/src/androidTest/java/io/realm/entities/AnnotationIndexTypes.java
+++ b/realm/src/androidTest/java/io/realm/entities/AnnotationIndexTypes.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import java.util.Date;
+
+import io.realm.RealmObject;
+import io.realm.annotations.Index;
+
+// Class for testing annotation index only
+public class AnnotationIndexTypes extends RealmObject {
+    @Index
+    private String indexString;
+    private String notIndexString;
+
+    @Index
+    private int indexInt;
+    private int notIndexInt;
+
+    @Index
+    private byte indexByte;
+    private byte notIndexByte;
+
+    @Index
+    private short indexShort;
+    private short notIndexShort;
+
+    @Index
+    private long indexLong;
+    private long notIndexLong;
+
+    @Index
+    private boolean indexBoolean;
+    private boolean notIndexBoolean;
+
+    @Index
+    private Date indexDate;
+    private Date notIndexDate;
+
+    public String getIndexString() {
+        return indexString;
+    }
+
+    public void setIndexString(String indexString) {
+        this.indexString = indexString;
+    }
+
+    public String getNotIndexString() {
+        return notIndexString;
+    }
+
+    public void setNotIndexString(String notIndexString) {
+        this.notIndexString = notIndexString;
+    }
+
+    public int getIndexInt() {
+        return indexInt;
+    }
+
+    public void setIndexInt(int indexInt) {
+        this.indexInt = indexInt;
+    }
+
+    public int getNotIndexInt() {
+        return notIndexInt;
+    }
+
+    public void setNotIndexInt(int notIndexInt) {
+        this.notIndexInt = notIndexInt;
+    }
+
+    public short getIndexShort() {
+        return indexShort;
+    }
+
+    public void setIndexShort(short indexShort) {
+        this.indexShort = indexShort;
+    }
+
+    public byte getIndexByte() {
+        return indexByte;
+    }
+
+    public void setIndexByte(byte indexByte) {
+        this.indexByte = indexByte;
+    }
+
+    public byte getNotIndexByte() {
+        return notIndexByte;
+    }
+
+    public void setNotIndexByte(byte notIndexByte) {
+        this.notIndexByte = notIndexByte;
+    }
+
+    public short getNotIndexShort() {
+        return notIndexShort;
+    }
+
+    public void setNotIndexShort(short notIndexShort) {
+        this.notIndexShort = notIndexShort;
+    }
+
+    public long getIndexLong() {
+        return indexLong;
+    }
+
+    public void setIndexLong(long indexLong) {
+        this.indexLong = indexLong;
+    }
+
+    public long getNotIndexLong() {
+        return notIndexLong;
+    }
+
+    public void setNotIndexLong(long notIndexLong) {
+        this.notIndexLong = notIndexLong;
+    }
+
+    public boolean isIndexBoolean() {
+        return indexBoolean;
+    }
+
+    public void setIndexBoolean(boolean indexBoolean) {
+        this.indexBoolean = indexBoolean;
+    }
+
+    public boolean isNotIndexBoolean() {
+        return notIndexBoolean;
+    }
+
+    public void setNotIndexBoolean(boolean notIndexBoolean) {
+        this.notIndexBoolean = notIndexBoolean;
+    }
+
+    public Date getIndexDate() {
+        return indexDate;
+    }
+
+    public void setIndexDate(Date indexDate) {
+        this.indexDate = indexDate;
+    }
+
+    public Date getNotIndexDate() {
+        return notIndexDate;
+    }
+
+    public void setNotIndexDate(Date notIndexDate) {
+        this.notIndexDate = notIndexDate;
+    }
+}

--- a/realm/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -371,16 +371,32 @@ public class JNITableTest extends AndroidTestCase {
     public void testShouldThrowWhenSetIndexOnWrongColumnType() {
         for (long colIndex = 0; colIndex < t.getColumnCount(); colIndex++) {
 
-            // Check all other column types than String throws exception when using addSearchIndex()/hasSearchIndex()
-            boolean exceptionExpected = (t.getColumnType(colIndex) != ColumnType.STRING);
+            // All types supported addSearchIndex and removeSearchIndex
+            boolean exceptionExpected = (
+                            t.getColumnType(colIndex) != ColumnType.STRING &&
+                            t.getColumnType(colIndex) != ColumnType.INTEGER &&
+                            t.getColumnType(colIndex) != ColumnType.BOOLEAN &&
+                            t.getColumnType(colIndex) != ColumnType.DATE);
 
             // Try to addSearchIndex()
             try {
                 t.addSearchIndex(colIndex);
-                if (exceptionExpected)
-                    fail("expected exception for colIndex " + colIndex);
-            } catch (IllegalArgumentException e) {
+                if (exceptionExpected) {
+                    fail("Expected exception for colIndex " + colIndex);
+                }
+            } catch (IllegalArgumentException ignored) {
             }
+
+            // Try to removeSearchIndex()
+            try {
+                // Currently core will do nothing if the column doesn't have a search index
+                t.removeSearchIndex(colIndex);
+                if (exceptionExpected) {
+                    fail("Expected exception for colIndex " + colIndex);
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+
 
             // Try to hasSearchIndex() for all columnTypes
             t.hasSearchIndex(colIndex);


### PR DESCRIPTION
1. Enable the search index annotation on byte, short, int, long,
   boolean, and Date.
2. Enable add/remove search index in java.
3. Annotation processor test to support better detailed test cases.
4. Refactor RealmQueryTest to apply all normal query test cases on a
   RealmObject with indexed fields.
5. Modify JNI test cases.
6. Update doc.

This is the first PR for #1039. Implicit index to int primary keys will
be handled in another PR.

- [x] Make PR for realm.io to update related Doc. https://github.com/realm/realm.io/pull/704
- [x] Modify changelog.
- [x] Bump version if needed.