### PR TITLE
Add RealmQuery.isEmpty()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 0.84.0
+ * Added RealmQuery.isEmpty().
  * Fixed a bug where closed Realms were trying to refresh themselves resulting in a NullPointerException.
  * Added Realm.isClosed() method.
  * Added Realm.distinct() method.

--- a/realm-jni/src/io_realm_internal_TableQuery.h
+++ b/realm-jni/src/io_realm_internal_TableQuery.h
@@ -489,6 +489,14 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull
 
 /*
  * Class:     io_realm_internal_TableQuery
+ * Method:    nativeIsEmpty
+ * Signature: (J[J)V
+ */
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsEmpty
+  (JNIEnv *, jobject, jlong, jlongArray);
+
+/*
+ * Class:     io_realm_internal_TableQuery
  * Method:    nativeIsNotNull
  * Signature: (J[J)V
  */

--- a/realm/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -18,10 +18,14 @@ package io.realm;
 
 import android.test.AndroidTestCase;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.Cat;
 import io.realm.entities.CatOwner;
@@ -31,8 +35,9 @@ import io.realm.entities.NullTypes;
 import io.realm.entities.Owner;
 import io.realm.entities.StringOnly;
 import io.realm.exceptions.RealmError;
+import io.realm.internal.ColumnType;
 
-public class RealmQueryTest extends AndroidTestCase{
+public class RealmQueryTest extends AndroidTestCase {
 
     protected final static int TEST_DATA_SIZE = 10;
 
@@ -219,8 +224,8 @@ public class RealmQueryTest extends AndroidTestCase{
                 .equalTo(FIELD_LONG, 5)
                 .or()
                 .not().beginGroup()
-                    .greaterThan(FIELD_LONG, 2)
-                 .endGroup()
+                .greaterThan(FIELD_LONG, 2)
+                .endGroup()
                 .findAll();
         assertEquals(4, list4.size());
         for (int i = 0; i < list4.size(); i++) {
@@ -488,7 +493,8 @@ public class RealmQueryTest extends AndroidTestCase{
             RealmResults<AllTypes> results = testRealm.where(AllTypes.class)
                     .findAllSorted(new String[]{}, new boolean[]{});
             fail();
-        } catch (IllegalArgumentException ignored) {}
+        } catch (IllegalArgumentException ignored) {
+        }
 
         // number of fields and sorting orders don't match
         try {
@@ -496,18 +502,21 @@ public class RealmQueryTest extends AndroidTestCase{
                     .findAllSorted(new String[]{FIELD_STRING},
                             new boolean[]{RealmResults.SORT_ORDER_ASCENDING, RealmResults.SORT_ORDER_ASCENDING});
             fail();
-        } catch (IllegalArgumentException ignored) {}
+        } catch (IllegalArgumentException ignored) {
+        }
 
         // null is not allowed
         try {
             RealmResults<AllTypes> results = testRealm.where(AllTypes.class).findAllSorted(null, null);
             fail();
-        } catch (IllegalArgumentException ignored) {}
+        } catch (IllegalArgumentException ignored) {
+        }
         try {
             RealmResults<AllTypes> results = testRealm.where(AllTypes.class).findAllSorted(new String[]{FIELD_STRING},
                     null);
             fail();
-        } catch (IllegalArgumentException ignored) {}
+        } catch (IllegalArgumentException ignored) {
+        }
 
         // non-existing field name
         try {
@@ -515,7 +524,8 @@ public class RealmQueryTest extends AndroidTestCase{
                     .findAllSorted(new String[]{FIELD_STRING, "dont-exist"},
                             new boolean[]{RealmResults.SORT_ORDER_ASCENDING, RealmResults.SORT_ORDER_ASCENDING});
             fail();
-        } catch (IllegalArgumentException ignored) {}
+        } catch (IllegalArgumentException ignored) {
+        }
     }
 
     public void testSortSingleField() {
@@ -662,71 +672,61 @@ public class RealmQueryTest extends AndroidTestCase{
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_STRING_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 2 Bytes
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_BYTES_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 3 Boolean
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_BOOLEAN_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 4 Byte
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_BYTE_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 5 Short
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_SHORT_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 6 Integer
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_INTEGER_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 7 Long
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_LONG_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 8 Float
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_FLOAT_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 9 Double
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_DOUBLE_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
         // 10 Date
         try {
             testRealm.where(NullTypes.class).isNull(NullTypes.FIELD_DATE_NOT_NULL).findAll();
             fail();
-        }
-        catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
     }
 
@@ -736,19 +736,19 @@ public class RealmQueryTest extends AndroidTestCase{
 
         // 1 String
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_STRING_NULL, "Horse").findAll().size());
-        assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_STRING_NULL, (String)null).findAll().size());
+        assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_STRING_NULL, (String) null).findAll().size());
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_STRING_NULL, "Fish").findAll().size());
         assertEquals(0, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_STRING_NULL, "Goat").findAll().size());
         // 2 Bytes skipped, doesn't support equalTo query
         // 3 Boolean
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BOOLEAN_NULL, true).findAll().size());
-        assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BOOLEAN_NULL, (Boolean)null).findAll().size());
+        assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BOOLEAN_NULL, (Boolean) null).findAll().size());
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BOOLEAN_NULL, false).findAll().size());
         // 4 Byte
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BYTE_NULL, 1).findAll().size());
-        assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BYTE_NULL, (byte)1).findAll().size());
+        assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BYTE_NULL, (byte) 1).findAll().size());
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BYTE_NULL, (Byte) null).findAll().size());
-        assertEquals(0, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BYTE_NULL, (byte)42).findAll().size());
+        assertEquals(0, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_BYTE_NULL, (byte) 42).findAll().size());
         // 5 Short for other long based columns, only test null
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_SHORT_NULL, 1).findAll().size());
         assertEquals(1, testRealm.where(NullTypes.class).equalTo(NullTypes.FIELD_SHORT_NULL, (short) 1).findAll().size());
