### PR TITLE
[Design] RxJava support

### DIFF
--- a/RxJava.md
+++ b/RxJava.md
@@ -1,0 +1,157 @@
+Proposal for RxJava API
+
+Starting to think about an API for this:
+
+## How to include RxJava?
+
+First concern is how to actually include RxJava. I see 3 solutions
+
+** A. Plugin (old RxAndroid) **
+
+```
+// Gradle dependency
+compile 'io.realm:realm-android:1.0.0'
+compile 'io.realm:realm-android-rxjava:1.0.0'
+
+// Usage
+RealmResults<Person> realmResults = realm.where(Person.class).findAll();
+Observable<RealmResults<Person>> observable = RxRealm.observable(realmResult);
+```
+
+Advantage is full flexibility for developers and a clear API. Downside is that 
+the code becomes less fluent because you have to rely on static methods on the 
+`RxRealm` helper class. 
+
+
+** B. Opt-in (StorIO does this) ** 
+
+```
+// Gradle dependency
+compile 'io.realm:realm-android:1.0.0'
+compile 'compile 'io.reactivex:rxjava:1.0.8'
+
+// Usage, can potentially crash
+Observable<RealmResults<Person>> observerable = realm.where(Person.class).findAll().observable(); 
+```
+
+RxJava would only be a provided dependency for Realm. This means that calling 
+`observable()` will crash unless the app provides the dependency. Advantage is 
+that users that don't want RxJava doesn't have to do anything, downside is that 
+the API exposes a method that crashes unless additional configuration is added 
+
+
+
+** C. Full support / opt-out **
+
+```
+// Gradle
+compile 'io.realm:realm-android:1.0.0'
+
+// Opt-out
+compile 'io.realm:realm-android:1.0.0' {
+	exclude group: 'io.reactivex', module: 'rxjava'
+}
+
+// Usage
+Observable<RealmResults<Person>> observable = realm.where(Person.class).findAll().observable();
+```
+
+Advantage is full support out of the box with minimal fuss. Downside is 
+increased method limit and app size unless people manually remove the RxJava 
+dependency. It also means we tie ourselves to RxJava with regard to future 
+releases/compatibility etc.
+
+
+
+** My thoughts ** 
+
+I am probably learning most towards C). It will provide ease-of-use out of the 
+box and we can add documentation to our website/examples on how to opt-out. If 
+some competing reactive framework shows itself in the future, we can consider 
+moving to a plug-in approach instead.
+
+
+### RxJava 2 / RxMobile
+
+We need to investigate any compatibility problems with RxJava2 and RxMobile. As 
+far as I know, they have interface parity, but we need to verify this.
+
+
+## API 
+
+Assuming we implement either solution B) or C) from above, I would suggest the 
+following API:
+
+```
+// All Realm API classes now has an additional `observable()` method for 
+// returning an Rx Observable.
+// This is a complement to our own ChangeListeners.
+
+Realm.observable();
+RealmResults.observable();
+RealmObject.observable();
+RealmList.observable();
+
+// Example usage: Find and display the combined age of all persons using async 
+// query.
+realm.where(Person.class).findAllAsync().observable()
+	.map(persons -> persons.sum("age"))
+	.subscribe(combinedAge -> printSum(combinedAge))
+
+
+// The above breaks the Rx contract slightly in the sense that work is 
+// actually being done before the subscriber is attached, and it is not possible
+// to decide on which thread the work is done. In order to support this we 
+// need:
+
+RealmQuery.observable()
+
+// Example
+RealmQuery query = new RealmQuery(realm, Person.class).equalTo("name", "foo");
+Observable<RealmResults<Person>> observer = query.observable()
+observer.subscribe(list -> doStuff(list));
+
+// This would be equivalent to 
+RealmResults results = realm.where(Person.class).equalTo("name", "foo").findAll();
+results.observable().subscribe(list -> doStuff(list));
+
+
+// ???
+- Should RealmAsyncTask be observable?
+- Do we need a RealmLifeCycleObserver so you can detect when a Realm is closed?
+- What about findFirst()/sum()/min()/max()/avg()/sorted variants on RealmQuery?
+- Anything else?
+
+```
+
+### Implementation details
+
+- Build on top of our existing ChangeListeners.
+- Each object is backed by a BehaviorSubject in order to push last change when 
+  people subscribe. This also fits the philosophy taken by our async API.
+- Due to Realm's auto-refresh Observables on Realm/RealmList/RealmResults/RealmObject are hot.
+- RealmQuery Observables are cold.
+
+We can already implement this today, with some downsides:
+
+a) Thread confinement prevents use of `subscribeOn`/`observeOn` and other 
+   Observables that use multiple threads.
+b) Auto-updating objects means you have to be careful comparing objects. 
+   Observables like `distinctUntilChanged` must be used on explicit fields, not 
+   the whole object.
+c) Lack of fine-grained notifications will trigger all live observers on each 
+   commit.
+
+a/b) will both be solved by introducing `freeze()` as discussed here: https://github.com/realm/realm-java/issues/1208
+An observable would automatically do this as mutable objects in a event stream 
+are bad design anyway.
+
+c) will be solved when we introduce fine-grained notifications: 
+   https://github.com/realm/realm-java/issues/989. Until then liberal use of 
+   `distinctUntilChanged` or similar will have to be used to prevent updating 
+   the UI needlesly. 
+
+Summary: We can add RxJava support today, but need to list a number of caveats. 
+These caveats will automatically be reduced in future releases without effecting 
+the Observable API. When both #1208 and #989 are implemented we will have full 
+RxJava support.


