### PR TITLE
Make security copies of the key in RealmConfiguration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 0.84.1
  * Fixed a bug where simultaneous opening and closing a Realm on different threads might result in a NullPointerException (#1646).
  * Suppressed warnings reported by `lint -Xlint:all` (#1644).
+ * Fixed a bug which allowed to externally modify the encryption key in a RealmConfiguration.
 
 0.84.0
  * Added support for async queries and transactions.

--- a/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
+++ b/realm/src/androidTest/java/io/realm/RealmConfigurationTest.java
@@ -17,6 +17,7 @@
 package io.realm;
 
 import android.test.AndroidTestCase;
+import android.test.MoreAsserts;
 
 import java.io.File;
 
@@ -415,5 +416,21 @@ public class RealmConfigurationTest extends AndroidTestCase {
         Realm realm2 = Realm.getInstance(config2);
         realm1.close();
         realm2.close();
+    }
+
+    public void testKeyStorage() throws Exception {
+        // Generate a key and use it in a RealmConfiguration
+        byte[] oldKey = TestHelper.getRandomKey(12345);
+        byte[] key = oldKey;
+        RealmConfiguration config = new RealmConfiguration.Builder(getContext()).encryptionKey(key).build();
+
+        // Generate a different key and assign it to the same variable
+        byte[] newKey = TestHelper.getRandomKey(67890);
+        MoreAsserts.assertNotEqual(key, newKey);
+        key = newKey;
+        MoreAsserts.assertEquals(key, newKey);
+
+        // Ensure that the stored key did not change
+        MoreAsserts.assertEquals(oldKey, config.getEncryptionKey());
     }
 }

--- a/realm/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/src/main/java/io/realm/RealmConfiguration.java
@@ -99,7 +99,7 @@ public class RealmConfiguration {
     }
 
     public byte[] getEncryptionKey() {
-        return key;
+        return key == null ? null : Arrays.copyOf(key, key.length);
     }
 
     public long getSchemaVersion() {
@@ -296,7 +296,7 @@ public class RealmConfiguration {
                 throw new IllegalArgumentException(String.format("The provided key must be %s bytes. Yours was: %s",
                         KEY_LENGTH, key.length));
             }
-            this.key = key;
+            this.key = Arrays.copyOf(key, key.length);
             return this;
         }
 


### PR DESCRIPTION
Saving and providing a mutable reference of the key is both a security threat and possibly the origin of subtle bugs.
We now make security copies of the byte arrays to solve the issue.