### PR TITLE
Extending tests for converting tables

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -371,7 +371,7 @@ public class JNITableTest extends AndroidTestCase {
 
     public void testColumnName() {
         Table t = new Table();
-        try { t.addColumn(STRING, "I am 64 characters.............................................."); fail("Only 63 characters supported"); } catch (IllegalArgumentException e) { }
+        try { t.addColumn(STRING, "I am 64 characters.............................................."); fail("Only 63 characters supported"); } catch (IllegalArgumentException ignored) { }
         t.addColumn(STRING, "I am 63 characters.............................................");
     }
 
@@ -487,11 +487,9 @@ public class JNITableTest extends AndroidTestCase {
                         table.addEmptyRow();
                         if (columnType == BINARY) {
                             table.setBinaryByteArray(colIndex, 1, null);
-                        }
-                        else if (columnType == STRING) {
+                        } else if (columnType == STRING) {
                             table.setString(colIndex, 1, null);
-                        }
-                        else {
+                        } else {
                             table.getCheckedRow(1).setNull(colIndex);
                         }
 
@@ -513,11 +511,9 @@ public class JNITableTest extends AndroidTestCase {
                     table.addEmptyRow();
                     if (columnType == BINARY) {
                         table.setBinaryByteArray(colIndex, 0, null);
-                    }
-                    else if (columnType == STRING) {
+                    } else if (columnType == STRING) {
                         table.setString(colIndex, 0, null);
-                    }
-                    else {
+                    } else {
                         table.getCheckedRow(0).setNull(colIndex);
                     }
 
@@ -525,11 +521,9 @@ public class JNITableTest extends AndroidTestCase {
 
                     if (columnType == BINARY) {
                         assertNull(table.getBinaryByteArray(colIndex, 1));
-                    }
-                    else if (columnType == STRING) {
+                    } else if (columnType == STRING) {
                         assertNull(table.getString(colIndex, 1));
-                    }
-                    else {
+                    } else {
                         assertTrue(table.getUncheckedRow(1).isNull(colIndex));
                     }
                 }
@@ -576,11 +570,9 @@ public class JNITableTest extends AndroidTestCase {
                         table.addEmptyRow();
                         if (columnType == BINARY) {
                             table.setBinaryByteArray(colIndex, 1, null);
-                        }
-                        else if (columnType == STRING) {
+                        } else if (columnType == STRING) {
                             table.setString(colIndex, 1, null);
-                        }
-                        else {
+                        } else {
                             table.getCheckedRow(1).setNull(colIndex);
                         }
 
@@ -602,11 +594,9 @@ public class JNITableTest extends AndroidTestCase {
                     try {
                         if (columnType == BINARY) {
                             table.setBinaryByteArray(colIndex, 0, null);
-                        }
-                        else if (columnType == STRING) {
+                        } else if (columnType == STRING) {
                             table.setString(colIndex, 0, null);
-                        }
-                        else {
+                        } else {
                             table.getCheckedRow(0).setNull(colIndex);
                         }
                         if (!nullable) {
@@ -619,12 +609,10 @@ public class JNITableTest extends AndroidTestCase {
 
                     if (columnType == BINARY) {
                         assertNotNull(table.getBinaryByteArray(colIndex, 1));
-                    }
-                    else if (columnType == STRING) {
+                    } else if (columnType == STRING) {
                         assertNotNull(table.getString(colIndex, 1));
                         assertEquals("", table.getString(colIndex, 1));
-                    }
-                    else {
+                    } else {
                         assertFalse(table.getUncheckedRow(1).isNull(colIndex));
                         switch (columnType) {
                             case BOOLEAN:

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -472,6 +472,7 @@ public class JNITableTest extends AndroidTestCase {
                         table.setBinaryByteArray(colIndex, 0, new byte[]{0});
                     else if (columnType == ColumnType.STRING)
                         table.setString(colIndex, 0, "Foo");
+                    // if column is nullable not exception should be thrown
                     try {
                         table.addEmptyRow();
                         if (columnType == ColumnType.BINARY)
@@ -485,6 +486,9 @@ public class JNITableTest extends AndroidTestCase {
                             fail();
                         }
                     } catch (IllegalArgumentException ignored) {
+                        if (nullable) {
+                            fail();
+                        }
                     }
                     table.removeLast();
                     assertEquals(1, table.size());
@@ -497,6 +501,7 @@ public class JNITableTest extends AndroidTestCase {
                     assertEquals(colIndex, table.getColumnIndex(columnName));
 
                     table.addEmptyRow();
+                    // after converting to nullable, it is fine to set value to null i.e. no exception is thrown
                     if (columnType == ColumnType.BINARY)
                         table.setBinaryByteArray(colIndex, 0, null);
                     else if (columnType == ColumnType.STRING)
@@ -543,6 +548,7 @@ public class JNITableTest extends AndroidTestCase {
                         table.setBinaryByteArray(colIndex, 0, new byte[]{0});
                     else if (columnType == ColumnType.STRING)
                         table.setString(colIndex, 0, "Foo");
+                    // if column is nullable, setting a value to null is allowed (no exception is thrown)
                     try {
                         table.addEmptyRow();
                         if (columnType == ColumnType.BINARY)
@@ -551,7 +557,6 @@ public class JNITableTest extends AndroidTestCase {
                             table.setString(colIndex, 1, null);
                         else
                             table.getCheckedRow(1).setNull(colIndex);
-
                         if (!nullable) {
                             fail();
                         }
@@ -567,6 +572,7 @@ public class JNITableTest extends AndroidTestCase {
                     assertEquals(colIndex, table.getColumnIndex(columnName));
 
                     table.addEmptyRow();
+                    // after converting to not-nullable, setting values to null must throw an exception
                     try {
                         if (columnType == ColumnType.BINARY)
                             table.setBinaryByteArray(colIndex, 0, null);
@@ -574,9 +580,7 @@ public class JNITableTest extends AndroidTestCase {
                             table.setString(colIndex, 0, null);
                         else
                             table.getCheckedRow(0).setNull(colIndex);
-                        if (!nullable) {
-                            fail();
-                        }
+                        fail();
                     } catch (IllegalArgumentException ignored) {
                     }
                     table.removeLast();

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -23,21 +23,23 @@ import java.util.Date;
 
 import io.realm.TestHelper;
 
+import static io.realm.internal.ColumnType.*;
+
 public class JNITableTest extends AndroidTestCase {
 
     Table t = new Table();
 
     Table createTestTable() {
         Table t = new Table();
-        t.addColumn(ColumnType.BINARY, "binary"); // 0
-        t.addColumn(ColumnType.BOOLEAN, "boolean");  // 1
-        t.addColumn(ColumnType.DATE, "date");     // 2
-        t.addColumn(ColumnType.DOUBLE, "double"); // 3
-        t.addColumn(ColumnType.FLOAT, "float");   // 4
-        t.addColumn(ColumnType.INTEGER, "long");      // 5
-        t.addColumn(ColumnType.MIXED, "mixed");   // 6
-        t.addColumn(ColumnType.STRING, "string"); // 7
-        t.addColumn(ColumnType.TABLE, "table");   // 8
+        t.addColumn(BINARY, "binary"); // 0
+        t.addColumn(BOOLEAN, "boolean");  // 1
+        t.addColumn(DATE, "date");     // 2
+        t.addColumn(DOUBLE, "double"); // 3
+        t.addColumn(FLOAT, "float");   // 4
+        t.addColumn(INTEGER, "long");      // 5
+        t.addColumn(MIXED, "mixed");   // 6
+        t.addColumn(STRING, "string"); // 7
+        t.addColumn(TABLE, "table");   // 8
         return t;
     }
 
@@ -49,9 +51,9 @@ public class JNITableTest extends AndroidTestCase {
     public void testTableToString() {
         Table t = new Table();
 
-        t.addColumn(ColumnType.STRING, "stringCol");
-        t.addColumn(ColumnType.INTEGER, "intCol");
-        t.addColumn(ColumnType.BOOLEAN, "boolCol");
+        t.addColumn(STRING, "stringCol");
+        t.addColumn(INTEGER, "intCol");
+        t.addColumn(BOOLEAN, "boolCol");
 
         t.add("s1", 1, true);
         t.add("s2", 2, false);
@@ -72,7 +74,7 @@ public class JNITableTest extends AndroidTestCase {
         try { t.remove(10); fail("No rows in table"); } catch (ArrayIndexOutOfBoundsException e) {}
 
         // Column added, remove rows again
-        t.addColumn(ColumnType.STRING, "");
+        t.addColumn(STRING, "");
         try { t.remove(0);  fail("No rows in table"); } catch (ArrayIndexOutOfBoundsException e) {}
         try { t.remove(10); fail("No rows in table"); } catch (ArrayIndexOutOfBoundsException e) {}
 
@@ -181,7 +183,7 @@ public class JNITableTest extends AndroidTestCase {
 
     public void testGetNonExistingColumn() {
         Table t = new Table();
-        t.addColumn(ColumnType.INTEGER, "int");
+        t.addColumn(INTEGER, "int");
 
         assertEquals(-1, t.getColumnIndex("non-existing column"));
         try { t.getColumnIndex(null); fail("column name null"); } catch (IllegalArgumentException e) { }
@@ -190,9 +192,9 @@ public class JNITableTest extends AndroidTestCase {
 
     public void testGetSortedView() {
         Table t = new Table();
-        t.addColumn(ColumnType.INTEGER, "");
-        t.addColumn(ColumnType.STRING, "");
-        t.addColumn(ColumnType.DOUBLE, "");
+        t.addColumn(INTEGER, "");
+        t.addColumn(STRING, "");
+        t.addColumn(DOUBLE, "");
 
         t.add(1, "s", 1000d);
         t.add(3,"sss", 10d);
@@ -247,10 +249,10 @@ public class JNITableTest extends AndroidTestCase {
 
     public void testSetNulls() {
         Table t = new Table();
-        t.addColumn(ColumnType.STRING, "");
-        t.addColumn(ColumnType.DATE, "");
-        t.addColumn(ColumnType.MIXED, "");
-        t.addColumn(ColumnType.BINARY, "");
+        t.addColumn(STRING, "");
+        t.addColumn(DATE, "");
+        t.addColumn(MIXED, "");
+        t.addColumn(BINARY, "");
         t.add("String val", new Date(), new Mixed(""), new byte[]{1, 2, 3});
 
         try { t.setString(0, 0, null);  fail("null string not allowed"); } catch (IllegalArgumentException e) { }
@@ -259,14 +261,14 @@ public class JNITableTest extends AndroidTestCase {
 
     public void testAddNegativeEmptyRows() {
         Table t = new Table();
-        t.addColumn(ColumnType.STRING, "colName");
+        t.addColumn(STRING, "colName");
 
         try { t.addEmptyRows(-1); fail("Argument is negative"); } catch (IllegalArgumentException e ) { }
     }
 
     public void testAddNullInMixedColumn() {
         Table t = new Table();
-        t.addColumn(ColumnType.MIXED, "mixed");
+        t.addColumn(MIXED, "mixed");
         t.add(new Mixed(true));
 
         try { t.setMixed(0, 0, null); fail("Argument is null"); } catch (IllegalArgumentException e) { }
@@ -285,7 +287,7 @@ public class JNITableTest extends AndroidTestCase {
         WriteTransaction wt = group.beginWrite();
         try {
             Table table = wt.getTable(TABLENAME);
-            table.addColumn(ColumnType.STRING, "col0");
+            table.addColumn(STRING, "col0");
             table.add("value0");
             table.add("value1");
             table.add("value2");
@@ -337,10 +339,10 @@ public class JNITableTest extends AndroidTestCase {
 
             // All types supported addSearchIndex and removeSearchIndex
             boolean exceptionExpected = (
-                            t.getColumnType(colIndex) != ColumnType.STRING &&
-                            t.getColumnType(colIndex) != ColumnType.INTEGER &&
-                            t.getColumnType(colIndex) != ColumnType.BOOLEAN &&
-                            t.getColumnType(colIndex) != ColumnType.DATE);
+                            t.getColumnType(colIndex) != STRING &&
+                            t.getColumnType(colIndex) != INTEGER &&
+                            t.getColumnType(colIndex) != BOOLEAN &&
+                            t.getColumnType(colIndex) != DATE);
 
             // Try to addSearchIndex()
             try {
@@ -369,16 +371,16 @@ public class JNITableTest extends AndroidTestCase {
 
     public void testColumnName() {
         Table t = new Table();
-        try { t.addColumn(ColumnType.STRING, "I am 64 characters.............................................."); fail("Only 63 characters supported"); } catch (IllegalArgumentException e) { }
-        t.addColumn(ColumnType.STRING, "I am 63 characters.............................................");
+        try { t.addColumn(STRING, "I am 64 characters.............................................."); fail("Only 63 characters supported"); } catch (IllegalArgumentException e) { }
+        t.addColumn(STRING, "I am 63 characters.............................................");
     }
 
     public void testTableNumbers() {
         Table t = new Table();
-        t.addColumn(ColumnType.INTEGER, "intCol");
-        t.addColumn(ColumnType.DOUBLE, "doubleCol");
-        t.addColumn(ColumnType.FLOAT, "floatCol");
-        t.addColumn(ColumnType.STRING, "StringCol");
+        t.addColumn(INTEGER, "intCol");
+        t.addColumn(DOUBLE, "doubleCol");
+        t.addColumn(FLOAT, "floatCol");
+        t.addColumn(STRING, "StringCol");
 
         // Add 3 rows of data with same values in each column
         t.add(1, 2.0d, 3.0f, "s1");
@@ -422,7 +424,7 @@ public class JNITableTest extends AndroidTestCase {
     public void testMaximumDate() {
 
         Table table = new Table();
-        table.addColumn(ColumnType.DATE, "date");
+        table.addColumn(DATE, "date");
 
         table.add(new Date(0));
         table.add(new Date(10000));
@@ -435,7 +437,7 @@ public class JNITableTest extends AndroidTestCase {
     public void testMinimumDate() {
 
         Table table = new Table();
-        table.addColumn(ColumnType.DATE, "date");
+        table.addColumn(DATE, "date");
 
         table.add(new Date(10000));
         table.add(new Date(0));
@@ -447,8 +449,8 @@ public class JNITableTest extends AndroidTestCase {
 
     // testing the migration of a string column to be nullable.
     public void testConvertToNullable() {
-        ColumnType[] columnTypes = {ColumnType.BOOLEAN, ColumnType.DATE, ColumnType.DOUBLE,
-                ColumnType.FLOAT, ColumnType.INTEGER, ColumnType.BINARY, ColumnType.STRING};
+        ColumnType[] columnTypes = {BOOLEAN, DATE, DOUBLE,
+                FLOAT, INTEGER, BINARY, STRING};
         for (ColumnType columnType : columnTypes) {
             // testing various combinations of column names and nullability
             String[] columnNames = {"foobar", "__TMP__0"};
@@ -456,39 +458,47 @@ public class JNITableTest extends AndroidTestCase {
                 for (String columnName : columnNames) {
                     Table table = new Table();
                     long colIndex = table.addColumn(columnType, columnName, nullable);
-                    table.addColumn(ColumnType.BOOLEAN, "bool");
+                    table.addColumn(BOOLEAN, "bool");
                     table.addEmptyRow();
-                    if (columnType == ColumnType.BOOLEAN)
-                        table.setBoolean(colIndex, 0, true);
-                    else if (columnType == ColumnType.DATE)
-                        table.setDate(colIndex, 0, new Date(0));
-                    else if (columnType == ColumnType.DOUBLE)
-                        table.setDouble(colIndex, 0, 1.0);
-                    else if (columnType == ColumnType.FLOAT)
-                        table.setFloat(colIndex, 0, 1.0f);
-                    else if (columnType == ColumnType.INTEGER)
-                        table.setLong(colIndex, 0, 1);
-                    else if (columnType == ColumnType.BINARY)
-                        table.setBinaryByteArray(colIndex, 0, new byte[]{0});
-                    else if (columnType == ColumnType.STRING)
-                        table.setString(colIndex, 0, "Foo");
-                    // if column is nullable not exception should be thrown
+                    switch (columnType) {
+                        case BOOLEAN:
+                            table.setBoolean(colIndex, 0, true);
+                            break;
+                        case DATE:
+                            table.setDate(colIndex, 0, new Date(0));
+                            break;
+                        case DOUBLE:
+                            table.setDouble(colIndex, 0, 1.0);
+                            break;
+                        case FLOAT:
+                            table.setFloat(colIndex, 0, 1.0f);
+                            break;
+                        case INTEGER:
+                            table.setLong(colIndex, 0, 1);
+                            break;
+                        case BINARY:
+                            table.setBinaryByteArray(colIndex, 0, new byte[]{0});
+                            break;
+                        case STRING:
+                            table.setString(colIndex, 0, "Foo");
+                            break;
+                    }
                     try {
                         table.addEmptyRow();
-                        if (columnType == ColumnType.BINARY)
+                        if (columnType == BINARY) {
                             table.setBinaryByteArray(colIndex, 1, null);
-                        else if (columnType == ColumnType.STRING)
+                        }
+                        else if (columnType == STRING) {
                             table.setString(colIndex, 1, null);
-                        else
+                        }
+                        else {
                             table.getCheckedRow(1).setNull(colIndex);
+                        }
 
                         if (!nullable) {
                             fail();
                         }
                     } catch (IllegalArgumentException ignored) {
-                        if (nullable) {
-                            fail();
-                        }
                     }
                     table.removeLast();
                     assertEquals(1, table.size());
@@ -501,30 +511,32 @@ public class JNITableTest extends AndroidTestCase {
                     assertEquals(colIndex, table.getColumnIndex(columnName));
 
                     table.addEmptyRow();
-                    // after converting to nullable, it is fine to set value to null i.e. no exception is thrown
-                    if (columnType == ColumnType.BINARY)
+                    if (columnType == BINARY)
                         table.setBinaryByteArray(colIndex, 0, null);
-                    else if (columnType == ColumnType.STRING)
+                    else if (columnType == STRING)
                         table.setString(colIndex, 0, null);
                     else
                         table.getCheckedRow(0).setNull(colIndex);
 
                     assertEquals(2, table.size());
 
-                    if (columnType == ColumnType.BINARY)
+                    if (columnType == BINARY) {
                         assertNull(table.getBinaryByteArray(colIndex, 1));
-                    else if (columnType == ColumnType.STRING)
+                    }
+                    else if (columnType == STRING) {
                         assertNull(table.getString(colIndex, 1));
-                    else
+                    }
+                    else {
                         assertTrue(table.getUncheckedRow(1).isNull(colIndex));
+                    }
                 }
             }
         }
     }
 
     public void testConvertToNotNullable() {
-        ColumnType[] columnTypes = {ColumnType.BOOLEAN, ColumnType.DATE, ColumnType.DOUBLE,
-                ColumnType.FLOAT, ColumnType.INTEGER, ColumnType.BINARY, ColumnType.STRING};
+        ColumnType[] columnTypes = {BOOLEAN, DATE, DOUBLE,
+                FLOAT, INTEGER, BINARY, STRING};
         for (ColumnType columnType : columnTypes) {
             // testing various combinations of column names and nullability
             String[] columnNames = {"foobar", "__TMP__0"};
@@ -532,31 +544,43 @@ public class JNITableTest extends AndroidTestCase {
                 for (String columnName : columnNames) {
                     Table table = new Table();
                     long colIndex = table.addColumn(columnType, columnName, nullable);
-                    table.addColumn(ColumnType.BOOLEAN, "bool");
+                    table.addColumn(BOOLEAN, "bool");
                     table.addEmptyRow();
-                    if (columnType == ColumnType.BOOLEAN)
-                        table.setBoolean(colIndex, 0, true);
-                    else if (columnType == ColumnType.DATE)
-                        table.setDate(colIndex, 0, new Date(1));
-                    else if (columnType == ColumnType.DOUBLE)
-                        table.setDouble(colIndex, 0, 1.0);
-                    else if (columnType == ColumnType.FLOAT)
-                        table.setFloat(colIndex, 0, 1.0f);
-                    else if (columnType == ColumnType.INTEGER)
-                        table.setLong(colIndex, 0, 1);
-                    else if (columnType == ColumnType.BINARY)
-                        table.setBinaryByteArray(colIndex, 0, new byte[]{0});
-                    else if (columnType == ColumnType.STRING)
-                        table.setString(colIndex, 0, "Foo");
-                    // if column is nullable, setting a value to null is allowed (no exception is thrown)
+                    switch (columnType) {
+                        case BOOLEAN:
+                            table.setBoolean(colIndex, 0, true);
+                            break;
+                        case DATE:
+                            table.setDate(colIndex, 0, new Date(1));
+                            break;
+                        case DOUBLE:
+                            table.setDouble(colIndex, 0, 1.0);
+                            break;
+                        case FLOAT:
+                            table.setFloat(colIndex, 0, 1.0f);
+                            break;
+                        case INTEGER:
+                            table.setLong(colIndex, 0, 1);
+                            break;
+                        case BINARY:
+                            table.setBinaryByteArray(colIndex, 0, new byte[]{0});
+                            break;
+                        case STRING:
+                            table.setString(colIndex, 0, "Foo");
+                            break;
+                    }
                     try {
                         table.addEmptyRow();
-                        if (columnType == ColumnType.BINARY)
+                        if (columnType == BINARY) {
                             table.setBinaryByteArray(colIndex, 1, null);
-                        else if (columnType == ColumnType.STRING)
+                        }
+                        else if (columnType == STRING) {
                             table.setString(colIndex, 1, null);
-                        else
+                        }
+                        else {
                             table.getCheckedRow(1).setNull(colIndex);
+                        }
+
                         if (!nullable) {
                             fail();
                         }
@@ -572,38 +596,50 @@ public class JNITableTest extends AndroidTestCase {
                     assertEquals(colIndex, table.getColumnIndex(columnName));
 
                     table.addEmptyRow();
-                    // after converting to not-nullable, setting values to null must throw an exception
                     try {
-                        if (columnType == ColumnType.BINARY)
+                        if (columnType == BINARY) {
                             table.setBinaryByteArray(colIndex, 0, null);
-                        else if (columnType == ColumnType.STRING)
+                        }
+                        else if (columnType == STRING) {
                             table.setString(colIndex, 0, null);
-                        else
+                        }
+                        else {
                             table.getCheckedRow(0).setNull(colIndex);
-                        fail();
+                        }
+                        if (!nullable) {
+                            fail();
+                        }
                     } catch (IllegalArgumentException ignored) {
                     }
                     table.removeLast();
                     assertEquals(2, table.size());
 
-                    if (columnType == ColumnType.BINARY)
+                    if (columnType == BINARY) {
                         assertNotNull(table.getBinaryByteArray(colIndex, 1));
-                    else if (columnType == ColumnType.STRING) {
+                    }
+                    else if (columnType == STRING) {
                         assertNotNull(table.getString(colIndex, 1));
                         assertEquals("", table.getString(colIndex, 1));
                     }
                     else {
                         assertFalse(table.getUncheckedRow(1).isNull(colIndex));
-                        if (columnType == ColumnType.BOOLEAN)
-                            assertEquals(false, table.getBoolean(colIndex, 1));
-                        else if (columnType == ColumnType.DATE)
-                            assertEquals(0, table.getDate(colIndex, 1).getTime());
-                        else if (columnType == ColumnType.DOUBLE)
-                            assertEquals(0.0, table.getDouble(colIndex, 1));
-                        else if (columnType == ColumnType.FLOAT)
-                            assertEquals(0.0f, table.getFloat(colIndex, 1));
-                        else if (columnType == ColumnType.INTEGER)
-                            assertEquals(0, table.getLong(colIndex, 1));
+                        switch (columnType) {
+                            case BOOLEAN:
+                                assertEquals(false, table.getBoolean(colIndex, 1));
+                                break;
+                            case DATE:
+                                assertEquals(0, table.getDate(colIndex, 1).getTime());
+                                break;
+                            case DOUBLE:
+                                assertEquals(0.0, table.getDouble(colIndex, 1));
+                                break;
+                            case FLOAT:
+                                assertEquals(0.0f, table.getFloat(colIndex, 1));
+                                break;
+                            case INTEGER:
+                                assertEquals(0, table.getLong(colIndex, 1));
+                                break;
+                        }
                     }
                 }
             }
@@ -613,7 +649,7 @@ public class JNITableTest extends AndroidTestCase {
     // migrating an mixed column to be nullable is not supported
     public void testConvertMixedToNullable() {
         Table table = new Table();
-        table.addColumn(ColumnType.MIXED, "mixed", Table.NOT_NULLABLE);
+        table.addColumn(MIXED, "mixed", Table.NOT_NULLABLE);
         try {
             table.convertColumnToNullable(0);
             fail();
@@ -624,8 +660,8 @@ public class JNITableTest extends AndroidTestCase {
     // add column and read back if it is nullable or not
     public void testIsNullable() {
         Table table = new Table();
-        table.addColumn(ColumnType.STRING, "string1", Table.NOT_NULLABLE);
-        table.addColumn(ColumnType.STRING, "string2", Table.NULLABLE);
+        table.addColumn(STRING, "string1", Table.NOT_NULLABLE);
+        table.addColumn(STRING, "string2", Table.NULLABLE);
 
         assertFalse(table.isColumnNullable(0));
         assertTrue(table.isColumnNullable(1));

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -511,12 +511,15 @@ public class JNITableTest extends AndroidTestCase {
                     assertEquals(colIndex, table.getColumnIndex(columnName));
 
                     table.addEmptyRow();
-                    if (columnType == BINARY)
+                    if (columnType == BINARY) {
                         table.setBinaryByteArray(colIndex, 0, null);
-                    else if (columnType == STRING)
+                    }
+                    else if (columnType == STRING) {
                         table.setString(colIndex, 0, null);
-                    else
+                    }
+                    else {
                         table.getCheckedRow(0).setNull(colIndex);
+                    }
 
                     assertEquals(2, table.size());
 


### PR DESCRIPTION
Due to an embarrassing error a unit test, the bug #1695 wasn't discovered before release. Retrospectively, the unit tests are complex and need a few comments to understand what is tested.

@realm/java
