### PR TITLE
Document RealmResults.{first,last} can throw

### DIFF
--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -183,7 +183,7 @@ public class RealmResultsTest extends AndroidTestCase {
         assertTrue(allTypes.getColumnString().startsWith("test data 0"));
     }
 
-    // first() and last() will throw an exception is no element exists
+    // first() and last() will throw an exception when no element exist
     public void testResultListFirstLastThrowIfEmpty() {
         testRealm.beginTransaction();
         testRealm.clear(AllTypes.class);

--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -183,6 +183,25 @@ public class RealmResultsTest extends AndroidTestCase {
         assertTrue(allTypes.getColumnString().startsWith("test data 0"));
     }
 
+    // first() and last() will throw an exception is no element exists
+    public void testResultListFirstLastThrowIfEmpty() {
+        testRealm.beginTransaction();
+        testRealm.clear(AllTypes.class);
+        testRealm.commitTransaction();
+
+        RealmResults<AllTypes> allTypes = testRealm.allObjects(AllTypes.class);
+        assertEquals(0, allTypes.size());
+        try {
+            allTypes.first();
+            fail();
+        } catch (ArrayIndexOutOfBoundsException ignored) {}
+
+        try {
+            allTypes.last();
+            fail();
+        } catch (ArrayIndexOutOfBoundsException ignored) {}
+    }
+
     public void testResultListLastIsLast() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
 

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -126,6 +126,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     /**
      * Get the first object from the list.
      * @return The first object.
+     * @throws ArrayIndexOutOfBoundsException if RealmResults is empty.
      */
     public E first() {
         return get(0);
@@ -134,6 +135,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     /**
      * Get the last object from the list.
      * @return The last object.
+     * @throws ArrayIndexOutOfBoundsException if RealmResults is empty.
      */
     public E last() {
         return get(size()-1);
@@ -193,7 +195,7 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
 
     /**
      * Sort (ascending) an existing {@link io.realm.RealmResults}.
-     * 
+     *
      * @param fieldName  The field name to sort by. Only fields of type boolean, short, int, long,
      *                   float, double, Date, and String are supported.
      * @throws java.lang.IllegalArgumentException if field name does not exist.


### PR DESCRIPTION
Documenting that RealmResults.{first,last} throw exception if result is empty. I have added a simple unit test and added the exception to the documentation.

Closes #1102.

@realm/java 