### PR TITLE
Updated Kotlin example with incremental build setting

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -22,6 +22,11 @@ android {
     command {
         events 2000
     }
+
+    // Incremental builds currently doesn't work with Kotlin
+    dexOptions {
+        incremental false
+    }
 }
 
 tasks.preBuild {


### PR DESCRIPTION
Apparently incremental build doesn't work with Kotlin (reported by a user). 
Example has been updated with that info.

@realm/java 