### PR TITLE
Schemas are now only validated once across threads.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 0.83
+ * Opening a Realm file from one thread will no longer be blocked by a write transaction from another thread.
  * BREAKING CHANGE: Removed deprecated methods and constructors from the Realm class.
  * Fixed a bug which might cause failure when loading the native library.
  * Fixed a bug which might trigger a timeout in Context.finalize().

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -1823,6 +1823,8 @@ public class RealmTest extends AndroidTestCase {
 
     public void testValidateSchemasOverThreads() throws InterruptedException, TimeoutException, ExecutionException {
         final RealmConfiguration config = TestHelper.createConfiguration(getContext(), "foo");
+        Realm.deleteRealm(config);
+
         final CountDownLatch bgThreadLocked = new CountDownLatch(1);
         final CountDownLatch mainThreadDone = new CountDownLatch(1);
 
@@ -1852,6 +1854,6 @@ public class RealmTest extends AndroidTestCase {
         });
 
         bgThreadLocked.await(2, TimeUnit.SECONDS);
-        assertTrue(future.get(2, TimeUnit.SECONDS));
+        assertTrue(future.get(10, TimeUnit.SECONDS));
     }
 }

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -1821,6 +1821,7 @@ public class RealmTest extends AndroidTestCase {
         assertNotNull(testRealm);
     }
 
+    // Tests that if the same Realm file is opened on multiple threads, we only need to validate the schema on the first thread.
     public void testValidateSchemasOverThreads() throws InterruptedException, TimeoutException, ExecutionException {
         final RealmConfiguration config = TestHelper.createConfiguration(getContext(), "foo");
         Realm.deleteRealm(config);

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -27,7 +27,6 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -40,7 +39,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -415,7 +415,7 @@ public final class Realm implements Closeable {
     private static Realm create(RealmConfiguration configuration) {
         boolean autoRefresh = Looper.myLooper() != null;
         try {
-            boolean validateSchema = validatedRealmFiles.contains(configuration.getPath());
+            boolean validateSchema = !validatedRealmFiles.contains(configuration.getPath());
             return createAndValidate(configuration, validateSchema, autoRefresh);
 
         } catch (RealmMigrationNeededException e) {

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -38,11 +38,13 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -129,7 +131,8 @@ public final class Realm implements Closeable {
     };
 
     // List of Realm files that has already been validated
-    private static final Map<String, Boolean> validatedRealmFiles = new ConcurrentHashMap<String, Boolean>();
+    private static final Set<String> validatedRealmFiles = Collections.newSetFromMap(
+            new ConcurrentHashMap<String, Boolean>());
 
     private static final ThreadLocal<Map<RealmConfiguration, Integer>> referenceCount =
             new ThreadLocal<Map<RealmConfiguration,Integer>>() {
@@ -412,7 +415,7 @@ public final class Realm implements Closeable {
     private static Realm create(RealmConfiguration configuration) {
         boolean autoRefresh = Looper.myLooper() != null;
         try {
-            boolean validateSchema = validatedRealmFiles.containsKey(configuration.getPath());
+            boolean validateSchema = validatedRealmFiles.contains(configuration.getPath());
             return createAndValidate(configuration, validateSchema, autoRefresh);
 
         } catch (RealmMigrationNeededException e) {
@@ -551,7 +554,7 @@ public final class Realm implements Closeable {
                 mediator.validateTable(modelClass, realm.transaction);
                 realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
             }
-            validatedRealmFiles.put(realm.getPath(), Boolean.TRUE);
+            validatedRealmFiles.add(realm.getPath());
         } finally {
             if (commitNeeded) {
                 realm.commitTransaction();

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -551,7 +551,7 @@ public final class Realm implements Closeable {
                 mediator.validateTable(modelClass, realm.transaction);
                 realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
             }
-            validatedRealmFiles.put(realm.getPath(), true);
+            validatedRealmFiles.put(realm.getPath(), Boolean.TRUE);
         } finally {
             if (commitNeeded) {
                 realm.commitTransaction();


### PR DESCRIPTION
Fixes #1373 

Prevents a long living write transaction on a background thread blocking opening Realm on the UI thread if it is the same file, as we then are sure that the schema has already been validated.

@realm/java 