### PR TITLE
1) Remove unnecessary object modification in Context.finalize(). If c…

### DIFF
--- a/realm-jni/build.gradle
+++ b/realm-jni/build.gradle
@@ -147,7 +147,7 @@ targets.each { target ->
         dependsOn "generateNdkToolchain${target.toolchain.name.capitalize()}"
         environment PATH: "${buildDir}/standalone-toolchains/${target.toolchain.name}/bin:${System.env.PATH}"
         environment CC: "${target.toolchain.commandPrefix}-${clang?'clang':'gcc'}"
-        environment STRIP: "${target.toolchain.commandPrefix}-strip -o librealm-jni-${target.name}-stripped.so"
+        environment STRIP: "${target.toolchain.commandPrefix}-strip -o libearthworm-${target.name}-stripped.so"
         environment REALM_ANDROID: '1'
         commandLine = [
             'make',
@@ -158,22 +158,22 @@ targets.each { target ->
             "BASE_DENOM=${target.name}",
             "REALM_LDFLAGS=-lrealm-android-${target.name} -lstdc++ -lsupc++ -llog -L${projectDir}/../core-${project.coreVersion} -Wl,--gc-sections -flto",
             'LIB_SUFFIX_SHARED=.so',
-            "librealm-jni-${target.name}.so"
+            "libearthworm-${target.name}.so"
         ]
     }
 
     task "copyAndroidJni${target.name.capitalize()}"(dependsOn: "buildAndroidJni${target.name.capitalize()}") << {
         copy {
-            from "${projectDir}/src/librealm-jni-${target.name}-stripped.so"
+            from "${projectDir}/src/libearthworm-${target.name}-stripped.so"
             into "${projectDir}/../realm/src/main/jniLibs/${target.jniFolder}"
-            rename "librealm-jni-${target.name}-stripped.so", 'librealm-jni.so'
+            rename "libearthworm-${target.name}-stripped.so", 'libearthworm.so'
         }
 
         // Store the unstripped version
         copy {
-            from "${projectDir}/src/librealm-jni-${target.name}.so"
+            from "${projectDir}/src/libearthworm-${target.name}.so"
             into "${projectDir}/../build/output/jniLibs-unstripped/${target.jniFolder}"
-            rename "librealm-jni-${target.name}.so", 'librealm-jni.so'
+            rename "libearthworm-${target.name}.so", 'libearthworm.so'
         }
     }
 }

--- a/realm-jni/src/Makefile
+++ b/realm-jni/src/Makefile
@@ -1,10 +1,10 @@
-lib_LIBRARIES = librealm-jni.a
+lib_LIBRARIES = libearthworm.a
 
 JNI_SOURCES := $(wildcard *.cpp)
-librealm_jni_a_SOURCES = $(JNI_SOURCES)
+libearthworm_a_SOURCES = $(JNI_SOURCES)
 
 # Used by ../../build.sh
 get-inst-libraries:
-	@echo $(filter-out librealm-jni-cov.%,$(TARGETS_LIB_SHARED_ALIASES))
+	@echo $(filter-out libearthworm-cov.%,$(TARGETS_LIB_SHARED_ALIASES))
 
 include ../generic.mk

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 android {
-    compileSdkVersion 20
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 22
+    buildToolsVersion '22.0.1'
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 20
+        targetSdkVersion 22
     }
 
 // TODO: re-enable once bug-fix is released
@@ -239,7 +239,7 @@ task copyLibrariesToEclipseFolder(dependsOn: 'androidJar') << {
     }
     abi.each() { abiName ->
         copy {
-            from "build/intermediates/eclipse/lib/${abiName}/librealm-jni.so"
+            from "build/intermediates/eclipse/lib/${abiName}/libearthworm.so"
             into "../distribution/eclipse/${abiName}"
         }
     }

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -10,7 +10,10 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 22
+        // Enabling multidex support.
+        multiDexEnabled true
     }
+
 
 // TODO: re-enable once bug-fix is released
 //    jacoco {
