### PR TITLE
Call TableView::clear() with RemoveMode::unordered

### DIFF
--- a/realm/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm/realm-jni/src/io_realm_internal_tableview.cpp
@@ -470,7 +470,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeClear(
     try {
         if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
             return;
-        TV(nativeViewPtr)->clear();
+        TV(nativeViewPtr)->clear(RemoveMode::unordered);
     } CATCH_STD()
 }
 
@@ -481,7 +481,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeRemoveRow(
         if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
             !ROW_INDEX_VALID(env, TV(nativeViewPtr), rowIndex))
             return;
-        TV(nativeViewPtr)->remove( S(rowIndex));
+        TV(nativeViewPtr)->remove( S(rowIndex), RemoveMode::unordered);
     } CATCH_STD()
 }
 


### PR DESCRIPTION
Call TableView::clear() and TableView::remove() with RemoveMode::unordered.

This change requires  a new core release as unordered removal is broken without realm/realm-core#1384.

So this PR should be merged after #1913

