### PR TITLE
Reduce rowReferences HashMap autoboxing allocations.

### DIFF
--- a/realm/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/src/main/java/io/realm/internal/CheckedRow.java
@@ -50,7 +50,7 @@ public class CheckedRow extends UncheckedRow {
     public static CheckedRow get(Context context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.nativePtr, index);
         CheckedRow row = new CheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), Integer.MIN_VALUE);
+        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
         return row;
     }
 
@@ -64,7 +64,7 @@ public class CheckedRow extends UncheckedRow {
     public static CheckedRow get(Context context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativeLinkViewPtr, index);
         CheckedRow row = new CheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent), nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), Integer.MIN_VALUE);
+        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
         return row;
     }
 

--- a/realm/src/main/java/io/realm/internal/Context.java
+++ b/realm/src/main/java/io/realm/internal/Context.java
@@ -30,6 +30,9 @@ public class Context {
     // whose disposal need to be handed over from the garbage 
     // collection thread to the users thread.
 
+    // Reserved to be used only as a placholder by rowReferences Map to avoid autoboxing allocations
+    static final Integer ROW_REFERENCES_VALUE = 0;
+
     private List<Long> abandonedTables = new ArrayList<Long>();
     private List<Long> abandonedTableViews = new ArrayList<Long>();
     private List<Long> abandonedQueries = new ArrayList<Long>();

--- a/realm/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/src/main/java/io/realm/internal/UncheckedRow.java
@@ -50,7 +50,7 @@ public class UncheckedRow extends NativeObject implements Row {
     public static UncheckedRow get(Context context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.nativePtr, index);
         UncheckedRow row = new UncheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), Integer.MIN_VALUE);
+        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
         return row;
     }
 
@@ -64,7 +64,7 @@ public class UncheckedRow extends NativeObject implements Row {
     public static UncheckedRow get(Context context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativeLinkViewPtr, index);
         UncheckedRow row = new UncheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent), nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), Integer.MIN_VALUE);
+        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
         return row;
     }
 


### PR DESCRIPTION
HashMap value of rowReferences is never used but the HashMap.put() call is always using a Integer.MIN_VALUE as value arg which is small integer and causes autoboxing allocations to Integer().

Use static Integer object to remove autoboxing and Integer object allocations.