### PR TITLE
Removed update() method from generated proxy class corresponding to un-updatable model.

### DIFF
--- a/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -689,6 +689,9 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitUpdateMethod(JavaWriter writer) throws IOException {
+        if (!metadata.hasPrimaryKey()) {
+            return;
+        }
 
         writer.beginMethod(
                 className, // Return type

--- a/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -284,14 +284,6 @@ public class BooleansRealmProxy extends Booleans
         return realmObject;
     }
 
-    static Booleans update(Realm realm, Booleans realmObject, Booleans newObject, Map<RealmObject, RealmObjectProxy> cache) {
-        realmObject.setDone(newObject.isDone());
-        realmObject.setReady(newObject.isReady());
-        realmObject.setmCompleted(newObject.ismCompleted());
-        realmObject.setAnotherBoolean(newObject.getAnotherBoolean());
-        return realmObject;
-    }
-
     @Override
     public String toString() {
         if (!isValid()) {

--- a/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1139,41 +1139,6 @@ public class NullTypesRealmProxy extends NullTypes
         return realmObject;
     }
 
-    static NullTypes update(Realm realm, NullTypes realmObject, NullTypes newObject, Map<RealmObject, RealmObjectProxy> cache) {
-        realmObject.setFieldStringNotNull(newObject.getFieldStringNotNull());
-        realmObject.setFieldStringNull(newObject.getFieldStringNull());
-        realmObject.setFieldBooleanNotNull(newObject.getFieldBooleanNotNull());
-        realmObject.setFieldBooleanNull(newObject.getFieldBooleanNull());
-        realmObject.setFieldBytesNotNull(newObject.getFieldBytesNotNull());
-        realmObject.setFieldBytesNull(newObject.getFieldBytesNull());
-        realmObject.setFieldByteNotNull(newObject.getFieldByteNotNull());
-        realmObject.setFieldByteNull(newObject.getFieldByteNull());
-        realmObject.setFieldShortNotNull(newObject.getFieldShortNotNull());
-        realmObject.setFieldShortNull(newObject.getFieldShortNull());
-        realmObject.setFieldIntegerNotNull(newObject.getFieldIntegerNotNull());
-        realmObject.setFieldIntegerNull(newObject.getFieldIntegerNull());
-        realmObject.setFieldLongNotNull(newObject.getFieldLongNotNull());
-        realmObject.setFieldLongNull(newObject.getFieldLongNull());
-        realmObject.setFieldFloatNotNull(newObject.getFieldFloatNotNull());
-        realmObject.setFieldFloatNull(newObject.getFieldFloatNull());
-        realmObject.setFieldDoubleNotNull(newObject.getFieldDoubleNotNull());
-        realmObject.setFieldDoubleNull(newObject.getFieldDoubleNull());
-        realmObject.setFieldDateNotNull(newObject.getFieldDateNotNull());
-        realmObject.setFieldDateNull(newObject.getFieldDateNull());
-        NullTypes fieldObjectNullObj = newObject.getFieldObjectNull();
-        if (fieldObjectNullObj != null) {
-            NullTypes cachefieldObjectNull = (NullTypes) cache.get(fieldObjectNullObj);
-            if (cachefieldObjectNull != null) {
-                realmObject.setFieldObjectNull(cachefieldObjectNull);
-            } else {
-                realmObject.setFieldObjectNull(NullTypesRealmProxy.copyOrUpdate(realm, fieldObjectNullObj, true, cache));
-            }
-        } else {
-            realmObject.setFieldObjectNull(null);
-        }
-        return realmObject;
-    }
-
     @Override
     public String toString() {
         if (!isValid()) {

--- a/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -204,12 +204,6 @@ public class SimpleRealmProxy extends Simple
         return realmObject;
     }
 
-    static Simple update(Realm realm, Simple realmObject, Simple newObject, Map<RealmObject, RealmObjectProxy> cache) {
-        realmObject.setName(newObject.getName());
-        realmObject.setAge(newObject.getAge());
-        return realmObject;
-    }
-
     @Override
     public String toString() {
         if (!isValid()) {


### PR DESCRIPTION
If model class has no primary key, we don't need to generate `update()` method in generated Proxy class.

fixes #1660