### PR TITLE
Add analytics on annotation

### DIFF
--- a/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -21,12 +21,24 @@ import io.realm.annotations.Index;
 import io.realm.annotations.PrimaryKey;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.*;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Utility class for holding metadata for RealmProxy classes.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -16,30 +16,17 @@
 
 package io.realm.processor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.Index;
+import io.realm.annotations.PrimaryKey;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.PackageElement;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
-
-import io.realm.annotations.Ignore;
-import io.realm.annotations.Index;
-import io.realm.annotations.PrimaryKey;
+import java.util.*;
 
 /**
  * Utility class for holding metadata for RealmProxy classes.
@@ -375,6 +362,10 @@ public class ClassMetaData {
             return false;
         }
         return (!type.endsWith(".RealmObject") && !type.endsWith("RealmProxy"));
+    }
+
+    public String getPackageName() {
+        return packageName;
     }
 
     public String getFullyQualifiedClassName() {

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
@@ -31,18 +31,18 @@ import java.util.List;
 //
 // Why are we doing this? Because it helps us build a better product for you.
 // None of the data personally identifies you, your employer or your app, but it
-// *will* help us understand what language you use, what Android versions you
-// target, etc. Having this info will help prioritizing our time, adding new
+// *will* help us understand what Realm version you use, what host OS you use,
+// etc. Having this info will help with prioritizing our time, adding new
 // features and deprecating old features. Collecting an anonymized bundle &
 // anonymized MAC is the only way for us to count actual usage of the other
 // metrics accurately. If we don’t have a way to deduplicate the info reported,
-// it will be useless, as a single developer building their Android app 10 times
-// would report 10 times more than a single developer that only
-// builds once, making the data all but useless. No one likes sharing data
-// unless it’s necessary, we get it, and we’ve debated adding this for a long
-// long time. Since Realm is a free product without an email signup, we feel
-// this is a necessary step so we can collect relevant data to build a better
-// product for you.
+// it will be useless, as a single developer building their app on Windows ten
+// times would report 10 times more than a single developer that only builds
+// once from Mac OS X, making the data all but useless. No one likes sharing
+// data unless it’s necessary, we get it, and we’ve debated adding this for a
+// long long time. Since Realm is a free product without an email signup, we
+// feel this is a necessary step so we can collect relevant data to build a
+// better product for you.
 //
 // Currently the following information is reported:
 // - What version of Realm is being used

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
@@ -56,7 +56,7 @@ public class RealmAnalytics {
     private static RealmAnalytics instance;
     private static final int READ_TIMEOUT = 2000;
     private static final int CONNECT_TIMEOUT = 4000;
-    private static final String ADDRESS_PREFIX = "http://api.mixpanel.com/track/?data=";
+    private static final String ADDRESS_PREFIX = "https://api.mixpanel.com/track/?data=";
     private static final String ADDRESS_SUFFIX = "&ip=1";
     private static final String TOKEN = "ce0fac19508f6c8f20066d345d360fd0";
     private static final String EVENT_NAME = "Run";
@@ -71,7 +71,7 @@ public class RealmAnalytics {
             + "      \"Binding\": \"java\",\n"
             + "      \"Realm Version\": \"%REALM_VERSION%\",\n"
             + "      \"Host OS Type\": \"%OS_TYPE%\",\n"
-            + "      \"Host OS Version\": \"%OS_VERSION%\"\n"
+            + "      \"Host OS Version\": \"%OS_VERSION%\",\n"
             + "      \"Target OS Type\": \"android\"\n"
             + "   }\n"
             + "}";

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
@@ -31,7 +31,7 @@ import java.util.Set;
 // processor is running
 //
 // To be clear: this does *not* run when your app is in production or on
-// your end-user’s devices; it will only run when you build your app from source.
+// your end-user's devices; it will only run when you build your app from source.
 //
 // Why are we doing this? Because it helps us build a better product for you.
 // None of the data personally identifies you, your employer or your app, but it
@@ -39,7 +39,7 @@ import java.util.Set;
 // etc. Having this info will help with prioritizing our time, adding new
 // features and deprecating old features. Collecting an anonymized bundle &
 // anonymized MAC is the only way for us to count actual usage of the other
-// metrics accurately. If we don’t have a way to deduplicate the info reported,
+// metrics accurately. If we don't have a way to deduplicate the info reported,
 // it will be useless, as a single developer building their app on Windows ten
 // times would report 10 times more than a single developer that only builds
 // once from Mac OS X, making the data all but useless. No one likes sharing
@@ -51,7 +51,7 @@ import java.util.Set;
 // Currently the following information is reported:
 // - What version of Realm is being used
 // - What OS you are running on
-// - An anonymous MAC address and bundle ID to aggregate the other information on.
+// - An anonymized MAC address and bundle ID to aggregate the other information on.
 public class RealmAnalytics {
     private static RealmAnalytics instance;
     private static final int READ_TIMEOUT = 2000;

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmAnalytics.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.processor;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.*;
+import java.security.NoSuchAlgorithmException;
+import java.util.Enumeration;
+import java.util.List;
+
+// Asynchronously submits build information to Realm when the annotation
+// processor is running
+//
+// To be clear: this does *not* run when your app is in production or on
+// your end-user’s devices; it will only run when you build your app from source.
+//
+// Why are we doing this? Because it helps us build a better product for you.
+// None of the data personally identifies you, your employer or your app, but it
+// *will* help us understand what language you use, what Android versions you
+// target, etc. Having this info will help prioritizing our time, adding new
+// features and deprecating old features. Collecting an anonymized bundle &
+// anonymized MAC is the only way for us to count actual usage of the other
+// metrics accurately. If we don’t have a way to deduplicate the info reported,
+// it will be useless, as a single developer building their Android app 10 times
+// would report 10 times more than a single developer that only
+// builds once, making the data all but useless. No one likes sharing data
+// unless it’s necessary, we get it, and we’ve debated adding this for a long
+// long time. Since Realm is a free product without an email signup, we feel
+// this is a necessary step so we can collect relevant data to build a better
+// product for you.
+//
+// Currently the following information is reported:
+// - What version of Realm is being used
+// - What OS you are running on
+// - An anonymous MAC address and bundle ID to aggregate the other information on.
+public class RealmAnalytics {
+    private static RealmAnalytics INSTANCE;
+    private static final String ADDRESS_PREFIX = "http://api.mixpanel.com/track/?data=";
+    private static final String ADDRESS_SUFFIX = "&ip=1";
+    private static final String TOKEN = "ce0fac19508f6c8f20066d345d360fd0";
+    private static final String EVENT_NAME = "Run";
+    private static final String JSON_TEMPLATE
+            = "{\n"
+            + "   \"event\": \"%EVENT%\",\n"
+            + "   \"properties\": {\n"
+            + "      \"token\": \"%TOKEN%\",\n"
+            + "      \"distinct_id\": \"%USER_ID%\",\n"
+            + "      \"Anonymized MAC Address\": \"%USER_ID%\",\n"
+            + "      \"Anonymized Bundle ID\": \"%APP_ID%\",\n"
+            + "      \"Binding\": \"java\",\n"
+            + "      \"Realm Version\": \"%REALM_VERSION%\",\n"
+            + "      \"Host OS Type\": \"%OS_TYPE%\",\n"
+            + "      \"Host OS Version\": \"%OS_VERSION%\"\n"
+            + "      \"Target OS Type\": \"android\"\n"
+            + "   }\n"
+            + "}";
+
+    // The list of packages the model classes reside in
+    private List<String> packages;
+
+    private RealmAnalytics(List<String> packages) {
+        this.packages = packages;
+    }
+
+    public static RealmAnalytics getInstance(List<String> packages) {
+        if (INSTANCE == null) {
+            INSTANCE = new RealmAnalytics(packages);
+        }
+        return INSTANCE;
+    }
+
+    public void send() {
+        try {
+            URL url = getUrl();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.connect();
+            connection.getResponseCode();
+        } catch (IOException ignored) {
+        } catch (NoSuchAlgorithmException ignored) {
+        }
+    }
+
+    public URL getUrl() throws
+            MalformedURLException,
+            SocketException,
+            NoSuchAlgorithmException,
+            UnsupportedEncodingException {
+        return new URL(ADDRESS_PREFIX + Utils.base64Encode(generateJson()) + ADDRESS_SUFFIX);
+    }
+
+    public String generateJson() throws SocketException, NoSuchAlgorithmException {
+        return JSON_TEMPLATE
+                .replaceAll("%EVENT%", EVENT_NAME)
+                .replaceAll("%TOKEN%", TOKEN)
+                .replaceAll("%USER_ID%", getAnonymousUserId())
+                .replaceAll("%APP_ID%", getAnonymousAppId())
+                .replaceAll("%REALM_VERSION%", Version.VERSION)
+                .replaceAll("%OS_TYPE%", System.getProperty("os.name"))
+                .replaceAll("%OS_VERSION%", System.getProperty("os.version"));
+    }
+
+    /**
+     * Compute an anonymous user id from the hashed MAC address of the first network interface
+     * @return the anonymous user id
+     * @throws NoSuchAlgorithmException
+     * @throws SocketException
+     */
+    public static String getAnonymousUserId() throws NoSuchAlgorithmException, SocketException {
+        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+
+        if (!networkInterfaces.hasMoreElements()) {
+            throw new IllegalStateException("No network interfaces detected");
+        }
+
+        NetworkInterface networkInterface = networkInterfaces.nextElement();
+        byte[] hardwareAddress = networkInterface.getHardwareAddress(); // Normally this is the MAC address
+
+        return Utils.hexStringify(Utils.sha256Hash(hardwareAddress));
+    }
+
+    /**
+     * Compute an anonymous app/library id from the packages containing Realm model classes
+     * @return the anonymous app/library id
+     * @throws NoSuchAlgorithmException
+     */
+    public String getAnonymousAppId() throws NoSuchAlgorithmException {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (String modelPackage : packages) {
+            stringBuilder.append(modelPackage).append(":");
+        }
+        byte[] packagesBytes = stringBuilder.toString().getBytes();
+
+        return Utils.hexStringify(Utils.sha256Hash(packagesBytes));
+    }
+}

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -131,12 +131,12 @@ public class RealmProcessor extends AbstractProcessor {
                 continue;
             }
             Utils.note("Processing class " + metadata.getSimpleClassName());
