### PR TITLE
Replaced all @InheritDoc with proper documentation.

### DIFF
--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -220,7 +220,10 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
-     * {@inheritDoc}
+     * Removes all elements from this list, leaving it empty.
+     *
+     * @see List#isEmpty
+     * @see List#size
      */
     @Override
     public void clear() {
@@ -232,7 +235,11 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
-     * {@inheritDoc}
+     * Removes the object at the specified location from this list.
+     *
+     * @param location the index of the object to remove.
+     * @return the removed object.
+     * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
      */
     @Override
     public E remove(int location) {
@@ -246,7 +253,11 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the element at the specified location in this list.
+     *
+     * @param location the index of the element to return.
+     * @return the element at the specified index.
+     * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
      */
     @Override
     public E get(int location) {
@@ -286,7 +297,9 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the number of elements in this {@code List}.
+     *
+     * @return the number of elements in this {@code List}.
      */
     @Override
     public int size() {

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -99,24 +99,30 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the element at the specified location in this list.
+     *
+     * @param location the index of the element to return.
+     * @return the element at the specified index.
+     * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
      */
     @Override
-    public E get(int rowIndex) {
+    public E get(int location) {
         E obj;
         realm.checkIfValid();
         TableOrView table = getTable();
         if (table instanceof TableView) {
-            obj = realm.get(classSpec, ((TableView)table).getSourceRowIndex(rowIndex));
+            obj = realm.get(classSpec, ((TableView)table).getSourceRowIndex(location));
         } else {
-            obj = realm.get(classSpec, rowIndex);
+            obj = realm.get(classSpec, location);
         }
 
         return obj;
     }
 
     /**
-     * {@inheritDoc}
+     * This method is not supported.
+     *
+     * @throws NoSuchMethodError always.
      */
     @Override
     public int indexOf(Object o) {
@@ -266,7 +272,6 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
         }
     }
 
-
     /**
      * Sort existing {@link io.realm.RealmResults} using two fields.
      *
@@ -298,7 +303,9 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     // Aggregates
 
     /**
-     * {@inheritDoc}
+     * Returns the number of elements in this query result.
+     *
+     * @return the number of elements in this query result.
      */
     @Override
     public int size() {

--- a/realm/src/main/java/io/realm/internal/ImplicitTransaction.java
+++ b/realm/src/main/java/io/realm/internal/ImplicitTransaction.java
@@ -68,7 +68,7 @@ public class ImplicitTransaction extends Group {
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the absolute path to the Realm file backing this transaction.
      */
     public String getPath() {
         return parent.getPath();


### PR DESCRIPTION
Fixes #1165 

All @InheritDoc tags has been replaced with proper documentation as @InheritDoc doesn't work well with the Android SDK.

@realm/java 