### PR TITLE
Release LinkView native pointers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
  * Fixed a bug making it impossible to convert a field to become required during a migration (#1695).
  * Fixed a bug making it impossible to read Realms created using primary keys and created by iOS (#1703).
  * Fixed some memory leaks when an Exception is thrown (#1730).
+ * Fixed a memory leak when using relationships. (#1285)
  * RealmQuery.isNull() and RealmQuery.isNotNull() now throw IllegalArgumentException instead of RealmError if the fieldname is a linked field and the last element is a link (#1693).
 
 0.84.1

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
@@ -1802,13 +1802,14 @@ public class RealmTest extends AndroidTestCase {
     // TODO: re-introduce this test mocking the ReferenceQueue instead of relying on the GC
 /*    // Check that FinalizerRunnable can free native resources (phantom refs)
     public void testReferenceCleaning() throws NoSuchFieldException, IllegalAccessException {
+        testRealm.close();
 
         RealmConfiguration config = new RealmConfiguration.Builder(getContext()).name("myown").build();
         Realm.deleteRealm(config);
         testRealm = Realm.getInstance(config);
 
         // Manipulate field accessibility to facilitate testing
-        Field realmFileReference = RealmBase.class.getDeclaredField("sharedGroupManager");
+        Field realmFileReference = BaseRealm.class.getDeclaredField("sharedGroupManager");
         realmFileReference.setAccessible(true);
         Field contextField = SharedGroup.class.getDeclaredField("context");
         contextField.setAccessible(true);
@@ -1821,7 +1822,7 @@ public class RealmTest extends AndroidTestCase {
         io.realm.internal.Context context = (io.realm.internal.Context) contextField.get(realmFile.getSharedGroup());
         assertNotNull(context);
 
-        List<Reference<?>> rowReferences = (List<Reference<?>>) rowReferencesField.get(context);
+        Map<Reference<?>, Integer> rowReferences = (Map<Reference<?>, Integer>) rowReferencesField.get(context);
         assertNotNull(rowReferences);
 
         // insert some rows, then give the thread some time to cleanup
@@ -1846,6 +1847,7 @@ public class RealmTest extends AndroidTestCase {
             numberOfRetries++;
             System.gc();
         }
+        context.cleanNativeReferences();
 
         // we can't guarantee that all references have been GC'ed but we should detect a decrease
         boolean isDecreasing = rowReferences.size() < totalNumberOfReferences;

--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -51,7 +51,8 @@ public class CheckedRow extends UncheckedRow {
     public static CheckedRow get(Context context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.nativePtr, index);
         CheckedRow row = new CheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
+        context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
+                Context.NATIVE_REFERENCES_VALUE);
         return row;
     }
 
@@ -64,9 +65,11 @@ public class CheckedRow extends UncheckedRow {
      * @return a checked instance of {@link Row} for the {@link LinkView} and index specified.
      */
     public static CheckedRow get(Context context, LinkView linkView, long index) {
-        long nativeRowPointer = linkView.nativeGetRow(linkView.nativeLinkViewPtr, index);
-        CheckedRow row = new CheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent), nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
+        long nativeRowPointer = linkView.nativeGetRow(linkView.nativePointer, index);
+        CheckedRow row = new CheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent),
+                nativeRowPointer);
+        context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
+                Context.NATIVE_REFERENCES_VALUE);
         return row;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/Context.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Context.java
@@ -30,8 +30,8 @@ public class Context {
     // whose disposal need to be handed over from the garbage 
     // collection thread to the users thread.
 
-    // Reserved to be used only as a placeholder by rowReferences Map to avoid autoboxing allocations
-    static final Integer ROW_REFERENCES_VALUE = 0;
+    // Reserved to be used only as a placeholder by native references Map to avoid autoboxing allocations
+    static final Integer NATIVE_REFERENCES_VALUE = 0;
 
     private List<Long> abandonedTables = new ArrayList<Long>();
     private List<Long> abandonedTableViews = new ArrayList<Long>();
@@ -62,14 +62,14 @@ public class Context {
             }
             abandonedQueries.clear();
 
-            cleanRows();
+            cleanNativeReferences();
         }
     }
 
-    public void cleanRows() {
+    public void cleanNativeReferences() {
         NativeObjectReference reference = (NativeObjectReference) referenceQueue.poll();
         while (reference != null) {
-            UncheckedRow.nativeClose(reference.nativePointer);
+            reference.clear();
             rowReferences.remove(reference);
             reference = (NativeObjectReference) referenceQueue.poll();
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
@@ -22,13 +22,25 @@ import java.lang.ref.ReferenceQueue;
  * This class is used for holding the reference to the native pointers present in NativeObjects.
  * This is required as phantom references cannot access the original objects for this value.
  */
-public class NativeObjectReference extends PhantomReference<NativeObject> {
+public abstract class NativeObjectReference extends PhantomReference<NativeObject> {
 
     // The pointer to the native object to be handled
-    final long nativePointer;
+    protected final long nativePointer;
 
     public NativeObjectReference(NativeObject referent, ReferenceQueue<? super NativeObject> referenceQueue) {
         super(referent, referenceQueue);
         nativePointer = referent.nativePointer;
+    }
+
+    /**
+     * This method is called when this reference gets cleared.
+     * Subclasses should implement this method to dealloc the native pointer.
+     */
+    protected abstract void cleanup();
+
+    @Override
+    public void clear() {
+        cleanup();
+        super.clear();
     }
 }


### PR DESCRIPTION
* Add abstract method to NativeObjectReference for native resource
  releasing.
* Implement NativeObjectReference.cleanup for UncheckRow and LinkView