### PR TITLE
Add a method to read the default configuration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.84.2
  * Fixed bug making it impossible to convert a field to being required during a migration.
+ * Add Realm.getDefaultConfiguration() method.
 
 0.84.1
  * Updated Realm Core to 0.94.4

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -233,6 +233,17 @@ public final class Realm extends BaseRealm {
     }
 
     /**
+     * Returns the {@link io.realm.RealmConfiguration} instance defined by
+     * {@link #setDefaultConfiguration(RealmConfiguration)}.
+     *
+     * @return the configuration set in {@link #setDefaultConfiguration(RealmConfiguration)}
+     * @see RealmConfiguration for details on how to configure a Realm.
+     */
+    public static RealmConfiguration getDefaultConfiguration() {
+        return defaultConfiguration;
+    }
+
+    /**
      * Removes the current default configuration (if any). Any further calls to {@link #getDefaultInstance()} will
      * fail until a new default configuration has been set using {@link #setDefaultConfiguration(RealmConfiguration)}.
      */


### PR DESCRIPTION
Refs realm/realm-java#1699

A `RealmConfiguration` instance is read-only so it is safe to expose the
default configuration used to create `Realm` instances.