### PR TITLE
Introduce RealmBase and SharedGroupManager

### DIFF
--- a/realm/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/src/androidTest/java/io/realm/TestHelper.java
@@ -105,11 +105,13 @@ public class TestHelper {
             long totalMemory = Runtime.getRuntime().totalMemory();
             garbageSize = (int)(maxMemory - totalMemory)/10*9;
         }
-        byte garbage[];
+        byte garbage[] = new byte[0];
         try {
-            garbage = new byte[garbageSize];
-            garbage[0] = 1;
-            garbage[garbage.length - 1] = 1;
+            if (garbageSize > 0) {
+                garbage = new byte[garbageSize];
+                garbage[0] = 1;
+                garbage[garbage.length - 1] = 1;
+            }
         } catch (OutOfMemoryError oom) {
             return allocGarbage(garbageSize/10*9);
         }

--- a/realm/src/main/java/io/realm/BaseRealm.java
+++ b/realm/src/main/java/io/realm/BaseRealm.java
@@ -1,0 +1,599 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.realm;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+
+import java.io.Closeable;
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.realm.exceptions.RealmEncryptionNotSupportedException;
+import io.realm.exceptions.RealmMigrationNeededException;
+import io.realm.internal.ColumnType;
+import io.realm.internal.RealmProxyMediator;
+import io.realm.internal.SharedGroup;
+import io.realm.internal.SharedGroupManager;
+import io.realm.internal.Table;
+import io.realm.internal.android.DebugAndroidLogger;
+import io.realm.internal.android.ReleaseAndroidLogger;
+import io.realm.internal.log.RealmLog;
+
+/**
+ * Base class for all Realm instances.
+ *
+ * @see io.realm.Realm
+ */
+abstract class BaseRealm implements Closeable {
+
+    private static final int REALM_CHANGED = 14930352; // Hopefully it won't clash with other message IDs.
+    protected static final long UNVERSIONED = -1;
+    private static final String INCORRECT_THREAD_CLOSE_MESSAGE = "Realm access from incorrect thread. Realm instance can only be closed on the thread it was created.";
+    private static final String INCORRECT_THREAD_MESSAGE = "Realm access from incorrect thread. Realm objects can only be accessed on the thread they were created.";
+    private static final String CLOSED_REALM_MESSAGE = "This Realm instance has already been closed, making it unusable.";
+    private static final String DIFFERENT_KEY_MESSAGE = "Wrong key used to decrypt Realm.";
+
+    // Map between all Realm file paths and all known configurations pointing to that file.
+    protected static final Map<String, List<RealmConfiguration>> globalPathConfigurationCache =
+            new HashMap<String, List<RealmConfiguration>>();
+
+    // Reference count on currently open Realm instances (both normal and dynamic).
+    protected static final Map<String, Integer> globalRealmFileReferenceCounter = new HashMap<String, Integer>();
+
+    // Map between a Handler and the canonical path to a Realm file
+    protected static final Map<Handler, String> handlers = new ConcurrentHashMap<Handler, String>();
+
+    protected final List<WeakReference<RealmChangeListener>> changeListeners =
+            new CopyOnWriteArrayList<WeakReference<RealmChangeListener>>();
+
+    protected long threadId;
+    protected RealmConfiguration configuration;
+    protected SharedGroupManager sharedGroupManager;
+    protected boolean autoRefresh;
+    Handler handler;
+
+    static {
+        RealmLog.add(BuildConfig.DEBUG ? new DebugAndroidLogger() : new ReleaseAndroidLogger());
+    }
+
+    protected BaseRealm(RealmConfiguration configuration, boolean autoRefresh) {
+        this.threadId = Thread.currentThread().getId();
+        this.configuration = configuration;
+        this.sharedGroupManager = new SharedGroupManager(configuration);
+        setAutoRefresh(autoRefresh);
+    }
+
+    /**
+     * Set the auto-refresh status of the Realm instance.
+     * <p>
+     * Auto-refresh is a feature that enables automatic update of the current Realm instance and all its derived objects
+     * (RealmResults and RealmObjects instances) when a commit is performed on a Realm acting on the same file in another thread.
+     * This feature is only available if the Realm instance lives is a {@link android.os.Looper} enabled thread.
+     *
+     * @param autoRefresh true will turn auto-refresh on, false will turn it off.
+     * @throws java.lang.IllegalStateException if trying to enable auto-refresh in a thread without Looper.
+     */
+    public void setAutoRefresh(boolean autoRefresh) {
+        if (autoRefresh && Looper.myLooper() == null) {
+            throw new IllegalStateException("Cannot set auto-refresh in a Thread without a Looper");
+        }
+
+        if (autoRefresh && !this.autoRefresh) { // Switch it on
+            handler = new Handler(new RealmCallback());
+            handlers.put(handler, configuration.getPath());
+        } else if (!autoRefresh && this.autoRefresh && handler != null) { // Switch it off
+            removeHandler(handler);
+        }
+        this.autoRefresh = autoRefresh;
+    }
+
+    /**
+     * Retrieve the auto-refresh status of the Realm instance.
+     * @return the auto-refresh status
+     */
+    public boolean isAutoRefresh() {
+        return autoRefresh;
+    }
+
+    /**
+     * Add a change listener to the Realm.
+     * <p>
+     * The listeners will be executed:
+     * <ul>
+     *     <li>Immediately if a change was committed by the local thread</li>
+     *     <li>On every loop of a Handler thread if changes were committed by another thread</li>
+     *     <li>On every call to {@link io.realm.Realm#refresh()}</li>
+     * </ul>
+     *
+     * @param listener the change listener
+     * @see io.realm.RealmChangeListener
+     */
+    public void addChangeListener(RealmChangeListener listener) {
+        checkIfValid();
+        for (WeakReference<RealmChangeListener> ref : changeListeners) {
+            if (ref.get() == listener) {
+                // It has already been added before
+                return;
+            }
+        }
+
+        changeListeners.add(new WeakReference<RealmChangeListener>(listener));
+    }
+
+    /**
+     * Remove the specified change listener
+     *
+     * @param listener the change listener to be removed
+     * @see io.realm.RealmChangeListener
+     */
+    public void removeChangeListener(RealmChangeListener listener) {
+        checkIfValid();
+        WeakReference<RealmChangeListener> weakRefToRemove = null;
+        for (WeakReference<RealmChangeListener> weakRef : changeListeners) {
+            if (listener == weakRef.get()) {
+                weakRefToRemove = weakRef;
+                // There won't be duplicated entries, checking is done when adding
+                break;
+            }
+        }
+        if (weakRefToRemove != null) {
+            changeListeners.remove(weakRefToRemove);
+        }
+    }
+
+    /**
+     * Remove all user-defined change listeners
+     *
+     * @see io.realm.RealmChangeListener
+     */
+    public void removeAllChangeListeners() {
+        checkIfValid();
+        changeListeners.clear();
+    }
+
+    protected void removeHandler(Handler handler) {
+        handler.removeCallbacksAndMessages(null);
+        handlers.remove(handler);
+    }
+
+    private void sendNotifications() {
+        Iterator<WeakReference<RealmChangeListener>> iterator = changeListeners.iterator();
+        List<WeakReference<RealmChangeListener>> toRemoveList = null;
+        while (iterator.hasNext()) {
+            WeakReference<RealmChangeListener> weakRef = iterator.next();
+            RealmChangeListener listener = weakRef.get();
+            if (listener == null) {
+                if (toRemoveList == null) {
+                    toRemoveList = new ArrayList<WeakReference<RealmChangeListener>>(changeListeners.size());
+                }
+                toRemoveList.add(weakRef);
+            } else {
+                listener.onChange();
+            }
+        }
+        if (toRemoveList != null) {
+            changeListeners.removeAll(toRemoveList);
+        }
+    }
+
+    /**
+     * Checks if any open Realm instances are still referencing this file.
+     */
+    protected static boolean isFileOpen(RealmConfiguration configuration) {
+        Integer refCount = globalRealmFileReferenceCounter.get(configuration.getPath());
+        return refCount != null && refCount > 0;
+    }
+
+    /**
+     * Write a compacted copy of the Realm to the given destination File.
+     * <p>
+     * The destination file cannot already exist.
+     * <p>
+     * Note that if this is called from within a write transaction it writes the
+     * current data, and not the data as it was when the last write transaction was committed.
+     *
+     * @param destination File to save the Realm to
+     * @throws java.io.IOException if any write operation fails
+     */
+    public void writeCopyTo(File destination) throws java.io.IOException {
+        writeEncryptedCopyTo(destination, null);
+    }
+
+    /**
+     * Write a compacted and encrypted copy of the Realm to the given destination File.
+     * <p>
+     * The destination file cannot already exist.
+     * <p>
+     * Note that if this is called from within a write transaction it writes the
+     * current data, and not the data as it was when the last write transaction was committed.
+     * <p>
+     * @param destination File to save the Realm to
+     * @throws java.io.IOException if any write operation fails
+     * @throws RealmEncryptionNotSupportedException if the device doesn't support Realm encryption.
+     */
+    public void writeEncryptedCopyTo(File destination, byte[] key) throws java.io.IOException {
+        if (destination == null) {
+            throw new IllegalArgumentException("The destination argument cannot be null");
+        }
+        checkIfValid();
+        sharedGroupManager.copyToFile(destination, key);
+    }
+
+    /**
+     * Refresh the Realm instance and all the RealmResults and RealmObjects instances coming from it.
+     * It also calls the listeners associated to the Realm instance.
+     */
+    @SuppressWarnings("UnusedDeclaration")
+    public void refresh() {
+        checkIfValid();
+        sharedGroupManager.advanceRead();
+        sendNotifications();
+    }
+
+    /**
+     * Starts a write transaction, this must be closed with {@link io.realm.Realm#commitTransaction()}
+     * or aborted by {@link io.realm.Realm#cancelTransaction()}. Write transactions are used to
+     * atomically create, update and delete objects within a realm.
+     * <br>
+     * Before beginning the write transaction, {@link io.realm.Realm#beginTransaction()} updates the
+     * realm in the case of pending updates from other threads.
+     * <br>
+     * Notice: it is not possible to nest write transactions. If you start a write
+     * transaction within a write transaction an exception is thrown.
+     * <br>
+     * @throws java.lang.IllegalStateException If already in a write transaction or incorrect thread.
+     *
+     */
+    public void beginTransaction() {
+        checkIfValid();
+        sharedGroupManager.promoteToWrite();
+    }
+
+    /**
+     * All changes since {@link io.realm.Realm#beginTransaction()} are persisted to disk and the
+     * Realm reverts back to being read-only. An event is sent to notify all other realm instances
+     * that a change has occurred. When the event is received, the other Realms will get their
+     * objects and {@link io.realm.RealmResults} updated to reflect
+     * the changes from this commit.
+     *
+     * @throws java.lang.IllegalStateException If the write transaction is in an invalid state or incorrect thread.
+     */
+    public void commitTransaction() {
+        checkIfValid();
+        sharedGroupManager.commitAndContinueAsRead();
+
+        for (Map.Entry<Handler, String> handlerIntegerEntry : handlers.entrySet()) {
+            Handler handler = handlerIntegerEntry.getKey();
+            String realmPath = handlerIntegerEntry.getValue();
+
+            // Notify at once on thread doing the commit
+            if (handler.equals(this.handler)) {
+                sendNotifications();
+                continue;
+            }
+
+            // For all other threads, use the Handler
+            if (
+                    realmPath.equals(configuration.getPath())    // It's the right realm
+                            && !handler.hasMessages(REALM_CHANGED)       // The right message
+                            && handler.getLooper().getThread().isAlive() // The receiving thread is alive
+                    ) {
+                handler.sendEmptyMessage(REALM_CHANGED);
+            }
+        }
+    }
+
+    /**
+     * Revert all writes (created, updated, or deleted objects) made in the current write
+     * transaction and end the transaction.
+     * <br>
+     * The Realm reverts back to read-only.
+     * <br>
+     * Calling this when not in a write transaction will throw an exception.
+     *
+     * @throws java.lang.IllegalStateException    If the write transaction is an invalid state,
+     *                                             not in a write transaction or incorrect thread.
+     */
+    public void cancelTransaction() {
+        checkIfValid();
+        sharedGroupManager.rollbackAndContinueAsRead();
+    }
+
+    /**
+     * Checks if a Realm's underlying resources are still available or not getting accessed from
+     * the wrong thread.
+     */
+    protected void checkIfValid() {
+        // Check if the Realm instance has been closed
+        if (sharedGroupManager != null && !sharedGroupManager.isOpen()) {
+            throw new IllegalStateException(BaseRealm.CLOSED_REALM_MESSAGE);
+        }
+
+        // Check if we are in the right thread
+        if (threadId != Thread.currentThread().getId()) {
+            throw new IllegalStateException(BaseRealm.INCORRECT_THREAD_MESSAGE);
+        }
+    }
+
+    /**
+     * Returns the canonical path to where this Realm is persisted on disk.
+     *
+     * @return The canonical path to the Realm file.
+     * @see File#getCanonicalPath()
+     */
+    public String getPath() {
+        return configuration.getPath();
+    }
+
+    /**
+     * Returns the {@link RealmConfiguration} for this Realm.
+     * @return {@link RealmConfiguration} for this Realm.
+     */
+    public RealmConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    /**
+     * Returns the schema version for this Realm.
+     * @return The schema version for the Realm file backing this Realm.
+     */
+    public long getVersion() {
+        if (!sharedGroupManager.hasTable("metadata")) {
+            return UNVERSIONED;
+        }
+        Table metadataTable = sharedGroupManager.getTable("metadata");
+        return metadataTable.getLong(0, 0);
+    }
+
+    /**
+     * Closes the Realm instance and all its resources.
+     * <p>
+     * It's important to always remember to close Realm instances when you're done with it in order
+     * not to leak memory, file descriptors or grow the size of Realm file out of measure.
+     *
+     * @throws java.lang.IllegalStateException if trying to close Realm on a different thread than the
+     * one it was created on.
+     */
+    @Override
+    public void close() {
+        if (this.threadId != Thread.currentThread().getId()) {
+            throw new IllegalStateException(INCORRECT_THREAD_CLOSE_MESSAGE);
+        }
+
+        Map<RealmConfiguration, Integer> localRefCount = getLocalReferenceCount();
+        String canonicalPath = configuration.getPath();
+        Integer references = localRefCount.get(configuration);
+        if (references == null) {
+            references = 0;
+        }
+        if (sharedGroupManager != null && references == 1) {
+            lastLocalInstanceClosed();
+            sharedGroupManager.close();
+            sharedGroupManager = null;
+            releaseFileReference();
+        }
+
+        int refCount = references - 1;
+        if (refCount < 0) {
+            RealmLog.w("Calling close() on a Realm that is already closed: " + canonicalPath);
+        }
+        localRefCount.put(configuration, Math.max(0, refCount));
+
+        if (handler != null && refCount <= 0) {
+            removeHandler(handler);
+            handler = null;
+        }
+    }
+
+    /**
+     * Returns the ThreadLocal reference counter for this Realm.
+     */
+    protected abstract Map<RealmConfiguration,Integer> getLocalReferenceCount();
+
+    /**
+     * Callback when the last ThreadLocal instance of this Realm type has been closed.
+     */
+    protected abstract void lastLocalInstanceClosed();
+
+    /**
+     * Acquire a reference to the given Realm file.
+     */
+    protected synchronized void acquireFileReference(RealmConfiguration configuration) {
+        String path = configuration.getPath();
+        Integer refCount = globalRealmFileReferenceCounter.get(path);
+        if (refCount == null) {
+            refCount = 0;
+        }
+        globalRealmFileReferenceCounter.put(path, refCount + 1);
+    }
+
+    /**
+     * Releases a reference to the Realm file. If reference count reaches 0 any cached configurations
+     * will be removed.
+     */
+    protected synchronized void releaseFileReference() {
+        String canonicalPath = configuration.getPath();
+        List<RealmConfiguration> pathConfigurationCache = globalPathConfigurationCache.get(canonicalPath);
+        pathConfigurationCache.remove(configuration);
+        if (pathConfigurationCache.isEmpty()) {
+            globalPathConfigurationCache.remove(canonicalPath);
+        }
+
+        Integer refCount = globalRealmFileReferenceCounter.get(canonicalPath);
+        if (refCount == null || refCount == 0) {
+            throw new IllegalStateException("Trying to release a Realm file that is already closed");
+        }
+        globalRealmFileReferenceCounter.put(canonicalPath, refCount - 1);
+    }
+
+    // package protected so unit tests can access it
+    protected void setVersion(long version) {
+        Table metadataTable = sharedGroupManager.getTable("metadata");
+        if (metadataTable.getColumnCount() == 0) {
+            metadataTable.addColumn(ColumnType.INTEGER, "version");
+            metadataTable.addEmptyRow();
+        }
+        metadataTable.setLong(0, 0, version);
+    }
+
+    /**
+     * Make sure that the new configuration doesn't clash with any existing configurations for the
+     * Realm.
+     *
+     * @throws IllegalArgumentException If the new configuration isn't valid.
+     */
+    protected static void validateAgainstExistingConfigurations(RealmConfiguration newConfiguration) {
+
+        String realmPath = newConfiguration.getPath();
+        List<RealmConfiguration> pathConfigurationCache = globalPathConfigurationCache.get(realmPath);
+
+        if (pathConfigurationCache != null && pathConfigurationCache.size() > 0) {
+
+            // For the current restrictions, it is enough to just check one of the existing configurations.
+            RealmConfiguration cachedConfiguration = pathConfigurationCache.get(0);
+
+            // Check that encryption keys aren't different
+            if (!Arrays.equals(cachedConfiguration.getEncryptionKey(), newConfiguration.getEncryptionKey())) {
+                throw new IllegalArgumentException(DIFFERENT_KEY_MESSAGE);
+            }
+
+            // Check schema versions are the same
+            if (cachedConfiguration.getSchemaVersion() != newConfiguration.getSchemaVersion()) {
+                throw new IllegalArgumentException(String.format("Configurations cannot have different schema versions " +
+                                "if used to open the same file. %d vs. %d", cachedConfiguration.getSchemaVersion(),
+                        newConfiguration.getSchemaVersion()));
+            }
+
+            // Check that schema is the same
+            RealmProxyMediator cachedSchema = cachedConfiguration.getSchemaMediator();
+            RealmProxyMediator schema = newConfiguration.getSchemaMediator();
+            if (!cachedSchema.equals(schema)) {
+                throw new IllegalArgumentException("Two configurations with different schemas are trying to open " +
+                        "the same Realm file. Their schema must be the same: " + newConfiguration.getPath());
+            }
+
+            // Check if the durability is the same
+            SharedGroup.Durability cachedDurability = cachedConfiguration.getDurability();
+            SharedGroup.Durability newDurability = newConfiguration.getDurability();
+            if (!cachedDurability.equals(newDurability)) {
+                throw new IllegalArgumentException("A Realm cannot be both in-memory and persisted. Two conflicting " +
+                        "configurations pointing to " + newConfiguration.getPath() + " are being used.");
+            }
+        }
+    }
+
+    /**
+     * Deletes the Realm file defined by the given configuration.
+     */
+    protected static synchronized boolean deleteRealm(RealmConfiguration configuration) {
+        if (isFileOpen(configuration)) {
+            throw new IllegalStateException("It's not allowed to delete the file associated with an open Realm. " +
+                    "Remember to close() all the instances of the Realm before deleting its file.");
+        }
+
+        boolean realmDeleted = true;
+        String canonicalPath = configuration.getPath();
+        File realmFolder = configuration.getRealmFolder();
+        String realmFileName = configuration.getRealmFileName();
+        List<File> filesToDelete = Arrays.asList(new File(canonicalPath),
+                new File(realmFolder, realmFileName + ".lock"),
+                new File(realmFolder, realmFileName + ".lock_a"),
+                new File(realmFolder, realmFileName + ".lock_b"),
+                new File(realmFolder, realmFileName + ".log"));
+        for (File fileToDelete : filesToDelete) {
+            if (fileToDelete.exists()) {
+                boolean deleteResult = fileToDelete.delete();
+                if (!deleteResult) {
+                    realmDeleted = false;
+                    RealmLog.w("Could not delete the file " + fileToDelete);
+                }
+            }
+        }
+
+        return realmDeleted;
+    }
+
+    /**
+     * Compacts the Realm file defined by the given configuration.
+     */
+    public static synchronized boolean compactRealm(RealmConfiguration configuration) {
+        if (configuration.getEncryptionKey() != null) {
+            throw new IllegalArgumentException("Cannot currently compact an encrypted Realm.");
+        }
+
+        if (isFileOpen(configuration)) {
+            throw new IllegalStateException("Cannot compact an open Realm");
+        }
+
+        return SharedGroupManager.compact(configuration);
+    }
+
+    /**
+     * Migrates the Realm file defined by the given configuration using the provided migration block.
+     */
+    public static synchronized void migrateRealm(RealmConfiguration configuration, RealmMigration migration, MigrationCallback callback) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("RealmConfiguration must be provided");
+        }
+        if (migration == null && configuration.getMigration() == null) {
+            throw new RealmMigrationNeededException(configuration.getPath(), "RealmMigration must be provided");
+        }
+
+        RealmMigration realmMigration = (migration == null) ? configuration.getMigration() : migration;
+        BaseRealm realm = null;
+        try {
+            realm = callback.getRealm(configuration);
+            realm.beginTransaction();
+            realm.setVersion(realmMigration.execute((Realm) realm, realm.getVersion())); // FIXME Remove cast with new migration API
+            realm.commitTransaction();
+        } finally {
+            if (realm != null) {
+                realm.close();
+                callback.migrationComplete();
+            }
+        }
+    }
+
+    // Internal Handler callback for Realm messages
+    private class RealmCallback implements Handler.Callback {
+        @Override
+        public boolean handleMessage(Message message) {
+            if (message.what == REALM_CHANGED) {
+                sharedGroupManager.advanceRead();
+                sendNotifications();
+            }
+            return true;
+        }
+    }
+
+    // Internal delegate for migrations
+    protected interface MigrationCallback {
+        BaseRealm getRealm(RealmConfiguration configuration);
+        void migrationComplete();
+    }
+}

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -21,14 +21,12 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.Message;
 import android.util.JsonReader;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,34 +35,25 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
 
