### PR TITLE
Handle null value for String in Json when updating

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.82.1
+ * Fixed a bug where String fields were ignored when updating objects from JSON with null values.
+
 0.82
  * RealmConfiguration.setModules() now accept ignore null values which Realm.getDefaultModule() might return.
  * Trying to access a deleted Realm object throw throws a proper IllegalStateException.
@@ -36,7 +39,7 @@
  * Fixed a memory leak when using RealmBaseAdapter.
  * RealmBaseAdapter now allow RealmResults to be null (thanks @zaki50).
  * Fixed a bug where a change to a model class (RealmList<A> to RealmList<B>) would not throw a RealmMigrationNeededException.
- * Fixed a bug where where setting multiple RealmLists didn't remove the previously added objects.
+ * Fixed a bug where setting multiple RealmLists didn't remove the previously added objects.
  * Solved ConcurrentModificationException thrown when addChangeListener/removeChangeListener got called in the onChange. (thanks @beeender)
  * Fixed duplicated listeners in the same realm instance. Trying to add duplicated listeners is ignored now. (thanks @beeender)
 

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -806,10 +806,20 @@ public class RealmProxyClassGenerator {
             String fieldName = field.getSimpleName().toString();
             String qualifiedFieldType = field.asType().toString();
 
-            if (i == 0) {
-                writer.beginControlFlow("if (name.equals(\"%s\") && reader.peek() != JsonToken.NULL)", fieldName);
+            if (Utils.isString(qualifiedFieldType)) {
+                if (i == 0) {
+                    writer.beginControlFlow("if (name.equals(\"%s\"))", fieldName);
+                } else {
+                    writer.nextControlFlow("else if (name.equals(\"%s\"))", fieldName);
+                }
             } else {
-                writer.nextControlFlow("else if (name.equals(\"%s\")  && reader.peek() != JsonToken.NULL)", fieldName);
+                // TODO: This else block should be removed after nullable support for all types
+                //       as well as the condition checking.
+                if (i == 0) {
+                    writer.beginControlFlow("if (name.equals(\"%s\") && reader.peek() != JsonToken.NULL)", fieldName);
+                } else {
+                    writer.nextControlFlow("else if (name.equals(\"%s\")  && reader.peek() != JsonToken.NULL)", fieldName);
+                }
             }
             if (typeUtils.isAssignable(field.asType(), realmObject)) {
                 RealmJsonTypeHelper.emitFillRealmObjectFromStream(

--- a/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
@@ -1,5 +1,10 @@
 package io.realm.processor;
 
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
@@ -12,10 +17,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import javax.xml.bind.DatatypeConverter;
-import java.io.UnsupportedEncodingException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
 
 /**
  * Utility methods working with the Realm processor.
@@ -69,6 +70,16 @@ public class Utils {
             return false;
         }
         return getFieldTypeSimpleName(field).equals("String");
+    }
+
+    /**
+     * Returns true if a given field type string is "java.lang.String", false otherwise.
+     */
+    public static boolean isString(String fieldType) {
+        if (fieldType == null) {
+            return false;
+        }
+        return String.class.getName().equals(fieldType);
     }
 
     /**

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -335,8 +335,12 @@ public class AllTypesRealmProxy extends AllTypes
         if (obj == null) {
             obj = realm.createObject(AllTypes.class);
         }
-        if (!json.isNull("columnString")) {
-            obj.setColumnString((String) json.getString("columnString"));
+        if (json.has("columnString")) {
+            if (json.isNull("columnString")) {
+                obj.setColumnString("");
+            } else {
+                obj.setColumnString((String) json.getString("columnString"));
+            }
         }
         if (!json.isNull("columnLong")) {
             obj.setColumnLong((long) json.getLong("columnLong"));
@@ -382,8 +386,13 @@ public class AllTypesRealmProxy extends AllTypes
         reader.beginObject();
         while (reader.hasNext()) {
             String name = reader.nextName();
-            if (name.equals("columnString") && reader.peek() != JsonToken.NULL) {
-                obj.setColumnString((String) reader.nextString());
+            if (name.equals("columnString")) {
+                if (reader.peek() == JsonToken.NULL) {
+                    obj.setColumnString("");
+                    reader.skipValue();
+                } else {
+                    obj.setColumnString((String) reader.nextString());
+                }
             } else if (name.equals("columnLong")  && reader.peek() != JsonToken.NULL) {
                 obj.setColumnLong((long) reader.nextLong());
             } else if (name.equals("columnFloat")  && reader.peek() != JsonToken.NULL) {

--- a/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -131,8 +131,12 @@ public class SimpleRealmProxy extends Simple
     public static Simple createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
         Simple obj = realm.createObject(Simple.class);
-        if (!json.isNull("name")) {
-            obj.setName((String) json.getString("name"));
+        if (json.has("name")) {
+            if (json.isNull("name")) {
+                obj.setName("");
+            } else {
+                obj.setName((String) json.getString("name"));
+            }
         }
         if (!json.isNull("age")) {
             obj.setAge((int) json.getInt("age"));
@@ -146,8 +150,13 @@ public class SimpleRealmProxy extends Simple
         reader.beginObject();
         while (reader.hasNext()) {
             String name = reader.nextName();
-            if (name.equals("name") && reader.peek() != JsonToken.NULL) {
-                obj.setName((String) reader.nextString());
+            if (name.equals("name")) {
+                if (reader.peek() == JsonToken.NULL) {
+                    obj.setName("");
+                    reader.skipValue();
+                } else {
+                    obj.setName((String) reader.nextString());
+                }
             } else if (name.equals("age")  && reader.peek() != JsonToken.NULL) {
                 obj.setAge((int) reader.nextInt());
             } else {

--- a/realm/src/androidTest/assets/all_types_primary_key_null.json
+++ b/realm/src/androidTest/assets/all_types_primary_key_null.json
@@ -1,0 +1,11 @@
+{
+	"columnString" : null,
+	"columnLong" : 1,
+	"columnFloat" : null,
+	"columnDouble" : null,
+	"columnBoolean" : null,
+	"columnBinary" : null,
+	"columnDate" : null,
+	"columnRealmObject" : null,
+	"columnRealmList" : null
+}

--- a/realm/src/androidTest/java/io/realm/RealmJsonTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmJsonTest.java
@@ -433,6 +433,79 @@ public class RealmJsonTest extends AndroidTestCase {
         assertEquals(0, obj.getColumnRealmList().size());
     }
 
+    // Test update a existing object with JSON stream.
+    public void testUpdateObjectFromJsonStream_nullValues() throws IOException {
+        AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
+        Date date = new Date(0);
+        // ID
+        obj.setColumnLong(1);
+        obj.setColumnBinary(new byte[]{1});
+        obj.setColumnBoolean(true);
+        obj.setColumnDate(date);
+        obj.setColumnDouble(1);
+        obj.setColumnFloat(1);
+        obj.setColumnString("1");
+        testRealm.beginTransaction();
+        testRealm.copyToRealm(obj);
+        testRealm.commitTransaction();
+
+        InputStream in = loadJsonFromAssets("all_types_primary_key_null.json");
+        testRealm.beginTransaction();
+        testRealm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, in);
+        testRealm.commitTransaction();
+        in.close();
+
+        // Check that all primitive types are imported correctly
+        obj = testRealm.allObjects(AllTypesPrimaryKey.class).first();
+        // TODO: We only handle updating null for String right now.
+        //       Clean this up after nullable support for all types.
+        assertEquals("", obj.getColumnString());
+        assertEquals(1L, obj.getColumnLong());
+        assertEquals(1f, obj.getColumnFloat());
+        assertEquals(1d, obj.getColumnDouble());
+        assertEquals(true, obj.isColumnBoolean());
+        assertEquals(date, obj.getColumnDate());
+        assertArrayEquals(new byte[]{1}, obj.getColumnBinary());
+        assertNull(obj.getColumnRealmObject());
+        assertEquals(0, obj.getColumnRealmList().size());
+    }
+
+    // Test update a existing object with JSON object.
+    public void testUpdateObjectFromJsonObject_nullValues() throws IOException {
+        AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
+        Date date = new Date(0);
+        // ID
+        obj.setColumnLong(1);
+        obj.setColumnBinary(new byte[]{1});
+        obj.setColumnBoolean(true);
+        obj.setColumnDate(date);
+        obj.setColumnDouble(1);
+        obj.setColumnFloat(1);
+        obj.setColumnString("1");
+        testRealm.beginTransaction();
+        testRealm.copyToRealm(obj);
+        testRealm.commitTransaction();
+
+        String json = TestHelper.streamToString(loadJsonFromAssets("all_types_primary_key_null.json"));
+        testRealm.beginTransaction();
+        testRealm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, json);
+        testRealm.commitTransaction();
+
+        // Check that all primitive types are imported correctly
+        obj = testRealm.allObjects(AllTypesPrimaryKey.class).first();
+        // TODO: We only handle updating String with null value right now.
+        //       Clean this up after nullable support for all types.
+        assertEquals("", obj.getColumnString());
+        assertEquals(1L, obj.getColumnLong());
+        assertEquals(1f, obj.getColumnFloat());
+        assertEquals(1d, obj.getColumnDouble());
+        assertEquals(true, obj.isColumnBoolean());
+        assertEquals(date, obj.getColumnDate());
+        assertArrayEquals(new byte[]{1}, obj.getColumnBinary());
+        assertNull(obj.getColumnRealmObject());
+        assertEquals(0, obj.getColumnRealmList().size());
+    }
+
     public void testCreateOrUpdateObject_noPrimaryKeyThrows() {
         try {
             testRealm.createOrUpdateObjectFromJson(AllTypes.class, new JSONObject());


### PR DESCRIPTION
Fix #1344
Update the object's String field to empty string when the corresponding
field in Json is null.