@@ -26,6 +29,8 @@ android {
 }
 
 dependencies {
+    compile 'com.android.support:multidex:1.0.0'
+    compile 'it.unimi.dsi:fastutil:7.0.7'
     compile 'com.intellij:annotations:+@jar'
     compile files("../realm-annotations/build/libs/realm-annotations-${version}.jar")
     androidTestApt files("../realm-annotations-processor/build/libs/realm-annotations-processor-${version}.jar")

--- a/realm/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/src/main/java/io/realm/internal/CheckedRow.java
@@ -50,7 +50,7 @@ public class CheckedRow extends UncheckedRow {
     public static CheckedRow get(Context context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.nativePtr, index);
         CheckedRow row = new CheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
+        context.rowReferences.add(new NativeObjectReference(row, context.referenceQueue));
         return row;
     }
 
@@ -64,7 +64,7 @@ public class CheckedRow extends UncheckedRow {
     public static CheckedRow get(Context context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativeLinkViewPtr, index);
         CheckedRow row = new CheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent), nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
+        context.rowReferences.add(new NativeObjectReference(row, context.referenceQueue));
         return row;
     }
 

--- a/realm/src/main/java/io/realm/internal/Context.java
+++ b/realm/src/main/java/io/realm/internal/Context.java
@@ -44,25 +44,32 @@ public class Context {
 
     public void executeDelayedDisposal() {
         synchronized (this) {
-            if(abandonedTables.size() > 0) {
-                for (long nativePointer : abandonedTables) {
-                    Table.nativeClose(nativePointer);
+            int size = abandonedTables.size();
+
+            if(size > 0) {
+                for (int i = 0; i < size; i++) {
+                    Table.nativeClose(abandonedTables.get(i));
                 }
 
                 abandonedTables.clear();
             }
 
-            if(abandonedTableViews.size() > 0) {
-                for (long nativePointer : abandonedTableViews) {
-                    TableView.nativeClose(nativePointer);
+            size = abandonedTableViews.size();
+
+            if(size > 0) {
+                for (int i = 0; i < size; i++) {
+                    TableView.nativeClose(abandonedTableViews.get(i));
                 }
 
                 abandonedTableViews.clear();
             }
 
+            size = abandonedQueries.size();
+
             if(abandonedQueries.size() > 0) {
-                for (long nativePointer : abandonedQueries) {
-                    TableQuery.nativeClose(nativePointer);
+
+                for (int i = 0; i < size; i++) {
+                    TableQuery.nativeClose(abandonedQueries.get(i));
                 }
 
                 abandonedQueries.clear();
@@ -75,6 +82,7 @@ public class Context {
     // Faster version used only for context.Finalize() calls. Difference is it does not modify registries but set them to null
     private void executeDelayedDisposalFinalize() {
         synchronized (this) {
+
             for (long nativePointer : abandonedTables) {
                 Table.nativeClose(nativePointer);
             }

--- a/realm/src/main/java/io/realm/internal/Context.java
+++ b/realm/src/main/java/io/realm/internal/Context.java
@@ -83,16 +83,29 @@ public class Context {
     private void executeDelayedDisposalFinalize() {
         synchronized (this) {
 
-            for (long nativePointer : abandonedTables) {
-                Table.nativeClose(nativePointer);
+            int size = abandonedTables.size();
+
+            if(size > 0) {
+                for (int i = 0; i < size; i++) {
+                    Table.nativeClose(abandonedTables.get(i));
+                }
             }
 
-            for (long nativePointer : abandonedTableViews) {
-                TableView.nativeClose(nativePointer);
+            size = abandonedTableViews.size();
+
+            if(size > 0) {
+                for (int i = 0; i < size; i++) {
+                    TableView.nativeClose(abandonedTableViews.get(i));
+                }
             }
 
-            for (long nativePointer : abandonedQueries) {
-                TableQuery.nativeClose(nativePointer);
+            size = abandonedQueries.size();
+
+            if(abandonedQueries.size() > 0) {
+
+                for (int i = 0; i < size; i++) {
+                    TableQuery.nativeClose(abandonedQueries.get(i));
+                }
             }
 
             cleanRowsFinalize();

--- a/realm/src/main/java/io/realm/internal/Context.java
+++ b/realm/src/main/java/io/realm/internal/Context.java
@@ -20,6 +20,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
@@ -38,7 +39,7 @@ public class Context {
     private LongArrayList abandonedTableViews = new LongArrayList();
     private LongArrayList abandonedQueries = new LongArrayList();
 
-    ReferenceOpenHashSet<Reference<?>>  rowReferences = new ReferenceOpenHashSet<Reference<?>>();
+    HashSet<Reference<?>> rowReferences = new HashSet<Reference<?>>();
     ReferenceQueue<NativeObject> referenceQueue = new ReferenceQueue<NativeObject>();
 
     private boolean isFinalized = false;

--- a/realm/src/main/java/io/realm/internal/Context.java
+++ b/realm/src/main/java/io/realm/internal/Context.java
@@ -22,6 +22,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.objects.ReferenceArraySet;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+
 public class Context {
 
     // Each group of related Realm objects will have a Context object in the root.
@@ -30,14 +34,11 @@ public class Context {
     // whose disposal need to be handed over from the garbage 
     // collection thread to the users thread.
 
-    // Reserved to be used only as a placholder by rowReferences Map to avoid autoboxing allocations
-    static final Integer ROW_REFERENCES_VALUE = 0;
+    private LongArrayList abandonedTables = new LongArrayList();
+    private LongArrayList abandonedTableViews = new LongArrayList();
+    private LongArrayList abandonedQueries = new LongArrayList();
 
-    private ArrayList<Long> abandonedTables = new ArrayList<Long>();
-    private ArrayList<Long> abandonedTableViews = new ArrayList<Long>();
-    private ArrayList<Long> abandonedQueries = new ArrayList<Long>();
-
-    HashMap<Reference<?>, Integer> rowReferences = new HashMap<Reference<?>, Integer>();
+    ReferenceOpenHashSet<Reference<?>>  rowReferences = new ReferenceOpenHashSet<Reference<?>>();
     ReferenceQueue<NativeObject> referenceQueue = new ReferenceQueue<NativeObject>();
 
     private boolean isFinalized = false;

--- a/realm/src/main/java/io/realm/internal/Context.java
+++ b/realm/src/main/java/io/realm/internal/Context.java
@@ -75,22 +75,16 @@ public class Context {
     // Faster version used only for context.Finalize() calls. Difference is it does not modify registries but set them to null
     private void executeDelayedDisposalFinalize() {
         synchronized (this) {
-            if(abandonedTables.size() > 0) {
-                for (long nativePointer : abandonedTables) {
-                    Table.nativeClose(nativePointer);
-                }
+            for (long nativePointer : abandonedTables) {
+                Table.nativeClose(nativePointer);
             }
 
-            if(abandonedTableViews.size() > 0) {
-                for (long nativePointer : abandonedTableViews) {
-                    TableView.nativeClose(nativePointer);
-                }
+            for (long nativePointer : abandonedTableViews) {
+                TableView.nativeClose(nativePointer);
             }
 
-            if(abandonedQueries.size() > 0) {
-                for (long nativePointer : abandonedQueries) {
-                    TableQuery.nativeClose(nativePointer);
-                }
+            for (long nativePointer : abandonedQueries) {
+                TableQuery.nativeClose(nativePointer);
             }
 
             cleanRowsFinalize();

--- a/realm/src/main/java/io/realm/internal/RealmCore.java
+++ b/realm/src/main/java/io/realm/internal/RealmCore.java
@@ -36,29 +36,11 @@ public class RealmCore {
     private static final String PATH_SEP = File.pathSeparator;          // On Windows ";"
     private static final String BINARIES_PATH = "lib" + PATH_SEP + ".." + FILE_SEP + "lib";
     private static final String JAVA_LIBRARY_PATH = "java.library.path";
+    private static final String JNILIB_NAME= "earthworm";
 //*/
 
     private static volatile boolean libraryIsLoaded = false;
 
-/*
-    private static String getJniFileName()
-    {
-        String os = System.getProperty("os.name").toLowerCase();
-        if (os.indexOf("win") >= 0)
-            return "realm_jni32.dll or realm_jni64.dll";
-        if (os.indexOf("mac") >= 0)
-            return "librealm-jni.jnilib";
-        if (os.indexOf("nix") >= 0 || os.indexOf("nux") >= 0 || os.indexOf("sunos") >= 0)
-            return "librealm-jni.so";
-        return "realm-jni";
-    }
-*/
-
-    public static boolean osIsWindows()
-    {
-        String os = System.getProperty("os.name").toLowerCase(Locale.getDefault());
-        return (os.contains("win"));
-    }
 
     public static byte[] serialize(Serializable value) {
         try {
@@ -87,11 +69,6 @@ public class RealmCore {
             throw new RuntimeException("Cannot deserialize the object!", e);
         }
     }
-/*
-    public static void print(String caption, AbstractCursor<?> cursor) {
-        System.out.println(caption + ": " + cursor);
-    }
-*/
 
     // Although loadLibrary is synchronized internally from AOSP 4.3, for the compatibility reason,
     // KEEP synchronized here for the old devices!
@@ -102,88 +79,12 @@ public class RealmCore {
             return;
         }
 
-        if (osIsWindows()) {
-            loadLibraryWindows();
-        }
         else {
-            String jnilib;
-            String debug = System.getenv("REALM_JAVA_DEBUG");
-            if (debug == null || debug.isEmpty()) {
-                jnilib = "realm-jni";
-            }
-            else {
-                jnilib = "realm-jni-dbg";
-            }
-            System.loadLibrary(jnilib);
+            System.loadLibrary(JNILIB_NAME);
         }
+
         libraryIsLoaded = true;
 
         Version.coreLibVersionCompatible(true);
     }
-
-    private static String loadLibraryWindows() {
-///*
-        try {
-            addNativeLibraryPath(BINARIES_PATH);
-            resetLibraryPath();
-        }
-        catch (Throwable e) {
-            // Above can't be used on Android.
-        }
-//*/
-        // Load debug library first - if available
-        String jnilib;
-        jnilib = loadCorrectLibrary("realm_jni32d", "realm_jni64d");
-        if (jnilib != null) {
-            System.out.println("!!! Realm debug version loaded. !!!\n");
-        }
-        else {
-            jnilib = loadCorrectLibrary("realm_jni32", "realm_jni64");
-            if (jnilib == null) {
-                System.err.println("Searched java.library.path=" + System.getProperty("java.library.path"));
-                throw new RuntimeException("Couldn't load the Realm JNI library 'realm_jni32.dll or realm_jni64.dll" +
-                                           "'. Please include the directory to the library in java.library.path.");
-            }
-        }
-        return jnilib;
-    }
-
-    private static String loadCorrectLibrary(String... libraryCandidateNames) {
-        for (String libraryCandidateName : libraryCandidateNames) {
-            try {
-                System.loadLibrary(libraryCandidateName);
-                return libraryCandidateName;
-            } catch (Throwable e) {
-            }
-        }
-        return null;
-    }
-
-// /*
-    public static void addNativeLibraryPath(String path) {
-        try {
-            String libraryPath = System.getProperty(JAVA_LIBRARY_PATH) + PATH_SEP + path + PATH_SEP;
-            System.setProperty(JAVA_LIBRARY_PATH, libraryPath);
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot set the library path!", e);
-        }
-    }
-
-    // Hack for having a cross platform location for the lib:
-    // The Classloader has a static field (sys_paths) that contains the paths.
-    // If that field is set to null, it is initialized automatically.
-    // Therefore forcing that field to null will result into the reevaluation of the library path
-    // as soon as loadLibrary() is called
-
-    private static void resetLibraryPath() {
-        try {
-            // reset the library path (a hack)
-            Field fieldSysPath = ClassLoader.class.getDeclaredField("sys_paths");
-            fieldSysPath.setAccessible(true);
-            fieldSysPath.set(null, null);
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot reset the library path!", e);
-        }
-    }
-// */
 }

--- a/realm/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/src/main/java/io/realm/internal/UncheckedRow.java
@@ -50,7 +50,7 @@ public class UncheckedRow extends NativeObject implements Row {
     public static UncheckedRow get(Context context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.nativePtr, index);
         UncheckedRow row = new UncheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
+        context.rowReferences.add(new NativeObjectReference(row, context.referenceQueue));
         return row;
     }
 
@@ -64,7 +64,7 @@ public class UncheckedRow extends NativeObject implements Row {
     public static UncheckedRow get(Context context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativeLinkViewPtr, index);
         UncheckedRow row = new UncheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent), nativeRowPointer);
-        context.rowReferences.put(new NativeObjectReference(row, context.referenceQueue), context.ROW_REFERENCES_VALUE);
+        context.rowReferences.add(new NativeObjectReference(row, context.referenceQueue));
         return row;
     }
 


### PR DESCRIPTION
…ontext.finalize() is called by GC, the context is already out of scope. Existing code does modification to HashMap and ArrayLists which are only held by context and are going to be GCed anyways. 2) Realm calls Jni-GC aka executeDelayedDisposal on every RealmObject creation so this is a very hot spot. Optimize this by A) using optimized java range loop B) avoid a method call to ArrayList.Clear() 3) Declare a few vars as ArrayList. Doesn't hurt and can only help with performance even if by 0.000001 percent.