### PR TITLE
Fixed weak change listeners being removed correctly

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -156,7 +156,6 @@ public class HandlerController implements Handler.Callback {
             // Check if Listener already exists
             if (weakListener == listener) {
                 addListener = false;
-                break;
             }
         }
         if (toRemoveList != null) {


### PR DESCRIPTION
Fixes #1875 

We didn't remove listeners correctly in `addChangeListenerAsWeakReference` compared to `notifyGlobalListeners`. 

No changelog needed as this hasn't been released yet.

@realm/java 