### PR TITLE
introduce @Keep annotation to mark classes to be kept by ProGuard/DexGuard

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
  * Fixed a bug where simultaneous opening and closing a Realm on different threads might result in a NullPointerException (#1646).
  * Suppressed warnings reported by `lint -Xlint:all` (#1644).
  * Fixed a bug which allowed to externally modify the encryption key in a RealmConfiguration.
+ * Updated ProGuard configuration. See documentation https://realm.io/docs/java/latest/#proguard for more details.
 
 0.84.0
  * Added support for async queries and transactions.

--- a/realm/src/main/java/io/realm/exceptions/RealmEncryptionNotSupportedException.java
+++ b/realm/src/main/java/io/realm/exceptions/RealmEncryptionNotSupportedException.java
@@ -16,6 +16,8 @@
 
 package io.realm.exceptions;
 
+import io.realm.internal.Keep;
+
 /**
  * On some devices (HTC One X for example), for some reason, the system doesn't pass the right
  * parameter (siginfo_t.si_addr) to the segfault signal handler which our encryption mechanism
@@ -24,6 +26,7 @@ package io.realm.exceptions;
  * problem exists which means that encryption cannot be used on this device.
  */
 @SuppressWarnings("unused") // Thrown by JNI
+@Keep
 public class RealmEncryptionNotSupportedException extends RuntimeException {
     public RealmEncryptionNotSupportedException(String message) {
         super(message);

--- a/realm/src/main/java/io/realm/exceptions/RealmError.java
+++ b/realm/src/main/java/io/realm/exceptions/RealmError.java
@@ -16,11 +16,14 @@
 
 package io.realm.exceptions;
 
+import io.realm.internal.Keep;
+
 /**
  * RealmError is Realm specific Error used when unrecoverable problems happen in the underlying
  * storage engine. An RealmError should never be caught or ignored. By doing so, the Realm
  * could possibly get corrupted.
  */
+@Keep
 public class RealmError extends Error {
     public RealmError(String detailMessage) {
         super(detailMessage);

--- a/realm/src/main/java/io/realm/exceptions/RealmIOException.java
+++ b/realm/src/main/java/io/realm/exceptions/RealmIOException.java
@@ -16,9 +16,12 @@
 
 package io.realm.exceptions;
 
+import io.realm.internal.Keep;
+
 /**
  * Class for reporting problems with Realm files.
  */
+@Keep
 public class RealmIOException extends RuntimeException {
 
     public RealmIOException(Throwable cause) {

--- a/realm/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
+++ b/realm/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
@@ -17,6 +17,9 @@ package io.realm.exceptions;
 
 import java.io.File;
 
+import io.realm.internal.Keep;
+
+@Keep
 public class RealmMigrationNeededException extends RuntimeException {
 
     private final String canonicalRealmPath;

--- a/realm/src/main/java/io/realm/exceptions/RealmPrimaryKeyConstraintException.java
+++ b/realm/src/main/java/io/realm/exceptions/RealmPrimaryKeyConstraintException.java
@@ -16,11 +16,14 @@
 
 package io.realm.exceptions;
 
+import io.realm.internal.Keep;
+
 /**
  * Class for reporting problems when the primary key constraint is being broken.
  *
  * @see io.realm.annotations.PrimaryKey
  */
+@Keep
 public class RealmPrimaryKeyConstraintException extends RuntimeException {
     public RealmPrimaryKeyConstraintException(String message) {
         super(message);

--- a/realm/src/main/java/io/realm/internal/ColumnType.java
+++ b/realm/src/main/java/io/realm/internal/ColumnType.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 // Make sure numbers match with <realm/column_type.hpp>
 // FIXME: Add a unit test that verifies the correct correspondence.
 
+@Keep
 public enum ColumnType {
     BOOLEAN(1),
     INTEGER(0),

--- a/realm/src/main/java/io/realm/internal/Keep.java
+++ b/realm/src/main/java/io/realm/internal/Keep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Realm Inc.
+ * Copyright 2015 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-package io.realm.exceptions;
+package io.realm.internal;
 
-import io.realm.internal.Keep;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * RealmException is Realm specific exceptions.
+ * This annotation is used to mark the classes to be kept by ProGuard/DexGuard.
+ * The ProGuard configuration must have '-keep class io.realm.internal.Keep'
+ * and '-keep @io.realm.internal.Keep class *'.
  */
-@Keep
-public class RealmException extends RuntimeException {
-
-    public RealmException(String detailMessage) {
-        super(detailMessage);
-    }
-
-    public RealmException(String detailMessage, Throwable exception) {
-        super(detailMessage, exception);
-    }
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface Keep {
 }

--- a/realm/src/main/java/io/realm/internal/OutOfMemoryError.java
+++ b/realm/src/main/java/io/realm/internal/OutOfMemoryError.java
@@ -24,6 +24,7 @@ package io.realm.internal;
  *
  */
 @SuppressWarnings("serial")
+@Keep
 public class OutOfMemoryError extends Error {
 
     public OutOfMemoryError() {

--- a/realm/src/main/java/io/realm/internal/TableSpec.java
+++ b/realm/src/main/java/io/realm/internal/TableSpec.java
@@ -19,6 +19,7 @@ package io.realm.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+@Keep
 public class TableSpec {
 
     public static class ColumnInfo {

--- a/realm/src/main/java/io/realm/internal/async/BadVersionException.java
+++ b/realm/src/main/java/io/realm/internal/async/BadVersionException.java
@@ -17,11 +17,13 @@
 package io.realm.internal.async;
 
 import io.realm.exceptions.RealmException;
+import io.realm.internal.Keep;
 
 /**
  * Triggered from JNI level when the result of a query (from a different thread) could not be used against
  * the current state of the Realm which might be more up-to-date than the provided results or vice versa.
  */
+@Keep
 public class BadVersionException extends RealmException {
 
     public BadVersionException(String detailMessage) {


### PR DESCRIPTION
Related to #1658

Introduced `@Keep` annotation.

Using `@Keep` annotation, we can simply write ProGuard configuration like:

    -keep class io.realm.internal.Keep
    -keep @io.realm.internal.Keep class *

instead of

```
-keep class io.realm.exceptions.* { *; }
-keep class io.realm.internal.async.BadVersionException { *; }
-keep class io.realm.internal.OutOfMemoryError { *; }
-keep class io.realm.internal.TableSpec { *; }
-keep class io.realm.internal.ColumnType { *; }
```

TODO:
- [x] changelog?

fixes #1658