### PR TITLE
Cleanup SharedGroup.java and Group.java

### DIFF
--- a/realm/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/src/main/java/io/realm/internal/SharedGroup.java
@@ -81,33 +81,21 @@ public class SharedGroup implements Closeable {
         checkNativePtrNotZero();
     }
 
-    private native long createNativeWithImplicitTransactions(long nativeReplicationPtr, int durability, byte[] key);
-
-    private native long nativeCreateReplication(String databaseFile, byte[] key);
-
     void advanceRead() {
         nativeAdvanceRead(nativePtr);
     }
-
-    private native void nativeAdvanceRead(long nativePtr);
 
     void promoteToWrite() {
         nativePromoteToWrite(nativePtr);
     }
 
-    private native void nativePromoteToWrite(long nativePtr);
-
     void commitAndContinueAsRead() {
         nativeCommitAndContinueAsRead(nativePtr);
     }
 
-    private native void nativeCommitAndContinueAsRead(long nativePtr);
-
     void rollbackAndContinueAsRead() {
         nativeRollbackAndContinueAsRead(nativePtr);
     }
-
-    private native void nativeRollbackAndContinueAsRead(long nativePtr);
 
     public ImplicitTransaction beginImplicitTransaction() {
         if (activeTransaction) {
@@ -119,8 +107,6 @@ public class SharedGroup implements Closeable {
         activeTransaction = true;
         return transaction;
     }
-
-    private native long nativeBeginImplicit(long nativePtr);
 
     public WriteTransaction beginWrite() {
         if (activeTransaction)
@@ -206,7 +192,6 @@ public class SharedGroup implements Closeable {
         activeTransaction = false;
     }
 
-
     boolean isClosed() {
         return nativePtr == 0;
     }
@@ -229,7 +214,6 @@ public class SharedGroup implements Closeable {
         return nativeCompact(nativePtr);
     }
 
-
     /**
      * Returns the absolute path to the file backing this SharedGroup.
      *
@@ -239,37 +223,33 @@ public class SharedGroup implements Closeable {
         return path;
     }
 
-    private native String nativeGetDefaultReplicationDatabaseFileName();
-
-    private native void nativeReserve(long nativePtr, long bytes);
-
-    private native boolean nativeHasChanged(long nativePtr);
-
-    private native long nativeBeginRead(long nativePtr);
-
-    private native void nativeEndRead(long nativePtr);
-
-    private native long nativeBeginWrite(long nativePtr);
-
-    private native void nativeCommit(long nativePtr);
-
-    private native void nativeRollback(long nativePtr);
-
-    private native long nativeCreate(String databaseFile,
-                                     int durabilityValue,
-                                     boolean no_create,
-                                     boolean enableReplication,
-                                     byte[] key);
-
-    private native boolean nativeCompact(long nativePtr);
-
     private void checkNativePtrNotZero() {
         if (this.nativePtr == 0) {
             throw new IOError(new RealmIOException("Realm could not be opened"));
         }
     }
 
+    private native long createNativeWithImplicitTransactions(long nativeReplicationPtr, int durability, byte[] key);
+    private native long nativeCreateReplication(String databaseFile, byte[] key);
+    private native void nativeAdvanceRead(long nativePtr);
+    private native void nativePromoteToWrite(long nativePtr);
+    private native void nativeCommitAndContinueAsRead(long nativePtr);
+    private native void nativeRollbackAndContinueAsRead(long nativePtr);
+    private native long nativeBeginImplicit(long nativePtr);
+    private native String nativeGetDefaultReplicationDatabaseFileName();
+    private native void nativeReserve(long nativePtr, long bytes);
+    private native boolean nativeHasChanged(long nativePtr);
+    private native long nativeBeginRead(long nativePtr);
+    private native void nativeEndRead(long nativePtr);
+    private native long nativeBeginWrite(long nativePtr);
+    private native void nativeCommit(long nativePtr);
+    private native void nativeRollback(long nativePtr);
+    private native long nativeCreate(String databaseFile,
+                                     int durabilityValue,
+                                     boolean no_create,
+                                     boolean enableReplication,
+                                     byte[] key);
+    private native boolean nativeCompact(long nativePtr);
     protected static native void nativeClose(long nativePtr);
-
     private native void nativeCloseReplication(long nativeReplicationPtr);
 }


### PR DESCRIPTION
Cleanup native methods to match earlier discussed style (=grouped at the bottom of the class).
Preparing for bugfix for #1406 