### PR TITLE
Deprecate RealmConfiguration.getSchemaMediator() from public API and add getRealmObjectClasses() instead

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
  * BREAKING CHANGE: RealmQuery.CASE_SENSITIVE and RealmQuery.CASE_INSENSITIVE constants have been replaced by Case.SENSITIVE and Case.INSENSITIVE enums.
  * BREAKING CHANGE: Realm.addChangeListener, RealmObject.addChangeListener and RealmResults.addChangeListener hold a strong reference to the listener, you should unregister the listener to avoid memory leaks.
  * BREAKING CHANGE: Removed deprecated methods RealmQuery.minimum{Int,Float,Double}, RealmQuery.maximum{Int,Float,Double}, RealmQuery.sum{Int,Float,Double} and RealmQuery.average{Int,Float,Double}. Use RealmQuery.min(), RealmQuery.max(), RealmQuery.sum() and RealmQuery.average() instead.
+ * BREAKING CHANGE: Removed RealmConfiguration.getSchemaMediator() which is public by mistake. And RealmConfiguration.getRealmObjectClasses() is added as an alternative in order to obtain the set of model classes (#1797).
  * Added new Dynamic API using DynamicRealm and DynamicRealmObject.
  * Added Realm.getSchema() and DynamicRealm.getSchema().
  * Realm.createOrUpdateObjectFromJson() now works correctly if the RealmObject class contains a primary key (#1777).

--- a/realm/realm-library/src/androidTest/java/io/realm/MediatorTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/MediatorTest.java
@@ -34,8 +34,7 @@ public class MediatorTest extends AndroidTestCase {
     @SuppressWarnings("AssertEqualsBetweenInconvertibleTypes")
     public void testMediatorsEquality() {
         final DefaultRealmModuleMediator defaultMediator = new DefaultRealmModuleMediator();
-        final CompositeMediator compositeMediator = new CompositeMediator();
-        compositeMediator.addMediator(defaultMediator);
+        final CompositeMediator compositeMediator = new CompositeMediator(defaultMediator);
         final FilterableMediator filterableMediator = new FilterableMediator(defaultMediator, defaultMediator.getModelClasses());
 
         assertEquals(defaultMediator, defaultMediator);
@@ -61,9 +60,10 @@ public class MediatorTest extends AndroidTestCase {
     }
 
     public void testCompositeMediatorModelClassesCount() {
-        final CompositeMediator mediator = new CompositeMediator();
-        mediator.addMediator(new HumanModuleMediator());
-        mediator.addMediator(new AnimalModuleMediator());
+        final CompositeMediator mediator = new CompositeMediator(
+                new HumanModuleMediator(),
+                new AnimalModuleMediator()
+        );
 
         final int modelsInHumanModule = HumanModule.class.getAnnotation(RealmModule.class).classes().length;
         final int modelsInAnimalModule = AnimalModule.class.getAnnotation(RealmModule.class).classes().length;

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -118,8 +118,25 @@ public class RealmConfiguration {
         return durability;
     }
 
+    /**
+     * Returns the mediator instance of schema which is defined by this configuration.
+     * This method is left public by mistake and will be removed.
+     *
+     * @return the mediator of the schema.
+     * @deprecated use {@link #getRealmObjectClasses()} instead if you need to access to the set of model classes.
+     */
+    @Deprecated
     public RealmProxyMediator getSchemaMediator() {
         return schemaMediator;
+    }
+
+    /**
+     * Returns the unmodifiable {@link Set} of model classes that make up the schema for this Realm.
+     *
+     * @return unmodifiable {@link Set} of model classes.
+     */
+    public Set<Class<? extends RealmObject>> getRealmObjectClasses() {
+        return schemaMediator.getModelClasses();
     }
 
     public String getPath() {
@@ -176,11 +193,13 @@ public class RealmConfiguration {
         }
 
         // Otherwise combine all mediators
-        CompositeMediator mediator = new CompositeMediator();
+        RealmProxyMediator[] mediators = new RealmProxyMediator[modules.size()];
+        int i = 0;
         for (Object module : modules) {
-            mediator.addMediator(getModuleMediator(module.getClass().getCanonicalName()));
+            mediators[i] = getModuleMediator(module.getClass().getCanonicalName());
+            i++;
         }
-        return mediator;
+        return new CompositeMediator(mediators);
     }
 
     // Finds the mediator associated with a given module

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -22,8 +22,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,12 +42,18 @@ import io.realm.internal.Util;
  */
 public class CompositeMediator extends RealmProxyMediator {
 
-    Map<Class<? extends RealmObject>, RealmProxyMediator> mediators = new HashMap<Class<? extends RealmObject>, RealmProxyMediator>();
+    private final Map<Class<? extends RealmObject>, RealmProxyMediator> mediators;
 
-    public void addMediator(RealmProxyMediator mediator) {
-        for (Class<? extends RealmObject> realmClass : mediator.getModelClasses()) {
-            mediators.put(realmClass, mediator);
+    public CompositeMediator(RealmProxyMediator... mediators) {
+        final HashMap<Class<? extends RealmObject>, RealmProxyMediator> tempMediators = new HashMap<>();
+        if (mediators != null) {
+            for (RealmProxyMediator mediator : mediators) {
+                for (Class<? extends RealmObject> realmClass : mediator.getModelClasses()) {
+                    tempMediators.put(realmClass, mediator);
+                }
+            }
         }
+        this.mediators = Collections.unmodifiableMap(tempMediators);
     }
 
     @Override
@@ -82,7 +88,7 @@ public class CompositeMediator extends RealmProxyMediator {
 
     @Override
     public Set<Class<? extends RealmObject>> getModelClasses() {
-        return new HashSet<Class<? extends RealmObject>>(mediators.keySet());
+        return mediators.keySet();
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,8 +44,8 @@ import io.realm.internal.Util;
  */
 public class FilterableMediator extends RealmProxyMediator {
 
-    private RealmProxyMediator originalMediator;
-    private Set<Class<? extends RealmObject>> allowedClasses = new HashSet<Class<? extends RealmObject>>();
+    private final RealmProxyMediator originalMediator;
+    private final Set<Class<? extends RealmObject>> allowedClasses;
 
     /**
      * Creates a filterable {@link RealmProxyMediator}.
@@ -54,14 +55,17 @@ public class FilterableMediator extends RealmProxyMediator {
      */
     public FilterableMediator(RealmProxyMediator originalMediator, Collection<Class<? extends RealmObject>> allowedClasses) {
         this.originalMediator = originalMediator;
+
+        Set<Class<? extends RealmObject>> tempAllowedClasses = new HashSet<Class<? extends RealmObject>>();
         if (originalMediator != null) {
             Set<Class<? extends RealmObject>> originalClasses = originalMediator.getModelClasses();
             for (Class<? extends RealmObject> clazz : allowedClasses) {
                 if (originalClasses.contains(clazz)) {
-                    this.allowedClasses.add(clazz);
+                    tempAllowedClasses.add(clazz);
                 }
             }
         }
+        this.allowedClasses = Collections.unmodifiableSet(tempAllowedClasses);
     }
 
     public RealmProxyMediator getOriginalMediator() {
@@ -100,7 +104,7 @@ public class FilterableMediator extends RealmProxyMediator {
 
     @Override
     public Set<Class<? extends RealmObject>> getModelClasses() {
-        return new HashSet<Class<? extends RealmObject>>(allowedClasses);
+        return allowedClasses;
     }
 
     @Override


### PR DESCRIPTION
* Removed `RealmConfiguration.getSchemaMediator()` which was left public by mistake
* Added `RealmConfiguration.getRealmClasses()` which returns the unmodifiable set of model classes that belong to the configuration.

I refactored for all implementations of `RealmProxyMediator.getModelClassed()` to return unmodifiable `Set`.

please review this @realm/java 

closes #1797 