### PR DESCRIPTION
This PR contains a document describing how we could go about adding RxJava support to Realm.

See #865 for the issue and https://github.com/realm/realm-java/tree/cm-lab-rxjava for some earlier prototype code.

**Update 26/10-2015**
After some discussion, we are narrowing down to Option B:

- First class `.observable()` support for all Realm classes.
- RxJava as an optional dependency.
- Support RxJava 1.*, RxJava 2.* and possible RxMobile using factory classes for constructing the observables for the correct version of Rx*. Should be pluggable. Depending on the differences between the factory classes we might want to release this as a separate dependency. If we are adding custom schedulers making it a separate plugin also makes a lot more sense.
- Investigate if we can use a custom schedulers to avoid Realms thread restrictions.

**Update 07/12-2015**

Basic API (v1)

- Add the following API's that work on top of RealmChangeListener
  * `Realm.asObservable()`
  * `RealmObject.asObservable()`
  * `RealmResults.asObservable()`
  * `DynamicRealm.asObservable()`
  * `DynamicRealmObject.asObservable()`
  * `RealmList.asObservable()` (not yet supported)

Using `asObservable()` instead of `observable()`. It will be consistent with the wording used by e.g Subjects and will fit well when we add `asCursor()` ( #1090 )

- Add the following to support different user configured ways of creating Observables.
 * New interface: `RxObservableFactory`
 * New class: `RealmObservabableFactory` for automatically converting RealmChangeListener to Observables (default behavior).
 * Add `RealmConfiguration.Builder.rxFactory(RxObservableFactory)`

Advanced API (v2):

- Add the following to RealmQuery, so people can execute queries on other threads. It will require exposing query handover in some shape.
  * `RealmQuery.asObservable()`

 * New class: `DetachedCopyObservableFactory` variant that automatically uses `Realm.copyFromRealm` to copy RealmObject/RealmResults to memory. Ideally it should be possible to control which thread does the copying which require exposing object/RealmResult handover.

Implementation notes:
- Realm objects are still thread confined and will be automatically updated. This will not change before #1208 is implemented. It means that some operators in RxJava have to be used with care. `Realm.copyFromRealm` can provide a temporary work-around, but is not without cost itself. 

**Examples**:
```
RealmConfiguration config = new RealmConfiguration.Builder()
  .rxFactory(new MySpecialRxJavaObservableFactory())
  .build();

// Async queries done in their own worker thread, all other operations can be done on the main thread
// beware of operators that work on special schedulers.
realm.where(Person.class).findAllAsync().asObservable()
  .filter(results.isLoaded()) // Only proceed once results are available
  .subscribe(showResultsOnScreen(results));

// Execute query on background/copy data to memory to work around thread confinement/live-updates at the cost of zero copy/consistency.
realm.where(AllPerson.class).asObservable()
  .flatmap(query.findAll().asObservable())
  .map(realm.copyFromRealm(results)) 
  .subscribeOn(Schedulers.computation())
  .observeOn(AndroidSchedulers.mainThread())
  .subscribe(showResultsOnScreen(results)); 
```

@realm/java 