### PR TITLE
Fix #1490

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
  * Following methods in managed RealmList now throw IllegalStateException instead of ArrayIndexOutOfBoundsException when RealmList.isValid() returns false: set(int,RealmObject), move(int,int), remove(int), get(int)
  * Following methods in managed RealmList now throw IllegalStateException instead of returning 0/null when RealmList.isValid() returns false: clear(), removeAll(Collection), remove(RealmObject), first(), last(), size(), where()
  * RealmPrimaryKeyConstraintException is now thrown instead of RealmException if two objects with same primary key are inserted.
+ * Fixed a bug affecting RealmConfiguration.equals().
 
 0.83
  * BREAKING CHANGE: Database file format update. The Realm file created by this version cannot be used by previous versions of Realm.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -67,11 +67,11 @@ public class RealmProxyMediatorGenerator {
         writer.emitImports(
                 "android.util.JsonReader",
                 "java.io.IOException",
-                "java.util.ArrayList",
                 "java.util.Collections",
+                "java.util.HashSet",
                 "java.util.List",
                 "java.util.Map",
-                "io.realm.exceptions.RealmException",
+                "java.util.Set",
                 "io.realm.internal.ImplicitTransaction",
                 "io.realm.internal.RealmObjectProxy",
                 "io.realm.internal.RealmProxyMediator",
@@ -108,13 +108,13 @@ public class RealmProxyMediatorGenerator {
     }
 
     private void emitFields(JavaWriter writer) throws IOException {
-        writer.emitField("List<Class<? extends RealmObject>>", "MODEL_CLASSES", EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL));
+        writer.emitField("Set<Class<? extends RealmObject>>", "MODEL_CLASSES", EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL));
         writer.beginInitializer(true);
-        writer.emitStatement("List<Class<? extends RealmObject>> modelClasses = new ArrayList<Class<? extends RealmObject>>()");
+        writer.emitStatement("Set<Class<? extends RealmObject>> modelClasses = new HashSet<Class<? extends RealmObject>>()");
         for (String clazz : simpleModelClasses) {
             writer.emitStatement("modelClasses.add(%s.class)", clazz);
         }
-        writer.emitStatement("MODEL_CLASSES = Collections.unmodifiableList(modelClasses)");
+        writer.emitStatement("MODEL_CLASSES = Collections.unmodifiableSet(modelClasses)");
         writer.endInitializer();
         writer.emitEmptyLine();
     }
