### PR TITLE
fixed a bug in RealmQuery.findFirst()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
  * Added Realm.copyFromRealm() for creating detached copies of Realm objects.
  * Added RealmObjectSchema.getFieldType()
  * Added unitTestExample to showcase unit and instrumentation tests. Examples include jUnit3, jUnit4, Espresso, Robolectric, and MPowermock usage with Realm (#1440).
+ * Fixed a bug where RealmQuery.findFirst() returned a wrong result if that RealmQuery had been created from RealmResults (#1905).
 
 0.86.0
  * BREAKING CHANGE: The Migration API has been replaced with a new API.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -1492,6 +1492,16 @@ public class RealmQueryTest extends AndroidTestCase {
         assertFalse(query.isValid());
     }
 
+    // test for https://github.com/realm/realm-java/issues/1905
+    public void testResultOfTableViewQuery() {
+        populateTestRealm();
+
+        final RealmResults<AllTypes> results = testRealm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 3L).findAll();
+        final RealmQuery<AllTypes> tableViewQuery = results.where();
+        assertEquals("test data 3", tableViewQuery.findAll().first().getColumnString());
+        assertEquals("test data 3", tableViewQuery.findFirst().getColumnString());
+    }
+
     public void testIsValidOfLinkViewQuery() {
         populateTestRealm(1);
         final RealmList<Dog> list = testRealm.where(AllTypes.class).findFirst().getColumnRealmList();


### PR DESCRIPTION
fixed a bug where RealmQuery.findFirst() returned a wrong result if that RealmQuery had been created from RealmResults.

review this please @realm/java 

closes #1905