### PR TITLE
Fixes change events getting lost in fast write scenarios

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 0.83
- * Fixed bug that could cause UI thread not to keep up with changes from background threads with many writes.Sh
+ * Fixed bug that could cause UI thread not to keep up with changes from background threads with many writes.
  * BREAKING CHANGE: Removed deprecated methods and constructors from the Realm class.
  * Fixed a bug which might cause failure when loading the native library.
  * Fixed a bug which might trigger a timeout in Context.finalize().

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 0.83
+ * Fixed bug that could cause UI thread not to keep up with changes from background threads with many writes.Sh
  * BREAKING CHANGE: Removed deprecated methods and constructors from the Realm class.
  * Fixed a bug which might cause failure when loading the native library.
  * Fixed a bug which might trigger a timeout in Context.finalize().

--- a/realm-jni/src/io_realm_internal_SharedGroup.cpp
+++ b/realm-jni/src/io_realm_internal_SharedGroup.cpp
@@ -295,3 +295,20 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedGroup_nativeCompact(
     CATCH_STD()
     return false;
 }
+
+JNIEXPORT jlongArray JNICALL Java_io_realm_internal_SharedGroup_nativeGetVersionID
+        (JNIEnv *env, jobject, jlong native_ptr)
+{
+    TR_ENTER()
+
+    SharedGroup::VersionID versionID = SG(native_ptr)->get_version_of_current_transaction();
+
+    jlong versionArray [2];
+    versionArray[0] = static_cast<jlong>(versionID.version);
+    versionArray[1] = static_cast<jlong>(versionID.index);
+
+    jlongArray versionData = env->NewLongArray(2);
+    env->SetLongArrayRegion(versionData, 0, 2, versionArray);
+
+    return versionData;
+}

--- a/realm-jni/src/io_realm_internal_SharedGroup.cpp
+++ b/realm-jni/src/io_realm_internal_SharedGroup.cpp
@@ -158,7 +158,7 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_SharedGroup_nativeAdvanceRea
         return Java_io_realm_internal_SharedGroup_nativeGetVersionID(env, obj, native_ptr);
     }
     CATCH_STD()