@@ -211,7 +211,7 @@ public class RealmProxyMediatorGenerator {
 
     private void emitGetClassModelList(JavaWriter writer) throws IOException {
         writer.emitAnnotation("Override");
-        writer.beginMethod("List<Class<? extends RealmObject>>", "getModelClasses", EnumSet.of(Modifier.PUBLIC));
+        writer.beginMethod("Set<Class<? extends RealmObject>>", "getModelClasses", EnumSet.of(Modifier.PUBLIC));
         writer.emitStatement("return MODEL_CLASSES");
         writer.endMethod();
         writer.emitEmptyLine();

--- a/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -2,16 +2,16 @@ package io.realm;
 
 
 import android.util.JsonReader;
-import io.realm.exceptions.RealmException;
 import io.realm.internal.ImplicitTransaction;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.RealmProxyMediator;
 import io.realm.internal.Table;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.json.JSONException;
 import org.json.JSONObject;
 import some.test.AllTypes;
@@ -19,11 +19,11 @@ import some.test.AllTypes;
 @io.realm.annotations.RealmModule
 class DefaultRealmModuleMediator extends RealmProxyMediator {
 
-    private static final List<Class<? extends RealmObject>> MODEL_CLASSES;
+    private static final Set<Class<? extends RealmObject>> MODEL_CLASSES;
     static {
-        List<Class<? extends RealmObject>> modelClasses = new ArrayList<Class<? extends RealmObject>>();
+        Set<Class<? extends RealmObject>> modelClasses = new HashSet<Class<? extends RealmObject>>();
         modelClasses.add(AllTypes.class);
-        MODEL_CLASSES = Collections.unmodifiableList(modelClasses);
+        MODEL_CLASSES = Collections.unmodifiableSet(modelClasses);
     }
 
     @Override
@@ -82,7 +82,7 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<Class<? extends RealmObject>> getModelClasses() {
+    public Set<Class<? extends RealmObject>> getModelClasses() {
         return MODEL_CLASSES;
     }
 

--- a/realm/src/androidTest/java/io/realm/MediatorTest.java
+++ b/realm/src/androidTest/java/io/realm/MediatorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm;
+
+import android.test.AndroidTestCase;
+
+import java.util.Arrays;
+
+import io.realm.annotations.RealmModule;
+import io.realm.entities.AllTypes;
+import io.realm.entities.AnimalModule;
+import io.realm.entities.Cat;
+import io.realm.entities.CatOwner;
+import io.realm.entities.Dog;
+import io.realm.entities.HumanModule;
+import io.realm.internal.modules.CompositeMediator;
+import io.realm.internal.modules.FilterableMediator;
+
+public class MediatorTest extends AndroidTestCase {
+
+    @SuppressWarnings("AssertEqualsBetweenInconvertibleTypes")
+    public void testMediatorsEquality() {
+        final DefaultRealmModuleMediator defaultMediator = new DefaultRealmModuleMediator();
+        final CompositeMediator compositeMediator = new CompositeMediator();
+        compositeMediator.addMediator(defaultMediator);
+        final FilterableMediator filterableMediator = new FilterableMediator(defaultMediator, defaultMediator.getModelClasses());
+
+        assertEquals(defaultMediator, defaultMediator);
+        assertEquals(defaultMediator.hashCode(), defaultMediator.hashCode());
+        assertEquals(defaultMediator, compositeMediator);
+        assertEquals(defaultMediator.hashCode(), compositeMediator.hashCode());
+        assertEquals(defaultMediator, filterableMediator);
+        assertEquals(defaultMediator.hashCode(), filterableMediator.hashCode());
+
+        assertEquals(compositeMediator, defaultMediator);
+        assertEquals(compositeMediator.hashCode(), defaultMediator.hashCode());
+        assertEquals(compositeMediator, compositeMediator);
+        assertEquals(compositeMediator.hashCode(), compositeMediator.hashCode());
+        assertEquals(compositeMediator, filterableMediator);
+        assertEquals(compositeMediator.hashCode(), filterableMediator.hashCode());
+
+        assertEquals(filterableMediator, defaultMediator);
+        assertEquals(filterableMediator.hashCode(), defaultMediator.hashCode());
+        assertEquals(filterableMediator, compositeMediator);
+        assertEquals(filterableMediator.hashCode(), compositeMediator.hashCode());
+        assertEquals(filterableMediator, filterableMediator);
+        assertEquals(filterableMediator.hashCode(), filterableMediator.hashCode());
+    }
+
+    public void testCompositeMediatorModelClassesCount() {
+        final CompositeMediator mediator = new CompositeMediator();
+        mediator.addMediator(new HumanModuleMediator());
+        mediator.addMediator(new AnimalModuleMediator());
+
+        final int modelsInHumanModule = HumanModule.class.getAnnotation(RealmModule.class).classes().length;
+        final int modelsInAnimalModule = AnimalModule.class.getAnnotation(RealmModule.class).classes().length;
+
+        assertEquals(modelsInHumanModule + modelsInAnimalModule, mediator.getModelClasses().size());
+    }
+
+    public void testFilterableMediatorModelClassesCount() {
+        //noinspection unchecked
+        final FilterableMediator mediator = new FilterableMediator(new AnimalModuleMediator(), Arrays.asList(Cat.class, CatOwner.class));
+
+        assertTrue(mediator.getModelClasses().contains(Cat.class));
+        // CatOwner is not a member of AnimalModuleMediator
+        assertFalse(mediator.getModelClasses().contains(CatOwner.class));
+        assertFalse(mediator.getModelClasses().contains(Dog.class));
+        assertFalse(mediator.getModelClasses().contains(AllTypes.class));
+    }
+}

--- a/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
@@ -22,8 +22,10 @@ import java.io.File;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
+import io.realm.entities.AnimalModule;
 import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
+import io.realm.entities.HumanModule;
 import io.realm.entities.Owner;
 import io.realm.exceptions.RealmMigrationNeededException;
 
@@ -294,6 +296,29 @@ public class RealmConfigurationTest extends AndroidTestCase {
     public void testHashCode() {
         RealmConfiguration config1 = new RealmConfiguration.Builder(getContext()).build();
         RealmConfiguration config2 = new RealmConfiguration.Builder(getContext()).build();
+        assertEquals(config1.hashCode(), config2.hashCode());
+    }
+
+    public void testEqualsWithCustomModules() {
+        RealmConfiguration config1 = new RealmConfiguration.Builder(getContext())
+                .setModules(new HumanModule(), new AnimalModule())
+                .build();
+
+        RealmConfiguration config2 = new RealmConfiguration.Builder(getContext())
+                .setModules(new AnimalModule(), new HumanModule())
+                .build();
+
+        assertTrue(config1.equals(config2));
+    }
+
+    public void testHashCodeWithCustomModules() {
+        RealmConfiguration config1 = new RealmConfiguration.Builder(getContext())
+                .setModules(new HumanModule(), new AnimalModule())
+                .build();
+        RealmConfiguration config2 = new RealmConfiguration.Builder(getContext())
+                .setModules(new AnimalModule(), new HumanModule())
+                .build();
+
         assertEquals(config1.hashCode(), config2.hashCode());
     }
 

--- a/realm/src/androidTest/java/io/realm/entities/AnimalModule.java
+++ b/realm/src/androidTest/java/io/realm/entities/AnimalModule.java
@@ -1,0 +1,7 @@
+package io.realm.entities;
+
+import io.realm.annotations.RealmModule;
+
+@RealmModule(classes = {Dog.class, Cat.class})
+public class AnimalModule {
+}

--- a/realm/src/androidTest/java/io/realm/entities/HumanModule.java
+++ b/realm/src/androidTest/java/io/realm/entities/HumanModule.java
@@ -1,0 +1,7 @@
+package io.realm.entities;
+
+import io.realm.annotations.RealmModule;
+
+@RealmModule(classes = {CatOwner.class})
+public class HumanModule {
+}

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -318,10 +318,8 @@ public final class Realm extends BaseRealm {
 
     private static void setupColumnIndices(Realm realm) {
         RealmProxyMediator mediator = realm.configuration.getSchemaMediator();
-        List<Class<? extends RealmObject>> modelClasses = mediator.getModelClasses();
-        int size = modelClasses.size();
-        for (int i = 0; i < size; i++) {
-            Class<? extends RealmObject> modelClass = modelClasses.get(i);
+        Set<Class<? extends RealmObject>> modelClasses = mediator.getModelClasses();
+        for (Class<? extends RealmObject> modelClass : modelClasses) {
             realm.columnIndices.addClass(modelClass, mediator.getColumnIndices(modelClass));
         }
     }

--- a/realm/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.realm.Realm;
 import io.realm.RealmObject;
@@ -87,7 +88,7 @@ public abstract class RealmProxyMediator {
      *
      * @return List of class references to model classes. Empty list if no models are supported.
      */
-    public abstract List<Class<? extends RealmObject>> getModelClasses();
+    public abstract Set<Class<? extends RealmObject>> getModelClasses();
 
     /**
      * Returns a map of the column indices for all Realm fields in the model class.

--- a/realm/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -22,10 +22,11 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.realm.Realm;
 import io.realm.RealmObject;
@@ -79,12 +80,8 @@ public class CompositeMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<Class<? extends RealmObject>> getModelClasses() {
-        List<Class<? extends RealmObject>> list = new ArrayList<Class<? extends RealmObject>>();
-        for (RealmProxyMediator mediator : mediators.values()) {
-            list.addAll(mediator.getModelClasses());
-        }
-        return list;
+    public Set<Class<? extends RealmObject>> getModelClasses() {
+        return new HashSet<Class<? extends RealmObject>>(mediators.keySet());
     }
 
     @Override

--- a/realm/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -22,7 +22,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -54,7 +53,7 @@ public class FilterableMediator extends RealmProxyMediator {
     public FilterableMediator(RealmProxyMediator originalMediator, Collection<Class<? extends RealmObject>> allowedClasses) {
         this.originalMediator = originalMediator;
         if (originalMediator != null) {
-            List<Class<? extends RealmObject>> originalClasses = originalMediator.getModelClasses();
+            Set<Class<? extends RealmObject>> originalClasses = originalMediator.getModelClasses();
             for (Class<? extends RealmObject> clazz : allowedClasses) {
                 if (originalClasses.contains(clazz)) {
                     this.allowedClasses.add(clazz);
@@ -98,8 +97,8 @@ public class FilterableMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<Class<? extends RealmObject>> getModelClasses() {
-        return new ArrayList<Class<? extends RealmObject>>(allowedClasses);
+    public Set<Class<? extends RealmObject>> getModelClasses() {
+        return new HashSet<Class<? extends RealmObject>>(allowedClasses);
     }
 
     @Override


### PR DESCRIPTION
change the return type of RealmProxyMediator#getModelClasses() to Set in order to guarantee its contents unordered and unique.

TODO

- [x] fix implementation (includes API changes)
- [x] add tests
- [x] update changelog
