### PR TITLE
Premature query validation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
  * Fixed a bug affecting RealmConfiguration.equals().
  * Add support for parsing JSON Dates with timezone information.
  * Fixed a bug in RealmQuery.isNotNull() which produced wrong results for binary data.
+ * Fixed a bug in RealmQuery.isNull() and RealmQuery.isNotNull() which validated the query prematurely.
 
 0.83.1 (15 Oct 2015)
  * Updated Realm core to version 0.94.1.

--- a/realm/src/androidTest/java/io/realm/internal/JNIQueryTest.java
+++ b/realm/src/androidTest/java/io/realm/internal/JNIQueryTest.java
@@ -80,24 +80,34 @@ public class JNIQueryTest extends TestCase {
         init();
 
         // All the following queries are not valid, e.g contain a group but not a closing group, an or() but not a second filter etc
-        try { table.where().equalTo(new long[]{0}, 1).or().findAll();       fail("missing a second filter"); }      catch (UnsupportedOperationException e) { }
-        try { table.where().or().findAll();                                 fail("just an or()"); }                 catch (UnsupportedOperationException e) { }
-        try { table.where().group().equalTo(new long[]{0}, 1).findAll();    fail("messing a clsong group"); }       catch (UnsupportedOperationException e) { }
-        try { table.where().endGroup().equalTo(new long[]{0}, 1).findAll(); fail("ends group, no start"); }         catch (UnsupportedOperationException e) { }
-        try { table.where().equalTo(new long[]{0}, 1).endGroup().findAll(); fail("ends group, no start"); }         catch (UnsupportedOperationException e) { }
+        try { table.where().equalTo(new long[]{0}, 1).or().findAll();       fail("missing a second filter"); }      catch (UnsupportedOperationException ignore) {}
+        try { table.where().or().findAll();                                 fail("just an or()"); }                 catch (UnsupportedOperationException ignore) {}
+        try { table.where().group().equalTo(new long[]{0}, 1).findAll();    fail("missing a closing group"); }      catch (UnsupportedOperationException ignore) {}
 
-        try { table.where().equalTo(new long[]{0}, 1).endGroup().find();    fail("ends group, no start"); }         catch (UnsupportedOperationException e) { }
-        try { table.where().equalTo(new long[]{0}, 1).endGroup().find(0);   fail("ends group, no start"); }         catch (UnsupportedOperationException e) { }
-        try { table.where().equalTo(new long[]{0}, 1).endGroup().find(1);   fail("ends group, no start"); }         catch (UnsupportedOperationException e) { }
+        try { table.where().group().count();                                fail(); }                               catch (UnsupportedOperationException ignore) {}
+        try { table.where().group().findAll();                              fail(); }                               catch (UnsupportedOperationException ignore) {}
+        try { table.where().group().find();                                 fail(); }                               catch (UnsupportedOperationException ignore) {}
+        try { table.where().group().minimumInt(0);                          fail(); }                               catch (UnsupportedOperationException ignore) {}
+        try { table.where().group().maximumInt(0);                          fail(); }                               catch (UnsupportedOperationException ignore) {}
+        try { table.where().group().sumInt(0);                              fail(); }                               catch (UnsupportedOperationException ignore) {}
+        try { table.where().group().averageInt(0);                          fail(); }                               catch (UnsupportedOperationException ignore) {}
 
-        try { table.where().equalTo(new long[]{0}, 1).endGroup().findAll(0, -1, -1); fail("ends group, no start"); }         catch (UnsupportedOperationException e) { }
+        try { table.where().endGroup().equalTo(new long[]{0}, 1).findAll(); fail("ends group, no start"); }         catch (UnsupportedOperationException ignore) {}
+        try { table.where().equalTo(new long[]{0}, 1).endGroup().findAll(); fail("ends group, no start"); }         catch (UnsupportedOperationException ignore) {}
+
+        try { table.where().equalTo(new long[]{0}, 1).endGroup().find();    fail("ends group, no start"); }         catch (UnsupportedOperationException ignore) {}
+        try { table.where().equalTo(new long[]{0}, 1).endGroup().find(0);   fail("ends group, no start"); }         catch (UnsupportedOperationException ignore) {}
+        try { table.where().equalTo(new long[]{0}, 1).endGroup().find(1);   fail("ends group, no start"); }         catch (UnsupportedOperationException ignore) {}
+
+        try { table.where().equalTo(new long[]{0}, 1).endGroup().findAll(0, -1, -1); fail("ends group, no start"); } catch (UnsupportedOperationException ignore) {}
+
 
 
         // step by step buildup
         TableQuery q = table.where().equalTo(new long[]{0}, 1); // valid
         q.findAll();
         q.or();                                                 // not valid
-        try { q.findAll();     fail("no start group"); }         catch (UnsupportedOperationException e) { }
+        try { q.findAll();     fail("no start group"); }         catch (UnsupportedOperationException ignore) { }
         q.equalTo(new long[]{0}, 100);                          // valid again
         q.findAll();
         q.equalTo(new long[]{0}, 200);                          // still valid
@@ -351,7 +361,7 @@ public class JNIQueryTest extends TestCase {
         Table t = new Table();
         t.addColumn(ColumnType.DATE, "dateCol");
         t.addColumn(ColumnType.STRING, "stringCol");
-        
+
         Date nullDate = null;
         try { t.where().equalTo(new long[]{0}, nullDate);               fail("Date is null"); } catch (IllegalArgumentException e) { }
         try { t.where().notEqualTo(new long[]{0}, nullDate);            fail("Date is null"); } catch (IllegalArgumentException e) { }
@@ -362,7 +372,7 @@ public class JNIQueryTest extends TestCase {
         try { t.where().between(new long[]{0}, nullDate, new Date());   fail("Date is null"); } catch (IllegalArgumentException e) { }
         try { t.where().between(new long[]{0}, new Date(), nullDate);   fail("Date is null"); } catch (IllegalArgumentException e) { }
         try { t.where().between(new long[]{0}, nullDate, nullDate);     fail("Dates are null"); } catch (IllegalArgumentException e) { }
-        
+
         String nullString = null;
         try { t.where().equalTo(new long[]{1}, nullString);             fail("String is null"); } catch (IllegalArgumentException e) { }
         try { t.where().equalTo(new long[]{1}, nullString, false);      fail("String is null"); } catch (IllegalArgumentException e) { }
@@ -377,7 +387,7 @@ public class JNIQueryTest extends TestCase {
     }
 
 
-    
+
     public void testShouldFind() {
         // Create a table
         Table table = new Table();
@@ -421,7 +431,7 @@ public class JNIQueryTest extends TestCase {
     }
 
 
-    
+
     public void testQueryTestForNoMatches() {
         Table t = new Table();
         t = TestHelper.getTableWithAllColumnTypes();
@@ -435,7 +445,7 @@ public class JNIQueryTest extends TestCase {
     }
 
 
-    
+
     public void testQueryWithWrongDataType() {
 
         Table table = TestHelper.getTableWithAllColumnTypes();
@@ -515,7 +525,7 @@ public class JNIQueryTest extends TestCase {
         */
     }
 
-    
+
     public void testColumnIndexOutOfBounds() {
         Table table = TestHelper.getTableWithAllColumnTypes();
 
@@ -639,7 +649,7 @@ public class JNIQueryTest extends TestCase {
         try { query.equalTo(new long[]{9}, true);                     assert(false); } catch(ArrayIndexOutOfBoundsException e) {}
     }
 
-    
+
     public void testQueryOnView() {
         Table table = new Table();
 
@@ -666,7 +676,7 @@ public class JNIQueryTest extends TestCase {
         assertEquals(1, view3.size());
     }
 
-    
+
     public void testQueryOnViewWithAlreadyQueriedTable() {
         Table table = new Table();
 
@@ -690,7 +700,7 @@ public class JNIQueryTest extends TestCase {
     }
 
 
-    
+
     public void testQueryWithSubtable() {
         Table table = new Table();
         table.addColumn(ColumnType.STRING, "username");
@@ -716,21 +726,21 @@ public class JNIQueryTest extends TestCase {
         assertEquals(2, view.size());
     }
 
-    
+
     public void testQueryWithUnbalancedSubtable() {
         Table table = new Table();
         table.addColumn(ColumnType.TABLE, "sub");
-        
+
         TableSchema tasks = table.getSubtableSchema(0);
         tasks.addColumn(ColumnType.STRING, "name");
-        
+
         try { table.where().subtable(0).count();               assert(false); } catch (UnsupportedOperationException e) {}
         try { table.where().endSubtable().count();             assert(false); } catch (UnsupportedOperationException e) {}
         try { table.where().endSubtable().subtable(0).count(); assert(false); } catch (UnsupportedOperationException e) {}
-        try { table.where().subtable(0).endSubtable().count(); assert(false); } catch (UnsupportedOperationException e) {} 
+        try { table.where().subtable(0).endSubtable().count(); assert(false); } catch (UnsupportedOperationException e) {}
     }
 
-    
+
     public void testMaximumDate() {
 
         Table table = new Table();
@@ -744,7 +754,7 @@ public class JNIQueryTest extends TestCase {
 
     }
 
-    
+
     public void testMinimumDate() {
 
         Table table = new Table();

--- a/realm/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/src/main/java/io/realm/internal/TableQuery.java
@@ -595,14 +595,14 @@ public class TableQuery implements Closeable {
 
     // isNull and isNotNull
     public TableQuery isNull(long columnIndices[]) {
-        queryValidated = false;
         nativeIsNull(nativePtr, columnIndices);
+        queryValidated = false;
         return this;
     }
 
     public TableQuery isNotNull(long columnIndices[]) {
-        queryValidated = false;
         nativeIsNotNull(nativePtr, columnIndices);
+        queryValidated = false;
         return this;
     }
 

--- a/realm/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/src/main/java/io/realm/internal/TableQuery.java
@@ -30,6 +30,9 @@ public class TableQuery implements Closeable {
     private final TableOrView origin; // Table or TableView which created this TableQuery
     private final Context context;
 
+    // All actions (find(), findAll(), sum(), etc.) must call validateQuery() before performing
+    // the actual action. The other methods must set queryValidated to false in order to enforce
+    // the first action to validate the syntax of the query.
     private boolean queryValidated = true;
 
     // TODO: Can we protect this?
@@ -57,7 +60,7 @@ public class TableQuery implements Closeable {
     public void close() {
         synchronized (context) {
             if (nativePtr != 0) {
-                nativeClose(nativePtr);  
+                nativeClose(nativePtr);
 
                 if (DEBUG)
                     System.err.println("++++ Query CLOSE, ptr= " + nativePtr);
@@ -99,6 +102,7 @@ public class TableQuery implements Closeable {
 
     public TableQuery group() {
         nativeGroup(nativePtr);
+        queryValidated = false;
         return this;
     }
 
@@ -268,7 +272,6 @@ public class TableQuery implements Closeable {
 
     public TableQuery equalTo(long columnIndex[], boolean value) {
         nativeEqual(nativePtr, columnIndex, value);
-
         queryValidated = false;
         return this;
     }
@@ -336,7 +339,7 @@ public class TableQuery implements Closeable {
     }
 
     // Query for String values.
-    
+
     private final static String STRING_NULL_ERROR_MESSAGE = "String value in query criteria must not be null.";
 
     // Equal
@@ -544,7 +547,7 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeMinimumDouble(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    
+
     public double averageDouble(long columnIndex, long start, long end, long limit) {
         validateQuery();
         return nativeAverageDouble(nativePtr, columnIndex, start, end, limit);
@@ -553,7 +556,7 @@ public class TableQuery implements Closeable {
         validateQuery();
         return nativeAverageDouble(nativePtr, columnIndex, 0, Table.INFINITE, Table.INFINITE);
     }
-    
+
     // date aggregation
 
     public Date maximumDate(long columnIndex, long start, long end, long limit) {
@@ -589,16 +592,16 @@ public class TableQuery implements Closeable {
         }
         return null;
     }
-    
+
     // isNull and isNotNull
     public TableQuery isNull(long columnIndices[]) {
-        validateQuery();
+        queryValidated = false;
         nativeIsNull(nativePtr, columnIndices);
         return this;
     }
 
     public TableQuery isNotNull(long columnIndices[]) {
-        validateQuery();
+        queryValidated = false;
         nativeIsNotNull(nativePtr, columnIndices);
         return this;
     }


### PR DESCRIPTION
Fixed a bug in `RealmQuery.isNull()` and `RealmQuery.isNotNull()` which validated the query prematurely.

@cmelchior @beeender 