### PR TITLE
Update Javadoc for Rx Observables to be more specific.

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -171,7 +171,7 @@ abstract class BaseRealm implements Closeable {
      * Returns an Rx Observable that monitors changes to this Realm. It will emit the current state when subscribed
      * to.
      *
-     * @return RxJava Observable
+     * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>
      */

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -271,7 +271,7 @@ public abstract class RealmObject {
      * type information, otherwise the type of the following observables will be {@code RealmObject}.
      *
      * @param <E> RealmObject class that is being observed. Must be this class or its super types.
-     * @return RxJava Observable.
+     * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>
      */

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -825,7 +825,7 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
      * Returns an Rx Observable that monitors changes to this RealmResults. It will emit the current RealmResults when
      * subscribed to.
      *
-     * @return RxJava Observable
+     * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>
      */


### PR DESCRIPTION
Based on external feedback this updates the `asObservable()` Javadoc to be more specific about it's behavior.

@realm/java 