### PR TITLE
throws IllegalArgumentException if isNull/isNotNull is called for unsupported field.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
  * Added Realm.isEmpty().
  * Fixed a bug making it impossible to convert a field to become required during a migration (#1695).
  * Fixed a bug making it impossible to read Realms created using primary keys and created by iOS (#1703).
+ * RealmQuery.isNull() and RealmQuery.isNotNull() now throw IllegalArgumentException instead of RealmError if the fieldname is a linked field and the last element is a link (#1693).
 
 0.84.1
  * Updated Realm Core to 0.94.4

--- a/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -1461,7 +1461,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(
         } else {
             switch (col_type) {
                 case type_Link:
-                    pQuery->and_query(src_table_ref->column<Link>(S(column_idx)).is_null());
+                    ThrowException(env, IllegalArgument, "isNull() by nested query for link field is not supported.");
                     break;
                 case type_LinkList:
                     // Cannot get here. Exception will be thrown in TBL_AND_COL_NULLABLE
@@ -1604,7 +1604,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull
         else {
             switch (col_type) {
                 case type_Link:
-                    pQuery->and_query(src_table_ref->column<Link>(S(column_idx)).is_not_null());
+                    ThrowException(env, IllegalArgument, "isNotNull() by nested query for link field is not supported.");
                     break;
                 case type_LinkList:
                     // Cannot get here. Exception will be thrown in TBL_AND_COL_NULLABLE

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -1103,14 +1103,14 @@ public class RealmQueryTest extends AndroidTestCase {
         assertEquals(2, testRealm.where(NullTypes.class).isNull(
                 NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_DATE_NULL).count());
         // 11 Object
-        // FIXME: Currently not support by Realm core
+        // FIXME: Currently, Realm Core does not support isNull() query for nested link field.
         //assertEquals(1, testRealm.where(NullTypes.class).isNull(
         //        NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL).count());
         try {
             testRealm.where(NullTypes.class).isNull(
-                    NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL).count();
+                    NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL);
             fail();
-        } catch (RealmError ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
     }
 
@@ -1228,12 +1228,12 @@ public class RealmQueryTest extends AndroidTestCase {
         // 11 Object
         //assertEquals(1, testRealm.where(NullTypes.class).isNotNull(
         //        NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL).count());
-        // FIXME: Currently, link queries don't work fully on null
+        // FIXME: Currently, Realm Core does not support isNotNull() query for nested link field.
         try {
             testRealm.where(NullTypes.class).isNotNull(
-                    NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL).count();
+                    NullTypes.FIELD_OBJECT_NULL + "." + NullTypes.FIELD_OBJECT_NULL);
             fail();
-        } catch (RealmError ignored) {
+        } catch (IllegalArgumentException ignored) {
         }
     }
 


### PR DESCRIPTION
Currently, `isNull()`/`isNotNull()` for linked field whose last element is a link is not supported.
We should throw `IllegalArgumentException` instead of `RealmError` if that happened.

refs #1693
