### PR TITLE
Expand Date range(#1510)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
  * Fixed an issue where opening the same Realm file on two Looper threads could potentially lead to an IllegalStateException being thrown.
  * Opening a Realm file from one thread will no longer be blocked by a write transaction from another thread.
  * Fixed an issue preventing the call of listeners on refresh().
+ * Range restrictions of Date fields have been removed. Date fields now accepts any value. Milliseconds are still removed.
 
 0.82.2
  * Fixed a bug which might cause failure when loading the native library.

--- a/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -510,11 +510,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqualDateTime(
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_DateTime))
                 return;
-            Q(nativeQueryPtr)->equal_datetime(S(arr[0]), DateTime(static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->equal_datetime(S(arr[0]), DateTime(value));
         }
         else {
             Table* tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_equal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->and_query(numeric_link_equal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], value));
         }
     } CATCH_STD()
     RELEASE_ARRAY()
@@ -528,11 +528,11 @@ JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqualD
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_DateTime))
                 return;
-            Q(nativeQueryPtr)->not_equal_datetime(S(arr[0]), DateTime(static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->not_equal_datetime(S(arr[0]), DateTime(value));
         }
         else {
             Table* tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_notequal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->and_query(numeric_link_notequal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], value));
         }
     } CATCH_STD()
     RELEASE_ARRAY()
@@ -546,11 +546,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterDateTime(
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_DateTime))
                 return;
-            Q(nativeQueryPtr)->greater_datetime(S(arr[0]), DateTime(static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->greater_datetime(S(arr[0]), DateTime(value));
         }
         else {
             Table* tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_greater<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->and_query(numeric_link_greater<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], value));
         }
     } CATCH_STD()
     RELEASE_ARRAY()
@@ -564,11 +564,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqualDateT
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_DateTime))
                 return;
-            Q(nativeQueryPtr)->greater_equal_datetime(S(arr[0]), DateTime(static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->greater_equal_datetime(S(arr[0]), DateTime(value));
         }
         else {
             Table* tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_greaterequal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->and_query(numeric_link_greaterequal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], value));
         }
     } CATCH_STD()
     RELEASE_ARRAY();
@@ -582,11 +582,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessDateTime(
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_DateTime))
                 return;
-            Q(nativeQueryPtr)->less_datetime(S(arr[0]), DateTime(static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->less_datetime(S(arr[0]), DateTime(value));
         }
         else {
             Table* tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_less<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->and_query(numeric_link_less<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], value));
         }
     } CATCH_STD()
     RELEASE_ARRAY();
@@ -600,11 +600,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqualDateTime
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_DateTime))
                 return;
-            Q(nativeQueryPtr)->less_equal_datetime(S(arr[0]), DateTime(static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->less_equal_datetime(S(arr[0]), DateTime(value));
         }
         else {
             Table* tbl = getTableLink(nativeQueryPtr, arr, arr_len);
-            Q(nativeQueryPtr)->and_query(numeric_link_lessequal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], static_cast<time_t>(value)));
+            Q(nativeQueryPtr)->and_query(numeric_link_lessequal<DateTime, DateTime, jlong>(tbl, arr[arr_len-1], value));
         }
     } CATCH_STD()
     RELEASE_ARRAY()
@@ -618,7 +618,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetweenDateTime(
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_DateTime))
                 return;
-            Q(nativeQueryPtr)->between_datetime(S(arr[0]), DateTime(static_cast<time_t>(value1)), DateTime(static_cast<time_t>(value2)));
+            Q(nativeQueryPtr)->between_datetime(S(arr[0]), DateTime(value1), DateTime(value2));
         }
         else {
             ThrowException(env, IllegalArgument, "between does not support link queries.");

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -936,7 +936,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstDate(
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_DateTime))
         return 0;
     try {
-        size_t res = TBL(nativeTablePtr)->find_first_datetime( S(columnIndex), (time_t)dateTimeValue);
+        size_t res = TBL(nativeTablePtr)->find_first_datetime( S(columnIndex), DateTime(dateTimeValue));
         return to_jlong_or_not_found( res );
     } CATCH_STD()
     return 0;
@@ -1011,7 +1011,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindAllDate(
         return 0;
     try {
         TableView* pTableView = new TableView( TBL(nativeTablePtr)->find_all_datetime( S(columnIndex),
-                                            static_cast<time_t>(dateTimeValue)) );
+                                            DateTime(dateTimeValue)) );
         return reinterpret_cast<jlong>(pTableView);
     } CATCH_STD()
     return 0;

--- a/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm-jni/src/io_realm_internal_tableview.cpp
@@ -538,7 +538,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstDate(
         if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
             !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_DateTime))
             return 0;