-            packages.add(metadata.getPackageName());
             boolean success = metadata.generate();
             if (!success) {
                 return true; // Abort processing by claiming all annotations
             }
             classesToValidate.add(metadata);
+            packages.add(metadata.getPackageName());
 
             RealmProxyClassGenerator sourceCodeGenerator = new RealmProxyClassGenerator(processingEnv, metadata);
             try {

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -26,7 +26,10 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * The RealmProcessor is responsible for creating the plumbing that connects the RealmObjects to a Realm. The process
@@ -114,7 +117,7 @@ public class RealmProcessor extends AbstractProcessor {
 
         Utils.initialize(processingEnv);
 
-        List<String> packages = new ArrayList<String>();
+        Set<String> packages = new TreeSet<String>();
 
         // Create all proxy classes
         for (Element classElement : roundEnv.getElementsAnnotatedWith(RealmClass.class)) {
@@ -146,7 +149,7 @@ public class RealmProcessor extends AbstractProcessor {
 	    }
 
         RealmAnalytics analytics = RealmAnalytics.getInstance(packages);
-        analytics.send();
+        analytics.execute();
 
         hasProcessedModules = true;
         return processModules(roundEnv);

--- a/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
@@ -1,19 +1,17 @@
 package io.realm.processor;
 
-import java.lang.reflect.ParameterizedType;
-import java.util.List;
-
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
+import javax.xml.bind.DatatypeConverter;
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
 
 /**
  * Utility methods working with the Realm processor.
@@ -128,5 +126,40 @@ public class Utils {
 
     public static Element getSuperClass(TypeElement classType) {
         return typeUtils.asElement(classType.getSuperclass());
+    }
+
+    /**
+     * Encode the given string with Base64
+     * @param data the string to encode
+     * @return the encoded string
+     * @throws UnsupportedEncodingException
+     */
+    public static String base64Encode(String data) throws UnsupportedEncodingException {
+        return DatatypeConverter.printBase64Binary(data.getBytes("UTF-8"));
+    }
+
+    /**
+     * Compute the SHA-256 hash of the given byte array
+     * @param data the byte array to hash
+     * @return the hashed byte array
+     * @throws NoSuchAlgorithmException
+     */
+    public static byte[] sha256Hash(byte[] data) throws NoSuchAlgorithmException {
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+        return messageDigest.digest(data);
+    }
+
+    /**
+     * Convert a byte array to its hex-string
+     * @param data the byte array to convert
+     * @return the hex-string of the byte array
+     */
+    public static String hexStringify(byte[] data) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (byte singleByte : data) {
+            stringBuilder.append(Integer.toString((singleByte & 0xff) + 0x100, 16).substring(1));
+        }
+
+        return stringBuilder.toString();
     }
 }

--- a/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
@@ -2,7 +2,11 @@ package io.realm.processor;
 
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.*;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;


### PR DESCRIPTION
Asynchronously submits build information to Realm when the annotation processor is running

To be clear: this does *not* run when your app is in production or on your end-user’s devices; it will only run when you build your app from source.

Why are we doing this? Because it helps us build a better product for you. None of the data personally identifies you, your employer or your app, but it *will* help us understand what Realm version you use, what host OS you use, etc. Having this info will help with prioritizing our time, adding new features and deprecating old features. Collecting an anonymized bundle & anonymized MAC is the only way for us to count actual usage of the other metrics accurately. If we don’t have a way to deduplicate the info reported, it will be useless, as a single developer building their app on Windows 10 times would report 10 times more than a single developer that only builds once from Mac OS X, making the data all but useless. No one likes sharing data unless it’s necessary, we get it, and we’ve debated adding this for a long long time. Since Realm is a free product without an email signup, we feel this is a necessary step so we can collect relevant data to build a better product for you.

Currently the following information is reported:
- What version of Realm is being used
- What OS you are running on
- An anonymised MAC address and bundle ID to aggregate the other information on.