### PR TITLE
RealmConfiguration now accepts Null modules

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 0.82
+ * RealmConfiguration.setModules() now accept ignore null values which Realm.getDefaultModule() might return.
  * Trying to access a deleted Realm object throw throws a proper IllegalStateException.
  * Added in-memory Realm support.
  * Closing realm on another thread different from where it was created now throws an exception.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -95,7 +95,7 @@ import java.util.TreeSet;
         "io.realm.annotations.Ignore",
         "io.realm.annotations.Index",
         "io.realm.annotations.PrimaryKey",
-        "io.realm.annotations.internal.RealmModule"
+        "io.realm.annotations.RealmModule"
 })
 public class RealmProcessor extends AbstractProcessor {
 

--- a/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
@@ -172,22 +172,6 @@ public class RealmConfigurationTest extends AndroidTestCase {
         }
     }
 
-    public void testSetModulesNullThrows() {
-        // Test first argument
-        try {
-            new RealmConfiguration.Builder(getContext()).setModules(null);
-            fail();
-        } catch (IllegalArgumentException expected) {
-        }
-
-        // Test second argument
-        try {
-            new RealmConfiguration.Builder(getContext()).setModules(Realm.getDefaultModule(), null, null);
-            fail();
-        } catch (IllegalArgumentException expected) {
-        }
-    }
-
     public void testSetModulesNonRealmModulesThrows() {
         // Test first argument
         try {
@@ -205,7 +189,7 @@ public class RealmConfigurationTest extends AndroidTestCase {
     }
 
     public void testSetModules() {
-        RealmConfiguration realmConfig = new RealmConfiguration.Builder(getContext()).setModules(Realm.getDefaultModule()).build();
+        RealmConfiguration realmConfig = new RealmConfiguration.Builder(getContext()).setModules(Realm.getDefaultModule(), null).build();
         realm = Realm.getInstance(realmConfig);
         assertNotNull(realm.getTable(AllTypes.class));
     }

--- a/realm/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/src/main/java/io/realm/RealmConfiguration.java
@@ -361,8 +361,7 @@ public class RealmConfiguration {
          * @param baseModule        First Realm module (required).
          * @param additionalModules Additional Realm modules
          *
-         * @throws IllegalArgumentException if any of the modules are {@code null} or doesn't have the
-         * {@link RealmModule} annotation.
+         * @throws IllegalArgumentException if any of the modules doesn't have the {@link RealmModule} annotation.
          * @see Realm#getDefaultModule()
          */
         public Builder setModules(Object baseModule, Object... additionalModules) {
@@ -371,7 +370,6 @@ public class RealmConfiguration {
             if (additionalModules != null) {
                 for (int i = 0; i < additionalModules.length; i++) {
                     Object module = additionalModules[i];
-                    checkModule(module);
                     addModule(module);
                 }
             }
@@ -379,8 +377,10 @@ public class RealmConfiguration {
         }
 
         private void addModule(Object module) {
-            checkModule(module);
-            modules.add(module);
+            if (module != null) {
+                checkModule(module);
+                modules.add(module);
+            }
         }
 
         /**
@@ -412,9 +412,6 @@ public class RealmConfiguration {
         }
 
         private void checkModule(Object module) {
-            if (module == null) {
-                throw new IllegalArgumentException("Provided RealmModule must not be null.");
-            }
             if (!module.getClass().isAnnotationPresent(RealmModule.class)) {
                 throw new IllegalArgumentException(module.getClass().getCanonicalName() + " is not a RealmModule. " +
                         "Add @RealmModule to the class definition.");


### PR DESCRIPTION
Fixes #1302

We had a fair amount of issues over the last weeks where people did not properly understanding when to use Realm.getDefaultModule(), which means they used even when no DefaultModule was created. This is fairly common when all your RealmClasses are in a library and your application just uses the RealmClasses from that library. 

This PR relaxes the requirements and allows a smaller programmer error by ignoring null values parsed to `RealmConfiguration.setModules()`. It turned out that returning a empty module would require a lot more code.

See #1302 for possible other solutions.

@realm/java 
