### PR TITLE
Check that double commit throws.

### DIFF
--- a/realm/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmTest.java
@@ -713,6 +713,16 @@ public class RealmTest extends AndroidTestCase {
         }
     }
 
+    public void testDoubleCommitThrows() {
+        testRealm.beginTransaction();
+        testRealm.commitTransaction();
+        try {
+            testRealm.commitTransaction();
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
     public void testCancelTransaction() {
         populateTestRealm();
 


### PR DESCRIPTION
Fixes #1417 

With core upgraded to 0.93+, this now throws an error in Core. Since we still have an `immutable` boolean in group it makes sense to keep the check there. So this PR just adds the test to verify that the behaviour doesn't change.

@realm/java 