-        return to_jlong_or_not_found( TV(nativeViewPtr)->find_first_datetime( S(columnIndex), (time_t)dateTimeValue) );
+        return to_jlong_or_not_found( TV(nativeViewPtr)->find_first_datetime( S(columnIndex), DateTime(dateTimeValue)) );
     } CATCH_STD()
     return 0;
 }
@@ -620,7 +620,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllDate(
             !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_DateTime))
             return 0;
         TableView* pResultView = new TableView( TV(nativeViewPtr)->find_all_datetime( S(columnIndex),
-                                                static_cast<time_t>(dateTimeValue)) );
+                                                DateTime(dateTimeValue)) );
         return reinterpret_cast<jlong>(pResultView);
     } CATCH_STD()
     return 0;

--- a/realm-jni/src/mixedutil.cpp
+++ b/realm-jni/src/mixedutil.cpp
@@ -92,7 +92,7 @@ jobject CreateJMixedFromMixed(JNIEnv* env, Mixed& mixed)
     }
     case type_DateTime:
         {
-            time_t timeValue = mixed.get_datetime().get_datetime();
+            int_fast64_t timeValue = mixed.get_datetime().get_datetime();
             jclass jDateClass = env->FindClass("java/util/Date");
             if (jDateClass == NULL) {
                 ThrowException(env, ClassNotFound, "Date");

--- a/realm/src/androidTest/java/io/realm/RealmObjectTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmObjectTest.java
@@ -338,9 +338,8 @@ public class RealmObjectTest extends AndroidTestCase {
     }
 
     public void testDateType() {
-        long testDatesNotValid[] = {Long.MIN_VALUE, Long.MAX_VALUE};
         long testDatesValid[] = {-1000, 0, 1000};
-        long testDatesLoosePrecision[] = {1, 1001};
+        long testDatesLoosePrecision[] = {Long.MIN_VALUE, 1, 1001, Long.MAX_VALUE};
 
         // test valid dates
         testRealm.beginTransaction();
@@ -371,18 +370,6 @@ public class RealmObjectTest extends AndroidTestCase {
             assertEquals("Item " + i, new Date(1000*(testDatesLoosePrecision[i]/1000)), allTypes.getColumnDate());
             i++;
         }
-
-        // test invalid dates
-        for (long value : testDatesNotValid) {
-            try {
-                testRealm.beginTransaction();
-                testRealm.clear(AllTypes.class);
-                AllTypes allTypes = testRealm.createObject(AllTypes.class);
-                allTypes.setColumnDate(new Date(value));
-                testRealm.commitTransaction();
-                fail();
-            } catch (IllegalArgumentException ignored) { testRealm.cancelTransaction(); }
-        }
     }
 
     private Date newDate(int year, int month, int dayOfMonth) {
@@ -409,33 +396,6 @@ public class RealmObjectTest extends AndroidTestCase {
 
         // Realm does not support millisec precision
         assertEquals(1000 * (date.getTime() / 1000), 1000 * (object.getColumnDate().getTime() / 1000));
-    }
-
-    public void testDateTypeOutOfRange() {
-        // ** Must throw if date is too old
-        for (int i = 0; i < 2; i++) {
-            try {
-                addDate(1900 + i, 1, 1);
-                fail();
-            } catch (IllegalArgumentException ignored) {
-                testRealm.cancelTransaction();
-            }
-        }
-
-        // ** Supported dates works
-        for (int i = 2; i < 10; i++) {
-            addDate(1900 + i, 1, 1);
-        }
-
-        // ** Must throw if date is too new
-        for (int i = 0; i < 2; i++) {
-            try {
-                addDate(2038 + i, 1, 20);
-                fail();
-            } catch (IllegalArgumentException ignored) {
-                testRealm.cancelTransaction();
-            }
-        }
     }
 
     public void testWriteMustThrowOutOfTransaction() {

--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.Cat;
@@ -49,6 +50,8 @@ public class RealmResultsTest extends AndroidTestCase {
     private final static String FIELD_KOREAN_CHAR = "델타";
     private final static String FIELD_GREEK_CHAR = "Δέλτα";
 
+    private final static long YEAR_MILLIS = TimeUnit.DAYS.toMillis(365);
+
     @Override
     protected void setUp() throws InterruptedException {
         RealmConfiguration realmConfig = new RealmConfiguration.Builder(getContext()).build();
@@ -66,7 +69,7 @@ public class RealmResultsTest extends AndroidTestCase {
             AllTypes allTypes = testRealm.createObject(AllTypes.class);
             allTypes.setColumnBoolean((i % 2) == 0);
             allTypes.setColumnBinary(new byte[]{1, 2, 3});
-            allTypes.setColumnDate(new Date((long) 1000 * i));
+            allTypes.setColumnDate(new Date(YEAR_MILLIS * (i - objects / 2)));
             allTypes.setColumnDouble(3.1415 + i);
             allTypes.setColumnFloat(1.234567f + i);
             allTypes.setColumnString("test data " + i);
@@ -704,8 +707,20 @@ public class RealmResultsTest extends AndroidTestCase {
     }
 
     public void testQueryDateField() {
-        RealmQuery<AllTypes> query = testRealm.where(AllTypes.class).equalTo(FIELD_DATE, new Date(5000));
+        RealmQuery<AllTypes> query = testRealm.where(AllTypes.class).equalTo(FIELD_DATE, new Date(YEAR_MILLIS * 5));
         RealmResults<AllTypes> all = query.findAll();
+        assertEquals(1, query.count());
+        assertEquals(1, all.size());
+
+        // before 1901
+        query = testRealm.where(AllTypes.class).equalTo(FIELD_DATE, new Date(YEAR_MILLIS * -100));
+        all = query.findAll();
+        assertEquals(1, query.count());
+        assertEquals(1, all.size());
+
+        // after 2038
+        query = testRealm.where(AllTypes.class).equalTo(FIELD_DATE, new Date(YEAR_MILLIS * 100));
+        all = query.findAll();
         assertEquals(1, query.count());
         assertEquals(1, all.size());
     }

--- a/realm/src/androidTest/java/io/realm/internal/JNIQueryTest.java
+++ b/realm/src/androidTest/java/io/realm/internal/JNIQueryTest.java
@@ -3,6 +3,7 @@ package io.realm.internal;
 import junit.framework.TestCase;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import io.realm.internal.test.TestHelper;
 
@@ -741,4 +742,101 @@ public class JNIQueryTest extends TestCase {
 
     }
 
+    public void testDateQuery() throws Exception {
+
+        Table table = new Table();
+        table.addColumn(ColumnType.DATE, "date");
+
+        final Date past = new Date(TimeUnit.SECONDS.toMillis(Integer.MIN_VALUE - 100L));
+        final Date future = new Date(TimeUnit.SECONDS.toMillis(Integer.MAX_VALUE + 1L));
+        final Date distantPast = new Date(Long.MIN_VALUE);
+        final Date distantFuture = new Date(Long.MAX_VALUE);
+
+        table.add(new Date(10000));
+        table.add(new Date(0));
+        table.add(new Date(1000));
+        table.add(future);
+        table.add(distantFuture);
+        table.add(past);
+        table.add(distantPast);
+
+        assertEquals(1L, table.where().equalTo(new long[]{0}, distantPast).count());
+        assertEquals(6L, table.where().notEqualTo(new long[]{0}, distantPast).count());
+        assertEquals(0L, table.where().lessThan(new long[]{0}, distantPast).count());
+        assertEquals(1L, table.where().lessThanOrEqual(new long[]{0}, distantPast).count());
+        assertEquals(6L, table.where().greaterThan(new long[]{0}, distantPast).count());
+        assertEquals(7L, table.where().greaterThanOrEqual(new long[]{0}, distantPast).count());
+
+        assertEquals(1L, table.where().equalTo(new long[]{0}, past).count());
+        assertEquals(6L, table.where().notEqualTo(new long[]{0}, past).count());
+        assertEquals(1L, table.where().lessThan(new long[]{0}, past).count());
+        assertEquals(2L, table.where().lessThanOrEqual(new long[]{0}, past).count());
+        assertEquals(5L, table.where().greaterThan(new long[]{0}, past).count());
+        assertEquals(6L, table.where().greaterThanOrEqual(new long[]{0}, past).count());
+
+        assertEquals(1L, table.where().equalTo(new long[]{0}, new Date(0)).count());
+        assertEquals(6L, table.where().notEqualTo(new long[]{0}, new Date(0)).count());
+        assertEquals(2L, table.where().lessThan(new long[]{0}, new Date(0)).count());
+        assertEquals(3L, table.where().lessThanOrEqual(new long[]{0}, new Date(0)).count());
+        assertEquals(4L, table.where().greaterThan(new long[]{0}, new Date(0)).count());
+        assertEquals(5L, table.where().greaterThanOrEqual(new long[]{0}, new Date(0)).count());
+
+        assertEquals(1L, table.where().equalTo(new long[]{0}, future).count());
+        assertEquals(6L, table.where().notEqualTo(new long[]{0}, future).count());
+        assertEquals(5L, table.where().lessThan(new long[]{0}, future).count());
+        assertEquals(6L, table.where().lessThanOrEqual(new long[]{0}, future).count());
+        assertEquals(1L, table.where().greaterThan(new long[]{0}, future).count());
+        assertEquals(2L, table.where().greaterThanOrEqual(new long[]{0}, future).count());
+
+        assertEquals(1L, table.where().equalTo(new long[]{0}, distantFuture).count());
+        assertEquals(6L, table.where().notEqualTo(new long[]{0}, distantFuture).count());
+        assertEquals(6L, table.where().lessThan(new long[]{0}, distantFuture).count());
+        assertEquals(7L, table.where().lessThanOrEqual(new long[]{0}, distantFuture).count());
+        assertEquals(0L, table.where().greaterThan(new long[]{0}, distantFuture).count());
+        assertEquals(1L, table.where().greaterThanOrEqual(new long[]{0}, distantFuture).count());
+
+        // between
+
+        assertEquals(1L, table.where().between(new long[]{0}, distantPast, distantPast).count());
+        assertEquals(2L, table.where().between(new long[]{0}, distantPast, past).count());
+        assertEquals(3L, table.where().between(new long[]{0}, distantPast, new Date(0)).count());
+        assertEquals(5L, table.where().between(new long[]{0}, distantPast, new Date(10000)).count());
+        assertEquals(6L, table.where().between(new long[]{0}, distantPast, future).count());
+        assertEquals(7L, table.where().between(new long[]{0}, distantPast, distantFuture).count());
+
+        assertEquals(0L, table.where().between(new long[]{0}, past, distantPast).count());
+        assertEquals(1L, table.where().between(new long[]{0}, past, past).count());
+        assertEquals(2L, table.where().between(new long[]{0}, past, new Date(0)).count());
+        assertEquals(4L, table.where().between(new long[]{0}, past, new Date(10000)).count());
+        assertEquals(5L, table.where().between(new long[]{0}, past, future).count());
+        assertEquals(6L, table.where().between(new long[]{0}, past, distantFuture).count());
+
+        assertEquals(0L, table.where().between(new long[]{0}, new Date(0), distantPast).count());
+        assertEquals(0L, table.where().between(new long[]{0}, new Date(0), past).count());
+        assertEquals(1L, table.where().between(new long[]{0}, new Date(0), new Date(0)).count());
+        assertEquals(3L, table.where().between(new long[]{0}, new Date(0), new Date(10000)).count());
+        assertEquals(4L, table.where().between(new long[]{0}, new Date(0), future).count());
+        assertEquals(5L, table.where().between(new long[]{0}, new Date(0), distantFuture).count());
+
+        assertEquals(0L, table.where().between(new long[]{0}, new Date(10000), distantPast).count());
+        assertEquals(0L, table.where().between(new long[]{0}, new Date(10000), past).count());
+        assertEquals(0L, table.where().between(new long[]{0}, new Date(10000), new Date(0)).count());
+        assertEquals(1L, table.where().between(new long[]{0}, new Date(10000), new Date(10000)).count());
+        assertEquals(2L, table.where().between(new long[]{0}, new Date(10000), future).count());
+        assertEquals(3L, table.where().between(new long[]{0}, new Date(10000), distantFuture).count());
+
+        assertEquals(0L, table.where().between(new long[]{0}, future, distantPast).count());
+        assertEquals(0L, table.where().between(new long[]{0}, future, past).count());
+        assertEquals(0L, table.where().between(new long[]{0}, future, new Date(0)).count());
+        assertEquals(0L, table.where().between(new long[]{0}, future, new Date(10000)).count());
+        assertEquals(1L, table.where().between(new long[]{0}, future, future).count());
+        assertEquals(2L, table.where().between(new long[]{0}, future, distantFuture).count());
+
+        assertEquals(0L, table.where().between(new long[]{0}, distantFuture, distantPast).count());
+        assertEquals(0L, table.where().between(new long[]{0}, distantFuture, past).count());
+        assertEquals(0L, table.where().between(new long[]{0}, distantFuture, new Date(0)).count());
+        assertEquals(0L, table.where().between(new long[]{0}, distantFuture, new Date(10000)).count());
+        assertEquals(0L, table.where().between(new long[]{0}, distantFuture, future).count());
+        assertEquals(1L, table.where().between(new long[]{0}, distantFuture, distantFuture).count());
+    }
 }

--- a/realm/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/src/main/java/io/realm/internal/UncheckedRow.java
@@ -199,9 +199,6 @@ public class UncheckedRow extends NativeObject implements Row {
             throw new IllegalArgumentException("Null Date is not allowed.");
         }
         long timestamp = date.getTime() / 1000;
-        if (timestamp >= Integer.MAX_VALUE || timestamp <= Integer.MIN_VALUE) {
-            throw new IllegalArgumentException("Date/timestamp is outside valid range");
-        }
         nativeSetDate(nativePointer, columnIndex, timestamp);
     }
 


### PR DESCRIPTION
Original code:

* `Date` value had range check when copied into Realm.
* `Date` value was cast to 32bit signed integer when copied from Realm.
* `Date` query parameters are also cast to 32bit signed integer.

This PR removes these checks and casts in order to expand `Date` range.