### PR TITLE
Throw exception when try to remove a changeListener from a non-looper thread.

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
@@ -2697,16 +2697,20 @@ public class RealmTest extends AndroidTestCase {
         }
     }
 
-    public void testHandlerControllerThrowNullPointExceptionOnNonLooperThread() {
+    public void testRemoveChangeListenerThrowExceptionOnNonLooperThread() {
         final CountDownLatch signalTestFinished = new CountDownLatch(1);
         Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {
                 Realm realm = Realm.getInstance(testConfig);
                 try {
-                    realm.handlerController.removeAllChangeListeners();
+                    realm.removeChangeListener(new RealmChangeListener() {
+                        @Override
+                        public void onChange() {
+                        }
+                    });
                     fail("");
-                } catch (NullPointerException ignored) {
+                } catch (IllegalStateException e) {
                     signalTestFinished.countDown();
                 } finally {
                     realm.close();
@@ -2722,7 +2726,7 @@ public class RealmTest extends AndroidTestCase {
         }
     }
 
-    public void testRemoveChangeListenerThrowExceptionOnNonLooperThread() {
+    public void testRemoveAllChangeListenersThrowExceptionOnNonLooperThread() {
         final CountDownLatch signalTestFinished = new CountDownLatch(1);
         Thread thread = new Thread(new Runnable() {
             @Override
@@ -2731,7 +2735,7 @@ public class RealmTest extends AndroidTestCase {
                 try {
                     realm.removeAllChangeListeners();
                     fail("");
-                } catch (IllegalStateException ignored) {
+                } catch (IllegalStateException e) {
                     signalTestFinished.countDown();
                 } finally {
                     realm.close();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
@@ -2696,4 +2696,54 @@ public class RealmTest extends AndroidTestCase {
             handlerThread.quit();
         }
     }
+
+    public void testHandlerControllerThrowNullPointExceptionOnNonLooperThread() {
+        final CountDownLatch signalTestFinished = new CountDownLatch(1);
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(testConfig);
+                try {
+                    realm.handlerController.removeAllChangeListeners();
+                    fail("");
+                } catch (NullPointerException ignored) {
+                    signalTestFinished.countDown();
+                } finally {
+                    realm.close();
+                }
+            }
+        });
+        thread.start();
+
+        try {
+            TestHelper.awaitOrFail(signalTestFinished);
+        } finally {
+            thread.interrupt();
+        }
+    }
+
+    public void testRemoveChangeListenerThrowExceptionOnNonLooperThread() {
+        final CountDownLatch signalTestFinished = new CountDownLatch(1);
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(testConfig);
+                try {
+                    realm.removeAllChangeListeners();
+                    fail("");
+                } catch (IllegalStateException ignored) {
+                    signalTestFinished.countDown();
+                } finally {
+                    realm.close();
+                }
+            }
+        });
+        thread.start();
+
+        try {
+            TestHelper.awaitOrFail(signalTestFinished);
+        } finally {
+            thread.interrupt();
+        }
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -186,7 +186,7 @@ abstract class BaseRealm implements Closeable {
     public void removeAllChangeListeners() {
         checkIfValid();
         if (handler == null) {
-            throw new IllegalStateException("You can't register listeners from a non-Looper thread ");
+            throw new IllegalStateException("You can't remove listeners from a non-Looper thread ");
         }
         handlerController.removeAllChangeListeners();
     }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -154,11 +154,15 @@ abstract class BaseRealm implements Closeable {
      * Removes the specified change listener.
      *
      * @param listener the change listener to be removed.
+     * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      * @see io.realm.RealmChangeListener
      * @see #addChangeListener(RealmChangeListener)
      */
     public void removeChangeListener(RealmChangeListener listener) {
         checkIfValid();
+        if (handler == null) {
+            throw new IllegalStateException("You can't remove a listener from a non-Looper thread ");
+        }
         handlerController.removeChangeListener(listener);
     }
 
@@ -175,11 +179,15 @@ abstract class BaseRealm implements Closeable {
     /**
      * Removes all user-defined change listeners.
      *
+     * @throws IllegalStateException if you try to remove listeners from a non-Looper Thread.
      * @see io.realm.RealmChangeListener
      * @see #addChangeListener(RealmChangeListener)
      */
     public void removeAllChangeListeners() {
         checkIfValid();
+        if (handler == null) {
+            throw new IllegalStateException("You can't register listeners from a non-Looper thread ");
+        }
         handlerController.removeAllChangeListeners();
     }
 


### PR DESCRIPTION
Removing changeListener from realm that is created form non-looper thread occurs NPE.

    java.lang.NullPointerException: Attempt to invoke virtual method 'void io.realm.HandlerController.removeAllChangeListeners()' on a null object reference
        at io.realm.BaseRealm.removeAllChangeListeners(BaseRealm.java:171)
        at io.realm.Realm.removeAllChangeListeners(Realm.java:107)

So as like a `addChangeListener`, it's better to throw `IllegalStateException` when called from non-looper thread.