### PR TITLE
Use Homebrew instead of Homebrew-versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ Prerequisites:
  * Download the [**JDK 7**](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) or [**JDK 8**](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) from Oracle and install it.
  * Download & install the Android SDK, **Android 4.4.2 (API 19)**, **Android 4.4W (API 20)** and **Android 5.0 (API 21)** (for example through Android Studio’s **Android SDK Manager**)
  * Download the **Android NDK (= r10e)** for [OS X](http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin) or [Linux](http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin).
- * Or you can use [Hombrew-versions](https://github.com/Homebrew/homebrew-versions) to install Android NDK for Mac:
+ * Or you can use [Hombrew](https://github.com/Homebrew/homebrew) to install Android NDK for Mac:
 
     ```
-    brew tap homebrew/versions
     brew install android-ndk
     ```
 


### PR DESCRIPTION
Since we use the latest NDK now, we use Homebrew instead of Homebrew-versions.