### PR TITLE
Cleanup native methods in TableQuery

### DIFF
--- a/realm/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/src/main/java/io/realm/internal/TableQuery.java
@@ -67,8 +67,6 @@ public class TableQuery implements Closeable {
         }
     }
 
-    protected static native void nativeClose(long nativeQueryPtr);
-
     protected void finalize() {
         synchronized (context) {
             if (nativePtr != 0) {
@@ -91,14 +89,11 @@ public class TableQuery implements Closeable {
         }
     }
 
-    protected native String nativeValidateQuery(long nativeQueryPtr);
-
     // Query TableView
     public TableQuery tableview(TableView tv) {
         nativeTableview(nativePtr, tv.nativePtr);
         return this;
     }
-    protected native void nativeTableview(long nativeQueryPtr, long nativeTableViewPtr);
 
     // Grouping
 
@@ -106,42 +101,36 @@ public class TableQuery implements Closeable {
         nativeGroup(nativePtr);
         return this;
     }
-    protected native void nativeGroup(long nativeQueryPtr);
 
     public TableQuery endGroup() {
         nativeEndGroup(nativePtr);
         queryValidated = false;
         return this;
     }
-    protected native void nativeEndGroup(long nativeQueryPtr);
 
     public TableQuery subtable(long columnIndex) {
         nativeSubtable(nativePtr, columnIndex);
         queryValidated = false;
         return this;
     }
-    protected native void nativeSubtable(long nativeQueryPtr, long columnIndex);
 
     public TableQuery endSubtable() {
         nativeParent(nativePtr);
         queryValidated = false;
         return this;
     }
-    protected native void nativeParent(long nativeQueryPtr);
 
     public TableQuery or() {
         nativeOr(nativePtr);
         queryValidated = false;
         return this;
     }
-    protected native void nativeOr(long nativeQueryPtr);
 
     public TableQuery not() {
         nativeNot(nativePtr);
         queryValidated = false;
         return this;
     }
-    protected native void nativeNot(long nativeQueryPtr);
 
     // Query for integer values.
 
@@ -150,50 +139,42 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeEqual(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery notEqualTo(long columnIndex[], long value) {
         nativeNotEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery greaterThan(long columnIndex[], long value) {
         nativeGreater(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeGreater(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery greaterThanOrEqual(long columnIndex[], long value) {
         nativeGreaterEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeGreaterEqual(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery lessThan(long columnIndex[], long value) {
         nativeLess(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeLess(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery lessThanOrEqual(long columnIndex[], long value) {
         nativeLessEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeLessEqual(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery between(long columnIndex[], long value1, long value2) {
         nativeBetween(nativePtr, columnIndex, value1, value2);
         queryValidated = false;
         return this;
     }
-    protected native void nativeBetween(long nativeQueryPtr, long columnIndex[], long value1, long value2);
-
 
     // Query for float values.
 
@@ -202,50 +183,42 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeEqual(long nativeQueryPtr, long columnIndex[], float value);
 
     public TableQuery notEqualTo(long columnIndex[], float value) {
         nativeNotEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], float value);
 
     public TableQuery greaterThan(long columnIndex[], float value) {
         nativeGreater(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeGreater(long nativeQueryPtr, long columnIndex[], float value);
 
     public TableQuery greaterThanOrEqual(long columnIndex[], float value) {
         nativeGreaterEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeGreaterEqual(long nativeQueryPtr, long columnIndex[], float value);
 
     public TableQuery lessThan(long columnIndex[], float value) {
         nativeLess(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeLess(long nativeQueryPtr, long columnIndex[], float value);
 
     public TableQuery lessThanOrEqual(long columnIndex[], float value) {
         nativeLessEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeLessEqual(long nativeQueryPtr, long columnIndex[], float value);
 
     public TableQuery between(long columnIndex[], float value1, float value2) {
         nativeBetween(nativePtr, columnIndex, value1, value2);
         queryValidated = false;
         return this;
     }
-    protected native void nativeBetween(long nativeQueryPtr, long columnIndex[], float value1, float value2);
-
 
     // Query for double values.
 
@@ -254,50 +227,42 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeEqual(long nativeQueryPtr, long columnIndex[], double value);
 
     public TableQuery notEqualTo(long columnIndex[], double value) {
         nativeNotEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], double value);
 
     public TableQuery greaterThan(long columnIndex[], double value) {
         nativeGreater(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeGreater(long nativeQueryPtr, long columnIndex[], double value);
 
     public TableQuery greaterThanOrEqual(long columnIndex[], double value) {
         nativeGreaterEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeGreaterEqual(long nativeQueryPtr, long columnIndex[], double value);
 
     public TableQuery lessThan(long columnIndex[], double value) {
         nativeLess(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeLess(long nativeQueryPtr, long columnIndex[], double value);
 
     public TableQuery lessThanOrEqual(long columnIndex[], double value) {
         nativeLessEqual(nativePtr, columnIndex, value);
         queryValidated = false;
         return this;
     }
-    protected native void nativeLessEqual(long nativeQueryPtr, long columnIndex[], double value);
 
     public TableQuery between(long columnIndex[], double value1, double value2) {
         nativeBetween(nativePtr, columnIndex, value1, value2);
         queryValidated = false;
         return this;
     }
-    protected native void nativeBetween(long nativeQueryPtr, long columnIndex[], double value1, double value2);
-
 
     // Query for boolean values.
 
@@ -307,7 +272,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeEqual(long nativeQueryPtr, long columnIndex[], boolean value);
 
     // Query for Date values
 
@@ -322,7 +286,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery notEqualTo(long columnIndex[], Date value){
         if (value == null)
@@ -331,7 +294,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeNotEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery greaterThan(long columnIndex[], Date value){
         if (value == null)
@@ -341,9 +303,6 @@ public class TableQuery implements Closeable {
         return this;
     }
 
-    protected native void nativeGreaterDateTime(long nativeQueryPtr, long columnIndex[], long value);
-
-
     public TableQuery greaterThanOrEqual(long columnIndex[], Date value){
         if (value == null)
             throw new IllegalArgumentException(DATE_NULL_ERROR_MESSAGE);
@@ -351,8 +310,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-
-    protected native void nativeGreaterEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
 
     public TableQuery lessThan(long columnIndex[], Date value){
         if (value == null)
@@ -362,9 +319,6 @@ public class TableQuery implements Closeable {
         return this;
     }
 
-    protected native void nativeLessDateTime(long nativeQueryPtr, long columnIndex[], long value);
-
-
     public TableQuery lessThanOrEqual(long columnIndex[], Date value){
         if (value == null)
             throw new IllegalArgumentException(DATE_NULL_ERROR_MESSAGE);
@@ -373,8 +327,6 @@ public class TableQuery implements Closeable {
         return this;
     }
 
-    protected native void nativeLessEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
-
     public TableQuery between(long columnIndex[], Date value1, Date value2){
         if (value1 == null || value2 == null)
             throw new IllegalArgumentException("Date values in query criteria must not be null."); // Different text
@@ -382,7 +334,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeBetweenDateTime(long nativeQueryPtr, long columnIndex[], long value1, long value2);
 
     // Query for String values.
     
@@ -399,7 +350,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeEqual(long nativeQueryPtr, long[] columnIndexes, String value, boolean caseSensitive);
 
     // Not Equal
     public TableQuery notEqualTo(long columnIndex[], String value, boolean caseSensitive) {
@@ -412,7 +362,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], String value, boolean caseSensitive);
 
     public TableQuery beginsWith(long columnIndices[], String value, boolean caseSensitive) {
         nativeBeginsWith(nativePtr, columnIndices, value, caseSensitive);
@@ -424,7 +373,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeBeginsWith(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
 
     public TableQuery endsWith(long columnIndices[], String value, boolean caseSensitive) {
         nativeEndsWith(nativePtr, columnIndices, value, caseSensitive);
@@ -436,7 +384,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeEndsWith(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
 
     public TableQuery contains(long columnIndices[], String value, boolean caseSensitive) {
         nativeContains(nativePtr, columnIndices, value, caseSensitive);
@@ -448,8 +395,6 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
-    protected native void nativeContains(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
-
 
     // Searching methods.
 
@@ -462,8 +407,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeFind(nativePtr, 0);
     }
-
-    protected native long nativeFind(long nativeQueryPtr, long fromTableRow);
 
     public TableView findAll(long start, long end, long limit) {
         validateQuery();
@@ -493,8 +436,6 @@ public class TableQuery implements Closeable {
         }
     }
 
-    protected native long nativeFindAll(long nativeQueryPtr, long start, long end, long limit);
-
     //
     // Aggregation methods
     //
@@ -509,8 +450,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeSumInt(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native long nativeSumInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public Long maximumInt(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -520,8 +459,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeMaximumInt(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native Long nativeMaximumInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public Long minimumInt(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -531,8 +468,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeMinimumInt(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native Long nativeMinimumInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public double averageInt(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -542,8 +477,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeAverageInt(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native double nativeAverageInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     // float aggregation
 
@@ -555,8 +488,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeSumFloat(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native double nativeSumFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public Float maximumFloat(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -566,8 +497,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeMaximumFloat(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native Float nativeMaximumFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public Float minimumFloat(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -577,8 +506,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeMinimumFloat(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native Float nativeMinimumFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public double averageFloat(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -588,8 +515,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeAverageFloat(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native double nativeAverageFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     // double aggregation
 
@@ -601,8 +526,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeSumDouble(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native double nativeSumDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public Double maximumDouble(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -612,8 +535,6 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeMaximumDouble(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native Double nativeMaximumDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public Double minimumDouble(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -623,9 +544,7 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeMinimumDouble(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native Double nativeMinimumDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
-
+    
     public double averageDouble(long columnIndex, long start, long end, long limit) {
         validateQuery();
         return nativeAverageDouble(nativePtr, columnIndex, start, end, limit);
@@ -634,8 +553,7 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeAverageDouble(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    protected native double nativeAverageDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
+    
     // date aggregation
 
     public Date maximumDate(long columnIndex, long start, long end, long limit) {
@@ -654,8 +572,6 @@ public class TableQuery implements Closeable {
         }
         return null;
     }
-    protected native Long nativeMaximumDate(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
 
     public Date minimumDate(long columnIndex, long start, long end, long limit) {
         validateQuery();
@@ -673,9 +589,7 @@ public class TableQuery implements Closeable {
         }
         return null;
     }
-    protected native Long nativeMinimumDate(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
-
-
+    
     // isNull and isNotNull
     public TableQuery isNull(long columnIndices[]) {
         validateQuery();
@@ -683,15 +597,11 @@ public class TableQuery implements Closeable {
         return this;
     }
 
-    private native void nativeIsNull(long nativePtr, long columnIndices[]);
-
     public TableQuery isNotNull(long columnIndices[]) {
         validateQuery();
         nativeIsNotNull(nativePtr, columnIndices);
         return this;
     }
-
-    private native void nativeIsNotNull(long nativePtr, long columnIndices[]);
 
     // count
 
@@ -706,9 +616,6 @@ public class TableQuery implements Closeable {
         return nativeCount(nativePtr, 0, Table.INFINITE, Table.INFINITE);
     }
 
-    protected native long nativeCount(long nativeQueryPtr, long start, long end, long limit);
-
-
     // Deletion.
     public long remove(long start, long end) {
         validateQuery();
@@ -722,9 +629,72 @@ public class TableQuery implements Closeable {
         return nativeRemove(nativePtr, 0, Table.INFINITE, Table.INFINITE);
     }
 
-    protected native long nativeRemove(long nativeQueryPtr, long start, long end, long limit);
-
     private void throwImmutable() {
         throw new IllegalStateException("Mutable method call during read transaction.");
     }
+
+    protected static native void nativeClose(long nativeQueryPtr);
+    private native String nativeValidateQuery(long nativeQueryPtr);
+    private native void nativeTableview(long nativeQueryPtr, long nativeTableViewPtr);
+    private native void nativeGroup(long nativeQueryPtr);
+    private native void nativeEndGroup(long nativeQueryPtr);
+    private native void nativeSubtable(long nativeQueryPtr, long columnIndex);
+    private native void nativeParent(long nativeQueryPtr);
+    private native void nativeOr(long nativeQueryPtr);
+    private native void nativeNot(long nativeQueryPtr);
+    private native void nativeEqual(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeGreater(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeGreaterEqual(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeLess(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeLessEqual(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeBetween(long nativeQueryPtr, long columnIndex[], long value1, long value2);
+    private native void nativeEqual(long nativeQueryPtr, long columnIndex[], float value);
+    private native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], float value);
+    private native void nativeGreater(long nativeQueryPtr, long columnIndex[], float value);
+    private native void nativeGreaterEqual(long nativeQueryPtr, long columnIndex[], float value);
+    private native void nativeLess(long nativeQueryPtr, long columnIndex[], float value);
+    private native void nativeLessEqual(long nativeQueryPtr, long columnIndex[], float value);
+    private native void nativeBetween(long nativeQueryPtr, long columnIndex[], float value1, float value2);
+    private native void nativeEqual(long nativeQueryPtr, long columnIndex[], double value);
+    private native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], double value);
+    private native void nativeGreater(long nativeQueryPtr, long columnIndex[], double value);
+    private native void nativeGreaterEqual(long nativeQueryPtr, long columnIndex[], double value);
+    private native void nativeLess(long nativeQueryPtr, long columnIndex[], double value);
+    private native void nativeLessEqual(long nativeQueryPtr, long columnIndex[], double value);
+    private native void nativeBetween(long nativeQueryPtr, long columnIndex[], double value1, double value2);
+    private native void nativeEqual(long nativeQueryPtr, long columnIndex[], boolean value);
+    private native void nativeEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeNotEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeGreaterDateTime(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeGreaterEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeLessDateTime(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeLessEqualDateTime(long nativeQueryPtr, long columnIndex[], long value);
+    private native void nativeBetweenDateTime(long nativeQueryPtr, long columnIndex[], long value1, long value2);
+    private native void nativeEqual(long nativeQueryPtr, long[] columnIndexes, String value, boolean caseSensitive);
+    private native void nativeNotEqual(long nativeQueryPtr, long columnIndex[], String value, boolean caseSensitive);
+    private native void nativeBeginsWith(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
+    private native void nativeEndsWith(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
+    private native void nativeContains(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
+    private native long nativeFind(long nativeQueryPtr, long fromTableRow);
+    private native long nativeFindAll(long nativeQueryPtr, long start, long end, long limit);
+    private native long nativeSumInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Long nativeMaximumInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Long nativeMinimumInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native double nativeAverageInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native double nativeSumFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Float nativeMaximumFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Float nativeMinimumFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native double nativeAverageFloat(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native double nativeSumDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Double nativeMaximumDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Double nativeMinimumDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native double nativeAverageDouble(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Long nativeMaximumDate(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native Long nativeMinimumDate(long nativeQueryPtr, long columnIndex, long start, long end, long limit);
+    private native void nativeIsNull(long nativePtr, long columnIndices[]);
+    private native void nativeIsNotNull(long nativePtr, long columnIndices[]);
+    private native long nativeCount(long nativeQueryPtr, long start, long end, long limit);
+    private native long nativeRemove(long nativeQueryPtr, long start, long end, long limit);
+
 }


### PR DESCRIPTION
Preparing to add `isEmpty()`
This reorders the native methods + fix their visibility pr. previous style fixes in other classes.

@realm/java 