### PR TITLE
Guard globalPathConfigurationCache properly.

### DIFF
--- a/realm/src/main/java/io/realm/BaseRealm.java
+++ b/realm/src/main/java/io/realm/BaseRealm.java
@@ -400,7 +400,7 @@ abstract class BaseRealm implements Closeable {
             lastLocalInstanceClosed();
             sharedGroupManager.close();
             sharedGroupManager = null;
-            releaseFileReference();
+            releaseFileReference(configuration);
         }
 
         int refCount = references - 1;
@@ -427,7 +427,7 @@ abstract class BaseRealm implements Closeable {
     /**
      * Acquire a reference to the given Realm file.
      */
-    protected synchronized void acquireFileReference(RealmConfiguration configuration) {
+    static synchronized void acquireFileReference(RealmConfiguration configuration) {
         String path = configuration.getPath();
         Integer refCount = globalRealmFileReferenceCounter.get(path);
         if (refCount == null) {
@@ -440,7 +440,7 @@ abstract class BaseRealm implements Closeable {
      * Releases a reference to the Realm file. If reference count reaches 0 any cached configurations
      * will be removed.
      */
-    protected synchronized void releaseFileReference() {
+    static synchronized void releaseFileReference(RealmConfiguration configuration) {
         String canonicalPath = configuration.getPath();
         List<RealmConfiguration> pathConfigurationCache = globalPathConfigurationCache.get(canonicalPath);
         pathConfigurationCache.remove(configuration);
@@ -471,7 +471,7 @@ abstract class BaseRealm implements Closeable {
      *
      * @throws IllegalArgumentException If the new configuration isn't valid.
      */
-    protected static void validateAgainstExistingConfigurations(RealmConfiguration newConfiguration) {
+    protected static synchronized void validateAgainstExistingConfigurations(RealmConfiguration newConfiguration) {
 
         String realmPath = newConfiguration.getPath();
         List<RealmConfiguration> pathConfigurationCache = globalPathConfigurationCache.get(realmPath);


### PR DESCRIPTION
We had a bug reported against current master:

```
88    09-26 22:15:09.497 E/ACRA ( 438): ACRA caught a ArrayIndexOutOfBoundsException for com.podfather.podfather
89    09-26 22:15:09.497 E/ACRA ( 438): java.lang.ArrayIndexOutOfBoundsException: length=0; index=0
90    09-26 22:15:09.497 E/ACRA ( 438): at java.util.concurrent.CopyOnWriteArrayList.get(CopyOnWriteArrayList.java:117)
91    09-26 22:15:09.497 E/ACRA ( 438): at io.realm.BaseRealm.validateAgainstExistingConfigurations(BaseRealm.java:482)
92    09-26 22:15:09.497 E/ACRA ( 438): at io.realm.Realm.createAndValidate(Realm.java:276)
93    09-26 22:15:09.497 E/ACRA ( 438): at io.realm.Realm.create(Realm.java:245)
94    09-26 22:15:09.497 E/ACRA ( 438): at io.realm.Realm.getDefaultInstance(Realm.java:200)
95    09-26 22:15:09.497 E/ACRA ( 438): at com.podfather.podfather.services.DataPostService.postPodImages(DataPostService.java:626)
96    09-26 22:15:09.497 E/ACRA ( 438): at com.podfather.podfather.services.DataPostService.onHandleIntent(DataPostService.java:86)
97    09-26 22:15:09.497 E/ACRA ( 438): at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:65)
98    09-26 22:15:09.497 E/ACRA ( 438): at android.os.Handler.dispatchMessage(Handler.java:102)
99    09-26 22:15:09.497 E/ACRA ( 438): at android.os.Looper.loop(Looper.java:135)
100    09-26 22:15:09.497 E/ACRA ( 438): at android.os.HandlerThread.run(HandlerThread.java:61)
```

It could happen because `releaseFileReference` was only synchronized against the instance of a Realm and not the `BaseRealm` class which other methods use when they access `globalPathConfigurationCache`. This can lead to a race condition where `validateAgainstExisitingConfiguration` will wrongly assume it has sole access which is wrong since `releaseFileReference` don't respect the lock on `BaseRealm`.

This PR changes the lock from the instance of Realm to the static `BaseRealm` instead.

@realm/java 



