### PR TITLE
Fix native crash and wrong exception in RealmList.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 0.83.1
  * Added Realm.isClosed() method.
+ * IllegalStateException is now thrown instead of native crash if following methods in RealmList are called after closing the Realm or removing parent object: add(int,RealmObject), add(RealmObject),
+ * IllegalStateException is now thrown instead of ArrayIndexOutOfBoundsException if following methods in RealmList are called after closing the Realm or removing parent object: set(int,RealmObject), move(int,int), remove(int), get(int)
+ * IllegalStateException is now thrown instead of returning 0/null if following methods in RealmList are called after closing the Realm or removing parent object: clear(), removeAll(Collection), remove(RealmObject), first(), last(), size(), where()
 
 0.83
  * BREAKING CHANGE: Database file format update. The Realm file created by this version cannot be used by previous versions of Realm.

--- a/realm-jni/src/io_realm_internal_LinkView.cpp
+++ b/realm-jni/src/io_realm_internal_LinkView.cpp
@@ -166,3 +166,13 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeWhere
     } CATCH_STD()
     return 0;
 }
+
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsAttached
+  (JNIEnv *env, jobject, jlong nativeLinkViewPtr)
+{
+    TR_ENTER_PTR(nativeLinkViewPtr)
+    try {
+        return LV(nativeLinkViewPtr)->is_attached();
+    } CATCH_STD()
+    return 0;
+}

--- a/realm-jni/src/io_realm_internal_LinkView.h
+++ b/realm-jni/src/io_realm_internal_LinkView.h
@@ -103,6 +103,14 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsEmpty
 JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeWhere
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     io_realm_internal_LinkView
+ * Method:    nativeIsAttached
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsAttached
+        (JNIEnv *, jobject, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/realm/src/androidTest/java/io/realm/RealmListTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmListTest.java
@@ -18,6 +18,8 @@ package io.realm;
 
 import android.test.AndroidTestCase;
 
+import java.util.Collections;
+
 import io.realm.entities.AllTypes;
 import io.realm.entities.CyclicType;
 import io.realm.entities.CyclicTypePrimaryKey;
@@ -53,6 +55,16 @@ public class RealmListTest extends AndroidTestCase {
             list.add(new Dog("Dog " + i));
         }
         return list;
+    }
+
+    private RealmList<Dog> createDeletedRealmList() {
+        Owner owner = testRealm.where(Owner.class).findFirst();
+        RealmList<Dog> dogs = owner.getDogs();
+
+        testRealm.beginTransaction();
+        owner.removeFromRealm();
+        testRealm.commitTransaction();
+        return dogs;
     }
 
     // Check that all methods work correctly on a empty RealmList
