### PR TITLE
Setters for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid object.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
  * Fixed a bug making it impossible to read Realms created using primary keys and created by iOS (#1703).
  * Fixed some memory leaks when an Exception is thrown (#1730).
  * RealmQuery.isNull() and RealmQuery.isNotNull() now throw IllegalArgumentException instead of RealmError if the fieldname is a linked field and the last element is a link (#1693).
- * Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid(standalone, removed, closed) object (#1749).
+ * Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid (standalone, removed, closed) object (#1749).
 
 0.84.1
  * Updated Realm Core to 0.94.4

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
  * Fixed a bug making it impossible to read Realms created using primary keys and created by iOS (#1703).
  * Fixed some memory leaks when an Exception is thrown (#1730).
  * RealmQuery.isNull() and RealmQuery.isNotNull() now throw IllegalArgumentException instead of RealmError if the fieldname is a linked field and the last element is a link (#1693).
+ * Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid(standalone, removed, closed) object (#1749).
 
 0.84.1
  * Updated Realm Core to 0.94.4

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
  * Fixed a bug making it impossible to read Realms created using primary keys and created by iOS (#1703).
  * Fixed some memory leaks when an Exception is thrown (#1730).
  * RealmQuery.isNull() and RealmQuery.isNotNull() now throw IllegalArgumentException instead of RealmError if the fieldname is a linked field and the last element is a link (#1693).
- * Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid (standalone, removed, closed) object (#1749).
+ * Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid (standalone, removed, closed, from different Realm) object (#1749).
 
 0.84.1
  * Updated Realm Core to 0.94.4

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -289,6 +289,9 @@ public class RealmProxyClassGenerator {
                 writer.beginControlFlow("if (!value.isValid())");
                     writer.emitStatement("throw new IllegalArgumentException(\"'value' is not a valid managed object.\")");
                 writer.endControlFlow();
+                writer.beginControlFlow("if (value.realm != this.realm)");
+                    writer.emitStatement("throw new IllegalArgumentException(\"'value' belongs to a different Realm.\")");
+                writer.endControlFlow();
                 writer.emitStatement("row.setLink(%s, value.row.getIndex())", fieldIndexVariableReference(field));
                 writer.endMethod();
             } else if (Utils.isRealmList(field)) {
@@ -332,6 +335,9 @@ public class RealmProxyClassGenerator {
                 writer.beginControlFlow("for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value)");
                     writer.beginControlFlow("if (!linkedObject.isValid())");
                         writer.emitStatement("throw new IllegalArgumentException(\"Each element of 'value' must be a valid managed object.\")");
+                    writer.endControlFlow();
+                    writer.beginControlFlow("if (linkedObject.realm != this.realm)");
+                        writer.emitStatement("throw new IllegalArgumentException(\"Each element of 'value' must belong to the same Realm.\")");
                     writer.endControlFlow();
                     writer.emitStatement("links.add(linkedObject.row.getIndex())");
                 writer.endControlFlow();

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -331,7 +331,7 @@ public class RealmProxyClassGenerator {
                 writer.endControlFlow();
                 writer.beginControlFlow("for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value)");
                     writer.beginControlFlow("if (!linkedObject.isValid())");
-                        writer.emitStatement("throw new IllegalArgumentException(\"Each element of 'value' must be an valid managed object.\")");
+                        writer.emitStatement("throw new IllegalArgumentException(\"Each element of 'value' must be a valid managed object.\")");
                     writer.endControlFlow();
                     writer.emitStatement("links.add(linkedObject.row.getIndex())");
                 writer.endControlFlow();

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -286,6 +286,9 @@ public class RealmProxyClassGenerator {
                     writer.emitStatement("row.nullifyLink(%s)", fieldIndexVariableReference(field));
                     writer.emitStatement("return");
                 writer.endControlFlow();
+                writer.beginControlFlow("if (!value.isValid())");
+                    writer.emitStatement("throw new IllegalArgumentException(\"'value' is not a valid managed object.\")");
+                writer.endControlFlow();
                 writer.emitStatement("row.setLink(%s, value.row.getIndex())", fieldIndexVariableReference(field));
                 writer.endMethod();
             } else if (Utils.isRealmList(field)) {
@@ -327,7 +330,10 @@ public class RealmProxyClassGenerator {
                     writer.emitStatement("return");
                 writer.endControlFlow();
                 writer.beginControlFlow("for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value)");
-                        writer.emitStatement("links.add(linkedObject.row.getIndex())");
+                    writer.beginControlFlow("if (!linkedObject.isValid())");
+                        writer.emitStatement("throw new IllegalArgumentException(\"Each element of 'value' must be an valid managed object.\")");
+                    writer.endControlFlow();
+                    writer.emitStatement("links.add(linkedObject.row.getIndex())");
                 writer.endControlFlow();
                 writer.endMethod();
             } else {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -214,6 +214,9 @@ public class AllTypesRealmProxy extends AllTypes
         if (!value.isValid()) {
             throw new IllegalArgumentException("'value' is not a valid managed object.");
         }
+        if (value.realm != this.realm) {
+            throw new IllegalArgumentException("'value' belongs to a different Realm.");
+        }
         row.setLink(columnInfo.columnObjectIndex, value.row.getIndex());
     }
 
@@ -247,6 +250,9 @@ public class AllTypesRealmProxy extends AllTypes
         for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value) {
             if (!linkedObject.isValid()) {
                 throw new IllegalArgumentException("Each element of 'value' must be a valid managed object.");
+            }
+            if (linkedObject.realm != this.realm) {
+                throw new IllegalArgumentException("Each element of 'value' must belong to the same Realm.");
             }
             links.add(linkedObject.row.getIndex());
         }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -246,7 +246,7 @@ public class AllTypesRealmProxy extends AllTypes
         }
         for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value) {
             if (!linkedObject.isValid()) {
-                throw new IllegalArgumentException("Each element of 'value' must be an valid managed object.");
+                throw new IllegalArgumentException("Each element of 'value' must be a valid managed object.");
             }
             links.add(linkedObject.row.getIndex());
         }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -211,6 +211,9 @@ public class AllTypesRealmProxy extends AllTypes
             row.nullifyLink(columnInfo.columnObjectIndex);
             return;
         }
+        if (!value.isValid()) {
+            throw new IllegalArgumentException("'value' is not a valid managed object.");
+        }
         row.setLink(columnInfo.columnObjectIndex, value.row.getIndex());
     }
 
@@ -242,6 +245,9 @@ public class AllTypesRealmProxy extends AllTypes
             return;
         }
         for (RealmObject linkedObject : (RealmList<? extends RealmObject>) value) {
+            if (!linkedObject.isValid()) {
+                throw new IllegalArgumentException("Each element of 'value' must be an valid managed object.");
+            }
             links.add(linkedObject.row.getIndex());
         }
     }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -525,6 +525,9 @@ public class NullTypesRealmProxy extends NullTypes
         if (!value.isValid()) {
             throw new IllegalArgumentException("'value' is not a valid managed object.");
         }
+        if (value.realm != this.realm) {
+            throw new IllegalArgumentException("'value' belongs to a different Realm.");
+        }
         row.setLink(columnInfo.fieldObjectNullIndex, value.row.getIndex());
     }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -522,6 +522,9 @@ public class NullTypesRealmProxy extends NullTypes
             row.nullifyLink(columnInfo.fieldObjectNullIndex);
             return;
         }
+        if (!value.isValid()) {
+            throw new IllegalArgumentException("'value' is not a valid managed object.");
+        }
         row.setLink(columnInfo.fieldObjectNullIndex, value.row.getIndex());
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTest.java
@@ -438,6 +438,135 @@ public class RealmObjectTest extends AndroidTestCase {
         assertNull(objA.getObject());
     }
 
+    public void testSetStandaloneObjectToLink() {
+        CyclicType standalone = new CyclicType();
+
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+
+            try {
+                target.setObject(standalone);
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testSetRemovedObjectToLink() {
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+
+            CyclicType removed = testRealm.createObject(CyclicType.class);
+            removed.removeFromRealm();
+
+            try {
+                target.setObject(removed);
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testSetClosedObjectToLink() {
+        testRealm.beginTransaction();
+        CyclicType closed = testRealm.createObject(CyclicType.class);
+        testRealm.commitTransaction();
+        testRealm.close();
+        assertTrue(testRealm.isClosed());
+
+        testRealm = Realm.getInstance(realmConfig);
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+
+            try {
+                target.setObject(closed);
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testSetStandaloneObjectToLinkLists() {
+        CyclicType standalone = new CyclicType();
+
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+
+            RealmList<CyclicType> list = new RealmList<>();
+            list.add(testRealm.createObject(CyclicType.class));
+            list.add(standalone);
+            list.add(testRealm.createObject(CyclicType.class));
+
+            try {
+                target.setObjects(list);
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testSetRemovedObjectToLinkLists() {
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+
+            CyclicType removed = testRealm.createObject(CyclicType.class);
+            removed.removeFromRealm();
+
+            RealmList<CyclicType> list = new RealmList<>();
+            list.add(testRealm.createObject(CyclicType.class));
+            list.add(removed);
+            list.add(testRealm.createObject(CyclicType.class));
+
+            try {
+                target.setObjects(list);
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
+    public void testSetClosedObjectToLinkLists() {
+        testRealm.beginTransaction();
+        CyclicType closed = testRealm.createObject(CyclicType.class);
+        testRealm.commitTransaction();
+        testRealm.close();
+        assertTrue(testRealm.isClosed());
+
+        testRealm = Realm.getInstance(realmConfig);
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+
+            RealmList<CyclicType> list = new RealmList<>();
+            list.add(testRealm.createObject(CyclicType.class));
+            list.add(closed);
+            list.add(testRealm.createObject(CyclicType.class));
+
+            try {
+                target.setObjects(list);
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testRealm.cancelTransaction();
+        }
+    }
+
     public void testThreadModelClass() {
         // The model class' name (Thread) clashed with a common Java class.
         // The annotation process must be able to handle that.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.CyclicType;
@@ -65,7 +66,6 @@ public class RealmObjectTest extends AndroidTestCase {
 
     // Row realmGetRow()
     public void testRealmGetRowReturnsValidRow() {
-
         testRealm.beginTransaction();
         RealmObject realmObject = testRealm.createObject(AllTypes.class);
 
@@ -224,7 +224,6 @@ public class RealmObjectTest extends AndroidTestCase {
     }
 
     public boolean methodWrongThread(final Method method) throws ExecutionException, InterruptedException {
-
         testRealm = Realm.getInstance(getContext());
         testRealm.beginTransaction();
         testRealm.createObject(AllTypes.class);
@@ -415,7 +414,6 @@ public class RealmObjectTest extends AndroidTestCase {
         } catch (Exception ignored) {
             fail();
         }
-
     }
 
     public void testSetNullLink() {
@@ -495,6 +493,79 @@ public class RealmObjectTest extends AndroidTestCase {
         }
     }
 
+    public void testSetObjectFromAnotherRealmToLink() {
+        Realm anotherRealm = Realm.getInstance(new RealmConfiguration.Builder(getContext())
+                .name("another.realm").build());
+        //noinspection TryFinallyCanBeTryWithResources
+        try {
+            anotherRealm.beginTransaction();
+            CyclicType objFromAnotherRealm = anotherRealm.createObject(CyclicType.class);
+            anotherRealm.commitTransaction();
+
+            testRealm.beginTransaction();
+            try {
+                CyclicType target = testRealm.createObject(CyclicType.class);
+
+                try {
+                    target.setObject(objFromAnotherRealm);
+                    fail();
+                } catch (IllegalArgumentException ignored) {
+                }
+            } finally {
+                testRealm.cancelTransaction();
+            }
+        } finally {
+            anotherRealm.close();
+        }
+    }
+
+    public void testSetObjectFromAnotherThreadToLink() throws InterruptedException {
+        final CountDownLatch createLatch = new CountDownLatch(1);
+        final CountDownLatch testEndLatch = new CountDownLatch(1);
+
+        final AtomicReference<CyclicType> objFromAnotherThread = new AtomicReference<>();
+
+        java.lang.Thread thread = new java.lang.Thread() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(realmConfig);
+
+                // 1. create an object
+                realm.beginTransaction();
+                objFromAnotherThread.set(realm.createObject(CyclicType.class));
+                realm.commitTransaction();
+
+                createLatch.countDown();
+                try {
+                    testEndLatch.await();
+                } catch (InterruptedException ignored) {
+                }
+
+                // 3. close Realm in this thread and finish.
+                realm.close();
+            }
+        };
+        thread.start();
+
+        createLatch.await();
+        // 2. set created object to target
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+            try {
+                target.setObject(objFromAnotherThread.get());
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testEndLatch.countDown();
+            testRealm.cancelTransaction();
+        }
+
+        // wait for finishing the thread
+        thread.join();
+    }
+
     public void testSetStandaloneObjectToLinkLists() {
         CyclicType standalone = new CyclicType();
 
@@ -565,6 +636,90 @@ public class RealmObjectTest extends AndroidTestCase {
         } finally {
             testRealm.cancelTransaction();
         }
+    }
+
+    public void testSetObjectFromAnotherRealmToLinkLists() {
+        Realm anotherRealm = Realm.getInstance(new RealmConfiguration.Builder(getContext())
+                .name("another.realm").build());
+        //noinspection TryFinallyCanBeTryWithResources
+        try {
+            anotherRealm.beginTransaction();
+            CyclicType objFromAnotherRealm = anotherRealm.createObject(CyclicType.class);
+            anotherRealm.commitTransaction();
+
+            testRealm.beginTransaction();
+            try {
+                CyclicType target = testRealm.createObject(CyclicType.class);
+
+                RealmList<CyclicType> list = new RealmList<>();
+                list.add(testRealm.createObject(CyclicType.class));
+                list.add(objFromAnotherRealm);
+                list.add(testRealm.createObject(CyclicType.class));
+
+                try {
+                    target.setObjects(list);
+                    fail();
+                } catch (IllegalArgumentException ignored) {
+                }
+            } finally {
+                testRealm.cancelTransaction();
+            }
+        } finally {
+            anotherRealm.close();
+        }
+    }
+
+    public void testSetObjectFromAnotherThreadToLinkLists() throws InterruptedException {
+        final CountDownLatch createLatch = new CountDownLatch(1);
+        final CountDownLatch testEndLatch = new CountDownLatch(1);
+
+        final AtomicReference<CyclicType> objFromAnotherThread = new AtomicReference<>();
+
+        java.lang.Thread thread = new java.lang.Thread() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(realmConfig);
+
+                // 1. create an object
+                realm.beginTransaction();
+                objFromAnotherThread.set(realm.createObject(CyclicType.class));
+                realm.commitTransaction();
+
+                createLatch.countDown();
+                try {
+                    testEndLatch.await();
+                } catch (InterruptedException ignored) {
+                }
+
+                // 3. close Realm in this thread and finish.
+                realm.close();
+            }
+        };
+        thread.start();
+
+        createLatch.await();
+        // 2. set created object to target
+        testRealm.beginTransaction();
+        try {
+            CyclicType target = testRealm.createObject(CyclicType.class);
+
+            RealmList<CyclicType> list = new RealmList<>();
+            list.add(testRealm.createObject(CyclicType.class));
+            list.add(objFromAnotherThread.get());
+            list.add(testRealm.createObject(CyclicType.class));
+
+            try {
+                target.setObjects(list);
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        } finally {
+            testEndLatch.countDown();
+            testRealm.cancelTransaction();
+        }
+
+        // wait for finishing the thread
+        thread.join();
     }
 
     public void testThreadModelClass() {


### PR DESCRIPTION
fixes #1749 and is related to #1745

review this please @realm/java 