+import io.realm.exceptions.RealmEncryptionNotSupportedException;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmIOException;
 import io.realm.exceptions.RealmMigrationNeededException;
-import io.realm.exceptions.RealmEncryptionNotSupportedException;
 import io.realm.internal.ColumnIndices;
-import io.realm.internal.ColumnType;
-import io.realm.internal.ImplicitTransaction;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.RealmProxyMediator;
-import io.realm.internal.SharedGroup;
 import io.realm.internal.Table;
 import io.realm.internal.TableView;
 import io.realm.internal.UncheckedRow;
 import io.realm.internal.Util;
-import io.realm.internal.android.DebugAndroidLogger;
-import io.realm.internal.android.ReleaseAndroidLogger;
 import io.realm.internal.log.RealmLog;
 
 /**
@@ -120,83 +109,35 @@ import io.realm.internal.log.RealmLog;
  * @see <a href="http://en.wikipedia.org/wiki/ACID">ACID</a>
  * @see <a href="https://github.com/realm/realm-java/tree/master/examples">Examples using Realm</a>
  */
-public final class Realm implements Closeable {
-    public static final String DEFAULT_REALM_NAME = "default.realm";
+public final class Realm extends BaseRealm {
+
+    public static final String DEFAULT_REALM_NAME = RealmConfiguration.DEFAULT_REALM_NAME;
 
     protected static final ThreadLocal<Map<RealmConfiguration, Realm>> realmsCache =
             new ThreadLocal<Map<RealmConfiguration, Realm>>() {
-        @Override
-        protected Map<RealmConfiguration, Realm> initialValue() {
-            return new HashMap<RealmConfiguration, Realm>();
-        }
-    };
-
-    // List of Realm files that has already been validated
-    private static final Set<String> validatedRealmFiles = new HashSet<String>();
+                @Override
+                protected Map<RealmConfiguration, Realm> initialValue() {
+                    return new HashMap<RealmConfiguration, Realm>();
+                }
+            };
 
     private static final ThreadLocal<Map<RealmConfiguration, Integer>> referenceCount =
             new ThreadLocal<Map<RealmConfiguration,Integer>>() {
-        @Override
-        protected Map<RealmConfiguration, Integer> initialValue() {
-            return new HashMap<RealmConfiguration, Integer>();
-        }
-    };
+                @Override
+                protected Map<RealmConfiguration, Integer> initialValue() {
+                    return new HashMap<RealmConfiguration, Integer>();
+                }
+            };
 