-    return 0;
+    return NULL;
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_SharedGroup_nativePromoteToWrite

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -280,8 +280,9 @@ public final class Realm implements Closeable {
         @Override
         public boolean handleMessage(Message message) {
             if (message.what == REALM_CHANGED) {
-                transaction.advanceRead();
-                sendNotifications();
+                if (transaction.advanceRead()) {
+                    sendNotifications();
+                }
             }
             return true;
         }
@@ -1326,7 +1327,9 @@ public final class Realm implements Closeable {
                     && !handler.hasMessages(REALM_CHANGED)       // The right message
                     && handler.getLooper().getThread().isAlive() // The receiving thread is alive
             ) {
-                handler.sendEmptyMessage(REALM_CHANGED);
+                if (!handler.sendEmptyMessage(REALM_CHANGED)) {
+                    RealmLog.d("Could not send onChange message on commit");
+                }
             }
         }
     }

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -1324,7 +1324,6 @@ public final class Realm implements Closeable {
             // For all other threads, use the Handler
             if (
                     realmPath.equals(configuration.getPath())    // It's the right realm
-                    && !handler.hasMessages(REALM_CHANGED)       // The right message
                     && handler.getLooper().getThread().isAlive() // The receiving thread is alive
             ) {
                 if (!handler.sendEmptyMessage(REALM_CHANGED)) {

--- a/realm/src/main/java/io/realm/internal/Group.java
+++ b/realm/src/main/java/io/realm/internal/Group.java
@@ -35,10 +35,6 @@ public class Group implements Closeable {
         RealmCore.loadLibrary();
     }
 
-    //
-    // Group construction and destruction
-    //
-
     private void checkNativePtrNotZero() {
         if (this.nativePtr == 0)
             // FIXME: It is wrong to assume that a null pointer means 'out
@@ -55,18 +51,16 @@ public class Group implements Closeable {
         checkNativePtrNotZero();
     }
 
-    protected native long createNative();
-
     public enum OpenMode {
         // Below values must match the values in realm::group::OpenMode in C++
         READ_ONLY(0),
         READ_WRITE(1),
         READ_WRITE_NO_CREATE(2);
         private int value;
-        private OpenMode(int value) {
+        OpenMode(int value) {
             this.value = value;
         }
-    };
+    }
 
     public Group(String filepath, OpenMode mode) {
         this.immutable = mode.equals(OpenMode.READ_ONLY);
@@ -75,8 +69,6 @@ public class Group implements Closeable {
         this.nativePtr = createNative(filepath, mode.value);
         checkNativePtrNotZero();
     }
-
-    protected native long createNative(String filepath, int value);
 
     public Group(String filepath) {
         this(filepath, OpenMode.READ_ONLY);
@@ -97,8 +89,6 @@ public class Group implements Closeable {
         }
     }
 
-    protected native long createNative(byte[] data);
-
     public Group(ByteBuffer buffer) {
         this.immutable = false;
         this.context = new Context();
@@ -109,8 +99,6 @@ public class Group implements Closeable {
             throw new IllegalArgumentException();
         }
     }
-
-    protected native long createNative(ByteBuffer buffer);
 
     Group(Context context, long nativePointer, boolean immutable) {
         this.context = context;
@@ -128,8 +116,6 @@ public class Group implements Closeable {
             }
         }
     }
-
-    protected static native void nativeClose(long nativeGroupPtr);
 
     /**
      * Checks if a group has been closed and can no longer be used.
@@ -149,10 +135,6 @@ public class Group implements Closeable {
         }
     }
 
-    //
-    // Group methods
-    //
-
     private void verifyGroupIsValid() {
         if (nativePtr == 0) {
             throw new IllegalStateException("Illegal to call methods on a closed Group.");
@@ -164,13 +146,9 @@ public class Group implements Closeable {
         return nativeSize(nativePtr);
     }
 
-    protected native long nativeSize(long nativeGroupPtr);
-
-
     public boolean isEmpty(){
         return size() == 0;
     }
-
 
     /**
      * Checks whether table exists in the Group.
@@ -183,8 +161,6 @@ public class Group implements Closeable {
         return name != null && nativeHasTable(nativePtr, name);
     }
 
-    protected native boolean nativeHasTable(long nativeGroupPtr, String name);
-
     public String getTableName(int index) {
         verifyGroupIsValid();
         long cnt = size();
@@ -195,8 +171,6 @@ public class Group implements Closeable {
         }
         return nativeGetTableName(nativePtr, index);
     }
-
-    protected native String nativeGetTableName(long nativeGroupPtr, int index);
 
     /**
      * Returns a table with the specified name.
@@ -228,11 +202,6 @@ public class Group implements Closeable {
         }
     }
 
-    protected native long nativeGetTableNativePtr(long nativeGroupPtr, String name);
-
-    protected native void nativeWriteToFile(long nativeGroupPtr, String fileName, byte[] keyArray)
-            throws IOException;
-
     /**
      * Serialize the group to the specific file on the disk using encryption.
      *
@@ -254,8 +223,6 @@ public class Group implements Closeable {
         nativeWriteToFile(nativePtr, file.getAbsolutePath(), key);
     }
 
-    protected static native long nativeLoadFromMem(byte[] buffer);
-
     /**
      * Serialize the group to a memory buffer. The byte[] is owned by the JVM.
      *
@@ -266,7 +233,6 @@ public class Group implements Closeable {
         return nativeWriteToMem(nativePtr);
     }
 
-    protected native byte[] nativeWriteToMem(long nativeGroupPtr);
 /*
  * TODO: Find a way to release the malloc'ed native memory automatically
 
@@ -287,17 +253,27 @@ public class Group implements Closeable {
         return nativeToJson(nativePtr);
     }
 
-    protected native String nativeToJson(long nativeGroupPtr);
-
     public String toString() {
         return nativeToString(nativePtr);
     }
 
-    protected native void nativeCommit(long nativeGroupPtr);
-
-    protected native String nativeToString(long nativeGroupPtr);
-
     private void throwImmutable() {
         throw new IllegalStateException("Objects cannot be changed outside a transaction; see beginTransaction() for details.");
     }
+
+    protected native long createNative();
+    protected native long createNative(String filepath, int value);
+    protected native long createNative(byte[] data);
+    protected native long createNative(ByteBuffer buffer);
+    protected static native void nativeClose(long nativeGroupPtr);
+    protected native long nativeSize(long nativeGroupPtr);
+    protected native String nativeGetTableName(long nativeGroupPtr, int index);
+    protected native boolean nativeHasTable(long nativeGroupPtr, String name);
+    protected native void nativeWriteToFile(long nativeGroupPtr, String fileName, byte[] keyArray) throws IOException;
+    protected native long nativeGetTableNativePtr(long nativeGroupPtr, String name);
+    protected static native long nativeLoadFromMem(byte[] buffer);
+    protected native byte[] nativeWriteToMem(long nativeGroupPtr);
+    protected native String nativeToJson(long nativeGroupPtr);
+    protected native void nativeCommit(long nativeGroupPtr);
+    protected native String nativeToString(long nativeGroupPtr);
 }

--- a/realm/src/main/java/io/realm/internal/ImplicitTransaction.java
+++ b/realm/src/main/java/io/realm/internal/ImplicitTransaction.java
@@ -25,9 +25,9 @@ public class ImplicitTransaction extends Group {
         parent = sharedGroup;
     }
 
-    public void advanceRead() {
+    public boolean advanceRead() {
         assertNotClosed();
-        parent.advanceRead();
+        return parent.advanceRead();
     }
 
     public void promoteToWrite() {

--- a/realm/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/src/main/java/io/realm/internal/SharedGroup.java
@@ -81,33 +81,21 @@ public class SharedGroup implements Closeable {
         checkNativePtrNotZero();
     }
 
-    private native long createNativeWithImplicitTransactions(long nativeReplicationPtr, int durability, byte[] key);
-
-    private native long nativeCreateReplication(String databaseFile, byte[] key);
-
     void advanceRead() {
         nativeAdvanceRead(nativePtr);
     }
-
-    private native void nativeAdvanceRead(long nativePtr);
 
     void promoteToWrite() {
         nativePromoteToWrite(nativePtr);
     }
 
-    private native void nativePromoteToWrite(long nativePtr);
-
     void commitAndContinueAsRead() {
         nativeCommitAndContinueAsRead(nativePtr);
     }
 
-    private native void nativeCommitAndContinueAsRead(long nativePtr);
-
     void rollbackAndContinueAsRead() {
         nativeRollbackAndContinueAsRead(nativePtr);
     }
-
-    private native void nativeRollbackAndContinueAsRead(long nativePtr);
 
     public ImplicitTransaction beginImplicitTransaction() {
         if (activeTransaction) {
@@ -119,8 +107,6 @@ public class SharedGroup implements Closeable {
         activeTransaction = true;
         return transaction;
     }
-
-    private native long nativeBeginImplicit(long nativePtr);
 
     public WriteTransaction beginWrite() {
         if (activeTransaction)
@@ -206,7 +192,6 @@ public class SharedGroup implements Closeable {
         activeTransaction = false;
     }
 
-
     boolean isClosed() {
         return nativePtr == 0;
     }
@@ -229,7 +214,6 @@ public class SharedGroup implements Closeable {
         return nativeCompact(nativePtr);
     }
 
-
     /**
      * Returns the absolute path to the file backing this SharedGroup.
      *
@@ -239,37 +223,33 @@ public class SharedGroup implements Closeable {
         return path;
     }
 
-    private native String nativeGetDefaultReplicationDatabaseFileName();
-
-    private native void nativeReserve(long nativePtr, long bytes);
-
-    private native boolean nativeHasChanged(long nativePtr);
-
-    private native long nativeBeginRead(long nativePtr);
-
-    private native void nativeEndRead(long nativePtr);
-
-    private native long nativeBeginWrite(long nativePtr);
-
-    private native void nativeCommit(long nativePtr);
-
-    private native void nativeRollback(long nativePtr);
-
-    private native long nativeCreate(String databaseFile,
-                                     int durabilityValue,
-                                     boolean no_create,
-                                     boolean enableReplication,
-                                     byte[] key);
-
-    private native boolean nativeCompact(long nativePtr);
-
     private void checkNativePtrNotZero() {
         if (this.nativePtr == 0) {
             throw new IOError(new RealmIOException("Realm could not be opened"));
         }
     }
 
+    private native long createNativeWithImplicitTransactions(long nativeReplicationPtr, int durability, byte[] key);
+    private native long nativeCreateReplication(String databaseFile, byte[] key);
+    private native void nativeAdvanceRead(long nativePtr);
+    private native void nativePromoteToWrite(long nativePtr);
+    private native void nativeCommitAndContinueAsRead(long nativePtr);
+    private native void nativeRollbackAndContinueAsRead(long nativePtr);
+    private native long nativeBeginImplicit(long nativePtr);
+    private native String nativeGetDefaultReplicationDatabaseFileName();
+    private native void nativeReserve(long nativePtr, long bytes);
+    private native boolean nativeHasChanged(long nativePtr);
+    private native long nativeBeginRead(long nativePtr);
+    private native void nativeEndRead(long nativePtr);
+    private native long nativeBeginWrite(long nativePtr);
+    private native void nativeCommit(long nativePtr);
+    private native void nativeRollback(long nativePtr);
+    private native long nativeCreate(String databaseFile,
+                                     int durabilityValue,
+                                     boolean no_create,
+                                     boolean enableReplication,
+                                     byte[] key);
+    private native boolean nativeCompact(long nativePtr);
     protected static native void nativeClose(long nativePtr);
-
     private native void nativeCloseReplication(long nativeReplicationPtr);
 }

--- a/realm/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/src/main/java/io/realm/internal/SharedGroup.java
@@ -89,7 +89,7 @@ public class SharedGroup implements Closeable {
      */
     boolean advanceRead() {
         long[] nextVersion = nativeAdvanceRead(nativePtr);
-        if (lastSeenVersion[0] != nextVersion[0] || lastSeenVersion[1] != nextVersion[1]) {
+        if (nextVersion != null && (lastSeenVersion[0] != nextVersion[0] || lastSeenVersion[1] != nextVersion[1])) {
             lastSeenVersion = nextVersion;
             return true;
         }


### PR DESCRIPTION
Fixes #1406 

It has not been possible to write a unit test that captures this problem, maybe due to how Handlers being less stressed in unit tests. The code presented in #1406 captures it every time though and it has been validated that this indeed fix the problem.

