### PR TITLE
Adding Realm.distinct() method.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.83.1
  * Added Realm.isClosed() method.
+ * Added Realm.distinct() method.
 
 0.83
  * BREAKING CHANGE: Database file format update. The Realm file created by this version cannot be used by previous versions of Realm.

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -1329,7 +1329,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetDistinctView(
             } CATCH_STD()
             break;
         default:
-            ThrowException(env, IllegalArgument, "Invalid type - only bool, integer, datatime, string are supported.");
+            ThrowException(env, IllegalArgument, "Invalid type - Only String, Date, boolean, short, int, long and their boxed variants are supported.");
             return 0;
         break;
     }

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -1315,17 +1315,24 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetDistinctView(
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
         return 0;
     if (!pTable->has_search_index(S(columnIndex))) {
-        ThrowException(env, UnsupportedOperation, "The column must be indexed before distinct() can be used.");
+        ThrowException(env, UnsupportedOperation, "The field must be indexed before distinct() can be used.");
         return 0;
     }
-    if (pTable->get_column_type(S(columnIndex)) != type_String) {
-        ThrowException(env, IllegalArgument, "Invalid columntype - only string columns are supported.");
-        return 0;
+    switch (pTable->get_column_type(S(columnIndex))) {
+        case type_Bool:
+        case type_Int:
+        case type_DateTime:
+        case type_String:
+            try {
+                TableView* pTableView = new TableView( pTable->get_distinct_view(S(columnIndex)) );
+                return reinterpret_cast<jlong>(pTableView);
+            } CATCH_STD()
+            break;
+        default:
+            ThrowException(env, IllegalArgument, "Invalid type - only bool, integer, datatime, string are supported.");
+            return 0;
+        break;
     }
-    try {
-        TableView* pTableView = new TableView( pTable->get_distinct_view(S(columnIndex)) );
-        return reinterpret_cast<jlong>(pTableView);
-    } CATCH_STD()
     return 0;
 }
 

--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -2059,19 +2059,19 @@ public class RealmTest extends AndroidTestCase {
         }
     }
 
