### PR TITLE
Fixed handler not being removed when using setAutoRefresh(false)

### DIFF
--- a/realm/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/src/androidTest/java/io/realm/NotificationsTest.java
@@ -18,6 +18,7 @@ package io.realm;
 import android.os.Handler;
 import android.os.Looper;
 import android.test.AndroidTestCase;
+import android.util.Log;
 
 import junit.framework.AssertionFailedError;
 
@@ -37,6 +38,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.Dog;
+import io.realm.internal.log.Logger;
+import io.realm.internal.log.RealmLog;
 
 public class NotificationsTest extends AndroidTestCase {
 
@@ -555,6 +558,62 @@ public class NotificationsTest extends AndroidTestCase {
 
         if (threadAssertionError[0] != null) {
             throw threadAssertionError[0];
+        }
+    }
+
+    // Test that we handle a Looper thread quiting it's looper before it is done executing the current loop ( = Realm.close()
+    // isn't called yet).
+    public void testLooperThreadQuitsLooperEarly() throws InterruptedException {
+        RealmConfiguration config = TestHelper.createConfiguration(getContext());
+        Realm.deleteRealm(config);
+
+        final CountDownLatch backgroundLooperStartedAndStopped = new CountDownLatch(1);
+        final CountDownLatch mainThreadCommitCompleted = new CountDownLatch(1);
+        final CountDownLatch backgroundThreadStopped = new CountDownLatch(1);
+
+        // Start background looper and let it hang
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                Looper.prepare(); // Fake background thread with a looper, eg. a IntentService
+
+                Realm realm = Realm.getInstance(getContext());
+                realm.setAutoRefresh(false);
+                Looper.myLooper().quit();
+                backgroundLooperStartedAndStopped.countDown();
+                try {
+                    mainThreadCommitCompleted.await();
+                } catch (InterruptedException e) {
+                    fail("Thread interrupted"); // This will prevent backgroundThreadStopped from being called.
+                }
+                realm.close();
+                backgroundThreadStopped.countDown();
+            }
+        });
+
+        // Create a commit on another thread
+        awaitOrThrow(backgroundLooperStartedAndStopped);
+        Realm realm = Realm.getInstance(config);
+        Logger logger = TestHelper.getFailureLogger(Log.WARN);
+        RealmLog.add(logger);
+
+        realm.beginTransaction();
+        realm.commitTransaction(); // If the Handler on the background is notified it will trigger a Log warning.
+        mainThreadCommitCompleted.countDown();
+        awaitOrThrow(backgroundThreadStopped);
+
+        realm.close();
+        RealmLog.remove(logger);
+    }
+
+    private void awaitOrThrow(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                fail("Latch timed out " + latch);
+            }
+        } catch (InterruptedException e) {
+            fail("Latch was interrupted " + e);
         }
     }
 }

--- a/realm/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/src/androidTest/java/io/realm/TestHelper.java
@@ -18,6 +18,7 @@ package io.realm;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.util.Log;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -31,6 +32,11 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Random;
+import java.util.logging.Level;
+
+import io.realm.internal.log.Logger;
+
+import static junit.framework.Assert.fail;
 
 public class TestHelper {
 
@@ -89,6 +95,73 @@ public class TestHelper {
         byte[] key = new byte[64];
         new Random(seed).nextBytes(key);
         return key;
+    }
+
+    /**
+     * Returns a Logger that will fail if it is asked to log a message above a certain level.
+     *
+     * @param failureLevel {@link Log} level from which the unit test will fail.
+     * @return Logger implementation
+     */
+    public static Logger getFailureLogger(final int failureLevel) {
+        return new Logger() {
+
+            private void failIfEqualOrAbove(int logLevel, int failureLevel) {
+                if (logLevel >= failureLevel) {
+                    fail("Message logged that was above valid level: " + logLevel + " >= " + failureLevel);
+                }
+            }
+
+            @Override
+            public void v(String message) {
+                failIfEqualOrAbove(Log.VERBOSE, failureLevel);
+            }
+
+            @Override
+            public void v(String message, Throwable t) {
+                failIfEqualOrAbove(Log.VERBOSE, failureLevel);
+            }
+
+            @Override
+            public void d(String message) {
+                failIfEqualOrAbove(Log.DEBUG, failureLevel);
+            }
+
+            @Override
+            public void d(String message, Throwable t) {
+                failIfEqualOrAbove(Log.DEBUG, failureLevel);
+            }
+
+            @Override
+            public void i(String message) {
+                failIfEqualOrAbove(Log.INFO, failureLevel);
+            }
+
+            @Override
+            public void i(String message, Throwable t) {
+                failIfEqualOrAbove(Log.INFO, failureLevel);
+            }
+
+            @Override
+            public void w(String message) {
+                failIfEqualOrAbove(Log.WARN, failureLevel);
+            }
+
+            @Override
+            public void w(String message, Throwable t) {
+                failIfEqualOrAbove(Log.WARN, failureLevel);
+            }
+
+            @Override
+            public void e(String message) {
+                failIfEqualOrAbove(Log.ERROR, failureLevel);
+            }
+
+            @Override
+            public void e(String message, Throwable t) {
+                failIfEqualOrAbove(Log.ERROR, failureLevel);
+            }
+        };
     }
 
     public static class StubInputStream extends InputStream {

--- a/realm/src/main/java/io/realm/BaseRealm.java
+++ b/realm/src/main/java/io/realm/BaseRealm.java
@@ -179,6 +179,7 @@ abstract class BaseRealm implements Closeable {
     protected void removeHandler(Handler handler) {
         handler.removeCallbacksAndMessages(null);
         handlers.remove(handler);
+        this.handler = null;
     }
 
     private void sendNotifications() {
@@ -303,7 +304,10 @@ abstract class BaseRealm implements Closeable {
                             && !handler.hasMessages(REALM_CHANGED)       // The right message
                             && handler.getLooper().getThread().isAlive() // The receiving thread is alive
                     ) {
-                handler.sendEmptyMessage(REALM_CHANGED);
+                if (!handler.sendEmptyMessage(REALM_CHANGED)) {
+                    RealmLog.w("Cannot update Looper threads when the Looper has quit. Use realm.setAutoRefresh(false) " +
+                            "to prevent this.");
+                }
             }
         }
     }
@@ -406,7 +410,6 @@ abstract class BaseRealm implements Closeable {
 
         if (handler != null && refCount <= 0) {
             removeHandler(handler);
-            handler = null;
         }
     }
 


### PR DESCRIPTION
This PR is the result of some bug hunting and turned out some minor issues:

1) If a Looper is explicitly quit (e.g. a IntentService). We risk triggering warnings in the Log with the following wording "Handler sending message to a handler on a dead thread". An additional log message is now added with a description on how to avoid this.

2) If using `realm.setAutoRefresh(false)` the internal handler is not properly cleared. This has now been fixed.

@realm/java 