### PR TITLE
Transaction should not block opening Realm

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2801,4 +2801,25 @@ public class RealmTests {
         assertEquals(0, realm.where(Cat.class).count());
         assertTrue(realm.isEmpty());
     }
+
+    // When there is a transaction holding by a typed Realm in one thread, getInstance from the
+    // other thread should not be blocked since we have cached the schemas already.
+    @Test
+    public void getInstance_shouldNotBeBlockedByTransactionInAnotherThread()
+            throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        realm.beginTransaction();
+
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(realmConfig);
+                realm.close();
+                latch.countDown();
+            }
+        });
+        thread.start();
+        TestHelper.awaitOrFail(latch);
+        realm.cancelTransaction();
+    }
 }


### PR DESCRIPTION
Minor issue, but it could blocking Realm reading which is not what we expected.

This is the test case only, the problem has been fixed when we introduce
the schema caches.

Since we are caching the schemas for typed Realm, when a transaction
lock is holding by one type Realm, open Realm instance in another thread
should not be blocked.
But if there is no typed Realm instance opened, DynamicRealm transaction
should block the typed Realm openning.