### PR TITLE
Nh/fix 1894 changelistener not called

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,8 @@
  * Fixed a bug which could cause a crash when closing Realm instances in change listeners (#1900).
  * Fix a crash occurring during update of multiple async queries (#1895).
  * Fixed listeners not triggered for RealmObject & RealmResults created using copy or create methods (#1884).
+ * Fix (#1894) RealmChangeListener never called inside RealmResults.
+ * Fix (#1886), crash when calling clear on a LinkView.
 
 0.86.0
  * BREAKING CHANGE: The Migration API has been replaced with a new API.

--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTest.java
@@ -269,8 +269,8 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
         assertEquals(1, typebasedCommitInvocations.get());
     }
 
-    //UC 0 using Realm.createObjectFromJson
-    public void test_callback_should_trigger_for_createObjectFromJson_inputStream() {
+    //UC 0 using Realm.copyToRealmOrUpdate
+    public void test_callback_should_trigger_for_createObjectFromJson() {
         handler.post(new Runnable() {
             @Override
             public void run() {
@@ -323,8 +323,8 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
         assertEquals(1, typebasedCommitInvocations.get());
     }
 
-    //UC 0 using Realm.createObjectFromJson
-    public void test_callback_should_trigger_for_createObjectFromJson_JSONObject() {
+    //UC 0 using Realm.copyToRealmOrUpdate
+    public void test_callback_should_trigger_for_createObjectFromJson_from_JSONObject() {
         handler.post(new Runnable() {
             @Override
             public void run() {
@@ -384,7 +384,7 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
     }
 
     //UC 0 using Realm.createOrUpdateObjectFromJson
-    public void test_callback_should_trigger_for_createOrUpdateObjectFromJson_InputStream() {
+    public void test_callback_should_trigger_for_createOrUpdateObjectFromJson() {
         handler.post(new Runnable() {
             @Override
             public void run() {
@@ -453,7 +453,7 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
         assertEquals(1, typebasedCommitInvocations.get());
     }
 
-    //UC 0 using Realm.createOrUpdateObjectFromJson
+    //UC 0 using Realm.copyToRealmOrUpdate
     public void test_callback_should_trigger_for_createOrUpdateObjectFromJson_from_JSONObject() {
         handler.post(new Runnable() {
             @Override
@@ -934,11 +934,11 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
                 });
 
                 realm.beginTransaction();
+                Dog akamaru = realm.createObject(Dog.class);
+                akamaru.setName("Akamaru");
                 realm.commitTransaction();
 
                 realm.beginTransaction();
-                Dog akamaru = realm.createObject(Dog.class);
-                akamaru.setName("Akamaru");
                 realm.commitTransaction();
 
                 realm.beginTransaction();
@@ -1043,11 +1043,12 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
                 }
 
                 realm.beginTransaction();
+                akamaru.setAge(17);
                 realm.commitTransaction();
 
                 realm.beginTransaction();
-                akamaru.setAge(17);
                 realm.commitTransaction();
+
             }
         });
         TestHelper.awaitOrFail(signalTestFinished);
@@ -1142,10 +1143,10 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
                 }
 
                 realm.beginTransaction();
+                akamaru.setAge(17);
                 realm.commitTransaction();
 
                 realm.beginTransaction();
-                akamaru.setAge(17);
                 realm.commitTransaction();
             }
         });
@@ -1281,7 +1282,7 @@ public class TypeBasedNotificationsTest extends AndroidTestCase {
             }
         });
         TestHelper.awaitOrFail(signalTestFinished);
-        assertEquals(1, typebasedCommitInvocations.get());
+        assertEquals(2, typebasedCommitInvocations.get());
     }
 
     // UC 3 Sync RealmResults

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -86,7 +86,7 @@ public abstract class RealmObject {
     private final List<RealmChangeListener> listeners = new CopyOnWriteArrayList<RealmChangeListener>();
     private Future<Long> pendingQuery;
     private boolean isCompleted = false;
-    protected long currentTableVersion = 0;
+    protected long currentTableVersion = -1;
 
     /**
      * Removes the object from the Realm it is currently associated to.
@@ -266,13 +266,15 @@ public abstract class RealmObject {
      * Notifies all registered listeners.
      */
     void notifyChangeListeners() {
-        if (row.getTable() == null) return;
+        if (listeners != null && !listeners.isEmpty()) {
+            if (row.getTable() == null) return;
 
-        long version = row.getTable().version();
-        if (currentTableVersion != version) {
-            currentTableVersion = version;
-            for (RealmChangeListener listener : listeners) {
-                listener.onChange();
+            long version = row.getTable().version();
+            if (currentTableVersion != version) {
+                currentTableVersion = version;
+                for (RealmChangeListener listener : listeners) {
+                    listener.onChange();
+                }
             }
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -64,7 +64,7 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
     private TableOrView table = null;
 
     private static final String TYPE_MISMATCH = "Field '%s': type mismatch - %s expected.";
-    private long currentTableViewVersion = 0;
+    private long currentTableViewVersion = -1;
 
     private final TableQuery query;
     private final List<RealmChangeListener> listeners = new CopyOnWriteArrayList<RealmChangeListener>();
@@ -824,15 +824,20 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
      * Notifies all registered listeners.
      */
     void notifyChangeListeners() {
-        // table might be null (if the async query didn't complete
-        // but we have already registered listeners for it)
-        if (pendingQuery != null && !isCompleted) return;
+        if (listeners != null && !listeners.isEmpty()) {
+            // table might be null (if the async query didn't complete
+            // but we have already registered listeners for it)
+            if (pendingQuery != null && !isCompleted) return;
 
-        long version = table.sync();
-        if (currentTableViewVersion != version) {
-            currentTableViewVersion = version;
-            for (RealmChangeListener listener : listeners) {
-                listener.onChange();
+            //FIXME: still waiting for Core to provide a fix
+            //       for crash when calling _sync_if_needed on a cleared View.
+            //       https://github.com/realm/realm-core/pull/1390
+            long version = table.sync();
+            if (currentTableViewVersion != version) {
+                currentTableViewVersion = version;
+                for (RealmChangeListener listener : listeners) {
+                    listener.onChange();
+                }
             }
         }
     }


### PR DESCRIPTION
fix #1894 + provide a work around for #1886 while waiting for core fix, the work around avoid calling _sync_if_needed_ if the RealmObject/RealmResults doesn't have any listeners

Note: it will be faster (small diff) to review this PR first https://github.com/realm/realm-java/pull/1892