### PR TITLE
Fix locale and encoding of Javadoc

### DIFF
--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -46,7 +46,13 @@ android.libraryVariants.all { variant ->
         source "../realm-annotations/src/main/java"
         ext.androidJar = files(project.android.getBootClasspath())
         classpath = files(variant.javaCompile.classpath.files) + ext.androidJar
-        options.memberLevel = JavadocMemberLevel.PUBLIC
+        options {
+            memberLevel = JavadocMemberLevel.PUBLIC
+            docEncoding = 'UTF-8'
+            encoding = 'UTF-8'
+            charSet = 'UTF-8'
+            locale = 'en_US'
+        }
         exclude '**/internal/**'
         exclude '**/BuildConfig.java'
         exclude '**/R.java'


### PR DESCRIPTION
Problem:
Language of generated Javadoc depends on build environment, because no locale/charset information is explicitly provided.
If Javadoc is generated on Japanese environment, generated Javadoc contains クラス instead of Classes.

This PR fixes that problem by prioviding explicit locale and charset information.