### PR TITLE
Prevent migration of open Realms

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 0.84.0
+ * Fixed a bug that made it possible to migrate open Realms, which could cause undefined behavior when querying, reading or writing data.
  * Added support for async queries and transactions.
  * Added RealmQuery.isEmpty().
  * Fixed a bug where closed Realms were trying to refresh themselves resulting in a NullPointerException.

--- a/realm/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -515,4 +515,23 @@ public class RealmMigrationTests extends AndroidTestCase {
             }
         }
     }
+
+    public void testRealmOpenBeforeMigrationThrows() {
+        RealmConfiguration config = TestHelper.createConfiguration(getContext());
+        Realm.deleteRealm(config);
+        realm = Realm.getInstance(config);
+
+        try {
+            // Trigger manual migration. This can potentially change the schema, so should only be allowed when
+            // no-one else is working on the Realm.
+            Realm.migrateRealm(config, new RealmMigration() {
+                @Override
+                public long execute(Realm realm, long version) {
+                    return 0;
+                }
+            });
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+    }
 }

--- a/realm/src/main/java/io/realm/BaseRealm.java
+++ b/realm/src/main/java/io/realm/BaseRealm.java
@@ -610,6 +610,9 @@ abstract class BaseRealm implements Closeable {
         if (migration == null && configuration.getMigration() == null) {
             throw new RealmMigrationNeededException(configuration.getPath(), "RealmMigration must be provided");
         }
+        if (isFileOpen(configuration)) {
+            throw new IllegalStateException("Cannot migrate a Realm file that is already open: " + configuration.getPath());
+        }
 
         RealmMigration realmMigration = (migration == null) ? configuration.getMigration() : migration;
         BaseRealm realm = null;


### PR DESCRIPTION
Found while investigating #1610 

It should not be possible to migrate open Realms as that can potentially invalidate the schema. As the schema is only validated when opening the Realm this can cause all kinds of strange behavior in querying/reading and writing data.

@realm/java