### PR TITLE
Missing realm check in some functions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
  * Following methods in managed RealmList now throw IllegalStateException instead of ArrayIndexOutOfBoundsException when RealmList.isValid() returns false: set(int,RealmObject), move(int,int), remove(int), get(int)
  * Following methods in managed RealmList now throw IllegalStateException instead of returning 0/null when RealmList.isValid() returns false: clear(), removeAll(Collection), remove(RealmObject), first(), last(), size(), where()
  * RealmPrimaryKeyConstraintException is now thrown instead of RealmException if two objects with same primary key are inserted.
+ * IllegalStateException is now thrown when calling Realm's clear(), RealmResults's remove(), removeLast(), clear() or RealmObject's removeFromRealm() from an incorrect thread.
  * Fixed a bug affecting RealmConfiguration.equals().
  * Fixed a bug in RealmQuery.isNotNull() which produced wrong results for binary data.
  * Fixed a bug in RealmQuery.isNull() and RealmQuery.isNotNull() which validated the query prematurely.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -232,6 +232,9 @@ public class RealmProxyClassGenerator {
                 // Getter
                 writer.emitAnnotation("Override");
                 writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
+                writer.emitStatement(
+                        "realm.checkIfValid()"
+                );
                 writer.beginControlFlow("if (row.isNullLink(%s))", staticFieldIndexVarName(field));
                         writer.emitStatement("return null");
                         writer.endControlFlow();
@@ -243,6 +246,9 @@ public class RealmProxyClassGenerator {
                 // Setter
                 writer.emitAnnotation("Override");
                 writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
+                writer.emitStatement(
+                        "realm.checkIfValid()"
+                );
                 writer.beginControlFlow("if (value == null)");
                     writer.emitStatement("row.nullifyLink(%s)", staticFieldIndexVarName(field));
                     writer.emitStatement("return");
@@ -258,7 +264,7 @@ public class RealmProxyClassGenerator {
                 // Getter
                 writer.emitAnnotation("Override");
                 writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
-
+                writer.emitStatement("realm.checkIfValid()");
                 writer.emitSingleLineComment("use the cached value if available");
                 writer.beginControlFlow("if (" + fieldName + "RealmList != null)");
                         writer.emitStatement("return " + fieldName + "RealmList");
@@ -281,6 +287,9 @@ public class RealmProxyClassGenerator {
                 // Setter
                 writer.emitAnnotation("Override");
                 writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
+                writer.emitStatement(
+                        "realm.checkIfValid()"
+                );
                 writer.emitStatement("LinkView links = row.getLinkList(%s)", staticFieldIndexVarName(field));
                 writer.emitStatement("links.clear()");
                 writer.beginControlFlow("if (value == null)");

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -152,6 +152,7 @@ public class AllTypesRealmProxy extends AllTypes
 
     @Override
     public AllTypes getColumnObject() {
+        realm.checkIfValid();
         if (row.isNullLink(INDEX_COLUMNOBJECT)) {
             return null;
         }
@@ -160,6 +161,7 @@ public class AllTypesRealmProxy extends AllTypes
 
     @Override
     public void setColumnObject(AllTypes value) {
+        realm.checkIfValid();
         if (value == null) {
             row.nullifyLink(INDEX_COLUMNOBJECT);
             return;
@@ -169,6 +171,7 @@ public class AllTypesRealmProxy extends AllTypes
 
     @Override
     public RealmList<AllTypes> getColumnRealmList() {
+        realm.checkIfValid();
         // use the cached value if available
         if (columnRealmListRealmList != null) {
             return columnRealmListRealmList;
@@ -176,7 +179,7 @@ public class AllTypesRealmProxy extends AllTypes
             LinkView linkView = row.getLinkList(INDEX_COLUMNREALMLIST);
             if (linkView == null) {
                 // return empty non managed RealmList if the LinkView is null
-                // useful for non-initialized RealmObject (async query return empty Row while the query is performing)
+                // useful for non-initialized RealmObject (async query returns empty Row while the query is still running)
                 return EMPTY_REALM_LIST_COLUMNREALMLIST;
             } else {
                 columnRealmListRealmList = new RealmList<AllTypes>(AllTypes.class, linkView, realm);
@@ -187,6 +190,7 @@ public class AllTypesRealmProxy extends AllTypes
 
     @Override
     public void setColumnRealmList(RealmList<AllTypes> value) {
+        realm.checkIfValid();
         LinkView links = row.getLinkList(INDEX_COLUMNREALMLIST);
         links.clear();
         if (value == null) {

--- a/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -414,6 +414,7 @@ public class NullTypesRealmProxy extends NullTypes
 
     @Override
     public NullTypes getFieldObjectNull() {
+        realm.checkIfValid();
         if (row.isNullLink(INDEX_FIELDOBJECTNULL)) {
             return null;
         }
@@ -422,6 +423,7 @@ public class NullTypesRealmProxy extends NullTypes
 
     @Override
     public void setFieldObjectNull(NullTypes value) {
+        realm.checkIfValid();
         if (value == null) {
             row.nullifyLink(INDEX_FIELDOBJECTNULL);
             return;

--- a/realm/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -138,11 +138,15 @@ public class RealmResultsTest extends AndroidTestCase {
         METHOD_SUM,
         METHOD_AVG,
         METHOD_SORT,
-        METHOD_WHERE
+        METHOD_WHERE,
+        METHOD_REMOVE,
+        METHOD_REMOVE_LAST,
+        METHOD_CLEAR
     }
 
     public boolean methodWrongThread(final Method method) throws ExecutionException, InterruptedException {
         final RealmResults<AllTypes> allTypeses = testRealm.where(AllTypes.class).findAll();
+        testRealm.beginTransaction();
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
             @Override
@@ -166,6 +170,16 @@ public class RealmResultsTest extends AndroidTestCase {
                             break;
                         case METHOD_WHERE:
                             allTypeses.where();
+                            break;
+                        case METHOD_REMOVE:
+                            allTypeses.remove(0);
+                            break;
+                        case METHOD_REMOVE_LAST:
+                            allTypeses.removeLast();
+                            break;
+                        case METHOD_CLEAR:
+                            allTypeses.clear();
+                            break;
                     }
                     return false;
                 } catch (IllegalStateException ignored) {
@@ -173,7 +187,9 @@ public class RealmResultsTest extends AndroidTestCase {
                 }
             }
         });
-        return future.get();
+        Boolean result = future.get();
+        testRealm.cancelTransaction();
+        return result;
     }
 
     // test io.realm.ResultList Api

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -689,6 +689,7 @@ public final class Realm extends BaseRealm {
      * @throws RealmException An object could not be created
      */
     public <E extends RealmObject> E createObject(Class<E> clazz) {
+        checkIfValid();
         Table table = getTable(clazz);
         long rowIndex = table.addEmptyRow();
         return get(clazz, rowIndex);
@@ -952,7 +953,7 @@ public final class Realm extends BaseRealm {
         if (fieldName == null) {
             throw new IllegalArgumentException("fieldName must be provided.");
         }
-
+        checkIfValid();
         Table table = this.getTable(clazz);
         long columnIndex = table.getColumnIndex(fieldName);
         if (columnIndex == -1) {
@@ -1077,14 +1078,17 @@ public final class Realm extends BaseRealm {
      * Remove all objects of the specified class.
      *
      * @param clazz The class which objects should be removed
+     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      * @throws java.lang.RuntimeException Any other error
      */
     public void clear(Class<? extends RealmObject> clazz) {
+        checkIfValid();
         getTable(clazz).clear();
     }
 
     @SuppressWarnings("unchecked")
     private <E extends RealmObject> E copyOrUpdate(E object, boolean update) {
+        checkIfValid();
         return configuration.getSchemaMediator().copyOrUpdate(this, object, update, new HashMap<RealmObject, RealmObjectProxy>());
     }
 

--- a/realm/src/main/java/io/realm/RealmList.java
+++ b/realm/src/main/java/io/realm/RealmList.java
@@ -140,7 +140,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     public void add(int location, E object) {
         checkValidObject(object);
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             object = copyToRealmIfNeeded(object);
             view.insert(location, object.row.getIndex());
         } else {
@@ -167,7 +167,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     public boolean add(E object) {
         checkValidObject(object);
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             object = copyToRealmIfNeeded(object);
             view.add(object.row.getIndex());
         } else {
@@ -198,7 +198,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     public E set(int location, E object) {
         checkValidObject(object);
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             object = copyToRealmIfNeeded(object);
             view.set(location, object.row.getIndex());
         } else {
@@ -233,7 +233,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      */
     public void move(int oldPos, int newPos) {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             view.move(oldPos, newPos);
         } else {
             checkIndex(oldPos);
@@ -257,7 +257,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     @Override
     public void clear() {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             view.clear();
         } else {
             nonManagedList.clear();
@@ -275,7 +275,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     @Override
     public E remove(int location) {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             E removedItem = get(location);
             view.remove(location);
             return removedItem;
@@ -295,7 +295,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     @Override
     public E get(int location) {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             return realm.get(clazz, view.getTargetRowIndex(location));
         } else {
             return nonManagedList.get(location);
@@ -310,7 +310,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      */
     public E first() {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             return view.isEmpty() ? null : get(0);
         } else if (nonManagedList != null && nonManagedList.size() > 0) {
             return nonManagedList.get(0);
@@ -326,7 +326,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      */
     public E last() {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             return view.isEmpty() ? null : get((int) view.size() - 1);
         } else if (nonManagedList != null && nonManagedList.size() > 0) {
             return nonManagedList.get(nonManagedList.size() - 1);
@@ -343,7 +343,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
     @Override
     public int size() {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             long size = view.size();
             return size < Integer.MAX_VALUE ? (int) size : Integer.MAX_VALUE;
         } else {
@@ -360,7 +360,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      */
     public RealmQuery<E> where() {
         if (managedMode) {
-            checkIfViewAttached();
+            checkValidView();
             return new RealmQuery<E>(this.realm, view, clazz);
         } else {
             throw new RealmException(ONLY_IN_MANAGED_MODE_MESSAGE);
@@ -380,7 +380,8 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
         }
     }
 
-    private void checkIfViewAttached() {
+    private void checkValidView() {
+        realm.checkIfValid();
         if (view == null || !view.isAttached()) {
             throw new IllegalStateException("Realm instance has been closed or parent object has been removed.");
         }

--- a/realm/src/main/java/io/realm/RealmObject.java
+++ b/realm/src/main/java/io/realm/RealmObject.java
@@ -94,6 +94,8 @@ public abstract class RealmObject {
      * <p>
      * After this method is called the object will be invalid and any operation (read or write)
      * performed on it will fail with an IllegalStateException
+     *
+     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      */
     public void removeFromRealm() {
         if (row == null) {
@@ -102,6 +104,8 @@ public abstract class RealmObject {
         if (realm == null) {
             throw new IllegalStateException("Object malformed: missing Realm. Make sure to instantiate RealmObjects with Realm.createObject()");
         }
+        realm.checkIfValid();
+
         row.getTable().moveLastOver(row.getIndex());
         row = InvalidRow.INSTANCE;
     }

--- a/realm/src/main/java/io/realm/RealmQuery.java
+++ b/realm/src/main/java/io/realm/RealmQuery.java
@@ -68,7 +68,6 @@ public class RealmQuery<E extends RealmObject> {
     private final Map<String, Long> columns;
     private final Class<E> clazz;
 
-    private static final String LINK_NOT_SUPPORTED_METHOD = "'%s' is not supported for link queries";
     private static final String TYPE_MISMATCH = "Field '%s': type mismatch - %s expected.";
 
     public static final boolean CASE_SENSITIVE = true;

--- a/realm/src/main/java/io/realm/RealmResults.java
+++ b/realm/src/main/java/io/realm/RealmResults.java
@@ -511,9 +511,11 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
      *
      * @param index      The array index identifying the object to be removed.
      * @return           Always return {@code null}.
+     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      */
     @Override
     public E remove(int index) {
+        realm.checkIfValid();
         TableOrView table = getTable();
         table.remove(index);
         return null; // Returning the object doesn't make sense, since it could no longer access any data.
@@ -525,8 +527,11 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
      *
      * Using this method while iterating the list can result in a undefined behavior. Use
      * {@link io.realm.RealmResults.RealmResultsListIterator#removeLast()} instead.
+     *
+     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      */
     public void removeLast() {
+        realm.checkIfValid();
         TableOrView table = getTable();
         table.removeLast();
     }
@@ -534,8 +539,11 @@ public class RealmResults<E extends RealmObject> extends AbstractList<E> {
     /**
      * Removes all objects from the list. This also deletes the objects from the
      * underlying Realm.
+     *
+     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      */
     public void clear() {
+        realm.checkIfValid();
         TableOrView table = getTable();
         table.clear();
     }


### PR DESCRIPTION
* Generate realm check for getter and setter of RealmObject and RealmList.
* Add realm check in RealmObject.removeFromRealm
* Add realm check in RealmResults's remove, removeLast, clear methods
* Add test cases
* Minor warning fix

Maybe related with #1554 ?