@@ -459,6 +471,186 @@ public class RealmListTest extends AndroidTestCase {
 
         assertTrue(result);
         assertEquals(TEST_OBJECTS - 1, dogs.size());
+    }
+
+    public void testAddAtAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            Dog dog = testRealm.createObject(Dog.class);
+            dog.setName("Dog");
+            try {
+                dogs.add(0, dog);
+                fail();
+            } catch (IllegalStateException ignore) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testAddAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            Dog dog = testRealm.createObject(Dog.class);
+            dog.setName("Dog");
+            try {
+                dogs.add(dog);
+                fail();
+            } catch (IllegalStateException ignore) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testSetAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            Dog dog = testRealm.createObject(Dog.class);
+            dog.setName("Dog");
+            try {
+                dogs.set(0, dog);
+                fail();
+            } catch (IllegalStateException ignore) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testMoveAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            dogs.move(0, 1);
+            fail();
+        } catch (IllegalStateException ignore) {
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testClearAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            dogs.clear();
+            fail();
+        } catch (IllegalStateException ignore) {
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testRemoveAtAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            Dog dog = testRealm.createObject(Dog.class);
+            dog.setName("Dog");
+            try {
+                dogs.remove(0);
+                fail();
+            } catch (IllegalStateException ignore) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testRemoveObjectAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            Dog dog = testRealm.createObject(Dog.class);
+            dog.setName("Dog");
+            try {
+                dogs.remove(dog);
+                fail();
+            } catch (IllegalStateException ignore) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testRemoveAllAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        testRealm.beginTransaction();
+        try {
+            dogs.removeAll(Collections.<Dog>emptyList());
+            fail();
+        } catch (IllegalStateException ignore) {
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testGetAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        try {
+            dogs.get(0);
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
+
+    public void testFirstAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        try {
+            dogs.first();
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
+
+    public void testLastAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        try {
+            dogs.last();
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
+
+    public void testSizeAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        try {
+            dogs.size();
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
+
+    public void testWhereAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        try {
+            dogs.where();
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
+
+    public void testToStringAfterContainerObjectRemoved() {
+        RealmList<Dog> dogs = createDeletedRealmList();
+
+        assertEquals("Dog@[invalid]", dogs.toString());
     }
 
     public void testQuery() {

--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -98,6 +98,10 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
         this.realm = realm;
     }
 
+    private boolean isAttached() {
+        return view != null && view.isAttached();
+    }
+
     /**
      * Inserts the specified object into this List at the specified location. The object is inserted before any previous
      * element at the specified location. If the location is equal to the size of this List, the object is added at the
@@ -113,12 +117,14 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * </ol>
      * @param location the index at which to insert.
      * @param object the object to add.
+     * @throws IllegalStateException if Realm instance has been closed or container object has been removed.
      * @throws IndexOutOfBoundsException if {@code location < 0 || location > size()}
      */
     @Override
     public void add(int location, E object) {
         checkValidObject(object);
         if (managedMode) {
+            checkIfViewAttached();
             object = copyToRealmIfNeeded(object);
             view.insert(location, object.row.getIndex());
         } else {
@@ -139,11 +145,13 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * </ol>
      * @param object the object to add.
      * @return true
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      */
     @Override
     public boolean add(E object) {
         checkValidObject(object);
         if (managedMode) {
+            checkIfViewAttached();
             object = copyToRealmIfNeeded(object);
             view.add(object.row.getIndex());
         } else {
@@ -167,12 +175,14 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * @param location the index at which to put the specified object.
      * @param object the object to add.
      * @return the previous element at the index.
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
      */
     @Override
     public E set(int location, E object) {
         checkValidObject(object);
         if (managedMode) {
+            checkIfViewAttached();
             object = copyToRealmIfNeeded(object);
             view.set(location, object.row.getIndex());
         } else {
@@ -202,10 +212,12 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      *               to the right. If oldPos &lt; newPos, indexes &gt; oldPos will be shifted once to the
      *               left.
      *
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      * @throws java.lang.IndexOutOfBoundsException if any position is outside [0, size()[.
      */
     public void move(int oldPos, int newPos) {
         if (managedMode) {
+            checkIfViewAttached();
             view.move(oldPos, newPos);
         } else {
             checkIndex(oldPos);
@@ -222,12 +234,14 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     /**
      * Removes all elements from this list, leaving it empty.
      *
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      * @see List#isEmpty
      * @see List#size
      */
     @Override
     public void clear() {
         if (managedMode) {
+            checkIfViewAttached();
             view.clear();
         } else {
             nonManagedList.clear();
@@ -239,11 +253,13 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      *
      * @param location the index of the object to remove.
      * @return the removed object.
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
      */
     @Override
     public E remove(int location) {
         if (managedMode) {
+            checkIfViewAttached();
             E removedItem = get(location);
             view.remove(location);
             return removedItem;
@@ -257,11 +273,13 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      *
      * @param location the index of the element to return.
      * @return the element at the specified index.
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}
      */
     @Override
     public E get(int location) {
         if (managedMode) {
+            checkIfViewAttached();
             return realm.get(clazz, view.getTargetRowIndex(location));
         } else {
             return nonManagedList.get(location);
@@ -272,10 +290,12 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * Find the first object.
      *
      * @return The first object or {@code null} if the list is empty.
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      */
     public E first() {
-        if (managedMode && !view.isEmpty()) {
-            return get(0);
+        if (managedMode) {
+            checkIfViewAttached();
+            return view.isEmpty() ? null : get(0);
         } else if (nonManagedList != null && nonManagedList.size() > 0) {
             return nonManagedList.get(0);
         }
@@ -286,10 +306,12 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * Find the last object.
      *
      * @return The last object or {@code null} if the list is empty.
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      */
     public E last() {
-        if (managedMode && !view.isEmpty()) {
-            return get((int) view.size() - 1);
+        if (managedMode) {
+            checkIfViewAttached();
+            return view.isEmpty() ? null : get((int) view.size() - 1);
         } else if (nonManagedList != null && nonManagedList.size() > 0) {
             return nonManagedList.get(nonManagedList.size() - 1);
         }
@@ -300,10 +322,12 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * Returns the number of elements in this {@code List}.
      *
      * @return the number of elements in this {@code List}.
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      */
     @Override
     public int size() {
         if (managedMode) {
+            checkIfViewAttached();
             long size = view.size();
             return size < Integer.MAX_VALUE ? (int) size : Integer.MAX_VALUE;
         } else {
@@ -315,10 +339,12 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * Returns a RealmQuery, which can be used to query for specific objects of this class
      *
      * @return A RealmQuery object
+     * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      * @see io.realm.RealmQuery
      */
     public RealmQuery<E> where() {
         if (managedMode) {
+            checkIfViewAttached();
             return new RealmQuery<E>(this.realm, view, clazz);
         } else {
             throw new RealmException(ONLY_IN_MANAGED_MODE_MESSAGE);
@@ -338,19 +364,29 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
         }
     }
 
+    private void checkIfViewAttached() {
+        if (view == null || !view.isAttached()) {
+            throw new IllegalStateException("Realm instance has been closed or parent object has been removed.");
+        }
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append(managedMode ? clazz.getSimpleName() : getClass().getSimpleName());
         sb.append("@[");
-        for (int i = 0; i < size(); i++) {
-            if (managedMode) {
-                sb.append(get(i).row.getIndex());
-            } else {
-                sb.append(System.identityHashCode(get(i)));
-            }
-            if (i < size() - 1) {
-                sb.append(',');
+        if (managedMode && !isAttached()) {
+            sb.append("invalid");
+        } else {
+            for (int i = 0; i < size(); i++) {
+                if (managedMode) {
+                    sb.append(get(i).row.getIndex());
+                } else {
+                    sb.append(System.identityHashCode(get(i)));
+                }
+                if (i < size() - 1) {
+                    sb.append(',');
+                }
             }
         }
         sb.append("]");

--- a/realm/src/main/java/io/realm/internal/LinkView.java
+++ b/realm/src/main/java/io/realm/internal/LinkView.java
@@ -112,6 +112,10 @@ public class LinkView {
         }
     }
 
+    public boolean isAttached() {
+        return nativeIsAttached(nativeLinkViewPtr);
+    }
+
     /**
      * Returns the Table which all links point to.
      */
@@ -137,4 +141,5 @@ public class LinkView {
     private native long nativeSize(long nativeLinkViewPtr);
     private native boolean nativeIsEmpty(long nativeLinkViewPtr);
     protected native long nativeWhere(long nativeLinkViewPtr);
+    private native boolean nativeIsAttached(long nativeLinkViewPtr);
 }


### PR DESCRIPTION
This commit fixes #1561

Methods listed below in RealmList now throws IllegalStateException if container object has been removed or Realm instance has been closed.

* add(int,RealmOject)
* add(RealmObject)
* set(int,RealmObject)
* move(int,int)
* clear()
* remove(int)
* remove(int)
* remove(RealmObject)
* removeAll(Collection)
* get(int)
* first()
* last()
* size()
* where()

RealmList#toString() now returns "<ClassName>@[invalid]" if container object has been removed or Realm instance has been closed.

@realm/java review this please