### PR TITLE
isValid should not throw

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
  * BREAKING CHANGE: Removed deprecated methods and constructors from the Realm class.
  * Fixed a bug which might cause failure when loading the native library.
  * Fixed a bug which might trigger a timeout in Context.finalize().
+ * Fixed a bug which might cause RealmObject.isValid() to throw an exception if the object is deleted.
 
 0.82.1
  * Fixed a bug where using the wrong encryption key first caused the right key to be seen as invalid.

--- a/realm/src/androidTest/java/io/realm/RealmObjectTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmObjectTest.java
@@ -543,4 +543,19 @@ public class RealmObjectTest extends AndroidTestCase {
         } catch (IllegalStateException ignored) {
         }
     }
+
+    public void testIsValid() {
+        testRealm.beginTransaction();
+        Dog dog = testRealm.createObject(Dog.class);
+        dog.setName("Fido");
+        testRealm.commitTransaction();
+
+        assertTrue(dog.isValid());
+
+        testRealm.beginTransaction();
+        dog.removeFromRealm();
+        testRealm.commitTransaction();
+
+        assertFalse(dog.isValid());
+    }
 }

--- a/realm/src/main/java/io/realm/internal/InvalidRow.java
+++ b/realm/src/main/java/io/realm/internal/InvalidRow.java
@@ -20,8 +20,9 @@ package io.realm.internal;
 import java.util.Date;
 
 /**
- * Row wrapper that stubs all access with IllegalStateExceptions. This can be used instead of adding null checks
- * everywhere when the underlying Row accessor in Realm Core is no longer available.
+ * Row wrapper that stubs all access with IllegalStateExceptions except for isAttached. This can be used instead of
+ * adding null checks everywhere when the underlying Row accessor in Realm's underlying storage engine is no longer
+ * available.
  */
 public enum InvalidRow implements Row {
     INSTANCE;
@@ -168,7 +169,7 @@ public enum InvalidRow implements Row {
 
     @Override
     public boolean isAttached() {
-        throw getStubException();
+        return false;
     }
 
     @Override


### PR DESCRIPTION
#1393 reports a bug in `isValid()`. When an object is deleted from a Realm, the underlaying row is change to an instance of the invalid row. Methods of invalid rows throw an exception unconditionally.

Fixes #1393

@realm/java 