### PR TITLE
fixed a bug in RealmQuery.findFirst()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,9 @@
  * Added RealmObjectSchema.getFieldType()
  * Added unitTestExample to showcase unit and instrumentation tests. Examples include jUnit3, jUnit4, Espresso, Robolectric, and MPowermock usage with Realm (#1440).
 
+0.86.1
+ * Fixed a bug where RealmQuery.findFirst() returned a wrong result if the RealmQuery had been created from a RealmResults.where() (#1905).
+
 0.86.0
  * BREAKING CHANGE: The Migration API has been replaced with a new API.
  * BREAKING CHANGE: RealmResults.SORT_ORDER_ASCENDING and RealmResults.SORT_ORDER_DESCENDING constants have been replaced by Sort.ASCENDING and Sort.DESCENDING enums.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTest.java
@@ -1492,6 +1492,16 @@ public class RealmQueryTest extends AndroidTestCase {
         assertFalse(query.isValid());
     }
 
+    // test for https://github.com/realm/realm-java/issues/1905
+    public void testResultOfTableViewQuery() {
+        populateTestRealm();
+
+        final RealmResults<AllTypes> results = testRealm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 3L).findAll();
+        final RealmQuery<AllTypes> tableViewQuery = results.where();
+        assertEquals("test data 3", tableViewQuery.findAll().first().getColumnString());
+        assertEquals("test data 3", tableViewQuery.findFirst().getColumnString());
+    }
+
     public void testIsValidOfLinkViewQuery() {
         populateTestRealm(1);
         final RealmList<Dog> list = testRealm.where(AllTypes.class).findFirst().getColumnRealmList();

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -30,7 +30,7 @@ import io.realm.annotations.Required;
 import io.realm.internal.LinkView;
 import io.realm.internal.Row;
 import io.realm.internal.SharedGroup;
-import io.realm.internal.Table;
+import io.realm.internal.TableOrView;
 import io.realm.internal.TableQuery;
 import io.realm.internal.TableView;
 import io.realm.internal.async.ArgumentsHolder;
@@ -60,7 +60,7 @@ public class RealmQuery<E extends RealmObject> {
     private BaseRealm realm;
     private Class<E> clazz;
     private String className;
-    private Table table;
+    private TableOrView table;
     private RealmObjectSchema schema;
     private LinkView view;
     private TableQuery query;
@@ -139,7 +139,7 @@ public class RealmQuery<E extends RealmObject> {
         this.realm = queryResults.realm;
         this.clazz = clazz;
         this.schema = realm.schema.getSchemaForClass(clazz);
-        this.table = schema.table;
+        this.table = queryResults.getTable();
         this.view = null;
         this.query = queryResults.getTable().where();
     }
@@ -192,7 +192,7 @@ public class RealmQuery<E extends RealmObject> {
         if (view != null) {
             return view.isAttached();
         }
-        return table != null && table.isValid();
+        return table != null && table.getTable().isValid();
     }
 
     /**
@@ -1750,9 +1750,9 @@ public class RealmQuery<E extends RealmObject> {
      */
     public E findFirst() {
         checkQueryIsNotReused();
-        long rowIndex = this.query.find();
-        if (rowIndex >= 0) {
-            E realmObject = realm.get(clazz, className, (view != null) ? view.getTargetRowIndex(rowIndex) : rowIndex);
+        long sourceRowIndex = getSourceRowIndexForFirstObject();
+        if (sourceRowIndex >= 0) {
+            E realmObject = realm.get(clazz, className, sourceRowIndex);
             if (realm.handlerController != null) { // non Looper Thread doesn't have a handlerController
                 WeakReference<RealmObject> realmObjectWeakReference
                         = new WeakReference<RealmObject>(realmObject, realm.handlerController.referenceQueueRealmObject);
@@ -1882,6 +1882,20 @@ public class RealmQuery<E extends RealmObject> {
     private void checkQueryIsNotReused() {
         if (argumentsHolder != null) {
             throw new IllegalStateException("This RealmQuery is already used by a find* query, please create a new query");
+        }
+    }
+
+    private long getSourceRowIndexForFirstObject() {
+        long rowIndex = this.query.find();
+        if (rowIndex < 0) {
+            return rowIndex;
+        }
+        if (this.view != null) {
+            return view.getTargetRowIndex(rowIndex);
+        } else if (table instanceof TableView){
+            return ((TableView) table).getSourceRowIndex(rowIndex);
+        } else {
+            return rowIndex;
         }
     }
 


### PR DESCRIPTION
merging 72b09ea912927b2f5fdef87b42940bb8c05ff27b on release/0.86 branch into master

fixed a bug where RealmQuery.findFirst() returned a wrong result if that RealmQuery had been created from RealmResults.

closes #1905