### PR TITLE
Fix flaky tests related with async transaction

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTest.java
@@ -2865,10 +2865,10 @@ public class RealmTest {
                         }
                     });
                     fail("Should not be able to invoke removeChangeListener");
-                } catch (IllegalStateException e) {
-                    signalTestFinished.countDown();
+                } catch (IllegalStateException ignored) {
                 } finally {
                     realm.close();
+                    signalTestFinished.countDown();
                 }
             }
         });
@@ -2891,10 +2891,10 @@ public class RealmTest {
                 try {
                     realm.removeAllChangeListeners();
                     fail("Should not be able to invoke removeChangeListener");
-                } catch (IllegalStateException e) {
-                    signalTestFinished.countDown();
+                } catch (IllegalStateException ignored) {
                 } finally {
                     realm.close();
+                    signalTestFinished.countDown();
                 }
             }
         });

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -291,8 +291,23 @@ abstract class BaseRealm implements Closeable {
      * changes from this commit.
      */
     public void commitTransaction() {
+        commitTransaction(null);
+    }
+
+    /**
+     * Commits transaction, runs the given runnable and then sends notifications. The runnable is useful to meet some
+     * timing conditions like the async transaction. In async transaction, the background Realm has to be closed before
+     * other threads see the changes to majoyly avoid the flaky tests.
+     *
+     * @param runAfterCommit runnable will run after transaction committed but before notification sent.
+     */
+    void commitTransaction(Runnable runAfterCommit) {
         checkIfValid();
         sharedGroupManager.commitAndContinueAsRead();
+
+        if (runAfterCommit != null)  {
+            runAfterCommit.run();
+        }
 
         for (Map.Entry<Handler, String> handlerIntegerEntry : handlers.entrySet()) {
             Handler handler = handlerIntegerEntry.getKey();

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1104,57 +1104,61 @@ public final class Realm extends BaseRealm {
         final Future<?> pendingQuery = asyncQueryExecutor.submit(new Runnable() {
             @Override
             public void run() {
-                if (!Thread.currentThread().isInterrupted()) {
-                    Realm bgRealm = Realm.getInstance(realmConfiguration);
-                    bgRealm.beginTransaction();
-                    try {
-                        transaction.execute(bgRealm);
+                if (Thread.currentThread().isInterrupted()) {
+                    return;
+                }
 
-                        if (!Thread.currentThread().isInterrupted()) {
-                            bgRealm.commitTransaction();
-                            if (callback != null
-                                    && handler != null
-                                    && !Thread.currentThread().isInterrupted()
-                                    && handler.getLooper().getThread().isAlive()) {
-                                // The bgRealm needs to be closed before post event to caller's handler to avoid concurrency problem
-                                // eg.: User wants to delete Realm in the callbacks.
+                boolean transactionCommitted = false;
+                final Exception[] exception = new Exception[1];
+                final Realm bgRealm = Realm.getInstance(realmConfiguration);
+                bgRealm.beginTransaction();
+                try {
+                    transaction.execute(bgRealm);
+
+                    if (!Thread.currentThread().isInterrupted()) {
+                        bgRealm.commitTransaction(new Runnable() {
+                            @Override
+                            public void run() {
+                                // The bgRealm needs to be closed before post event to caller's handler to avoid
+                                // concurrency problem. eg.: User wants to delete Realm in the callbacks.
+                                // This will close Realm before sending REALM_CHANGED.
                                 bgRealm.close();
-                                handler.post(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        callback.onSuccess();
-                                    }
-                                });
                             }
-                        } else {
-                            if (bgRealm.isInTransaction()) {
-                                bgRealm.cancelTransaction();
-                            } else {
-                                RealmLog.w("Thread is interrupted. Could not cancel transaction, not currently in a transaction.");
-                            }
-                        }
-
-                    } catch (final Exception e) {
+                        });
+                        transactionCommitted = true;
+                    }
+                } catch (final Exception e) {
+                    exception[0] = e;
+                } finally {
+                    if (!bgRealm.isClosed()) {
                         if (bgRealm.isInTransaction()) {
                             bgRealm.cancelTransaction();
-                        } else {
+                        } else if (exception[0] != null) {
                             RealmLog.w("Could not cancel transaction, not currently in a transaction.");
                         }
-                        if (callback != null
-                                && handler != null
-                                && !Thread.currentThread().isInterrupted()
-                                && handler.getLooper().getThread().isAlive()) {
-                            bgRealm.close();
+                        bgRealm.close();
+                    }
+
+                    // Send response as the final step to ensure the bg thread quit before others get the response!
+                    if (callback != null
+                            && handler != null
+                            && !Thread.currentThread().isInterrupted()
+                            && handler.getLooper().getThread().isAlive()) {
+                        if (transactionCommitted) {
                             handler.post(new Runnable() {
                                 @Override
                                 public void run() {
-                                    callback.onError(e);
+                                    callback.onSuccess();
                                 }
                             });
-                        }
-                    } finally {
-                        if (!bgRealm.isClosed()) {
-                            bgRealm.close();
+                        } else if (exception[0] != null) {
+                            // transaction has not been canceled by there is a exception during transaction.
+                            handler.post(new Runnable() {
+                                @Override
+                                public void run() {
+                                    callback.onError(exception[0]);
+                                }
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
* Background realm needs to be closed before notifying other threads
  in async transaction.
* Latch needs to be called after Realm closed.