### PR TITLE
fix RealmProxy code generator to avoid warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.84.1
  * Fixed a bug where simultaneous opening and closing a Realm on different threads might result in a NullPointerException (#1646).
+ * Suppressed warnings reported by `lint -Xlint:all` (#1644).
 
 0.84.0
  * Added support for async queries and transactions.

--- a/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
@@ -71,26 +71,4 @@ public class Constants {
         JAVA_TO_COLUMN_TYPES.put("java.util.Date", "ColumnType.DATE");
         JAVA_TO_COLUMN_TYPES.put("byte[]", "ColumnType.BINARY");
     }
-
-    static final Map<String, String> CASTING_TYPES;
-    static {
-        CASTING_TYPES = new HashMap<String, String>();
-        CASTING_TYPES.put("byte", "long");
-        CASTING_TYPES.put("short", "long");
-        CASTING_TYPES.put("int", "long");
-        CASTING_TYPES.put("long", "long");
-        CASTING_TYPES.put("float", "float");
-        CASTING_TYPES.put("double", "double");
-        CASTING_TYPES.put("boolean", "boolean");
-        CASTING_TYPES.put("java.lang.Byte", "long");
-        CASTING_TYPES.put("java.lang.Short", "long");
-        CASTING_TYPES.put("java.lang.Integer", "long");
-        CASTING_TYPES.put("java.lang.Long", "long");
-        CASTING_TYPES.put("java.lang.Float", "float");
-        CASTING_TYPES.put("java.lang.Double", "double");
-        CASTING_TYPES.put("java.lang.Boolean", "boolean");
-        CASTING_TYPES.put("java.lang.String", "String");
-        CASTING_TYPES.put("java.util.Date", "Date");
-        CASTING_TYPES.put("byte[]", "byte[]");
-    }
 }

--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -166,7 +166,7 @@ public class RealmProxyClassGenerator {
 
     private void emitClassFields(JavaWriter writer) throws IOException {
         writer.emitField(columnInfoClassName(), "columnInfo", EnumSet.of(Modifier.PRIVATE, Modifier.FINAL));
-        Set<String> emptyRealmLists = new HashSet<String>();
+        List<String> emptyRealmListInitializations = new ArrayList<String>();
         for (VariableElement variableElement : metadata.getFields()) {
             if (Utils.isRealmList(variableElement)) {
                 String genericType = Utils.getGenericType(variableElement);
@@ -175,14 +175,14 @@ public class RealmProxyClassGenerator {
                 String emptyRealmListName = "EMPTY_REALM_LIST_" + variableElement.getSimpleName().toString().toUpperCase();
                 writer.emitField("RealmList<" + genericType + ">", emptyRealmListName,
                         EnumSet.of(Modifier.PRIVATE, Modifier.STATIC));
-                emptyRealmLists.add(emptyRealmListName);
+                emptyRealmListInitializations.add(String.format("%s = new RealmList<%s>()", emptyRealmListName, genericType));
             }
         }
 
         writer.emitField("List<String>", "FIELD_NAMES", EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL));
         writer.beginInitializer(true);
-        for (String emptyRealmListName : emptyRealmLists) {
-            writer.emitStatement(emptyRealmListName + " = new RealmList()");
+        for (String emptyListInitializationStatement : emptyRealmListInitializations) {
+            writer.emitStatement(emptyListInitializationStatement);
         }
         writer.emitStatement("List<String> fieldNames = new ArrayList<String>()");
         for (VariableElement field : metadata.getFields()) {
@@ -211,10 +211,10 @@ public class RealmProxyClassGenerator {
                  * Primitives and boxed types
                  */
                 String realmType = Constants.JAVA_TO_REALM_TYPES.get(fieldTypeCanonicalName);
-                String castingType = Constants.CASTING_TYPES.get(fieldTypeCanonicalName);
 
                 // Getter
                 writer.emitAnnotation("Override");
+                writer.emitAnnotation("SuppressWarnings", "\"cast\"");
                 writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
                 writer.emitStatement("realm.checkIfValid()");
 
@@ -258,8 +258,8 @@ public class RealmProxyClassGenerator {
                         .endControlFlow();
                 }
                 writer.emitStatement(
-                        "row.set%s(%s, (%s) value)",
-                        realmType, fieldIndexVariableReference(field), castingType);
+                        "row.set%s(%s, value)",
+                        realmType, fieldIndexVariableReference(field));
                 writer.endMethod();
             } else if (Utils.isRealmObject(field)) {
                 /**
@@ -838,6 +838,7 @@ public class RealmProxyClassGenerator {
 
 
     private void emitCreateOrUpdateUsingJsonObject(JavaWriter writer) throws IOException {
+        writer.emitAnnotation("SuppressWarnings", "\"cast\"");
         writer.beginMethod(
                 className,
                 "createOrUpdateUsingJsonObject",
@@ -908,6 +909,7 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitCreateUsingJsonStream(JavaWriter writer) throws IOException {
+        writer.emitAnnotation("SuppressWarnings", "\"cast\"");
         writer.beginMethod(
                 className,
                 "createUsingJsonStream",

--- a/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -77,7 +77,7 @@ public class AllTypesRealmProxy extends AllTypes
     private static RealmList<AllTypes> EMPTY_REALM_LIST_COLUMNREALMLIST;
     private static final List<String> FIELD_NAMES;
     static {
-        EMPTY_REALM_LIST_COLUMNREALMLIST = new RealmList();
+        EMPTY_REALM_LIST_COLUMNREALMLIST = new RealmList<AllTypes>();
         List<String> fieldNames = new ArrayList<String>();
         fieldNames.add("columnString");
         fieldNames.add("columnLong");
@@ -96,6 +96,7 @@ public class AllTypesRealmProxy extends AllTypes
     }
 
     @Override
+    @SuppressWarnings("cast")
     public String getColumnString() {
         realm.checkIfValid();
         return (java.lang.String) row.getString(columnInfo.columnStringIndex);
@@ -107,10 +108,11 @@ public class AllTypesRealmProxy extends AllTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field columnString to null.");
         }
-        row.setString(columnInfo.columnStringIndex, (String) value);
+        row.setString(columnInfo.columnStringIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public long getColumnLong() {
         realm.checkIfValid();
         return (long) row.getLong(columnInfo.columnLongIndex);
@@ -119,10 +121,11 @@ public class AllTypesRealmProxy extends AllTypes
     @Override
     public void setColumnLong(long value) {
         realm.checkIfValid();
-        row.setLong(columnInfo.columnLongIndex, (long) value);
+        row.setLong(columnInfo.columnLongIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public float getColumnFloat() {
         realm.checkIfValid();
         return (float) row.getFloat(columnInfo.columnFloatIndex);
@@ -131,10 +134,11 @@ public class AllTypesRealmProxy extends AllTypes
     @Override
     public void setColumnFloat(float value) {
         realm.checkIfValid();
-        row.setFloat(columnInfo.columnFloatIndex, (float) value);
+        row.setFloat(columnInfo.columnFloatIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public double getColumnDouble() {
         realm.checkIfValid();
         return (double) row.getDouble(columnInfo.columnDoubleIndex);
@@ -143,10 +147,11 @@ public class AllTypesRealmProxy extends AllTypes
     @Override
     public void setColumnDouble(double value) {
         realm.checkIfValid();
-        row.setDouble(columnInfo.columnDoubleIndex, (double) value);
+        row.setDouble(columnInfo.columnDoubleIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public boolean isColumnBoolean() {
         realm.checkIfValid();
         return (boolean) row.getBoolean(columnInfo.columnBooleanIndex);
@@ -155,10 +160,11 @@ public class AllTypesRealmProxy extends AllTypes
     @Override
     public void setColumnBoolean(boolean value) {
         realm.checkIfValid();
-        row.setBoolean(columnInfo.columnBooleanIndex, (boolean) value);
+        row.setBoolean(columnInfo.columnBooleanIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Date getColumnDate() {
         realm.checkIfValid();
         return (java.util.Date) row.getDate(columnInfo.columnDateIndex);
@@ -170,10 +176,11 @@ public class AllTypesRealmProxy extends AllTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field columnDate to null.");
         }
-        row.setDate(columnInfo.columnDateIndex, (Date) value);
+        row.setDate(columnInfo.columnDateIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public byte[] getColumnBinary() {
         realm.checkIfValid();
         return (byte[]) row.getBinaryByteArray(columnInfo.columnBinaryIndex);
@@ -185,7 +192,7 @@ public class AllTypesRealmProxy extends AllTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field columnBinary to null.");
         }
-        row.setBinaryByteArray(columnInfo.columnBinaryIndex, (byte[]) value);
+        row.setBinaryByteArray(columnInfo.columnBinaryIndex, value);
     }
 
     @Override
@@ -386,6 +393,7 @@ public class AllTypesRealmProxy extends AllTypes
         return FIELD_NAMES;
     }
 
+    @SuppressWarnings("cast")
     public static AllTypes createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
         AllTypes obj = null;
@@ -481,6 +489,7 @@ public class AllTypesRealmProxy extends AllTypes
         return obj;
     }
 
+    @SuppressWarnings("cast")
     public static AllTypes createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         AllTypes obj = realm.createObject(AllTypes.class);

--- a/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -68,6 +68,7 @@ public class BooleansRealmProxy extends Booleans
     }
 
     @Override
+    @SuppressWarnings("cast")
     public boolean isDone() {
         realm.checkIfValid();
         return (boolean) row.getBoolean(columnInfo.doneIndex);
@@ -76,10 +77,11 @@ public class BooleansRealmProxy extends Booleans
     @Override
     public void setDone(boolean value) {
         realm.checkIfValid();
-        row.setBoolean(columnInfo.doneIndex, (boolean) value);
+        row.setBoolean(columnInfo.doneIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public boolean isReady() {
         realm.checkIfValid();
         return (boolean) row.getBoolean(columnInfo.isReadyIndex);
@@ -88,10 +90,11 @@ public class BooleansRealmProxy extends Booleans
     @Override
     public void setReady(boolean value) {
         realm.checkIfValid();
-        row.setBoolean(columnInfo.isReadyIndex, (boolean) value);
+        row.setBoolean(columnInfo.isReadyIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public boolean ismCompleted() {
         realm.checkIfValid();
         return (boolean) row.getBoolean(columnInfo.mCompletedIndex);
@@ -100,10 +103,11 @@ public class BooleansRealmProxy extends Booleans
     @Override
     public void setmCompleted(boolean value) {
         realm.checkIfValid();
-        row.setBoolean(columnInfo.mCompletedIndex, (boolean) value);
+        row.setBoolean(columnInfo.mCompletedIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public boolean getAnotherBoolean() {
         realm.checkIfValid();
         return (boolean) row.getBoolean(columnInfo.anotherBooleanIndex);
@@ -112,7 +116,7 @@ public class BooleansRealmProxy extends Booleans
     @Override
     public void setAnotherBoolean(boolean value) {
         realm.checkIfValid();
-        row.setBoolean(columnInfo.anotherBooleanIndex, (boolean) value);
+        row.setBoolean(columnInfo.anotherBooleanIndex, value);
     }
 
     public static Table initTable(ImplicitTransaction transaction) {
@@ -191,6 +195,7 @@ public class BooleansRealmProxy extends Booleans
         return FIELD_NAMES;
     }
 
+    @SuppressWarnings("cast")
     public static Booleans createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
         Booleans obj = realm.createObject(Booleans.class);
@@ -225,6 +230,7 @@ public class BooleansRealmProxy extends Booleans
         return obj;
     }
 
+    @SuppressWarnings("cast")
     public static Booleans createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         Booleans obj = realm.createObject(Booleans.class);

--- a/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -153,6 +153,7 @@ public class NullTypesRealmProxy extends NullTypes
     }
 
     @Override
+    @SuppressWarnings("cast")
     public String getFieldStringNotNull() {
         realm.checkIfValid();
         return (java.lang.String) row.getString(columnInfo.fieldStringNotNullIndex);
@@ -164,10 +165,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldStringNotNull to null.");
         }
-        row.setString(columnInfo.fieldStringNotNullIndex, (String) value);
+        row.setString(columnInfo.fieldStringNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public String getFieldStringNull() {
         realm.checkIfValid();
         return (java.lang.String) row.getString(columnInfo.fieldStringNullIndex);
@@ -180,10 +182,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldStringNullIndex);
             return;
         }
-        row.setString(columnInfo.fieldStringNullIndex, (String) value);
+        row.setString(columnInfo.fieldStringNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Boolean getFieldBooleanNotNull() {
         realm.checkIfValid();
         return (boolean) row.getBoolean(columnInfo.fieldBooleanNotNullIndex);
@@ -195,10 +198,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldBooleanNotNull to null.");
         }
-        row.setBoolean(columnInfo.fieldBooleanNotNullIndex, (boolean) value);
+        row.setBoolean(columnInfo.fieldBooleanNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Boolean getFieldBooleanNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldBooleanNullIndex)) {
@@ -214,10 +218,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldBooleanNullIndex);
             return;
         }
-        row.setBoolean(columnInfo.fieldBooleanNullIndex, (boolean) value);
+        row.setBoolean(columnInfo.fieldBooleanNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public byte[] getFieldBytesNotNull() {
         realm.checkIfValid();
         return (byte[]) row.getBinaryByteArray(columnInfo.fieldBytesNotNullIndex);
@@ -229,10 +234,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldBytesNotNull to null.");
         }
-        row.setBinaryByteArray(columnInfo.fieldBytesNotNullIndex, (byte[]) value);
+        row.setBinaryByteArray(columnInfo.fieldBytesNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public byte[] getFieldBytesNull() {
         realm.checkIfValid();
         return (byte[]) row.getBinaryByteArray(columnInfo.fieldBytesNullIndex);
@@ -245,10 +251,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldBytesNullIndex);
             return;
         }
-        row.setBinaryByteArray(columnInfo.fieldBytesNullIndex, (byte[]) value);
+        row.setBinaryByteArray(columnInfo.fieldBytesNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Byte getFieldByteNotNull() {
         realm.checkIfValid();
         return (byte) row.getLong(columnInfo.fieldByteNotNullIndex);
@@ -260,10 +267,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldByteNotNull to null.");
         }
-        row.setLong(columnInfo.fieldByteNotNullIndex, (long) value);
+        row.setLong(columnInfo.fieldByteNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Byte getFieldByteNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldByteNullIndex)) {
@@ -279,10 +287,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldByteNullIndex);
             return;
         }
-        row.setLong(columnInfo.fieldByteNullIndex, (long) value);
+        row.setLong(columnInfo.fieldByteNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Short getFieldShortNotNull() {
         realm.checkIfValid();
         return (short) row.getLong(columnInfo.fieldShortNotNullIndex);
@@ -294,10 +303,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldShortNotNull to null.");
         }
-        row.setLong(columnInfo.fieldShortNotNullIndex, (long) value);
+        row.setLong(columnInfo.fieldShortNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Short getFieldShortNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldShortNullIndex)) {
@@ -313,10 +323,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldShortNullIndex);
             return;
         }
-        row.setLong(columnInfo.fieldShortNullIndex, (long) value);
+        row.setLong(columnInfo.fieldShortNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Integer getFieldIntegerNotNull() {
         realm.checkIfValid();
         return (int) row.getLong(columnInfo.fieldIntegerNotNullIndex);
@@ -328,10 +339,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldIntegerNotNull to null.");
         }
-        row.setLong(columnInfo.fieldIntegerNotNullIndex, (long) value);
+        row.setLong(columnInfo.fieldIntegerNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Integer getFieldIntegerNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldIntegerNullIndex)) {
@@ -347,10 +359,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldIntegerNullIndex);
             return;
         }
-        row.setLong(columnInfo.fieldIntegerNullIndex, (long) value);
+        row.setLong(columnInfo.fieldIntegerNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Long getFieldLongNotNull() {
         realm.checkIfValid();
         return (long) row.getLong(columnInfo.fieldLongNotNullIndex);
@@ -362,10 +375,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldLongNotNull to null.");
         }
-        row.setLong(columnInfo.fieldLongNotNullIndex, (long) value);
+        row.setLong(columnInfo.fieldLongNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Long getFieldLongNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldLongNullIndex)) {
@@ -381,10 +395,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldLongNullIndex);
             return;
         }
-        row.setLong(columnInfo.fieldLongNullIndex, (long) value);
+        row.setLong(columnInfo.fieldLongNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Float getFieldFloatNotNull() {
         realm.checkIfValid();
         return (float) row.getFloat(columnInfo.fieldFloatNotNullIndex);
@@ -396,10 +411,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldFloatNotNull to null.");
         }
-        row.setFloat(columnInfo.fieldFloatNotNullIndex, (float) value);
+        row.setFloat(columnInfo.fieldFloatNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Float getFieldFloatNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldFloatNullIndex)) {
@@ -415,10 +431,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldFloatNullIndex);
             return;
         }
-        row.setFloat(columnInfo.fieldFloatNullIndex, (float) value);
+        row.setFloat(columnInfo.fieldFloatNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Double getFieldDoubleNotNull() {
         realm.checkIfValid();
         return (double) row.getDouble(columnInfo.fieldDoubleNotNullIndex);
@@ -430,10 +447,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldDoubleNotNull to null.");
         }
-        row.setDouble(columnInfo.fieldDoubleNotNullIndex, (double) value);
+        row.setDouble(columnInfo.fieldDoubleNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Double getFieldDoubleNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldDoubleNullIndex)) {
@@ -449,10 +467,11 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldDoubleNullIndex);
             return;
         }
-        row.setDouble(columnInfo.fieldDoubleNullIndex, (double) value);
+        row.setDouble(columnInfo.fieldDoubleNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Date getFieldDateNotNull() {
         realm.checkIfValid();
         return (java.util.Date) row.getDate(columnInfo.fieldDateNotNullIndex);
@@ -464,10 +483,11 @@ public class NullTypesRealmProxy extends NullTypes
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field fieldDateNotNull to null.");
         }
-        row.setDate(columnInfo.fieldDateNotNullIndex, (Date) value);
+        row.setDate(columnInfo.fieldDateNotNullIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public Date getFieldDateNull() {
         realm.checkIfValid();
         if (row.isNull(columnInfo.fieldDateNullIndex)) {
@@ -483,7 +503,7 @@ public class NullTypesRealmProxy extends NullTypes
             row.setNull(columnInfo.fieldDateNullIndex);
             return;
         }
-        row.setDate(columnInfo.fieldDateNullIndex, (Date) value);
+        row.setDate(columnInfo.fieldDateNullIndex, value);
     }
 
     @Override
@@ -758,6 +778,7 @@ public class NullTypesRealmProxy extends NullTypes
         return FIELD_NAMES;
     }
 
+    @SuppressWarnings("cast")
     public static NullTypes createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
         NullTypes obj = realm.createObject(NullTypes.class);
@@ -922,6 +943,7 @@ public class NullTypesRealmProxy extends NullTypes
         return obj;
     }
 
+    @SuppressWarnings("cast")
     public static NullTypes createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         NullTypes obj = realm.createObject(NullTypes.class);

--- a/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -58,6 +58,7 @@ public class SimpleRealmProxy extends Simple
     }
 
     @Override
+    @SuppressWarnings("cast")
     public String getName() {
         realm.checkIfValid();
         return (java.lang.String) row.getString(columnInfo.nameIndex);
@@ -70,10 +71,11 @@ public class SimpleRealmProxy extends Simple
             row.setNull(columnInfo.nameIndex);
             return;
         }
-        row.setString(columnInfo.nameIndex, (String) value);
+        row.setString(columnInfo.nameIndex, value);
     }
 
     @Override
+    @SuppressWarnings("cast")
     public int getAge() {
         realm.checkIfValid();
         return (int) row.getLong(columnInfo.ageIndex);
@@ -82,7 +84,7 @@ public class SimpleRealmProxy extends Simple
     @Override
     public void setAge(int value) {
         realm.checkIfValid();
-        row.setLong(columnInfo.ageIndex, (long) value);
+        row.setLong(columnInfo.ageIndex, value);
     }
 
     public static Table initTable(ImplicitTransaction transaction) {
@@ -141,6 +143,7 @@ public class SimpleRealmProxy extends Simple
         return FIELD_NAMES;
     }
 
+    @SuppressWarnings("cast")
     public static Simple createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
         Simple obj = realm.createObject(Simple.class);
@@ -161,6 +164,7 @@ public class SimpleRealmProxy extends Simple
         return obj;
     }
 
+    @SuppressWarnings("cast")
     public static Simple createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         Simple obj = realm.createObject(Simple.class);


### PR DESCRIPTION
we had twe kind of warnings.

* rawtype
* useless cast

This PR fixes #1644

TODO:
- [x] fix `rawtype` warnings
- [x] fix `cast` warnings
- [x] update changelog