### PR TITLE
Fixed race condition when closing Realms

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 0.84.0
+ * Fixed a bug where closed Realms were trying to refresh themselves resulting in a NullPointerException.
  * Added Realm.isClosed() method.
  * Added Realm.distinct() method.
  * Added RealmQuery.isValid(), RealmResults.isValid() and RealmList.isValid(). Each method checks whether the instance is still valid to use or not(for example, the Realm has been closed or any parent object has been removed).

--- a/realm/src/main/java/io/realm/BaseRealm.java
+++ b/realm/src/main/java/io/realm/BaseRealm.java
@@ -99,6 +99,7 @@ abstract class BaseRealm implements Closeable {
      * @throws java.lang.IllegalStateException if trying to enable auto-refresh in a thread without Looper.
      */
     public void setAutoRefresh(boolean autoRefresh) {
+        checkIfValid();
         if (autoRefresh && Looper.myLooper() == null) {
             throw new IllegalStateException("Cannot set auto-refresh in a Thread without a Looper");
         }
@@ -107,7 +108,7 @@ abstract class BaseRealm implements Closeable {
             handler = new Handler(new RealmCallback());
             handlers.put(handler, configuration.getPath());
         } else if (!autoRefresh && this.autoRefresh && handler != null) { // Switch it off
-            removeHandler(handler);
+            removeHandler();
         }
         this.autoRefresh = autoRefresh;
     }
@@ -176,9 +177,13 @@ abstract class BaseRealm implements Closeable {
         changeListeners.clear();
     }
 
-    protected void removeHandler(Handler handler) {
-        handler.removeCallbacksAndMessages(null);
+    /**
+     * Remove and stop the current thread handler as gracefully as possible.
+     */
+    protected void removeHandler() {
         handlers.remove(handler);
+        // Warning: This only clears the Looper queue. Handler.Callback is not removed.
+        handler.removeCallbacksAndMessages(null);
         this.handler = null;
     }
 
@@ -300,8 +305,11 @@ abstract class BaseRealm implements Closeable {
             }
 
             // For all other threads, use the Handler
+            // Note there is a race condition with handler.hasMessages() and handler.sendEmptyMessage()
+            // as the target thread consumes messages at the same time. In this case it is not a problem as worst
+            // case we end up with two REALM_CHANGED messages in the queue.
             if (
-                    realmPath.equals(configuration.getPath())    // It's the right realm
+                    realmPath.equals(configuration.getPath())            // It's the right realm
                             && !handler.hasMessages(REALM_CHANGED)       // The right message
                             && handler.getLooper().getThread().isAlive() // The receiving thread is alive
                     ) {
@@ -410,7 +418,7 @@ abstract class BaseRealm implements Closeable {
         localRefCount.put(configuration, Math.max(0, refCount));
 
         if (handler != null && refCount <= 0) {
-            removeHandler(handler);
+            removeHandler();
         }
     }
 
@@ -600,7 +608,12 @@ abstract class BaseRealm implements Closeable {
     private class RealmCallback implements Handler.Callback {
         @Override
         public boolean handleMessage(Message message) {
-            if (message.what == REALM_CHANGED) {
+            // Due to how a ConcurrentHashMap iterator is created we cannot be sure that other threads are
+            // aware when this threads handler is removed before they send messages to it. We don't wish to synchronize
+            // access to the handlers as they are the prime mean of notifying about updates. Instead we make sure
+            // that if a message does slip though (however unlikely), it will not try to update a SharedGroup that no
+            // longer exists. `sharedGroupManager` will only be null if a Realm is really closed.
+            if (message.what == REALM_CHANGED && sharedGroupManager != null) {
                 sharedGroupManager.advanceRead();
                 sendNotifications();
             }


### PR DESCRIPTION
Fixes #1608 

To qoute Dianne Hackborn: "Once you think you understand concurrency, It will jump right back and bite you" :(
Also WTF is a method called `removeCallbacksAndMessages` not removing the only thing in the Handler API actually called Callback.

Problem is that we store our handlers in a ConcurrentHashMap. This means that if we start iterating over them in another thread it is over a copy of the map, so if a Realm is closed in the meantime on the original thread, the iterator will still post messages to it. At the same time, we have no way of telling the handler on the original thread to actually stop handling messages.

Only way around this would be to synchronize access to all our handlers, which I want to avoid for performance reasons as the Handlers are our main way of propagating changes. So instead our `Handler.Callback` now checks if the Realm is actually still open.

@realm/java 
@andrewthecoder 