@@ -930,7 +930,7 @@ public class RealmQueryTest extends AndroidTestCase{
         // 6 Integer
         assertEquals(1, testRealm.where(NullTypes.class).greaterThanOrEqualTo(NullTypes.FIELD_INTEGER_NULL, 3).count());
         // 7 Long
-        assertEquals(1, testRealm.where(NullTypes.class).greaterThanOrEqualTo(NullTypes.FIELD_LONG_NULL, 3L).count ());
+        assertEquals(1, testRealm.where(NullTypes.class).greaterThanOrEqualTo(NullTypes.FIELD_LONG_NULL, 3L).count());
         // 8 Float
         assertEquals(1, testRealm.where(NullTypes.class).greaterThanOrEqualTo(NullTypes.FIELD_FLOAT_NULL, 3F).count());
         // 9 Double
@@ -983,7 +983,7 @@ public class RealmQueryTest extends AndroidTestCase{
         final int count = 30;
         RealmResults<CatOwner> results = testRealm.where(CatOwner.class).findAll();
 
-        for (int i=1; i<=count; i++) {
+        for (int i = 1; i <= count; i++) {
             @SuppressWarnings({"unused"})
             byte garbage[] = TestHelper.allocGarbage(0);
             results = results.where().findAll();
@@ -1110,8 +1110,8 @@ public class RealmQueryTest extends AndroidTestCase{
             testRealm.where(NullTypes.class).isNull(
                     NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL).count();
             fail();
+        } catch (RealmError ignored) {
         }
-        catch (RealmError ignored) {}
     }
 
     // Test isNull on link's not-nullable field. should throw
@@ -1200,7 +1200,7 @@ public class RealmQueryTest extends AndroidTestCase{
                 NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_STRING_NULL).count());
         // 2 Bytes
         assertEquals(1, testRealm.where(NullTypes.class).isNotNull(
-               NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_BYTES_NULL).count());
+                NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_BYTES_NULL).count());
         // 3 Boolean
         assertEquals(1, testRealm.where(NullTypes.class).isNotNull(
                 NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_BOOLEAN_NULL).count());
@@ -1233,8 +1233,8 @@ public class RealmQueryTest extends AndroidTestCase{
             testRealm.where(NullTypes.class).isNotNull(
                     NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL).count();
             fail();
+        } catch (RealmError ignored) {
         }
