### PR TITLE
compact returns false if the file is opened

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
  * Added Realm.getSchema() and DynamicRealm.getSchema().
  * Realm.createOrUpdateObjectFromJson() now works correctly if the RealmObject class contains a primary key (#1777).
  * Updated Realm Core to 0.95.1
+ * Realm.compactRealm() doesn't throw an exception if the Realm file is opened. It just returns false instead.
 
 0.85.1
  * Fixed a bug which could corrupt primary key information when updating from a Realm version <= 0.84.1 (#1775).

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
@@ -1051,16 +1051,12 @@ public class RealmTest extends AndroidTestCase {
         final RealmConfiguration configuration = testRealm.getConfiguration();
         testRealm.close();
         testRealm = null;
-        Realm.compactRealm(configuration);
+        assertTrue(Realm.compactRealm(configuration));
         testRealm = Realm.getInstance(configuration);
     }
 
-    public void testCompactRealmFileThrowsIfOpen() throws IOException {
-        try {
-            Realm.compactRealm(TestHelper.createConfiguration(getContext()));
-            fail();
-        } catch (IllegalStateException expected) {
-        }
+    public void testCompactRealmFileFailsIfOpen() throws IOException {
+        assertFalse(Realm.compactRealm(TestHelper.createConfiguration(getContext())));
     }
 
     public void testCompactEncryptedEmptyRealmFile() {

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -592,24 +592,12 @@ abstract class BaseRealm implements Closeable {
     /**
      * Compacts the Realm file defined by the given configuration.
      */
-    public static boolean compactRealm(final RealmConfiguration configuration) {
+    static boolean compactRealm(final RealmConfiguration configuration) {
         if (configuration.getEncryptionKey() != null) {
             throw new IllegalArgumentException("Cannot currently compact an encrypted Realm.");
         }
 
-        final AtomicBoolean result = new AtomicBoolean(false);
-
-        RealmCache.invokeWithGlobalRefCount(configuration, new RealmCache.Callback() {
-            @Override
-            public void onResult(int count) {
-                if (count != 0) {
-                    throw new IllegalStateException("Cannot compact an open Realm");
-                }
-                result.set(SharedGroupManager.compact(configuration));
-            }
-        });
-
-        return result.get();
+        return SharedGroupManager.compact(configuration);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1094,12 +1094,14 @@ public final class Realm extends BaseRealm {
      * This method removes this free space and the file size is thereby reduced.
      * Objects within the Realm files are untouched.
      * <p>
-     * The file must be closed before this method is called.<br>
+     * The file must be closed before this method is called, otherwise {@code false} will be returned.<br>
      * The file system should have free space for at least a copy of the Realm file.<br>
      * The Realm file is left untouched if any file operation fails.<br>
      *
      * @param configuration a {@link RealmConfiguration} pointing to a Realm file.
      * @return {@code true} if successful, {@code false} if any file operation failed.
+     * @throws IllegalArgumentException if the realm file is encrypted. Compacting an encrypted Realm file is not
+     * supported yet.
      */
     public static boolean compactRealm(RealmConfiguration configuration) {
         return BaseRealm.compactRealm(configuration);


### PR DESCRIPTION
Core will guarantee the file is not opened while compacting.
Core also guarantee opening Realm will be blocked until compacting
finished.