### PR TITLE
Checking to see if a transaction is in progress & more.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
 0.85.0
+ * BREAKING CHANGE: Realm.executeTransaction() now directly throws any RuntimeException instead of wrapping it in a RealmException (#1682).
  * Added Realm.isEmpty().
  * RealmQuery.isNull() and RealmQuery.isNotNull() now throw IllegalArgumentException instead of RealmError if the fieldname is a linked field and the last element is a link (#1693).
  * Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid (standalone, removed, closed, from different Realm) object (#1749).
- * Attempting to refresh a Realm while a transaction is in process will now throw an IllegalStateException (#1712) 
+ * Attempting to refresh a Realm while a transaction is in process will now throw an IllegalStateException (#1712).
  * The Realm AAR now also contains the ProGuard configuration (#1767). (Thank you @skyisle)
 
 0.84.2

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -242,6 +242,70 @@ public class TestHelper {
         };
     }
 
+    /**
+     * Returns a naive logger that can be used to test the values that are sent to the logger.
+     */
+    public static class TestLogger implements Logger {
+
+        public String message;
+        public Throwable throwable;
+
+        @Override
+        public void v(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void v(String message, Throwable t) {
+            this.message = message;
+            this.throwable = t;
+        }
+
+        @Override
+        public void d(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void d(String message, Throwable t) {
+            this.message = message;
+            this.throwable = t;
+        }
+
+        @Override
+        public void i(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void i(String message, Throwable t) {
+            this.message = message;
+            this.throwable = t;
+        }
+
+        @Override
+        public void w(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void w(String message, Throwable t) {
+            this.message = message;
+            this.throwable = t;
+        }
+
+        @Override
+        public void e(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void e(String message, Throwable t) {
+            this.message = message;
+            this.throwable = t;
+        }
+    }
+
     public static class StubInputStream extends InputStream {
         @Override
         public int read() throws IOException {

--- a/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
@@ -45,7 +45,7 @@ public class RealmAsyncTask {
         // accumulate in work queues, which may causes a memory leak
         // if the task hold references (to an enclosing class for example)
         // we can use purge() but one caveat applies: if a second thread attempts to add
-        // something to the pool (suing the execute() method) at the same time the
+        // something to the pool (using the execute() method) at the same time the
         // first thread is attempting to purge the queue the attempt to purge
         // the queue fails and the cancelled object remain in the queue.
         // A better way to cancel objects with thread pools is to use the remove()


### PR DESCRIPTION
 Fixes #1682

Checking to see if a transaction is currently in progress for sync and async transaction pathways. Also adding logging. Added a test helper to assist with log assertion.