### PR TITLE
Isolate test Realm files

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -45,6 +45,7 @@ import io.realm.entities.NullTypes;
 import io.realm.entities.StringOnly;
 import io.realm.internal.Table;
 import io.realm.internal.log.Logger;
+import io.realm.rule.TestRealmConfigurationFactory;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
@@ -355,22 +356,42 @@ public class TestHelper {
         }
     }
 
+    /**
+     * @deprecated Use {@link TestRealmConfigurationFactory#createConfiguration()} instead.
+     */
+    @Deprecated
     public static RealmConfiguration createConfiguration(Context context) {
         return createConfiguration(context, Realm.DEFAULT_REALM_NAME);
     }
 
+    /**
+     * @deprecated Use {@link TestRealmConfigurationFactory#createConfiguration(String)} instead.
+     */
+    @Deprecated
     public static RealmConfiguration createConfiguration(Context context, String name) {
         return createConfiguration(context.getFilesDir(), name);
     }
 
+    /**
+     * @deprecated Use {@link TestRealmConfigurationFactory#createConfiguration(String)} instead.
+     */
+    @Deprecated
     public static RealmConfiguration createConfiguration(File folder, String name) {
         return createConfiguration(folder, name, null);
     }
 
+    /**
+     * @deprecated Use {@link TestRealmConfigurationFactory#createConfiguration(String, byte[])} instead.
+     */
+    @Deprecated
     public static RealmConfiguration createConfiguration(Context context, String name, byte[] key) {
         return createConfiguration(context.getFilesDir(), name, key);
     }
 
+    /**
+     * @deprecated Use {@link TestRealmConfigurationFactory#createConfiguration(String, byte[])} instead.
+     */
+    @Deprecated
     public static RealmConfiguration createConfiguration(File dir, String name, byte[] key) {
         RealmConfiguration.Builder config = new RealmConfiguration.Builder(dir).name(name);
         if (key != null) {

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.rule;
+
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.realm.Realm;
+import io.realm.RealmConfiguration;
+
+/**
+ * Rule that creates the {@link RealmConfiguration } in a temporary directory and deletes the Realm created with that
+ * configuration once the test finishes. Be sure to close all Realm instances before finishing the test. Otherwise
+ * {@link Realm#deleteRealm(RealmConfiguration)} will throw an exception in the {@link #after()} method.
+ * The temp directory will be deleted regardless if the {@link Realm#deleteRealm(RealmConfiguration)} fails or not.
+ */
+public class TestRealmConfigurationFactory extends TemporaryFolder {
+    private Map<RealmConfiguration, Boolean> map = new ConcurrentHashMap<RealmConfiguration, Boolean>();
+    private Set<RealmConfiguration> configurations = Collections.newSetFromMap(map);
+
+    @Override
+    protected void before() throws Throwable {
+        super.before();
+    }
+
+    @Override
+    protected void after() {
+        try {
+            for (RealmConfiguration configuration : configurations) {
+                Realm.deleteRealm(configuration);
+            }
+        } finally {
+            // This will delete the temp folder.
+            super.after();
+        }
+    }
+
+    public RealmConfiguration createConfiguration() {
+        RealmConfiguration configuration = new RealmConfiguration.Builder(getRoot())
+                .build();
+
+        configurations.add(configuration);
+        return configuration;
+    }
+
+    public RealmConfiguration createConfiguration(String name) {
+        RealmConfiguration configuration = new RealmConfiguration.Builder(getRoot())
+                .name(name)
+                .build();
+
+        configurations.add(configuration);
+        return configuration;
+    }
+
+    public RealmConfiguration createConfiguration(String name, byte[] key) {
+        RealmConfiguration configuration = new RealmConfiguration.Builder(getRoot())
+                .name(name)
+                .encryptionKey(key)
+                .build();
+
+        configurations.add(configuration);
+        return configuration;
+    }
+}


### PR DESCRIPTION
* Add JUnit rule TemporaryRealmFolder which helps to create test Realm
  file in the temp folder.
* Deprecate similar functions in TestHelper.
* Adapt changes to RealmTest.

I will adapt this to other test cases later.