-    // Map between all Realm file paths and all known configurations pointing to that file.
-    private static final Map<String, List<RealmConfiguration>> globalPathConfigurationCache =
-            new HashMap<String, List<RealmConfiguration>>();
-
-    // Map how many times a Realm path has been opened across all threads.
-    // This is only needed by deleteRealmFile.
-    private static final Map<String, AtomicInteger> globalOpenInstanceCounter =
-            new ConcurrentHashMap<String, AtomicInteger>();
-
-    protected static final Map<Handler, String> handlers = new ConcurrentHashMap<Handler, String>();
-    private static final int REALM_CHANGED = 14930352; // Hopefully it won't clash with other message IDs.
-
-    private static RealmConfiguration defaultConfiguration;
+    // List of Realm files that has already been validated
+    private static final Set<String> validatedRealmFiles = new HashSet<String>();
 
     // Caches Class objects (both model classes and proxy classes) to Realm Tables
     private final Map<Class<? extends RealmObject>, Table> classToTable =
             new HashMap<Class<? extends RealmObject>, Table>();
 
-    private static final String INCORRECT_THREAD_MESSAGE = "Realm access from incorrect thread. Realm objects can only be accessed on the thread they were created.";
-    private static final String INCORRECT_THREAD_CLOSE_MESSAGE = "Realm access from incorrect thread. Realm instance can only be closed on the thread it was created.";
-    private static final String CLOSED_REALM_MESSAGE = "This Realm instance has already been closed, making it unusable.";
-    private static final String DIFFERENT_KEY_MESSAGE = "Wrong key used to decrypt Realm.";
-
-    @SuppressWarnings("UnusedDeclaration")
-    private static SharedGroup.Durability defaultDurability = SharedGroup.Durability.FULL;
-    private boolean autoRefresh;
-    Handler handler;
-
-    private long threadId;
-    private RealmConfiguration configuration;
-    private SharedGroup sharedGroup;
-    private final ImplicitTransaction transaction;
-
-    private final List<WeakReference<RealmChangeListener>> changeListeners =
-            new CopyOnWriteArrayList<WeakReference<RealmChangeListener>>();
-
-    private static final long UNVERSIONED = -1;
-
-    final ColumnIndices columnIndices = new ColumnIndices();
-
-    static {
-        RealmLog.add(BuildConfig.DEBUG ? new DebugAndroidLogger() : new ReleaseAndroidLogger());
-    }
-
-    protected void checkIfValid() {
-        // Check if the Realm instance has been closed
-        if (sharedGroup == null) {
-            throw new IllegalStateException(CLOSED_REALM_MESSAGE);
-        }
-
-        // Check if we are in the right thread
-        if (threadId != Thread.currentThread().getId()) {
-            throw new IllegalStateException(INCORRECT_THREAD_MESSAGE);
-        }
-    }
+    private static RealmConfiguration defaultConfiguration;
+    protected ColumnIndices columnIndices = new ColumnIndices();
 
     /**
      * The constructor is private to enforce the use of the static one.
@@ -207,136 +148,18 @@ public final class Realm implements Closeable {
      * @throws RealmEncryptionNotSupportedException if the device doesn't support Realm encryption.
      */
     private Realm(RealmConfiguration configuration, boolean autoRefresh) {
-        this.threadId = Thread.currentThread().getId();
-        this.configuration = configuration;
-        this.sharedGroup = new SharedGroup(configuration.getPath(), true, configuration.getDurability(),
-                configuration.getEncryptionKey());
-        this.transaction = sharedGroup.beginImplicitTransaction();
-        setAutoRefresh(autoRefresh);
+        super(configuration, autoRefresh);
     }
 
     @Override
     protected void finalize() throws Throwable {
-        if (sharedGroup != null) {
+        if (sharedGroupManager != null && sharedGroupManager.isOpen()) {
             RealmLog.w("Remember to call close() on all Realm instances. " +
                             "Realm " + configuration.getPath() + " is being finalized without being closed, " +
                             "this can lead to running out of native memory."
             );
         }
         super.finalize();
-    }
-
-    /**
-     * Closes the Realm instance and all its resources.
-     * <p>
-     * It's important to always remember to close Realm instances when you're done with it in order
-     * not to leak memory, file descriptors or grow the size of Realm file out of measure.
-     *
-     * @throws java.lang.IllegalStateException if trying to close Realm on a different thread than the
-     * one it was created on.
-     */
-    @Override
-    public void close() {
-        if (this.threadId != Thread.currentThread().getId()) {
-            throw new IllegalStateException(INCORRECT_THREAD_CLOSE_MESSAGE);
-        }
-
-        Map<RealmConfiguration, Integer> localRefCount = referenceCount.get();
-        String canonicalPath = configuration.getPath();
-        Integer references = localRefCount.get(configuration);
-        if (references == null) {
-            references = 0;
-        }
-        if (sharedGroup != null && references == 1) {
-            realmsCache.get().remove(configuration);
-            sharedGroup.close();
-            sharedGroup = null;
-
-            // It is necessary to be synchronized here since there is a chance that before the counter removed,
-            // the other thread could get the counter and increase it in createAndValidate.
-            synchronized (Realm.class) {
-                validatedRealmFiles.remove(configuration.getPath());
-                List<RealmConfiguration>  pathConfigurationCache = globalPathConfigurationCache.get(canonicalPath);
-                pathConfigurationCache.remove(configuration);
-                if (pathConfigurationCache.isEmpty()) {
-                    globalPathConfigurationCache.remove(canonicalPath);
-                }
-                AtomicInteger counter = globalOpenInstanceCounter.get(canonicalPath);
-                if (counter.decrementAndGet() == 0) {
-                    globalOpenInstanceCounter.remove(canonicalPath);
-                }
-            }
-        }
-
-        int refCount = references - 1;
-        if (refCount < 0) {
-            RealmLog.w("Calling close() on a Realm that is already closed: " + canonicalPath);
-        }
-        localRefCount.put(configuration, Math.max(0, refCount));
-
-        if (handler != null && refCount <= 0) {
-            removeHandler(handler);
-            handler = null;
-        }
-    }
-
-    private void removeHandler(Handler handler) {
-        handler.removeCallbacksAndMessages(null);
-        handlers.remove(handler);
-    }
-
-    private class RealmCallback implements Handler.Callback {
-        @Override
-        public boolean handleMessage(Message message) {
-            if (message.what == REALM_CHANGED) {
-                transaction.advanceRead();
-                sendNotifications();
-            }
-            return true;
-        }
-    }
-
-    /**
-     * Retrieve the auto-refresh status of the Realm instance.
-     * @return the auto-refresh status
-     */
-    public boolean isAutoRefresh() {
-        return autoRefresh;
-    }
-
-    /**
-     * Set the auto-refresh status of the Realm instance.
-     * <p>
-     * Auto-refresh is a feature that enables automatic update of the current Realm instance and all its derived objects
-     * (RealmResults and RealmObjects instances) when a commit is performed on a Realm acting on the same file in another thread.
-     * This feature is only available if the Realm instance lives is a {@link android.os.Looper} enabled thread.
-     *
-     * @param autoRefresh true will turn auto-refresh on, false will turn it off.
-     * @throws java.lang.IllegalStateException if trying to enable auto-refresh in a thread without Looper.
-     */
-    public void setAutoRefresh(boolean autoRefresh) {
-        if (autoRefresh && Looper.myLooper() == null) {
-            throw new IllegalStateException("Cannot set auto-refresh in a Thread without a Looper");
-        }
-
-        if (autoRefresh && !this.autoRefresh) { // Switch it on
-            handler = new Handler(new RealmCallback());
-            handlers.put(handler, configuration.getPath());
-        } else if (!autoRefresh && this.autoRefresh && handler != null) { // Switch it off
-            removeHandler(handler);
-        }
-        this.autoRefresh = autoRefresh;
-    }
-
-    // Public because of migrations
-    public Table getTable(Class<? extends RealmObject> clazz) {
-        Table table = classToTable.get(clazz);
-        if (table == null) {
-            clazz = Util.getOriginalModelClass(clazz);
-            table = transaction.getTable(configuration.getSchemaMediator().getTableName(clazz));
-            classToTable.put(clazz, table);
-        }
-        return table;
     }
 
     /**
@@ -433,109 +256,60 @@ public final class Realm implements Closeable {
     }
 
     private static Realm createAndValidate(RealmConfiguration configuration, boolean validateSchema, boolean autoRefresh) {
-        // Check if a cached instance already exists for this thread
-        String canonicalPath = configuration.getPath();
-        Map<RealmConfiguration, Integer> localRefCount = referenceCount.get();
-        Integer references = localRefCount.get(configuration);
-        if (references == null) {
-            references = 0;
-        }
-        Map<RealmConfiguration, Realm> realms = realmsCache.get();
-        Realm realm = realms.get(configuration);
-        if (realm != null) {
+        synchronized (BaseRealm.class) {
+            // Check if a cached instance already exists for this thread
+            String canonicalPath = configuration.getPath();
+            Map<RealmConfiguration, Integer> localRefCount = referenceCount.get();
+            Integer references = localRefCount.get(configuration);
+            if (references == null) {
+                references = 0;
+            }
+            Map<RealmConfiguration, Realm> realms = realmsCache.get();
+            Realm realm = realms.get(configuration);
+            if (realm != null) {
+                localRefCount.put(configuration, references + 1);
+                return realm;
+            }
+
+            // Create new Realm and cache it. All exception code paths must close the Realm otherwise we risk serving
+            // faulty cache data.
+            validateAgainstExistingConfigurations(configuration);
+            realm = new Realm(configuration, autoRefresh);
+            List<RealmConfiguration> pathConfigurationCache = globalPathConfigurationCache.get(canonicalPath);
+            if (pathConfigurationCache == null) {
+                pathConfigurationCache = new CopyOnWriteArrayList<RealmConfiguration>();
+                globalPathConfigurationCache.put(canonicalPath, pathConfigurationCache);
+            }
+            pathConfigurationCache.add(configuration);
+            realms.put(configuration, realm);
             localRefCount.put(configuration, references + 1);
-            return realm;
-        }
 
-        // Create new Realm and cache it. All exception code paths must close the Realm otherwise we risk serving
-        // faulty cache data.
-        validateAgainstExistingConfigurations(configuration);
-        realm = new Realm(configuration, autoRefresh);
-        List<RealmConfiguration> pathConfigurationCache = globalPathConfigurationCache.get(canonicalPath);
-        if (pathConfigurationCache == null) {
-            pathConfigurationCache = new CopyOnWriteArrayList<RealmConfiguration>();
-            globalPathConfigurationCache.put(canonicalPath, pathConfigurationCache);
-        }
-        pathConfigurationCache.add(configuration);
-        realms.put(configuration, realm);
-        localRefCount.put(configuration, references + 1);
+            // Increment global reference counter
+            realm.acquireFileReference(configuration);
 
-        // Increment global reference counter
-        if (references == 0) {
-            AtomicInteger counter = globalOpenInstanceCounter.get(canonicalPath);
-            if (counter == null) {
-                globalOpenInstanceCounter.put(canonicalPath, new AtomicInteger(1));
-            } else {
-                counter.incrementAndGet();
-            }
-        }
-
-        // Check versions of Realm
-        long currentVersion = realm.getVersion();
-        long requiredVersion = configuration.getSchemaVersion();
-        if (currentVersion != UNVERSIONED && currentVersion < requiredVersion && validateSchema) {
-            realm.close();
-            throw new RealmMigrationNeededException(canonicalPath, String.format("Realm on disc need to migrate from v%s to v%s", currentVersion, requiredVersion));
-        }
-        if (currentVersion != UNVERSIONED && requiredVersion < currentVersion && validateSchema) {
-            realm.close();
-            throw new IllegalArgumentException(String.format("Realm on disc is newer than the one specified: v%s vs. v%s", currentVersion, requiredVersion));
-        }
-
-        // Initialize Realm schema if needed
-        if (validateSchema) {
-            try {
-                initializeRealm(realm);
-            } catch (RuntimeException e) {
+            // Check versions of Realm
+            long currentVersion = realm.getVersion();
+            long requiredVersion = configuration.getSchemaVersion();
+            if (currentVersion != UNVERSIONED && currentVersion < requiredVersion && validateSchema) {
                 realm.close();
-                throw e;
+                throw new RealmMigrationNeededException(configuration.getPath(), String.format("Realm on disk need to migrate from v%s to v%s", currentVersion, requiredVersion));
             }
-        } else {
-            loadMediatorClasses(realm);
-        }
-
-        return realm;
-    }
-
-    // Make sure that the new configuration doesn't clash with any existing configurations for the Realm
-    private static void validateAgainstExistingConfigurations(RealmConfiguration newConfiguration) {
-
-        // Ensure cache state
-        String realmPath = newConfiguration.getPath();
-        List<RealmConfiguration> pathConfigurationCache = globalPathConfigurationCache.get(realmPath);
-
-        if (pathConfigurationCache != null && pathConfigurationCache.size() > 0) {
-
-            // For the current restrictions, it is enough to just check one of the existing configurations.
-            RealmConfiguration cachedConfiguration = pathConfigurationCache.get(0);
-
-            // Check that encryption keys aren't different
-            if (!Arrays.equals(cachedConfiguration.getEncryptionKey(), newConfiguration.getEncryptionKey())) {
-                throw new IllegalArgumentException(DIFFERENT_KEY_MESSAGE);
+            if (currentVersion != UNVERSIONED && requiredVersion < currentVersion && validateSchema) {
+                realm.close();
+                throw new IllegalArgumentException(String.format("Realm on disk is newer than the one specified: v%s vs. v%s", currentVersion, requiredVersion));
             }
 
-            // Check schema versions are the same
-            if (cachedConfiguration.getSchemaVersion() != newConfiguration.getSchemaVersion()) {
-                throw new IllegalArgumentException(String.format("Configurations cannot have different schema versions " +
-                                "if used to open the same file. %d vs. %d", cachedConfiguration.getSchemaVersion(),
-                        newConfiguration.getSchemaVersion()));
+            // Initialize Realm schema if needed
+            if (validateSchema) {
+                try {
+                    initializeRealm(realm);
+                } catch (RuntimeException e) {
+                    realm.close();
+                    throw e;
+                }
             }
 
-            // Check that schema is the same
-            RealmProxyMediator cachedSchema = cachedConfiguration.getSchemaMediator();
-            RealmProxyMediator schema = newConfiguration.getSchemaMediator();
-            if (!cachedSchema.equals(schema)) {
-                throw new IllegalArgumentException("Two configurations with different schemas are trying to open " +
-                        "the same Realm file. Their schema must be the same: " + newConfiguration.getPath());
-            }
-
-            // Check if the durability is the same
-            SharedGroup.Durability cachedDurability = cachedConfiguration.getDurability();
-            SharedGroup.Durability newDurability = newConfiguration.getDurability();
-            if (!cachedDurability.equals(newDurability)) {
-                throw new IllegalArgumentException("A Realm cannot be both in-memory and persisted. Two conflicting " +
-                        "configurations pointing to " + newConfiguration.getPath() + " are being used.");
-            }
+            return realm;
         }
     }
 
@@ -554,9 +328,9 @@ public final class Realm implements Closeable {
             for (Class<? extends RealmObject> modelClass : mediator.getModelClasses()) {
                 // Create and validate table
                 if (version == UNVERSIONED) {
-                    mediator.createTable(modelClass, realm.transaction);
+                    mediator.createTable(modelClass, realm.sharedGroupManager.getTransaction());
                 }
-                mediator.validateTable(modelClass, realm.transaction);
+                mediator.validateTable(modelClass, realm.sharedGroupManager.getTransaction());
                 realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
             }
             validatedRealmFiles.add(realm.getPath());
@@ -566,13 +340,6 @@ public final class Realm implements Closeable {
             } else {
                 realm.cancelTransaction();
             }
-        }
-    }
-
-    private static void loadMediatorClasses(Realm realm) {
-        RealmProxyMediator mediator = realm.configuration.getSchemaMediator();
-        for (Class<? extends RealmObject> modelClass : mediator.getModelClasses()) {
-            realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
         }
     }
 
@@ -909,42 +676,6 @@ public final class Realm implements Closeable {
     }
 
     /**
-     * Write a compacted copy of the Realm to the given destination File.
-     * <p>
-     * The destination file cannot already exist.
-     * <p>
-     * Note that if this is called from within a write transaction it writes the
-     * current data, and not the data as it was when the last write transaction was committed.
-     *
-     * @param destination File to save the Realm to
-     * @throws java.io.IOException if any write operation fails
-     */
-    public void writeCopyTo(File destination) throws IOException {
-        writeEncryptedCopyTo(destination, null);
-    }
-
-    /**
-     * Write a compacted and encrypted copy of the Realm to the given destination File.
-     * <p>
-     * The destination file cannot already exist.
-     * <p>
-     * Note that if this is called from within a write transaction it writes the
-     * current data, and not the data as it was when the last write transaction was committed.
-     * <p>
-     * @param destination File to save the Realm to
-     * @throws java.io.IOException if any write operation fails
-     * @throws RealmEncryptionNotSupportedException if the device doesn't support Realm encryption.
-     */
-    public void writeEncryptedCopyTo(File destination, byte[] key) throws IOException {
-        if (destination == null) {
-            throw new IllegalArgumentException("The destination argument cannot be null");
-        }
-        checkIfValid();
-        transaction.writeToFile(destination, key);
-    }
-
-
-    /**
      * Instantiates and adds a new object to the Realm.
      *
      * @param clazz The Class of the object to create
@@ -965,7 +696,7 @@ public final class Realm implements Closeable {
      * @param clazz The Class of the object to create
      * @param primaryKeyValue Value for the primary key field.
      * @return The new object
-     * @throws {@link RealmException} if object could not be created.
+     * @throws RealmException if object could not be created.
      */
     <E extends RealmObject> E createObject(Class<E> clazz, Object primaryKeyValue) {
         Table table = getTable(clazz);
@@ -1135,7 +866,7 @@ public final class Realm implements Closeable {
      * @throws java.lang.IllegalArgumentException if a field name does not exist.
      */
     public <E extends RealmObject> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldName1,
-                                                               boolean sortAscending1, String fieldName2,
+                                                                    boolean sortAscending1, String fieldName2,
                                                                     boolean sortAscending2) {
         return allObjectsSorted(clazz, new String[]{fieldName1, fieldName2}, new boolean[]{sortAscending1,
                 sortAscending2});
@@ -1202,64 +933,6 @@ public final class Realm implements Closeable {
         return new RealmResults(this, tableView, clazz);
     }
 
-    // Notifications
-
-    /**
-     * Add a change listener to the Realm.
-     * <p>
-     * The listeners will be executed:
-     * <ul>
-     *     <li>Immediately if a change was committed by the local thread</li>
-     *     <li>On every loop of a Handler thread if changes were committed by another thread</li>
-     *     <li>On every call to {@link io.realm.Realm#refresh()}</li>
-     * </ul>
-     *
-     * @param listener the change listener
-     * @see io.realm.RealmChangeListener
-     */
-    public void addChangeListener(RealmChangeListener listener) {
-        checkIfValid();
-        for (WeakReference<RealmChangeListener> ref : changeListeners) {
-            if (ref.get() == listener) {
-                // It has already been added before
-                return;
-            }
-        }
-
-        changeListeners.add(new WeakReference<RealmChangeListener>(listener));
-    }
-
-    /**
-     * Remove the specified change listener
-     *
-     * @param listener the change listener to be removed
-     * @see io.realm.RealmChangeListener
-     */
-    public void removeChangeListener(RealmChangeListener listener) {
-        checkIfValid();
-        WeakReference<RealmChangeListener> weakRefToRemove = null;
-        for (WeakReference<RealmChangeListener> weakRef : changeListeners) {
-            if (listener == weakRef.get()) {
-                weakRefToRemove = weakRef;
-                // There won't be duplicated entries, checking is done when adding
-                break;
-            }
-        }
-        if (weakRefToRemove != null) {
-            changeListeners.remove(weakRefToRemove);
-        }
-    }
-
-    /**
-     * Remove all user-defined change listeners
-     *
-     * @see io.realm.RealmChangeListener
-     */
-    public void removeAllChangeListeners() {
-        checkIfValid();
-        changeListeners.clear();
-    }
-
     /**
      * Return change listeners
      * For internal testing purpose only
@@ -1270,113 +943,9 @@ public final class Realm implements Closeable {
         return changeListeners;
     }
 
-    private void sendNotifications() {
-        Iterator<WeakReference<RealmChangeListener>> iterator = changeListeners.iterator();
-        List<WeakReference<RealmChangeListener>> toRemoveList = null;
-        while (iterator.hasNext()) {
-            WeakReference<RealmChangeListener> weakRef = iterator.next();
-            RealmChangeListener listener = weakRef.get();
-            if (listener == null) {
-                if (toRemoveList == null) {
-                    toRemoveList = new ArrayList<WeakReference<RealmChangeListener>>(changeListeners.size());
-                }
-                toRemoveList.add(weakRef);
-            } else {
-                listener.onChange();
-            }
-        }
-        if (toRemoveList != null) {
-            changeListeners.removeAll(toRemoveList);
-        }
-    }
-
     @SuppressWarnings("UnusedDeclaration")
     boolean hasChanged() {
-        return sharedGroup.hasChanged();
-    }
-
-    /**
-     * Transactions
-     */
-
-    /**
-     * Refresh the Realm instance and all the RealmResults and RealmObjects instances coming from it.
-     * It also calls the listeners associated to the Realm instance.
-     */
-    @SuppressWarnings("UnusedDeclaration")
-    public void refresh() {
-        checkIfValid();
-        transaction.advanceRead();
-        sendNotifications();
-    }
-
-    /**
-     * Starts a write transaction, this must be closed with {@link io.realm.Realm#commitTransaction()}
-     * or aborted by {@link io.realm.Realm#cancelTransaction()}. Write transactions are used to
-     * atomically create, update and delete objects within a realm.
-     * <br>
-     * Before beginning the write transaction, {@link io.realm.Realm#beginTransaction()} updates the
-     * realm in the case of pending updates from other threads.
-     * <br>
-     * Notice: it is not possible to nest write transactions. If you start a write
-     * transaction within a write transaction an exception is thrown.
-     * <br>
-     * @throws java.lang.IllegalStateException If already in a write transaction or incorrect thread.
-     *
-     */
-    public void beginTransaction() {
-        checkIfValid();
-        transaction.promoteToWrite();
-    }
-
-    /**
-     * All changes since {@link io.realm.Realm#beginTransaction()} are persisted to disk and the
-     * Realm reverts back to being read-only. An event is sent to notify all other realm instances
-     * that a change has occurred. When the event is received, the other Realms will get their
-     * objects and {@link io.realm.RealmResults} updated to reflect
-     * the changes from this commit.
-     *
-     * @throws java.lang.IllegalStateException If the write transaction is in an invalid state or incorrect thread.
-     */
-    public void commitTransaction() {
-        checkIfValid();
-        transaction.commitAndContinueAsRead();
-
-        for (Map.Entry<Handler, String> handlerIntegerEntry : handlers.entrySet()) {
-            Handler handler = handlerIntegerEntry.getKey();
-            String realmPath = handlerIntegerEntry.getValue();
-
-            // Notify at once on thread doing the commit
-            if (handler.equals(this.handler)) {
-                sendNotifications();
-                continue;
-            }
-
-            // For all other threads, use the Handler
-            if (
-                    realmPath.equals(configuration.getPath())    // It's the right realm
-                    && !handler.hasMessages(REALM_CHANGED)       // The right message
-                    && handler.getLooper().getThread().isAlive() // The receiving thread is alive
-            ) {
-                handler.sendEmptyMessage(REALM_CHANGED);
-            }
-        }
-    }
-
-    /**
-     * Revert all writes (created, updated, or deleted objects) made in the current write
-     * transaction and end the transaction.
-     * <br>
-     * The Realm reverts back to read-only.
-     * <br>
-     * Calling this when not in a write transaction will throw an exception.
-     *
-     * @throws java.lang.IllegalStateException    If the write transaction is an invalid state,
-     *                                             not in a write transaction or incorrect thread.
-     */
-    public void cancelTransaction() {
-        checkIfValid();
-        transaction.rollbackAndContinueAsRead();
+        return sharedGroupManager.hasChanged();
     }
 
     /**
@@ -1411,25 +980,6 @@ public final class Realm implements Closeable {
      */
     public void clear(Class<? extends RealmObject> clazz) {
         getTable(clazz).clear();
-    }
-
-    // package protected so unit tests can access it
-    long getVersion() {
-        if (!transaction.hasTable("metadata")) {
-            return UNVERSIONED;
-        }
-        Table metadataTable = transaction.getTable("metadata");
-        return metadataTable.getLong(0, 0);
-    }
-
-    // package protected so unit tests can access it
-    void setVersion(long version) {
-        Table metadataTable = transaction.getTable("metadata");
-        if (metadataTable.getColumnCount() == 0) {
-            metadataTable.addColumn(ColumnType.INTEGER, "version");
-            metadataTable.addEmptyRow();
-        }
-        metadataTable.setLong(0, 0, version);
     }
 
     @SuppressWarnings("unchecked")
@@ -1467,6 +1017,21 @@ public final class Realm implements Closeable {
         }
     }
 
+    protected void checkIfValid() {
+        super.checkIfValid();
+    }
+
+    @Override
+    protected Map<RealmConfiguration, Integer> getLocalReferenceCount() {
+        return referenceCount.get();
+    }
+
+    @Override
+    protected void lastLocalInstanceClosed() {
+        validatedRealmFiles.remove(configuration.getPath());
+        realmsCache.get().remove(configuration);
+    }
+
     /**
      * Manually trigger the migration associated with a given RealmConfiguration. If Realm is already at the
      * latest version, nothing will happen.
@@ -1483,28 +1048,19 @@ public final class Realm implements Closeable {
      * @param migration {@link RealmMigration} to run on the Realm. This will override any migration set on the
      * configuration.
      */
-    public static synchronized void migrateRealm(RealmConfiguration configuration, RealmMigration migration) {
-        if (configuration == null) {
-            throw new IllegalArgumentException("RealmConfiguration must be provided");
-        }
-        if (migration == null && configuration.getMigration() == null) {
-            throw new RealmMigrationNeededException(configuration.getPath(), "RealmMigration must be provided");
-        }
+    public static void migrateRealm(RealmConfiguration configuration, RealmMigration migration) {
+        BaseRealm.migrateRealm(configuration, migration, new MigrationCallback() {
 
-        RealmMigration realmMigration = (migration == null) ? configuration.getMigration() : migration;
-        Realm realm = null;
-        try {
-            realm = Realm.createAndValidate(configuration, false, Looper.myLooper() != null);
-            realm.beginTransaction();
-            realm.setVersion(realmMigration.execute(realm, realm.getVersion()));
-            realm.commitTransaction();
-            validatedRealmFiles.remove(configuration.getPath());
-        } finally {
-            if (realm != null) {
-                realm.close();
+            @Override
+            public BaseRealm getRealm(RealmConfiguration configuration) {
+                return Realm.createAndValidate(configuration, false, Looper.myLooper() != null);
+           }
+
+            @Override
+            public void migrationComplete() {
                 realmsCache.remove();
             }
-        }
+        });
     }
 
     /**
@@ -1516,34 +1072,8 @@ public final class Realm implements Closeable {
      *
      * @throws java.lang.IllegalStateException if trying to delete a Realm that is already open.
      */
-    public static synchronized boolean deleteRealm(RealmConfiguration configuration) {
-        boolean realmDeleted = true;
-
-        String id = configuration.getPath();
-        AtomicInteger counter = globalOpenInstanceCounter.get(id);
-        if (counter != null && counter.get() > 0) {
-            throw new IllegalStateException("It's not allowed to delete the file associated with an open Realm. " +
-                    "Remember to close() all the instances of the Realm before deleting its file.");
-        }
-
-        File realmFolder = configuration.getRealmFolder();
-        String realmFileName = configuration.getRealmFileName();
-        List<File> filesToDelete = Arrays.asList(new File(configuration.getPath()),
-                new File(realmFolder, realmFileName + ".lock"),
-                new File(realmFolder, realmFileName + ".lock_a"),
-                new File(realmFolder, realmFileName + ".lock_b"),
-                new File(realmFolder, realmFileName + ".log"));
-        for (File fileToDelete : filesToDelete) {
-            if (fileToDelete.exists()) {
-                boolean deleteResult = fileToDelete.delete();
-                if (!deleteResult) {
-                    realmDeleted = false;
-                    RealmLog.w("Could not delete the file " + fileToDelete);
-                }
-            }
-        }
-
-        return realmDeleted;
+    public static boolean deleteRealm(RealmConfiguration configuration) {
+        return BaseRealm.deleteRealm(configuration);
     }
 
     /**
@@ -1561,44 +1091,7 @@ public final class Realm implements Closeable {
      * @throws java.lang.IllegalStateException if trying to compact a Realm that is already open.
      */
     public static boolean compactRealm(RealmConfiguration configuration) {
-        if (configuration.getEncryptionKey() != null) {
-            throw new IllegalArgumentException("Cannot currently compact an encrypted Realm.");
-        }
-
-        String canonicalPath = configuration.getPath();
-        AtomicInteger openInstances = globalOpenInstanceCounter.get(canonicalPath);
-        if (openInstances != null && openInstances.get() > 0) {
-            throw new IllegalStateException("Cannot compact an open Realm");
-        }
-        SharedGroup sharedGroup = null;
-        boolean result = false;
-        try {
-            sharedGroup = new SharedGroup(canonicalPath, false, SharedGroup.Durability.FULL, configuration.getEncryptionKey());
-            result = sharedGroup.compact();
-        } finally {
-            if (sharedGroup != null) {
-                sharedGroup.close();
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Returns the canonical path to where this Realm is persisted on disk.
-     *
-     * @return The canonical path to the Realm file.
-     * @see File#getCanonicalPath()
-     */
-    public String getPath() {
-        return configuration.getPath();
-    }
-
-    /**
-     * Returns the {@link RealmConfiguration} for this Realm.
-     * @return {@link RealmConfiguration} for this Realm.
-     */
-    public RealmConfiguration getConfiguration() {
-        return configuration;
+        return BaseRealm.compactRealm(configuration);
     }
 
     // Get the canonical path for a given file
@@ -1608,6 +1101,22 @@ public final class Realm implements Closeable {
         } catch (IOException e) {
             throw new RealmException("Could not resolve the canonical path to the Realm file: " + realmFile.getAbsolutePath());
         }
+    }
+
+    // Return all handlers registered for this Realm
+    static Map<Handler, String> getHandlers() {
+        return handlers;
+    }
+
+    // Public because of migrations
+    public Table getTable(Class<? extends RealmObject> clazz) {
+        Table table = classToTable.get(clazz);
+        if (table == null) {
+            clazz = Util.getOriginalModelClass(clazz);
+            table = sharedGroupManager.getTable(configuration.getSchemaMediator().getTableName(clazz));
+            classToTable.put(clazz, table);
+        }
+        return table;
     }
 
     /**

--- a/realm/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/src/main/java/io/realm/RealmConfiguration.java
@@ -53,10 +53,12 @@ import io.realm.internal.modules.FilterableMediator;
  */
 public class RealmConfiguration {
 
+    public static final String DEFAULT_REALM_NAME = "default.realm";
     public static final int KEY_LENGTH = 64;
 
     private static final Object DEFAULT_MODULE;
     private static final RealmProxyMediator DEFAULT_MODULE_MEDIATOR;
+
     static {
         DEFAULT_MODULE = Realm.getDefaultModule();
         if (DEFAULT_MODULE != null) {

--- a/realm/src/main/java/io/realm/dynamic/DynamicRealmObject.java
+++ b/realm/src/main/java/io/realm/dynamic/DynamicRealmObject.java
@@ -18,6 +18,7 @@ package io.realm.dynamic;
 import java.util.Date;
 
 import io.realm.Realm;
+import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.internal.CheckedRow;
 import io.realm.internal.ColumnType;
@@ -149,7 +150,7 @@ public class DynamicRealmObject extends RealmObject {
      * @return The byte[] value.
      * @throws IllegalArgumentException if field name doesn't exists or it doesn't contain binary data.
      */
-    public byte[] getBlob (String fieldName) {
+    public byte[] getBlob(String fieldName) {
         long columnIndex = row.getColumnIndex(fieldName);
         return row.getBinaryByteArray(columnIndex);
     }

--- a/realm/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/src/main/java/io/realm/internal/SharedGroup.java
@@ -24,6 +24,14 @@ import io.realm.exceptions.RealmIOException;
 
 public class SharedGroup implements Closeable {
 
+    public static final boolean IMPLICIT_TRANSACTION = true;
+    public static final boolean EXPLICIT_TRANSACTION = false;
+
+    private static final boolean CREATE_FILE_YES = false;
+    private static final boolean CREATE_FILE_NO = true;
+    private static final boolean ENABLE_REPLICATION = true;
+    private static final boolean DISABLE_REPLICATION = false;
+
     private final String path;
     private long nativePtr;
     private long nativeReplicationPtr;
@@ -50,34 +58,27 @@ public class SharedGroup implements Closeable {
     public SharedGroup(String databaseFile) {
         context = new Context();
         path = databaseFile;
-        nativePtr = nativeCreate(databaseFile, Durability.FULL.value, false, false, null);
+        nativePtr = nativeCreate(databaseFile, Durability.FULL.value, CREATE_FILE_YES, DISABLE_REPLICATION, null);
         checkNativePtrNotZero();
     }
 
-    public SharedGroup(String databaseFile, boolean enableImplicitTransactions, Durability durability, byte[] key) {
+    public SharedGroup(String canonicalPath, boolean enableImplicitTransactions, Durability durability, byte[] key) {
         if (enableImplicitTransactions) {
-            nativeReplicationPtr = nativeCreateReplication(databaseFile, key);
+            nativeReplicationPtr = nativeCreateReplication(canonicalPath, key);
             nativePtr = createNativeWithImplicitTransactions(nativeReplicationPtr, durability.value, key);
             implicitTransactionsEnabled = true;
         } else {
-            nativePtr = nativeCreate(databaseFile, Durability.FULL.value, false, false, key);
+            nativePtr = nativeCreate(canonicalPath, Durability.FULL.value, CREATE_FILE_YES, DISABLE_REPLICATION, key);
         }
         context = new Context();
-        path = databaseFile;
+        path = canonicalPath;
         checkNativePtrNotZero();
     }
 
-    public SharedGroup(String databaseFile, Durability durability, byte[] key) {
-        path = databaseFile;
+    public SharedGroup(String canonicalPath, Durability durability, byte[] key) {
+        path = canonicalPath;
         context = new Context();
-        nativePtr = nativeCreate(databaseFile, durability.value, false, false, key);
-        checkNativePtrNotZero();
-    }
-
-    public SharedGroup(String databaseFile, Durability durability, boolean fileMustExist) {
-        path = databaseFile;
-        context = new Context();
-        nativePtr = nativeCreate(databaseFile, durability.value, fileMustExist, false, null);
+        nativePtr = nativeCreate(canonicalPath, durability.value, false, false, key);
         checkNativePtrNotZero();
     }
 
@@ -217,7 +218,7 @@ public class SharedGroup implements Closeable {
     /**
      * Returns the absolute path to the file backing this SharedGroup.
      *
-     * @return Absolute path to the Realm file.
+     * @return Canonical path to the Realm file.
      */
     public String getPath() {
         return path;
@@ -246,7 +247,7 @@ public class SharedGroup implements Closeable {
     private native void nativeRollback(long nativePtr);
     private native long nativeCreate(String databaseFile,
                                      int durabilityValue,
-                                     boolean no_create,
+                                     boolean dontCreateFile,
                                      boolean enableReplication,
                                      byte[] key);
     private native boolean nativeCompact(long nativePtr);

--- a/realm/src/main/java/io/realm/internal/SharedGroupManager.java
+++ b/realm/src/main/java/io/realm/internal/SharedGroupManager.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.realm.internal;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+import io.realm.RealmConfiguration;
+
+/**
+ * This class wraps access to a given Realm file on a single thread including its {@link SharedGroup}
+ * and {@link ImplicitTransaction}. By nature this means that this class is not thread safe and
+ * should only be used from the thread that created it.
+ *
+ * Realm is a MVCC database (Multiversion concurrency control), which means that multiple
+ * versions of the data might exist in the same file. By default the file is always opened on the
+ * latest version and it is possible to advance to the latest version by calling
+ * {@link #advanceRead()}.
+ */
+public class SharedGroupManager implements Closeable {
+
+    private SharedGroup sharedGroup;
+    private ImplicitTransaction transaction;
+
+    /**
+     * Creates a new instance of the FileWrapper for the given configuration on this thread.
+     */
+    public  SharedGroupManager(RealmConfiguration configuration) {
+        this.sharedGroup = new SharedGroup(
+                configuration.getPath(),
+                SharedGroup.IMPLICIT_TRANSACTION,
+                configuration.getDurability(),
+                configuration.getEncryptionKey());
+        this.transaction = sharedGroup.beginImplicitTransaction();
+    }
+
+    /**
+     * Close the underlying {@link SharedGroup} and free any native resources.
+     */
+    @Override
+    public void close() {
+        sharedGroup.close();
+        sharedGroup = null;
+        transaction = null;
+    }
+
+    /**
+     * Checks if the Realm file is accessible.
+     *
+     * @return {@code true} if the file is open and data can be accessed, {@code false} otherwise.
+     */
+    public boolean isOpen() {
+        return sharedGroup != null;
+    }
+
+    /**
+     * Advance the Realm file to the latest version.
+     */
+    public void advanceRead() {
+        transaction.advanceRead();
+    }
+
+    // Public because of migrations. Gets the full table name. Prefix will not be added.
+    // TODO Remove when new Migration API is introduced.
+    public Table getTable(String tableName) {
+        return transaction.getTable(tableName);
+    }
+
+    /**
+     * Checks if a Realm file can be advanced to a newer version.
+     */
+    public boolean hasChanged() {
+        return sharedGroup.hasChanged();
+    }
+
+    /**
+     * Make the file writable. This will block all other threads and processes from making it writable as well.
+     */
+    public void promoteToWrite() {
+        transaction.promoteToWrite();
+    }
+
+    /**
+     * Commit any pending changes to the file and return to read-only mode.
+     */
+    public void commitAndContinueAsRead() {
+        transaction.commitAndContinueAsRead();
+    }
+
+    /**
+     * Rollback any changes to the file since it was made writable and continue in read-only mode.
+     */
+    public void rollbackAndContinueAsRead() {
+        transaction.rollbackAndContinueAsRead();
+    }
+
+    /**
+     * Checks if a given table exists.
+     * @return {code true} if the table exists. {@code false} otherwise.
+     */
+    public boolean hasTable(String tableName) {
+        return transaction.hasTable(tableName);
+    }
+
+    /**
+     * Writes a copy of this Realm file to another location.
+     */
+    public void copyToFile(File destination, byte[] key) throws IOException {
+        transaction.writeToFile(destination, key);
+    }
+
+    /**
+     * Returns a reference to current {@link SharedGroup}.
+     */
+    public SharedGroup getSharedGroup() {
+        return sharedGroup;
+    }
+
+    /**
+     * Returns a reference to the current {@link ImplicitTransaction}.
+     */
+    public ImplicitTransaction getTransaction() {
+        return transaction;
+    }
+
+    /**
+     * Compacts a Realm file. It cannot be open when calling this method.
+     */
+    public static boolean compact(RealmConfiguration configuration) {
+        SharedGroup sharedGroup = null;
+        boolean result = false;
+        try {
+            sharedGroup = new SharedGroup(
+                    configuration.getPath(),
+                    SharedGroup.EXPLICIT_TRANSACTION,
+                    SharedGroup.Durability.FULL,
+                    configuration.getEncryptionKey());
+            result = sharedGroup.compact();
+        } finally {
+            if (sharedGroup != null) {
+                sharedGroup.close();
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
**Description**
Two new abstractions has been added: SharedGroupManager and RealmBase

- *SharedGroupManager*: Encapsulates the SharedGroup and Transaction to encapsulate reuse across Realm/DynamicRealm.
- *RealmBase*: Abstract class for sharing code/logic between Realm/DynamicRealm. 

**Missing**:
- [x] SharedGroup should be shared between DynamicRealm/Realm for the same configuration on the    same thread.
- [x] Move all non-static methods from Realm to RealmBase (those that don't take Clazz<> as parameter)
- [x] Naming: RealmInstance -> RealmBase and RealmFileWriter -> SharedGroupManager.

- [x] Should we move RealmInstance to the public `io.realm` instead of `io.realm.internal`? It would solve problems with inheriting JavaDoc and make the code cleaner as we don't have to explicitly call super for a lot of methods. Downside is a useless file in the JavaDoc? Can't find a way to not include it while still allowing the JavaDoc to show up: ANSWER: RealmBase moved to `io.realm` as we are consolidating all public API's there.

