### PR TITLE
fix #1675 RealmChangeListener are strong reference now. 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.86.0
+* BREAKING CHANGE: `Realm.addChangeListener`, `RealmObject.addChangeListener` and `RealmResults.addChangeListener` hold a strong reference to the listener, you should unregister the listener to avoid memory leaks.
+
 0.85.0
  * BREAKING CHANGE: Removed RealmEncryptionNotSupportedException since the encryption implementation changed in Realm's underlying storage engine. Encryption is now supported on all devices.
  * BREAKING CHANGE: Realm.executeTransaction() now directly throws any RuntimeException instead of wrapping it in a RealmException (#1682).

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -16,6 +16,7 @@
 package io.realm;
 
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.Looper;
 import android.test.AndroidTestCase;
 import android.util.Log;
@@ -473,7 +474,7 @@ public class NotificationsTest extends AndroidTestCase {
                 counter.incrementAndGet();
             }
         };
-        realm.addChangeListener(listener);
+        realm.addChangeListenerAsWeakReference(listener);
 
         // There is no guaranteed way to release the WeakReference,
         // just clear it.
@@ -605,6 +606,87 @@ public class NotificationsTest extends AndroidTestCase {
 
         realm.close();
         RealmLog.remove(logger);
+    }
+
+    public void testHandlerThreadShouldReceiveNotification() throws ExecutionException, InterruptedException {
+        final AssertionFailedError[] assertionFailedErrors = new AssertionFailedError[1];
+        final CountDownLatch backgroundThreadReady = new CountDownLatch(1);
+        final CountDownLatch numberOfInvocation = new CountDownLatch(1);
+
+        HandlerThread handlerThread = new HandlerThread("handlerThread");
+        handlerThread.start();
+        Handler handler = new Handler(handlerThread.getLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    assertEquals("handlerThread", Thread.currentThread().getName());
+                } catch (AssertionFailedError e) {
+                    assertionFailedErrors[0] = e;
+                }
+                final Realm backgroundRealm = Realm.getInstance(getContext());
+                backgroundRealm.addChangeListener(new RealmChangeListener() {
+                    @Override
+                    public void onChange() {
+                        backgroundRealm.close();
+                        numberOfInvocation.countDown();
+                    }
+                });
+                backgroundThreadReady.countDown();
+            }
+        });
+        awaitOrThrow(backgroundThreadReady);
+        // At this point the background thread started & registered the listener
+
+        Realm realm = Realm.getInstance(getContext());
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+
+        awaitOrThrow(numberOfInvocation);
+        realm.close();
+        handlerThread.quit();
+        if (assertionFailedErrors[0] != null) {
+            throw assertionFailedErrors[0];
+        }
+    }
+
+    public void testNonLooperThreadShouldNotifyLooperThreadAboutCommit() throws Throwable {
+        final CountDownLatch mainThreadReady = new CountDownLatch(1);
+        final CountDownLatch numberOfInvocation = new CountDownLatch(1);
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                TestHelper.awaitOrFail(mainThreadReady);
+                Realm realm = Realm.getInstance(getContext());
+                realm.beginTransaction();
+                realm.createObject(AllTypes.class);
+                realm.commitTransaction();
+                realm.close();
+            }
+        };
+        thread.start();
+
+        HandlerThread mainThread = new HandlerThread("mainThread");
+        mainThread.start();
+        Handler handler = new Handler(mainThread.getLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                final Realm mainRealm = Realm.getInstance(getContext());
+                mainRealm.addChangeListener(new RealmChangeListener() {
+                    @Override
+                    public void onChange() {
+                        mainRealm.close();
+                        numberOfInvocation.countDown();
+                    }
+                });
+                mainThreadReady.countDown();
+            }
+        });
+
+        awaitOrThrow(numberOfInvocation);
+        mainThread.quit();
     }
 
     private void awaitOrThrow(CountDownLatch latch) {

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -988,8 +988,8 @@ public final class Realm extends BaseRealm {
      *
      * @return changeListeners list of this Realm instance.
      */
-    protected List<WeakReference<RealmChangeListener>> getChangeListeners() {
-        return changeListeners;
+    List<WeakReference<RealmChangeListener>> getChangeListeners() {
+        return weakChangeListeners;
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/realm/realm-library/src/main/java/io/realm/RealmBaseAdapter.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmBaseAdapter.java
@@ -53,7 +53,7 @@ public abstract class RealmBaseAdapter<T extends RealmObject> extends BaseAdapte
         };
 
         if (listener != null && realmResults != null) {
-            realmResults.getRealm().addChangeListener(listener);
+            realmResults.getRealm().addChangeListenerAsWeakReference(listener);
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
@@ -17,7 +17,12 @@
 package io.realm;
 
 /**
- * Using RealmChangeListener, it is possible to be notified when a Realm instance has been updated.
+ * RealmChangeListener can be registered with a {@link Realm}, {@link RealmResults} or {@link RealmObject}
+ * to receive a notification about updates.
+ * <p>
+ * When registered against a {@code Realm} you'll get notified when a Realm instance has been updated.
+ * Register against a {@code RealmResults} or {@code RealmObject} to only get notified about changes to them.
+ *
  * <p>
  * Realm instances on a thread without an {@link android.os.Looper} (almost all background threads) don't get updated
  * automatically, but have to call {@link Realm#refresh()} manually. This will in turn trigger the RealmChangeListener


### PR DESCRIPTION
**Breaking change:**
`realm.addChangeListener` hold a string reference 
```java
realm.addChangeListener(listener); //keep a strong reference to listener
realm.removeChangeListener(listener); // to remove a non-anonymous listener
realm.removeAllChangeListeners(); // to remove all listeners (including anonymous one)

realm. addChangeListenerAsWeakReference(listener); // add a WeakReference listener (this is package-private) for internal use only (RealmBaseAdapter)
```
- [x] update Javadoc as `RealmChangeListener` is used for both async & general notification, explain the triggering difference 