### PR TITLE
Enable code coverage for realm-library

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -19,6 +19,12 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    buildTypes {
+        debug {
+            testCoverageEnabled = true
+        }
+    }
+
     lintOptions {
         abortOnError false
     }


### PR DESCRIPTION
Code coverage finally seems to be working for Android library projects running instrumentation tests.
This PR enables creating a Jacoco code coverage report for `realm-library` as part of running the unit tests.

```
cd realm
./gradlew createDebugCoverageReport
``` 

will run the unit tests and create a coverage report in `/realm/realm-library/build/reports/coverage/debug`

@realm/java 