### PR TITLE
Fix ConcurrentModificationException in listeners

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.87.2
  * Fixed a bug when RealmObjectSchema.addField called with PRIMARY_KEY modifier, the field was not set as a required field (#2001).
+ * Fixed a bug which could throw a ConcurrentModificationException in RealmObject's or RealmResults' change listener (#1970).
 
 0.87.1
  * Upgraded to NDK R10e. Using gcc 4.9 for all architectures.


### PR DESCRIPTION
 * It should be legal to modify realmObjects map in listener.
 * It should be legal to modify syncRealmResults/asyncRealmResults map
   in listener.

Fix #1970