### PR TITLE
convertColumnToNotNullable now works correctly.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.84.2
+ * Fixed bug making it impossible to convert a field to being required during a migration.
+
 0.84.1
  * Updated Realm Core to 0.94.4
    - Fixed a bug that could cause a crash when running the same query multiple times.

--- a/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm-jni/src/io_realm_internal_table.cpp
@@ -291,7 +291,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNotNull
             std::ostringstream ss;
             ss << std::string("__TMP__") << j;
             if (table->get_column_index(ss.str()) == realm::not_found) {
-                table->insert_column(column_index, column_type, ss.str(), true);
+                table->insert_column(column_index, column_type, ss.str(), false);
                 tmp_column_name = ss.str();
                 break;
             }

--- a/realm/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -490,6 +490,7 @@ public class JNITableTest extends AndroidTestCase {
                     assertEquals(1, table.size());
 
                     table.convertColumnToNullable(colIndex);
+                    assertTrue(table.isColumnNullable(colIndex));
                     assertEquals(1, table.size());
                     assertEquals(2, table.getColumnCount());
                     assertTrue(table.getColumnIndex(columnName) >= 0);
@@ -559,6 +560,7 @@ public class JNITableTest extends AndroidTestCase {
                     assertEquals(2, table.size());
 
                     table.convertColumnToNotNullable(colIndex);
+                    assertFalse(table.isColumnNullable(colIndex));
                     assertEquals(2, table.size());
                     assertEquals(2, table.getColumnCount());
                     assertTrue(table.getColumnIndex(columnName) >= 0);


### PR DESCRIPTION
`Table.convertColumnToNotNullable` did not create a non-nullable column, but a nullable one.

@realm/java 