### PR TITLE
IllegalArgumentException when calling copyFromRealm(dynamicRealmObject)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.87.3
+ * IllegalArgumentException is now properly thrown when calling Realm.copyFromRealm() with a DynamicRealmObject (#2058).
+
 0.87.2
  * Fixed a bug when RealmObjectSchema.addField() was called with the PRIMARY_KEY modifier, the field was not set as a required field (#2001).
  * Removed explicit GC call when committing a transaction (#1925).

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
@@ -2641,6 +2641,37 @@ public class RealmTest {
         assertTrue(results.get(0) == results.get(1));
     }
 
+    @Test
+    public void testCopyFromRealmDynamicRealmObjectThrows() {
+        testRealm.beginTransaction();
+        AllTypes obj = testRealm.createObject(AllTypes.class);
+        testRealm.commitTransaction();
+        DynamicRealmObject dObj = new DynamicRealmObject(obj);
+
+        try {
+            testRealm.copyFromRealm(dObj);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testCopyFromRealmDynamicRealmListThrows() {
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+        dynamicRealm.beginTransaction();
+        RealmList<DynamicRealmObject> dynamicList = dynamicRealm.createObject(AllTypes.CLASS_NAME).getList(AllTypes.FIELD_REALMLIST);
+        DynamicRealmObject dObj = dynamicRealm.createObject(AllTypes.CLASS_NAME);
+        dynamicList.add(dObj);
+        dynamicRealm.commitTransaction();
+        try {
+            testRealm.copyFromRealm(dynamicList);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            dynamicRealm.close();
+        }
+    }
+
     // Test if close can be called from Realm change listener when there is no other listeners
     @Test
     public void testCloseRealmInChangeListener() {
@@ -2850,6 +2881,7 @@ public class RealmTest {
         }
     }
 
+    @Test
     public void testRemoveChangeListenerThrowExceptionOnNonLooperThread() {
         final CountDownLatch signalTestFinished = new CountDownLatch(1);
         Thread thread = new Thread(new Runnable() {
@@ -2879,6 +2911,7 @@ public class RealmTest {
         }
     }
 
+    @Test
     public void testRemoveAllChangeListenersThrowExceptionOnNonLooperThread() {
         final CountDownLatch signalTestFinished = new CountDownLatch(1);
         Thread thread = new Thread(new Runnable() {

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -775,7 +775,7 @@ public final class Realm extends BaseRealm {
      * @param realmObjects RealmObjects to copy
      * @param <E> type of object.
      * @return an in-memory detached copy of managed RealmObjects.
-     * @throws IllegalArgumentException if the RealmObjects are not accessible.
+     * @throws IllegalArgumentException if the RealmObject is no longer accessible or it is a {@link DynamicRealmObject}.
      * @see #copyToRealmOrUpdate(Iterable)
      */
     public <E extends RealmObject> List<E> copyFromRealm(Iterable<E> realmObjects) {
@@ -798,7 +798,8 @@ public final class Realm extends BaseRealm {
      * @param maxDepth limit of the deep copy. All references after this depth will be {@code null}. Starting depth is {@code 0}.
      * @param <E> type of object.
      * @return an in-memory detached copy of the RealmObjects.
-     * @throws IllegalArgumentException if {@code maxDepth < 0} or the RealmObjects aren't accessible.
+     * @throws IllegalArgumentException if {@code maxDepth < 0}, the RealmObject is no longer accessible or it is a
+     *         {@link DynamicRealmObject}.
      * @see #copyToRealmOrUpdate(Iterable)
      */
     public <E extends RealmObject> List<E> copyFromRealm(Iterable<E> realmObjects, int maxDepth) {
@@ -831,7 +832,7 @@ public final class Realm extends BaseRealm {
      * @param realmObject {@link RealmObject} to copy
      * @param <E> type of object.
      * @return an in-memory detached copy of the managed {@link RealmObject}.
-     * @throws IllegalArgumentException if the RealmObject is no longer accessible.
+     * @throws IllegalArgumentException if the RealmObject is no longer accessible or it is a {@link DynamicRealmObject}.
      * @see #copyToRealmOrUpdate(RealmObject)
      */
     public <E extends RealmObject> E copyFromRealm(E realmObject) {
@@ -854,7 +855,8 @@ public final class Realm extends BaseRealm {
      * @param maxDepth limit of the deep copy. All references after this depth will be {@code null}. Starting depth is {@code 0}.
      * @param <E> type of object.
      * @return an in-memory detached copy of the managed {@link RealmObject}.
-     * @throws IllegalArgumentException if {@code maxDepth < 0} or the RealmObject is no longer accessible.
+     * @throws IllegalArgumentException if {@code maxDepth < 0}, the RealmObject is no longer accessible or it is a
+     *         {@link DynamicRealmObject}.
      * @see #copyToRealmOrUpdate(RealmObject)
      */
     public <E extends RealmObject> E copyFromRealm(E realmObject, int maxDepth) {
@@ -1195,6 +1197,9 @@ public final class Realm extends BaseRealm {
         }
         if (!realmObject.isValid()) {
             throw new IllegalArgumentException("RealmObject is not valid, so it cannot be copied.");
+        }
+        if (realmObject instanceof DynamicRealmObject) {
+            throw new IllegalArgumentException("DynamicRealmObject cannot be copied from Realm.");
         }
     }
 


### PR DESCRIPTION
Fixes #2058

It should not be possible to call `Realm.copyFromRealm()` with DynamicRealmObject. Right now it crashes with a weird schema exception "cannot find RealmObject".

@realm/java 