-    private void populateForDistinct(Realm realm, long numberOfBlocks, long numberOfObjects) {
+    private void populateForDistinct(Realm realm, long numberOfBlocks, long numberOfObjects, boolean withNull) {
         realm.beginTransaction();
         for (int i = 0; i < numberOfObjects * numberOfBlocks; i++) {
             for (int j = 0; j < numberOfBlocks; j++) {
                 AnnotationIndexTypes obj = realm.createObject(AnnotationIndexTypes.class);
                 obj.setIndexBoolean(j % 2 == 0);
                 obj.setIndexLong(j);
-                obj.setIndexDate(new Date(1000 * j));
-                obj.setIndexString("Test " + j);
+                obj.setIndexDate(withNull ? null : new Date(1000 * j));
+                obj.setIndexString(withNull ? null :  "Test " + j);
                 obj.setNotIndexBoolean(j % 2 == 0);
                 obj.setNotIndexLong(j);
-                obj.setNotIndexDate(new Date(1000 * j));
-                obj.setNotIndexString("Test " + j);
+                obj.setNotIndexDate(withNull ? null : new Date(1000 * j));
+                obj.setNotIndexString(withNull ? null : "Test " + j);
             }
         }
         realm.commitTransaction();
@@ -2082,7 +2082,7 @@ public class RealmTest extends AndroidTestCase {
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // must be greater than 1
 
-        populateForDistinct(testRealm, numberOfBlocks, numberOfObjects);
+        populateForDistinct(testRealm, numberOfBlocks, numberOfObjects, false);
 
         RealmResults<AnnotationIndexTypes> distinctBool = testRealm.distinct(AnnotationIndexTypes.class, "indexBoolean");
         assertEquals(2, distinctBool.size());
@@ -2093,11 +2093,23 @@ public class RealmTest extends AndroidTestCase {
         }
     }
 
+    public void testDistinctWithNull() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10; // must be greater than 1
+
+        populateForDistinct(testRealm, numberOfBlocks, numberOfObjects, true);
+
+        for (String fieldName : new String[]{"Date", "String"}) {
+            RealmResults<AnnotationIndexTypes> distinct = testRealm.distinct(AnnotationIndexTypes.class, "index" + fieldName);
+            assertEquals("index" + fieldName, 1, distinct.size());
+        }
+    }
+
     public void testDistinctNotIndexedFields() {
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // must be greater than 1
 
-        populateForDistinct(testRealm, numberOfBlocks, numberOfObjects);
+        populateForDistinct(testRealm, numberOfBlocks, numberOfObjects, false);
 
         for (String fieldName : new String[]{"Boolean", "Long", "Date", "String"}) {
             try {
@@ -2112,7 +2124,7 @@ public class RealmTest extends AndroidTestCase {
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // must be greater than 1
 
-        populateForDistinct(testRealm, numberOfBlocks, numberOfObjects);
+        populateForDistinct(testRealm, numberOfBlocks, numberOfObjects, false);
 
         try {
             testRealm.distinct(AnnotationIndexTypes.class, "doesNotExist");

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -946,14 +946,12 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Return a distinct set of objects of a specific class. If no objects exist, the
-     * returned {@link RealmResults} will not be @{code null}. The RealmResults.size() to check the
-     * number of objects instead. As a Realm is unordered, it is undefined which objects are
-     * returned if cases of multiple occurrencies.
+     * Return a distinct set of objects of a specific class. As a Realm is unordered, it is undefined which objects are
+     * returned in cases of multiple occurrences.
      *
      * @param clazz the Class to get objects of.
      * @param fieldName the field name.
-     * @return A RealmResults containing objects.
+     * @return A non-null {@link RealmResults} containing the distinct objects.
      * @throws IllegalArgumentException if a field name does not exist or the field is not indexed.
      */
     public <E extends RealmObject> RealmResults<E> distinct(Class<E> clazz, String fieldName) {

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -947,7 +947,7 @@ public final class Realm extends BaseRealm {
 
     /**
      * Return a distinct set of objects of a specific class. If no objects exist, the
-     * returned {@link RealmResulsts} will not be @{code null}. The RealmResults.size() to check the
+     * returned {@link RealmResults} will not be @{code null}. The RealmResults.size() to check the
      * number of objects instead.
      * @param clazz the Class to get objects of.
      * @param fieldName the field name.

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -946,6 +946,30 @@ public final class Realm extends BaseRealm {
     }
 
     /**
+     * Return a distinct set of objects of a specific class. If no objects exist, the
+     * returned {@link RealmResulsts} will not be @{code null}. The RealmResults.size() to check the
+     * number of objects instead.
+     * @param clazz the Class to get objects of.
+     * @param fieldName the field name.
+     * @return A RealmResults containing objects.
+     * @throws IllegalArgumentException if a field name does not exist or the field is not indexed.
+     */
+    public <E extends RealmObject> RealmResults<E> distinct(Class<E> clazz, String fieldName) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("fieldName must be provided.");
+        }
+
+        Table table = this.getTable(clazz);
+        long columnIndex = table.getColumnIndex(fieldName);
+        if (columnIndex == -1) {
+            throw new IllegalArgumentException(String.format("Field name '%s' does not exist.", fieldName));
+        }
+
+        TableView tableView = table.getDistinctView(columnIndex);
+        return new RealmResults(this, tableView, clazz);
+    }
+
+    /**
      * Return change listeners
      * For internal testing purpose only
      *

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -948,7 +948,9 @@ public final class Realm extends BaseRealm {
     /**
      * Return a distinct set of objects of a specific class. If no objects exist, the
      * returned {@link RealmResults} will not be @{code null}. The RealmResults.size() to check the
-     * number of objects instead.
+     * number of objects instead. As a Realm is unordered, it is undefined which objects are
+     * returned if cases of multiple occurrencies.
+     *
      * @param clazz the Class to get objects of.
      * @param fieldName the field name.
      * @return A RealmResults containing objects.


### PR DESCRIPTION
Issue #960 requests a `distinct()` method. As Realm's underlying storage engine added support for the method recently, it is time to add such a method to Realm Java.

Closes #960 

@realm/java 