### PR TITLE
Fix Kotlin example

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -51,5 +51,6 @@ dependencies {
     compile 'org.jetbrains.anko:anko-sdk15:0.7.2'
     compile "io.realm:realm-android-library:${version}@aar"
     compile "io.realm:realm-annotations:${version}"
+    kapt "io.realm:realm-annotations:${version}"
     kapt "io.realm:realm-annotations-processor:${version}"
 }


### PR DESCRIPTION
Some people have been reporting problems with the Kotlin example and I experienced it myself yesterday when testing our distribution package. The error doesn't always happen though, so I am a bit perplexed.

In any case. Adding this line to `build.gradle` prevents it from happening.