-        catch (RealmError ignored) {}
     }
 
     // Test isNotNull on link's not-nullable field. should throw
@@ -1379,7 +1379,7 @@ public class RealmQueryTest extends AndroidTestCase{
                             latch.countDown();
                         }
                     }
-                );
+            );
             thread.start();
         }
 
@@ -1445,5 +1445,123 @@ public class RealmQueryTest extends AndroidTestCase{
 
         // invalid if parent has been removed
         assertFalse(query.isValid());
+    }
+
+
+    private static final List<ColumnType> SUPPORTED_IS_EMPTY_TYPES = Arrays.asList(
+            ColumnType.STRING,
+            ColumnType.BINARY,
+            ColumnType.LINK_LIST);
+
+    private static final List<ColumnType> NOT_SUPPORTED_IS_EMPTY_TYPES;
+    static {
+        final ArrayList<ColumnType> list = new ArrayList<ColumnType>(Arrays.asList(ColumnType.values()));
+        list.removeAll(SUPPORTED_IS_EMPTY_TYPES);
+        list.remove(ColumnType.MIXED);
+        list.remove(ColumnType.TABLE);
+        NOT_SUPPORTED_IS_EMPTY_TYPES = list;
+    }
+
+    private void createIsEmptyDataSet(Realm realm) {
+        realm.beginTransaction();
+
+        AllJavaTypes emptyValues = new AllJavaTypes();
+        emptyValues.setFieldLong(1);
+        emptyValues.setFieldString("");
+        emptyValues.setFieldBinary(new byte[0]);
+        emptyValues.setFieldObject(emptyValues);
+        emptyValues.setFieldList(new RealmList<AllJavaTypes>());
+        realm.copyToRealm(emptyValues);
+
+        AllJavaTypes nonEmpty = new AllJavaTypes();
+        nonEmpty.setFieldLong(2);
+        nonEmpty.setFieldString("Foo");
+        nonEmpty.setFieldBinary(new byte[]{1, 2, 3});
+        nonEmpty.setFieldObject(nonEmpty);
+        nonEmpty.setFieldList(new RealmList<AllJavaTypes>(emptyValues));
+        realm.copyToRealmOrUpdate(nonEmpty);
+
+        realm.commitTransaction();
+    }
+
+    public void testIsEmpty() {
+        createIsEmptyDataSet(testRealm);
+        for (ColumnType type : SUPPORTED_IS_EMPTY_TYPES) {
+            switch (type) {
+                case STRING:
+                    assertEquals(1, testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_STRING).count());
+                    break;
+                case BINARY:
+                    assertEquals(1, testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_BINARY).count());
+                    break;
+                case LINK_LIST:
+                    assertEquals(1, testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_LIST).count());
+                    break;
+                default:
+                    fail("Unknown type: " + type);
+            }
+        }
+    }
+
+    public void testIsEmptyAcrossLink() {
+        createIsEmptyDataSet(testRealm);
+        for (ColumnType type : SUPPORTED_IS_EMPTY_TYPES) {
+            switch (type) {
+                case STRING:
+                    assertEquals(1, testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_STRING).count());
+                    break;
+                case BINARY:
+                    assertEquals(1, testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_BINARY).count());
+                    break;
+                case LINK_LIST:
+                    assertEquals(1, testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_LIST).count());
+                    break;
+                default:
+                    fail("Unknown type: " + type);
+            }
+        }
+    }
+
+    public void testIsEmptyIllegalFieldTypeThrows() {
+        for (ColumnType type : NOT_SUPPORTED_IS_EMPTY_TYPES) {
+            try {
+                switch (type) {
+                    case INTEGER:
+                        testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_LONG).findAll();
+                        break;
+                    case FLOAT:
+                        testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_FLOAT).findAll();
+                        break;
+                    case DOUBLE:
+                        testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_DOUBLE).findAll();
+                        break;
+                    case BOOLEAN:
+                        testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_BOOLEAN).findAll();
+                        break;
+                    case LINK:
+                        testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_OBJECT).findAll();
+                        break;
+                    case DATE:
+                        testRealm.where(AllJavaTypes.class).isEmpty(AllJavaTypes.FIELD_DATE).findAll();
+                        break;
+                    default:
+                        fail("Unknown type: " + type);
+                }
+                fail(type + " should throw an exception");
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    public void testIsEmptyInvalidFieldNameThrows() {
+        String[] fieldNames = new String[] {null, "", "foo", AllJavaTypes.FIELD_OBJECT + ".foo"};
+
+        for (String fieldName : fieldNames) {
+            try {
+                testRealm.where(AllJavaTypes.class).isEmpty(fieldName).findAll();
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
     }
 }

--- a/realm/src/main/java/io/realm/RealmQuery.java
+++ b/realm/src/main/java/io/realm/RealmQuery.java
@@ -18,6 +18,7 @@ package io.realm;
 
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -133,13 +134,27 @@ public class RealmQuery<E extends RealmObject> {
         return arr;
     }
 
+    /**
+     * Returns the column indices for the given field name. If a linked field is defined, the column index for
+     * each
+     *
+     * @param fieldDescription fieldName or link path to a field name.
+     * @param validColumnTypes Legal field type for the last field a
+     * @return
+     */
     // TODO: consider another caching strategy so linked classes are included in the cache.
-    private long[] getColumnIndices(String fieldName, ColumnType fieldType) {
+    private long[] getColumnIndices(String fieldDescription, ColumnType... validColumnTypes) {
+        if (fieldDescription == null || fieldDescription.equals("")) {
+            throw new IllegalArgumentException("Non-empty fieldname must be provided");
+        }
         Table table = this.table;
-        if (containsDot(fieldName)) {
-            String[] names = splitString(fieldName); //fieldName.split("\\.");
+        boolean checkColumnType = validColumnTypes != null && validColumnTypes.length > 0;
+        if (containsDot(fieldDescription)) {
+
+            // Resolve field description down to last field name
+            String[] names = splitString(fieldDescription); //fieldName.split("\\.");
             long[] columnIndices = new long[names.length];
-            for (int i = 0; i < names.length-1; i++) {
+            for (int i = 0; i < names.length - 1; i++) {
                 long index = table.getColumnIndex(names[i]);
                 if (index < 0) {
                     throw new IllegalArgumentException("Invalid query: " + names[i] + " does not refer to a class.");
@@ -152,24 +167,38 @@ public class RealmQuery<E extends RealmObject> {
                     throw new IllegalArgumentException("Invalid query: " + names[i] + " does not refer to a class.");
                 }
             }
-            columnIndices[names.length - 1] = table.getColumnIndex(names[names.length - 1]);
-            if (fieldType != null && fieldType != table.getColumnType(columnIndices[names.length - 1])) {
+
+            // Check if last field name is a valid field
+            String columnName = names[names.length - 1];
+            long columnIndex = table.getColumnIndex(columnName);
+            columnIndices[names.length - 1] = columnIndex;
+            if (columnIndex < 0) {
+                throw new IllegalArgumentException(columnName + " is not a field name in class " + table.getName());
+            }
+            if (checkColumnType && !isValidType(table.getColumnType(columnIndex), validColumnTypes)) {
                 throw new IllegalArgumentException(String.format("Field '%s': type mismatch.", names[names.length - 1]));
             }
             return columnIndices;
         } else {
-            if (columns.get(fieldName) == null) {
-                throw new IllegalArgumentException(String.format("Field '%s' does not exist.", fieldName));
+            if (columns.get(fieldDescription) == null) {
+                throw new IllegalArgumentException(String.format("Field '%s' does not exist.", fieldDescription));
             }
-
-            ColumnType tableColumnType = table.getColumnType(columns.get(fieldName));
-            if (fieldType != null && fieldType != tableColumnType) {
+            ColumnType tableColumnType = table.getColumnType(columns.get(fieldDescription));
+            if (checkColumnType && !isValidType(tableColumnType, validColumnTypes)) {
                 throw new IllegalArgumentException(String.format("Field '%s': type mismatch. Was %s, expected %s.",
-                        fieldName, fieldType, tableColumnType
-                ));
+                        fieldDescription, tableColumnType, Arrays.toString(validColumnTypes)));
             }
-            return new long[] {columns.get(fieldName)};
+            return new long[] {columns.get(fieldDescription)};
         }
+    }
+
+    private boolean isValidType(ColumnType columnType, ColumnType[] validColumnTypes) {
+        for (int i = 0; i < validColumnTypes.length; i++) {
+            if (validColumnTypes[i] == columnType) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -202,7 +231,7 @@ public class RealmQuery<E extends RealmObject> {
      * @see Required for further infomation.
      */
     public RealmQuery<E> isNull(String fieldName) {
-        long columnIndices[] = getColumnIndices(fieldName, null);
+        long columnIndices[] = getColumnIndices(fieldName);
 
         // checking that fieldName has the correct type is done in C++
         this.query.isNull(columnIndices);
@@ -218,7 +247,7 @@ public class RealmQuery<E extends RealmObject> {
      * @see Required for further infomation.
      */
     public RealmQuery<E> isNotNull(String fieldName) {
-        long columnIndices[] = getColumnIndices(fieldName, null);
+        long columnIndices[] = getColumnIndices(fieldName);
 
         // checking that fieldName has the correct type is done in C++
         this.query.isNotNull(columnIndices);
@@ -1121,6 +1150,20 @@ public class RealmQuery<E extends RealmObject> {
         return this;
     }
 
+    /**
+     * Condition that find values that are considered "empty", i.e. an empty list, the 0-length string or byte array.
+     *
+     * @param fieldName The field to compare
+     * @return The query object
+     * @throws java.lang.IllegalArgumentException If the field name isn't valid or its type isn't either a RealmList,
+     *                                            String or byte array.
+     */
+    public RealmQuery<E> isEmpty(String fieldName) {
+        long columnIndices[] = getColumnIndices(fieldName, ColumnType.STRING, ColumnType.BINARY, ColumnType.LINK_LIST);
+        this.query.isEmpty(columnIndices);
+        return this;
+    }
+
     // Aggregates
 
     // Sum
@@ -1416,8 +1459,6 @@ public class RealmQuery<E extends RealmObject> {
     public long count() {
         return this.query.count();
     }
-
-    // Execute
 
     /**
      * Find all objects that fulfill the query conditions.

--- a/realm/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/src/main/java/io/realm/internal/TableQuery.java
@@ -348,6 +348,7 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
+
     public TableQuery equalTo(long[] columnIndexes, String value) {
         nativeEqual(nativePtr, columnIndexes, value, true);
         queryValidated = false;
@@ -371,6 +372,7 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
+
     public TableQuery beginsWith(long columnIndices[], String value) {
         nativeBeginsWith(nativePtr, columnIndices, value, true);
         queryValidated = false;
@@ -382,6 +384,7 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
+
     public TableQuery endsWith(long columnIndices[], String value) {
         nativeEndsWith(nativePtr, columnIndices, value, true);
         queryValidated = false;
@@ -393,8 +396,15 @@ public class TableQuery implements Closeable {
         queryValidated = false;
         return this;
     }
+
     public TableQuery contains(long columnIndices[], String value) {
         nativeContains(nativePtr, columnIndices, value, true);
+        queryValidated = false;
+        return this;
+    }
+
+    public TableQuery isEmpty(long[] columnIndices) {
+        nativeIsEmpty(nativePtr, columnIndices);
         queryValidated = false;
         return this;
     }
@@ -679,6 +689,7 @@ public class TableQuery implements Closeable {
     private native void nativeBeginsWith(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
     private native void nativeEndsWith(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
     private native void nativeContains(long nativeQueryPtr, long columnIndices[], String value, boolean caseSensitive);
+    private native void nativeIsEmpty(long nativePtr, long[] columnIndices);
     private native long nativeFind(long nativeQueryPtr, long fromTableRow);
     private native long nativeFindAll(long nativeQueryPtr, long start, long end, long limit);
     private native long nativeSumInt(long nativeQueryPtr, long columnIndex, long start, long end, long limit);


### PR DESCRIPTION
Fixes #1601 

Adds a method to RealmQuery called `isEmpty()` it can be used to check if Strings are empty (non-null), binary arrays have length 0 (non-null) and if RealmLists have size 0. 

That last was the primary reason as this was no longer possible after adding Null support.

@realm/java 

