### PR TITLE
Upgraded Gradle to latest version

### DIFF
--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 24 10:43:34 EST 2015
+#Tue Jan 05 14:18:17 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 16 12:55:34 CEST 2015
+#Tue Jan 05 14:18:17 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 30 15:14:20 CEST 2015
+#Tue Jan 05 14:18:17 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'de.undercouch:gradle-download-task:2.0.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'

--- a/realm/gradle/wrapper/gradle-wrapper.properties
+++ b/realm/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 13 11:49:33 CET 2015
+#Tue Jan 05 14:18:17 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     provided 'io.reactivex:rxjava:1.1.0'
     compile project(':realm-annotations')
 
+    androidTestCompile 'io.reactivex:rxjava:1.1.0'
     androidTestCompile 'com.android.support:support-annotations:23.1.1'
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -18,6 +18,10 @@ android {
         consumerProguardFiles 'proguard-rules.pro'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Changing `-bin` to `-all` for all Gradle wrappers to avoid those annoying Android Studio popups. Also provides sources + doc at the expense of a little extra disc space.

Bumped Gradle to latest version, 2.10. That required bumping Android Build Tools to 1.5.0 in the process. I didn't want to promote my bleeding edge tendencies by bumping to "2.0.0-alpha3" (although it seems stable enough from what I can tell).

@realm/java  