### PR TITLE
Add tests of average for nullable column

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -1011,6 +1011,27 @@ public class RealmQueryTest extends AndroidTestCase {
         assertNull(query.minimumDate(NullTypes.FIELD_DATE_NULL));
     }
 
+    // Test min on columns with partial null rows
+    public void testMinGivesCorrectValueForAllNonNullRows() {
+        TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        assertEquals(-1, query.min(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(-2f, query.min(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
+        assertEquals(-3d, query.min(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+        assertEquals(-2000, query.minimumDate(NullTypes.FIELD_DATE_NULL).getTime());
+    }
+
+    // Test min on columns with partial null rows
+    public void testMinGivesCorrectValueForPartialNullRows() {
+        TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        assertEquals(3, query.min(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(4f, query.min(NullTypes.FIELD_FLOAT_NULL).floatValue());
+        assertEquals(5d, query.min(NullTypes.FIELD_DOUBLE_NULL).doubleValue());
+    }
+
     // Test max on empty columns
     public void testMaxValueForEmptyColumns() {
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
@@ -1031,6 +1052,28 @@ public class RealmQueryTest extends AndroidTestCase {
         assertNull(query.maximumDate(NullTypes.FIELD_DATE_NULL));
     }
 
+    // Test max on columns with partial null rows
+    public void testMaxGivesCorrectValueForAllNonNullRows() {
+        TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        assertEquals(4, query.max(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(5f, query.max(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
+        assertEquals(6d, query.max(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+        assertEquals(12000, query.maximumDate(NullTypes.FIELD_DATE_NULL).getTime());
+    }
+
+    // Test max on columns with partial null rows
+    public void testMaxGivesCorrectValueForPartialNullRows() {
+        TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        assertEquals(4, query.max(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(5f, query.max(NullTypes.FIELD_FLOAT_NULL).floatValue());
+        assertEquals(6d, query.max(NullTypes.FIELD_DOUBLE_NULL).doubleValue());
+        assertEquals(12000, query.maximumDate(NullTypes.FIELD_DATE_NULL).getTime());
+    }
+
     // Test average on empty columns
     public void testAverageValueForEmptyColumns() {
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
@@ -1049,6 +1092,28 @@ public class RealmQueryTest extends AndroidTestCase {
         assertEquals(0d, query.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
     }
 
+    // Test average on columns with partial null rows
+    public void testAvgGivesCorrectValueForAllNonNullRows() {
+        TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        // TODO update expected value after core's fix
+        assertEquals(43.0 /* should be 2.0 */, query.average(NullTypes.FIELD_INTEGER_NULL), 0d);
+        assertEquals(7.0 / 3, query.average(NullTypes.FIELD_FLOAT_NULL), 0.001d);
+        assertEquals(8.0 / 3, query.average(NullTypes.FIELD_DOUBLE_NULL), 0.001d);
+    }
+
+    // Test average on columns with partial null rows
+    public void testAvgGivesCorrectValueForPartialNullRows() {
+        TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        // TODO update expected values after core's fix
+        assertEquals(11.0/* should be 3.5 */, query.average(NullTypes.FIELD_INTEGER_NULL), 0d);
+        assertEquals(3.0 /* should be 4.5 */, query.average(NullTypes.FIELD_FLOAT_NULL), 0f);
+        assertEquals(3.666 /* should be 5.5 */, query.average(NullTypes.FIELD_DOUBLE_NULL), 0.001d);
+    }
+
     // Test sum on empty columns
     public void testSumValueForEmptyColumns() {
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
@@ -1065,6 +1130,26 @@ public class RealmQueryTest extends AndroidTestCase {
         assertEquals(0, query.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
         assertEquals(0f, query.sum(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
         assertEquals(0d, query.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+    }
+
+    // Test sum on columns with partial null rows
+    public void testSumGivesCorrectValueForAllNonNullRows() {
+        TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        assertEquals(6, query.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(7f, query.sum(NullTypes.FIELD_FLOAT_NULL).floatValue());
+        assertEquals(8d, query.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue());
+    }
+
+    // Test sum on columns with partial null rows
+    public void testSumGivesCorrectValueForPartialNullRows() {
+        TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
+        RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
+
+        assertEquals(7, query.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(9f, query.sum(NullTypes.FIELD_FLOAT_NULL).floatValue());
+        assertEquals(11d, query.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue());
     }
 
     // Test isNull on link's nullable field.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -1011,8 +1011,8 @@ public class RealmQueryTest extends AndroidTestCase {
         assertNull(query.minimumDate(NullTypes.FIELD_DATE_NULL));
     }
 
-    // Test min on columns with partial null rows
-    public void testMinGivesCorrectValueForAllNonNullRows() {
+    // Test min on columns with all non-null rows
+    public void testMinForAllNonNullRows() {
         TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 
@@ -1023,7 +1023,7 @@ public class RealmQueryTest extends AndroidTestCase {
     }
 
     // Test min on columns with partial null rows
-    public void testMinGivesCorrectValueForPartialNullRows() {
+    public void testMinForPartialNullRows() {
         TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 
@@ -1052,8 +1052,8 @@ public class RealmQueryTest extends AndroidTestCase {
         assertNull(query.maximumDate(NullTypes.FIELD_DATE_NULL));
     }
 
-    // Test max on columns with partial null rows
-    public void testMaxGivesCorrectValueForAllNonNullRows() {
+    // Test max on columns with all non-null rows
+    public void testMaxForAllNonNullRows() {
         TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 
@@ -1064,7 +1064,7 @@ public class RealmQueryTest extends AndroidTestCase {
     }
 
     // Test max on columns with partial null rows
-    public void testMaxGivesCorrectValueForPartialNullRows() {
+    public void testMaxForPartialNullRows() {
         TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 
@@ -1092,8 +1092,8 @@ public class RealmQueryTest extends AndroidTestCase {
         assertEquals(0d, query.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
     }
 
-    // Test average on columns with partial null rows
-    public void testAvgGivesCorrectValueForAllNonNullRows() {
+    // Test average on columns with all non-null rows
+    public void testAvgForAllNonNullRows() {
         TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 
@@ -1104,7 +1104,7 @@ public class RealmQueryTest extends AndroidTestCase {
     }
 
     // Test average on columns with partial null rows
-    public void testAvgGivesCorrectValueForPartialNullRows() {
+    public void testAvgForPartialNullRows() {
         TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 
@@ -1132,8 +1132,8 @@ public class RealmQueryTest extends AndroidTestCase {
         assertEquals(0d, query.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
     }
 
-    // Test sum on columns with partial null rows
-    public void testSumGivesCorrectValueForAllNonNullRows() {
+    // Test sum on columns with all non-null rows
+    public void testSumForAllNonNullRows() {
         TestHelper.populateAllNonNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 
@@ -1143,7 +1143,7 @@ public class RealmQueryTest extends AndroidTestCase {
     }
 
     // Test sum on columns with partial null rows
-    public void testSumGivesCorrectValueForPartialNullRows() {
+    public void testSumForPartialNullRows() {
         TestHelper.populatePartialNullRowsForNumericTesting(testRealm);
         RealmQuery<NullTypes> query = testRealm.where(NullTypes.class);
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -420,14 +420,14 @@ public class RealmResultsTest extends AndroidTestCase {
         assertEquals(0d, resultList.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
     }
 
-    // Test sum on nullable rows with partial null values
+    // Test average on nullable rows with partial null values
     public void testAvgGivesCorrectValueForPartialNullRows() {
         populatePartialNullRowsForNumericTesting();
         RealmResults<NullTypes> resultList = testRealm.where(NullTypes.class).findAll();
 
-        assertEquals(1, resultList.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
-        assertEquals(2f, resultList.sum(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
-        assertEquals(3d, resultList.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+        assertEquals(0.5, resultList.average(NullTypes.FIELD_INTEGER_NULL), 0d);
+        assertEquals(1.0, resultList.average(NullTypes.FIELD_FLOAT_NULL), 0f);
+        assertEquals(1.5, resultList.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
     }
 
     public void testRemove() {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTest.java
@@ -333,7 +333,7 @@ public class RealmResultsTest extends AndroidTestCase {
         assertEquals(3d, results.max(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
     }
 
-    public void testSumGivesCorrectValue() {
+    public void testSum() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
 
         Number sum = resultList.sum(FIELD_LONG);
@@ -342,7 +342,7 @@ public class RealmResultsTest extends AndroidTestCase {
     }
 
     // Test sum on nullable rows with all null values
-    public void testSumGivesCorrectValueForAllNullRows() {
+    public void testSumForAllNullRows() {
         TestHelper.populateAllNullRowsForNumericTesting(testRealm);
 
         RealmResults<NullTypes> resultList = testRealm.where(NullTypes.class).findAll();
@@ -352,7 +352,7 @@ public class RealmResultsTest extends AndroidTestCase {
     }
 
     // Test sum on nullable rows with partial null values
-    public void testSumGivesCorrectValueForPartialNullRows() {
+    public void testSumForPartialNullRows() {
         populatePartialNullRowsForNumericTesting();
         RealmResults<NullTypes> resultList = testRealm.where(NullTypes.class).findAll();
 
@@ -361,7 +361,7 @@ public class RealmResultsTest extends AndroidTestCase {
         assertEquals(3d, resultList.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
     }
 
-    public void testSumGivesCorrectValueWithNonLatinColumnNames() {
+    public void testSumWithNonLatinColumnNames() {
         RealmResults<NonLatinFieldNames> resultList = testRealm.where(NonLatinFieldNames.class).findAll();
 
         Number sum = resultList.sum(FIELD_KOREAN_CHAR);
@@ -373,7 +373,7 @@ public class RealmResultsTest extends AndroidTestCase {
         assertEquals((TEST_DATA_SIZE - 1) * TEST_DATA_SIZE / 2, sum.intValue());
     }
 
-    public void testAvgGivesCorrectValue() {
+    public void testAvg() {
         RealmResults<AllTypes> resultList = testRealm.where(AllTypes.class).findAll();
         double N = (double) TEST_DATA_SIZE;
 
@@ -402,7 +402,7 @@ public class RealmResultsTest extends AndroidTestCase {
     }
 
     // Test average on empty columns
-    public void testAvgGivesCorrectValueForEmptyColumns() {
+    public void testAvgForEmptyColumns() {
         RealmResults<NullTypes> resultList = testRealm.where(NullTypes.class).findAll();
 
         assertEquals(0d, resultList.average(NullTypes.FIELD_INTEGER_NOT_NULL), 0d);
@@ -411,7 +411,7 @@ public class RealmResultsTest extends AndroidTestCase {
     }
 
     // Test average on nullable rows with all null values
-    public void testAvgGivesCorrectValueForAllNullRows() {
+    public void testAvgForAllNullRows() {
         TestHelper.populateAllNullRowsForNumericTesting(testRealm);
 
         RealmResults<NullTypes> resultList = testRealm.where(NullTypes.class).findAll();
@@ -421,7 +421,7 @@ public class RealmResultsTest extends AndroidTestCase {
     }
 
     // Test average on nullable rows with partial null values
-    public void testAvgGivesCorrectValueForPartialNullRows() {
+    public void testAvgForPartialNullRows() {
         populatePartialNullRowsForNumericTesting();
         RealmResults<NullTypes> resultList = testRealm.where(NullTypes.class).findAll();
 

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -450,6 +450,70 @@ public class TestHelper {
         testRealm.commitTransaction();
     }
 
+    public static void populateAllNonNullRowsForNumericTesting (Realm realm) {
+        NullTypes nullTypes1 = new NullTypes();
+        nullTypes1.setId(1);
+        nullTypes1.setFieldIntegerNull(3);
+        nullTypes1.setFieldFloatNull(4F);
+        nullTypes1.setFieldDoubleNull(5D);
+        nullTypes1.setFieldBooleanNull(true);
+        nullTypes1.setFieldStringNull("4");
+        nullTypes1.setFieldDateNull(new Date(12345));
+
+        NullTypes nullTypes2 = new NullTypes();
+        nullTypes2.setId(2);
+        nullTypes2.setFieldIntegerNull(-1);
+        nullTypes2.setFieldFloatNull(-2F);
+        nullTypes2.setFieldDoubleNull(-3D);
+        nullTypes2.setFieldBooleanNull(false);
+        nullTypes2.setFieldStringNull("str");
+        nullTypes2.setFieldDateNull(new Date(-2000));
+
+        NullTypes nullTypes3 = new NullTypes();
+        nullTypes3.setId(3);
+        nullTypes3.setFieldIntegerNull(4);
+        nullTypes3.setFieldFloatNull(5F);
+        nullTypes3.setFieldDoubleNull(6D);
+        nullTypes3.setFieldBooleanNull(false);
+        nullTypes3.setFieldStringNull("0");
+        nullTypes3.setFieldDateNull(new Date(0));
+
+        realm.beginTransaction();
+        realm.copyToRealm(nullTypes1);
+        realm.copyToRealm(nullTypes2);
+        realm.copyToRealm(nullTypes3);
+        realm.commitTransaction();
+    }
+
+    public static void populatePartialNullRowsForNumericTesting (Realm realm) {
+        NullTypes nullTypes1 = new NullTypes();
+        nullTypes1.setId(1);
+        nullTypes1.setFieldIntegerNull(3);
+        nullTypes1.setFieldFloatNull(4F);
+        nullTypes1.setFieldDoubleNull(5D);
+        nullTypes1.setFieldBooleanNull(true);
+        nullTypes1.setFieldStringNull("4");
+        nullTypes1.setFieldDateNull(new Date(12345));
+
+        NullTypes nullTypes2 = new NullTypes();
+        nullTypes2.setId(2);
+
+        NullTypes nullTypes3 = new NullTypes();
+        nullTypes3.setId(3);
+        nullTypes3.setFieldIntegerNull(4);
+        nullTypes3.setFieldFloatNull(5F);
+        nullTypes3.setFieldDoubleNull(6D);
+        nullTypes3.setFieldBooleanNull(false);
+        nullTypes3.setFieldStringNull("0");
+        nullTypes3.setFieldDateNull(new Date(0));
+
+        realm.beginTransaction();
+        realm.copyToRealm(nullTypes1);
+        realm.copyToRealm(nullTypes2);
+        realm.copyToRealm(nullTypes3);
+        realm.commitTransaction();
+    }
+
     public static void populateAllNullRowsForNumericTesting(Realm realm) {
         NullTypes nullTypes1 = new NullTypes();
         nullTypes1.setId(1);


### PR DESCRIPTION
Added tests for aggregation methods in `RealmQuery` for partial null rows .

`RealmQueryTest.testSumGivesCorrectValueForPartialNullRows()` and `RealmQueryTest.testAvgGivesCorrectValueForAllNonNullRows()` tests wrong value for now.

These tests must be updated after core's fix.

related to #1803 