### PR TITLE
fix possible null assignment to Realm.columnIndices.

### DIFF
--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -16,6 +16,7 @@
 package io.realm;
 
 import android.content.Context;
+import android.os.SystemClock;
 import android.test.AndroidTestCase;
 
 import junit.framework.AssertionFailedError;
@@ -44,7 +45,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.realm.dynamic.DynamicRealmObject;
-import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.AnnotationIndexTypes;
@@ -2218,5 +2218,52 @@ public class RealmTest extends AndroidTestCase {
         assertTrue(testRealm.isInTransaction());
         testRealm.cancelTransaction();
         assertFalse(testRealm.isInTransaction());
+    }
+
+    // test for https://github.com/realm/realm-java/issues/1646
+    public void testClosingRealmWhileOtherThreadIsOpeningRealm() throws Exception {
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(1);
+
+        final List<Exception> exception = new ArrayList<Exception>();
+
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    exception.add(e);
+                    return;
+                }
+
+                final Realm realm = Realm.getInstance(testConfig);
+                try {
+                    realm.where(AllTypes.class).equalTo("columnLong", 0L).findFirst();
+                } catch (Exception e) {
+                    exception.add(e);
+                } finally {
+                    endLatch.countDown();
+                    realm.close();
+                }
+            }
+        }.start();
+
+        // prevent for another thread to enter Realm.createAndValidate().
+        synchronized (BaseRealm.class) {
+            startLatch.countDown();
+
+            // wait for another thread's entering Realm.createAndValidate().
+            SystemClock.sleep(100L);
+
+            testRealm.close();
+            testRealm = null;
+        }
+
+        endLatch.await();
+
+        if (!exception.isEmpty()) {
+            throw exception.get(0);
+        }
     }
 }

--- a/realm/src/main/java/io/realm/Realm.java
+++ b/realm/src/main/java/io/realm/Realm.java
@@ -243,8 +243,7 @@ public final class Realm extends BaseRealm {
     private static synchronized Realm create(RealmConfiguration configuration) {
         boolean autoRefresh = Looper.myLooper() != null;
         try {
-            boolean validateSchema = !validatedRealmFiles.containsKey(configuration.getPath());
-            return createAndValidate(configuration, validateSchema, autoRefresh);
+            return createAndValidate(configuration, null, autoRefresh);
 
         } catch (RealmMigrationNeededException e) {
             if (configuration.shouldDeleteRealmIfMigrationNeeded()) {
@@ -257,8 +256,12 @@ public final class Realm extends BaseRealm {
         }
     }
 
-    private static Realm createAndValidate(RealmConfiguration configuration, boolean validateSchema, boolean autoRefresh) {
+    private static Realm createAndValidate(RealmConfiguration configuration, Boolean validateSchema, boolean autoRefresh) {
         synchronized (BaseRealm.class) {
+            if (validateSchema == null) {
+                validateSchema = !validatedRealmFiles.containsKey(configuration.getPath());
+            }
+
             // Check if a cached instance already exists for this thread
             String canonicalPath = configuration.getPath();
             Map<RealmConfiguration, Integer> localRefCount = referenceCount.get();
@@ -1149,7 +1152,10 @@ public final class Realm extends BaseRealm {
 
     @Override
     protected void lastLocalInstanceClosed() {
-        validatedRealmFiles.remove(configuration.getPath());
+        // validatedRealmFiles must not modified while other thread is executing createAndValidate()
+        synchronized (BaseRealm.class) {
+            validatedRealmFiles.remove(configuration.getPath());
+        }
         realmsCache.get().remove(configuration);
     }
 


### PR DESCRIPTION
Problem:
  `Realm#lastLocalInstanceClosed()` which is called by `Realm#close()` can remove entries from `validatedRealmFiles` while other thread is executing `Realm#createAndValidate()`.
  This might lead to `null` assignment to `Realm.columnIndices`.

Solution:
  Modified to deal with `validatedRealmFiles` in synchronized block of `Realm.class`.

this PR fixes #1646