### PR TITLE
ColumnIndices are now setup correctly for all Realms

### DIFF
--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -308,8 +308,16 @@ public final class Realm extends BaseRealm {
                     throw e;
                 }
             }
+            setupColumnIndices(realm);
 
             return realm;
+        }
+    }
+
+    private static void setupColumnIndices(Realm realm) {
+        RealmProxyMediator mediator = realm.configuration.getSchemaMediator();
+        for (Class<? extends RealmObject> modelClass : mediator.getModelClasses()) {
+            realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
         }
     }
 
@@ -331,7 +339,6 @@ public final class Realm extends BaseRealm {
                     mediator.createTable(modelClass, realm.sharedGroupManager.getTransaction());
                 }
                 mediator.validateTable(modelClass, realm.sharedGroupManager.getTransaction());
-                realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
             }
             validatedRealmFiles.add(realm.getPath());
         } finally {

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -316,7 +316,10 @@ public final class Realm extends BaseRealm {
 
     private static void setupColumnIndices(Realm realm) {
         RealmProxyMediator mediator = realm.configuration.getSchemaMediator();
-        for (Class<? extends RealmObject> modelClass : mediator.getModelClasses()) {
+        List<Class<? extends RealmObject>> modelClasses = mediator.getModelClasses();
+        int size = modelClasses.size();
+        for (int i = 0; i < size; i++) {
+            Class<? extends RealmObject> modelClass = modelClasses.get(i);
             realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
         }
     }


### PR DESCRIPTION
This fixes a recently introduced bug (caught by the async branch) where column indices are not configured correctly if the same Realm is opened on multiple threads causing queries to crash.

@realm/java 