### PR TITLE
Not throw always in TestRealmConfigurationFactory

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
@@ -17,6 +17,8 @@
 package io.realm.rule;
 
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 import java.util.Collections;
 import java.util.Map;
@@ -35,6 +37,25 @@ import io.realm.RealmConfiguration;
 public class TestRealmConfigurationFactory extends TemporaryFolder {
     private Map<RealmConfiguration, Boolean> map = new ConcurrentHashMap<RealmConfiguration, Boolean>();
     private Set<RealmConfiguration> configurations = Collections.newSetFromMap(map);
+    private boolean unitTestFailed = false;
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                before();
+                try {
+                    base.evaluate();
+                } catch (Throwable throwable) {
+                    unitTestFailed = true;
+                    throw throwable;
+                } finally {
+                    after();
+                }
+            }
+        };
+    }
 
     @Override
     protected void before() throws Throwable {
@@ -46,6 +67,11 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
         try {
             for (RealmConfiguration configuration : configurations) {
                 Realm.deleteRealm(configuration);
+            }
+        } catch (IllegalStateException e) {
+            // Only throw the exception caused by deleting the opened Realm if the test case itself doesn't throw.
+            if (!unitTestFailed) {
+                throw e;
             }
         } finally {
             // This will delete the temp folder.


### PR DESCRIPTION
Only throw the exception caused by deleting the opened Realm if the test
case itself doesn't throw. Otherwise the test case cannot fail by the
original exception.