### PR TITLE
Improve formatting of copyright headers

### DIFF
--- a/realm/realm-jni/src/utf8.hpp
+++ b/realm/realm-jni/src/utf8.hpp
@@ -1,22 +1,19 @@
-/*************************************************************************
+/*
+ * Copyright 2011 Realm Inc.
  *
- * REALM CONFIDENTIAL
- * __________________
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  [2011] - [2012] Realm Inc
- *  All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * NOTICE:  All information contained herein is, and remains
- * the property of Realm Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Realm Incorporated
- * and its suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Realm Incorporated.
- *
- **************************************************************************/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef REALM_UTIL_UTF8_HPP
 #define REALM_UTIL_UTF8_HPP
 

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.test.AndroidTestCase;

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTest.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm;

--- a/realm/realm-library/src/androidTest/java/io/realm/IOSRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/IOSRealmTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.test.AndroidTestCase;

--- a/realm/realm-library/src/androidTest/java/io/realm/MediatorTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/MediatorTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.test.AndroidTestCase;

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.os.Handler;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAdapterTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAdapterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.test.AndroidTestCase;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.test.AndroidTestCase;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmInMemoryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmInMemoryTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.os.StrictMode;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.content.res.AssetManager;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsIteratorTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsIteratorTests.java
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
 package io.realm;
 
 import android.test.AndroidTestCase;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm;
 
 import android.content.Context;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIMixedTypeTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIMixedTypeTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal;
 
 import junit.framework.Test;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIParameterizedTestExample.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIParameterizedTestExample.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal;
 
 import junit.framework.Test;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableInsertTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableInsertTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal;
 
 import android.test.MoreAsserts;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableSpecTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableSpecTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal;
 
 import junit.framework.Test;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITestSuite.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITestSuite.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal;
 
 import android.annotation.TargetApi;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/CodeGenTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/CodeGenTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import io.realm.internal.DefineTable;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/ColumnTypeData.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/ColumnTypeData.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal.test;
 
 import io.realm.RealmFieldType;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/DataProviderUtil.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/DataProviderUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import java.util.Arrays;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/EmployeeData.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/EmployeeData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import java.nio.ByteBuffer;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/EmployeesFixture.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/EmployeesFixture.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import java.util.Date;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/ExtraTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/ExtraTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import java.lang.reflect.Array;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/MixedData.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/MixedData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import io.realm.RealmFieldType;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/PhoneData.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/PhoneData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 public class PhoneData {

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Realm Inc.
+ * Copyright 2015 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Realm Inc.
+ * Copyright 2014 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestTableModel.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestTableModel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import java.util.Date;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestValue.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/TestValue.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal.test;
 
 public class TestValue {

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/test/VariationsIterator.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/test/VariationsIterator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.test;
 
 import java.util.Iterator;

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm;

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm;

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm;

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.exceptions;
 
 import java.io.File;

--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm.internal;

--- a/realm/realm-library/src/main/java/io/realm/internal/InvalidRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/InvalidRow.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm.internal;

--- a/realm/realm-library/src/main/java/io/realm/internal/NativeObject.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/NativeObject.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal;
 
 /**

--- a/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.realm.internal;
 
 import java.lang.ref.PhantomReference;

--- a/realm/realm-library/src/main/java/io/realm/internal/Row.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Row.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm.internal;

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedGroupManager.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedGroupManager.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.realm.internal;

--- a/realm/realm-library/src/main/java/io/realm/internal/android/AndroidLogger.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/AndroidLogger.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.android;
 
 import android.util.Log;

--- a/realm/realm-library/src/main/java/io/realm/internal/android/DebugAndroidLogger.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/DebugAndroidLogger.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.android;
 
 import io.realm.internal.log.RealmLog;

--- a/realm/realm-library/src/main/java/io/realm/internal/android/ReleaseAndroidLogger.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/ReleaseAndroidLogger.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.android;
 
 import io.realm.internal.log.RealmLog;

--- a/realm/realm-library/src/main/java/io/realm/internal/async/ArgumentsHolder.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/async/ArgumentsHolder.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package io.realm.internal.async;
 
 import io.realm.Sort;

--- a/realm/realm-library/src/main/java/io/realm/internal/log/Logger.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/log/Logger.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.log;
 
 /**

--- a/realm/realm-library/src/main/java/io/realm/internal/log/RealmLog.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/log/RealmLog.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.log;
 
 import java.util.List;


### PR DESCRIPTION
* Confidential -> Apache
* Add missing copyright headers.
* Add new lines after headers.
* Delete unnecessary new lines in headers

Some of them were created on 2015. (2014 -> 2015)