### PR TITLE
Micro benchmarks

### DIFF
--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -15,6 +15,10 @@ buildscript {
     }
 }
 
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}
+
 allprojects {
     def props = new Properties()
     props.load(new FileInputStream("${rootDir}/../realm.properties"))

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -26,6 +26,9 @@ allprojects {
     version = file("${rootDir}/../version.txt").text.trim();
     repositories {
         jcenter()
+        maven {
+            url 'http://oss.jfrog.org/artifactory/oss-snapshot-local'
+        }
     }
 }
 

--- a/realm/gradle/wrapper/gradle-wrapper.properties
+++ b/realm/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 29 11:05:05 CEST 2015
+#Thu Nov 05 21:27:58 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'dk.ilios:spanner:0.2.0-SNAPSHOT'
+    androidTestCompile 'dk.ilios:spanner:0.2.1-SNAPSHOT'
 }
 
 task sourcesJar(type: Jar) {

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'dk.ilios:spanner:0.2.1-SNAPSHOT'
+    androidTestCompile 'dk.ilios:spanner:0.3.0-SNAPSHOT'
 }
 
 task sourcesJar(type: Jar) {

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -15,6 +15,17 @@ android {
         minSdkVersion 9
         targetSdkVersion 23
         project.archivesBaseName = "realm-android"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+
+    sourceSets {
+        androidTest {
+            java.srcDirs = ['src/benchmarks/java', 'src/androidTest/java']
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
     }
 }
 
@@ -24,6 +35,12 @@ dependencies {
 
     androidTestApt project(':realm-annotations-processor')
     androidTestApt project(':realm-annotations')
+
+    androidTestCompile 'com.android.support:support-annotations:23.0.1'
+    androidTestCompile 'com.android.support.test:runner:0.4.1'
+    androidTestCompile 'com.android.support.test:rules:0.4.1'
+    androidTestCompile 'junit:junit:4.12'
+    androidTestCompile 'dk.ilios:spanner:0.2.0-SNAPSHOT'
 }
 
 task sourcesJar(type: Jar) {

--- a/realm/realm-library/src/benchmarks/java/io/realm/CustomReadbenchmarks.java
+++ b/realm/realm-library/src/benchmarks/java/io/realm/CustomReadbenchmarks.java
@@ -1,0 +1,173 @@
+package io.realm;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.runner.RunWith;
+
+import dk.ilios.spanner.AfterExperiment;
+import dk.ilios.spanner.BeforeExperiment;
+import dk.ilios.spanner.Benchmark;
+import dk.ilios.spanner.CustomMeasurement;
+import dk.ilios.spanner.junit.SpannerRunner;
+import io.realm.entities.AllTypes;
+
+@RunWith(SpannerRunner.class)
+public class CustomReadbenchmarks {
+
+    private Realm realm;
+    private AllTypes realmObject;
+    private AllTypes javaObject;
+
+    private SQLiteDatabase db;
+    private SQLiteDatabaseHelper helper;
+    private Cursor cursor;
+    private int strColumnIndex;
+    private int intColumnIndex;
+    private int boolColumnIndex;
+
+    private int reps = 100000;
+
+    @BeforeExperiment
+    public void before() {
+
+        // Realm setup
+        RealmConfiguration config = TestHelper.createConfiguration(InstrumentationRegistry.getTargetContext(), "bench");
+        Realm.deleteRealm(config);
+        realm = Realm.getInstance(config);
+        realm.beginTransaction();
+        realm.clear(AllTypes.class);
+        realmObject = realm.createObject(AllTypes.class);
+        realmObject.setColumnLong(1);
+        realmObject.setColumnString("foo");
+        realmObject.setColumnBoolean(true);
+        realm.commitTransaction();
+
+        // Java setup
+        javaObject = new AllTypes();
+        javaObject.setColumnLong(1);
+        javaObject.setColumnString("foo");
+        javaObject.setColumnBoolean(true);
+
+        // SQLite setup
+        helper = new SQLiteDatabaseHelper(InstrumentationRegistry.getTargetContext());
+        db = helper.getWritableDatabase();
+        db.beginTransaction();
+        db.execSQL("DELETE FROM Simple");
+        db.execSQL("INSERT INTO Simple VALUES('Foo', 1, 1)");
+        db.setTransactionSuccessful();
+        db.endTransaction();
+        cursor = db.query("Simple", new String[]{"str", "int", "bool"}, null, null, null, null, null);
+        cursor.moveToFirst();
+        strColumnIndex = cursor.getColumnIndexOrThrow("str");
+        intColumnIndex = cursor.getColumnIndexOrThrow("int");
+        boolColumnIndex = cursor.getColumnIndexOrThrow("bool");
+    }
+
+    @AfterExperiment
+    public void after() {
+        realm.close();
+        cursor.close();
+        db.close();
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readRealmString() {
+        String str;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            str = realmObject.getColumnString();
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readRealmInt() {
+        long value;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            value = realmObject.getColumnLong();
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readRealmBoolean() {
+        boolean bool;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            bool = realmObject.isColumnBoolean();
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readJavaString() {
+        String str;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            str = javaObject.getColumnString();
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readJavaInt() {
+        long value;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            value = javaObject.getColumnLong();
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readJavaBoolean() {
+        boolean bool;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            bool = javaObject.isColumnBoolean();
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readCursorString() {
+        String str;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            str = cursor.getString(strColumnIndex);
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readCursorInt() {
+        int value;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            value = cursor.getInt(intColumnIndex);
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+
+    @CustomMeasurement(units = "ns")
+    public double readCursorBoolean() {
+        boolean bool;
+        long start = System.nanoTime();
+        for (int i = 0; i < reps; i++) {
+            bool = cursor.getInt(boolColumnIndex) == 1;
+        }
+        long end = System.nanoTime();
+        return (end - start)/(double) reps;
+    }
+}

--- a/realm/realm-library/src/benchmarks/java/io/realm/ReadBenchmarks.java
+++ b/realm/realm-library/src/benchmarks/java/io/realm/ReadBenchmarks.java
@@ -1,0 +1,67 @@
+package io.realm;
+
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.runner.RunWith;
+
+import dk.ilios.spanner.AfterExperiment;
+import dk.ilios.spanner.BeforeExperiment;
+import dk.ilios.spanner.Benchmark;
+import dk.ilios.spanner.junit.SpannerRunner;
+import io.realm.entities.AllTypes;
+
+@RunWith(SpannerRunner.class)
+public class ReadBenchmarks {
+
+    private Realm realm;
+    private AllTypes realmObject;
+    private AllTypes javaObject;
+
+    @BeforeExperiment
+    public void before() {
+        RealmConfiguration config = TestHelper.createConfiguration(InstrumentationRegistry.getTargetContext(), "bench");
+        Realm.deleteRealm(config);
+        realm = Realm.getInstance(config);
+        realm.beginTransaction();
+        realm.clear(io.realm.entities.AllTypes.class);
+        realmObject = realm.createObject(io.realm.entities.AllTypes.class);
+        realmObject.setColumnLong(1);
+        realmObject.setColumnString("foo");
+        realmObject.setColumnBoolean(true);
+
+        javaObject = new AllTypes();
+        javaObject.setColumnLong(1);
+        javaObject.setColumnString("foo");
+        javaObject.setColumnBoolean(true);
+    }
+
+    @AfterExperiment
+    public void after() {
+        realm.close();
+    }
+
+
+    @Benchmark
+    public void readRealmString(int reps) {
+        String str;
+        for (int i = 0; i < reps; i++) {
+            str = realmObject.getColumnString();
+        }
+    }
+
+    @Benchmark
+    public void readRealmInt(int reps) {
+        long value;
+        for (int i = 0; i < reps; i++) {
+            value = realmObject.getColumnLong();
+        }
+    }
+
+    @Benchmark
+    public void readRealmBoolean(int reps) {
+        boolean bool;
+        for (int i = 0; i < reps; i++) {
+            bool = realmObject.isColumnBoolean();
+        }
+    }
+}

--- a/realm/realm-library/src/benchmarks/java/io/realm/ReadBenchmarks.java
+++ b/realm/realm-library/src/benchmarks/java/io/realm/ReadBenchmarks.java
@@ -1,5 +1,7 @@
 package io.realm;
 
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.support.test.InstrumentationRegistry;
 
 import org.junit.runner.RunWith;
@@ -17,8 +19,17 @@ public class ReadBenchmarks {
     private AllTypes realmObject;
     private AllTypes javaObject;
 
+    private SQLiteDatabase db;
+    private SQLiteDatabaseHelper helper;
+    private Cursor cursor;
+    private int strColumnIndex;
+    private int intColumnIndex;
+    private int boolColumnIndex;
+
     @BeforeExperiment
     public void before() {
+
+        // Realm setup
         RealmConfiguration config = TestHelper.createConfiguration(InstrumentationRegistry.getTargetContext(), "bench");
         Realm.deleteRealm(config);
         realm = Realm.getInstance(config);
@@ -28,18 +39,36 @@ public class ReadBenchmarks {
         realmObject.setColumnLong(1);
         realmObject.setColumnString("foo");
         realmObject.setColumnBoolean(true);
+        realm.commitTransaction();
 
+        // Java setup
         javaObject = new AllTypes();
         javaObject.setColumnLong(1);
         javaObject.setColumnString("foo");
         javaObject.setColumnBoolean(true);
+
+        // SQLite setup
+        helper = new SQLiteDatabaseHelper(InstrumentationRegistry.getTargetContext());
+        db = helper.getWritableDatabase();
+        db.beginTransaction();
+        db.execSQL("DELETE FROM Simple");
+        db.execSQL("INSERT INTO Simple VALUES('Foo', 1, 1)");
+        db.setTransactionSuccessful();
+        db.endTransaction();
+        cursor = db.query("Simple", new String[]{"str", "int", "bool"}, null, null, null, null, null);
+        cursor.moveToFirst();
+        strColumnIndex = cursor.getColumnIndexOrThrow("str");
+        intColumnIndex = cursor.getColumnIndexOrThrow("int");
+        boolColumnIndex = cursor.getColumnIndexOrThrow("bool");
+
     }
 
     @AfterExperiment
     public void after() {
         realm.close();
+        cursor.close();
+        db.close();
     }
-
 
     @Benchmark
     public void readRealmString(int reps) {
@@ -62,6 +91,54 @@ public class ReadBenchmarks {
         boolean bool;
         for (int i = 0; i < reps; i++) {
             bool = realmObject.isColumnBoolean();
+        }
+    }
+
+    @Benchmark
+    public void readJavaString(int reps) {
+        String str;
+        for (int i = 0; i < reps; i++) {
+            str = javaObject.getColumnString();
+        }
+    }
+
+    @Benchmark
+    public void readJavaInt(int reps) {
+        long value;
+        for (int i = 0; i < reps; i++) {
+            value = javaObject.getColumnLong();
+        }
+    }
+
+    @Benchmark
+    public void readJavaBoolean(int reps) {
+        boolean bool;
+        for (int i = 0; i < reps; i++) {
+            bool = javaObject.isColumnBoolean();
+        }
+    }
+
+    @Benchmark
+    public void readCursorString(int reps) {
+        String str;
+        for (int i = 0; i < reps; i++) {
+            str = cursor.getString(strColumnIndex);
+        }
+    }
+
+    @Benchmark
+    public void readCursorInt(int reps) {
+        int value;
+        for (int i = 0; i < reps; i++) {
+            value = cursor.getInt(intColumnIndex);
+        }
+    }
+
+    @Benchmark
+    public void readCursorBoolean(int reps) {
+        boolean bool;
+        for (int i = 0; i < reps; i++) {
+            bool = cursor.getInt(boolColumnIndex) == 1;
         }
     }
 }

--- a/realm/realm-library/src/benchmarks/java/io/realm/SQLiteDatabaseHelper.java
+++ b/realm/realm-library/src/benchmarks/java/io/realm/SQLiteDatabaseHelper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+public class SQLiteDatabaseHelper extends SQLiteOpenHelper {
+    private final Context context;
+
+    public final String TABLE_NAME = "Simple";
+
+    public SQLiteDatabaseHelper(Context context) {
+        super(context, "sqlite.db", null, 1);
+        this.context = context;
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_NAME);
+        db.execSQL("CREATE TABLE " + TABLE_NAME + " ("
+                + "str INTEGER, "
+                + "int INTEGER, "
+                + "bool INTEGER"
+                + ")");
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        onCreate(db);
+    }
+}

--- a/realm/realm-library/src/main/AndroidManifest.xml
+++ b/realm/realm-library/src/main/AndroidManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="io.realm" >
-    <uses-sdk tools:overrideLibrary="dk.ilios.caliperx" />
+    <uses-sdk tools:overrideLibrary="dk.ilios.spanner" />
     <application android:allowBackup="true"/>
 </manifest>

--- a/realm/realm-library/src/main/AndroidManifest.xml
+++ b/realm/realm-library/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.realm" >
+          xmlns:tools="http://schemas.android.com/tools"
+          package="io.realm" >
+    <uses-sdk tools:overrideLibrary="dk.ilios.caliperx" />
     <application android:allowBackup="true"/>
 </manifest>


### PR DESCRIPTION
Example of how we could implement micro-benchmarks.

Take-aways so far has been:
- The library produces very stable output when run back-to-back. Results are <5%. If killing Genymotion and running again, the variance is bigger, but usually within 0-15%.
- Just using standard for-loops to benchmark is insanely unstable. Back-to-back runs produce results that can vary 0-100%

Fun facts:
- We are slightly faster than raw Cursor access at least for simple String/Int/booleans.
- Reading the String "foo" from Realm is 200x-250x times slower than reading it from Java.