### PR TITLE
Increase XX:MaxPermSize to avoid PermGen space problem.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-XX:MaxPermSize=512m


### PR DESCRIPTION
I encountered the following error.

```
Execution failed for task ':assembleExamples.'.
> Failed to notify build listener.
    > PermGen space
```

So I increased the default MaxPermSize to 512m.

Please review this, @realm/java.