### PR TITLE
Add annotations to @Required for better Kotlin compatibility

### DIFF
--- a/realm-annotations/src/main/java/io/realm/annotations/Required.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/Required.java
@@ -15,6 +15,10 @@
  */
 
 package io.realm.annotations;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * This annotation will mark the field as not nullable. When the field is {@link Required},
@@ -25,6 +29,8 @@ package io.realm.annotations;
  * Fields with primitive types and the {@link io.realm.RealmList} type are required implicitly.
  * Fields with {@link io.realm.RealmObject} type are always nullable.
  */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
 public @interface Required {
 
 }


### PR DESCRIPTION
Currently (as documented in #1647) the `@Required` annotation, when used from a constructor in Kotlin, must be applied to a field explicitly using Kotlin's `@field:` syntax.

This change brings the annotations for the `@Required` interface in line with other Realm annotation interfaces to improve Kotlin compatibility. It follows the same format found in the `@Ignore`, `@Index` and `@PrimaryKey` annotations.

cc @zaki50 