### PR TITLE
Removed RealmQuery.between() for link queries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
  * @Index annotation can also be applied to byte/short/int/long/boolean/Date now.
  * Fields with annotation @PrimaryKey are indexed automatically now.
  * Fixed a bug where RealmQuery objects are prematurely garbage collected.
+ * Removed RealmQuery.between() for link queries. 
 
 0.81.1
  * Fixed memory leak causing Realm to never release Realm objects.

--- a/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -221,21 +221,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JJJ(
     JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value1, jlong value2)
 {
     GET_ARRAY()
-    try {
-        if (arr_len == 1) {
-            if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_Int))
-                return;
+    if (arr_len == 1) {
+        if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_Int))
+            return;
+        try {
             Q(nativeQueryPtr)->between(S(arr[0]), static_cast<int64_t>(value1), static_cast<int64_t>(value2));
-        }
-        else {
-            Q(nativeQueryPtr)->group();
-            Table* tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_greaterequal<Int, int64_t, jlong>(tbl, arr[arr_len-1], value1));
-            tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_lessequal<Int, int64_t, jlong>(tbl, arr[arr_len-1], value2));
-            Q(nativeQueryPtr)->end_group();
-        }
-    } CATCH_STD()
+        } CATCH_STD()
+    }
+    else {
+        ThrowException(env, IllegalArgument, "between does not support link queries.");
+    }
     RELEASE_ARRAY();
 }
 

--- a/realm/src/androidTest/java/io/realm/RealmLinkTests.java
+++ b/realm/src/androidTest/java/io/realm/RealmLinkTests.java
@@ -148,9 +148,11 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(1, owners6.size());
         assertEquals(12, owners6.first().getCat().getAge());
 
-        RealmResults<Owner> owners7 = testRealm.where(Owner.class).between("cat.age", 1, 20).findAll();
-        assertEquals(1, owners7.size());
-        assertEquals(12, owners7.first().getCat().getAge());
+        try {
+            RealmResults<Owner> owners7 = testRealm.where(Owner.class).between("cat.age", 1, 20).findAll();
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
     }
 
     public void testQuerySingleRelationDate() {
@@ -309,8 +311,10 @@ public class RealmLinkTests extends AndroidTestCase {
         RealmResults<Owner> owners6 = testRealm.where(Owner.class).lessThanOrEqualTo("dogs.age", 9).findAll();
         assertEquals(1, owners6.size());
 
-        RealmResults<Owner> owners7 = testRealm.where(Owner.class).between("dogs.age", 9, 11).findAll();
-        assertEquals(1, owners7.size());
+        try {
+            RealmResults<Owner> owners7 = testRealm.where(Owner.class).between("dogs.age", 9, 11).findAll();
+            fail();
+        } catch (IllegalArgumentException ignored) {}
     }
 
     public void testQueryMultipleRelationsDate() {


### PR DESCRIPTION
As discussed at length in #1237 `RealmQuery.between()` does not work as expected in many cases. As the underlaying storage engine does not provide a operator directly, I think it is better for remove it.

@realm/java 