### PR TITLE
Removing LTO from debugging builds

### DIFF
--- a/realm/realm-jni/build.gradle
+++ b/realm/realm-jni/build.gradle
@@ -2,7 +2,7 @@ import java.security.MessageDigest
 
 ext.coreVersion = '0.95.7'
 // empty or comment out this to disable hash checking
-//ext.coreSha256Hash = '11c82f5da9b43b62fbf55fbd3aa61dc6956bc3483bbaa5f69262018144c8cc3c'
+ext.coreSha256Hash = '11c82f5da9b43b62fbf55fbd3aa61dc6956bc3483bbaa5f69262018144c8cc3c'
 ext.forceDownloadCore =
         project.hasProperty('forceDownloadCore') ? project.getProperty('forceDownloadCore').toBoolean() : false
 // gcc is default for the NDK. It also produces smaller binaries
@@ -18,7 +18,7 @@ ext.coreSourcePath = project.hasProperty('coreSourcePath') ? project.getProperty
 def commonCflags = [ '-Os', '-std=c++11' ]
 // LTO and debugging don't play well together
 if (!ext.debugBuild) {
-    commonCflags += [ '-ffunction-sections', '-fdata-sections', '-flto' ]
+    commonCflags += [ '-fvisibility=hidden', '-ffunction-sections', '-fdata-sections', '-flto' ]
 }
 
 enum Compiler {

--- a/realm/realm-jni/build.gradle
+++ b/realm/realm-jni/build.gradle
@@ -2,7 +2,7 @@ import java.security.MessageDigest
 
 ext.coreVersion = '0.95.7'
 // empty or comment out this to disable hash checking
-ext.coreSha256Hash = '11c82f5da9b43b62fbf55fbd3aa61dc6956bc3483bbaa5f69262018144c8cc3c'
+//ext.coreSha256Hash = '11c82f5da9b43b62fbf55fbd3aa61dc6956bc3483bbaa5f69262018144c8cc3c'
 ext.forceDownloadCore =
         project.hasProperty('forceDownloadCore') ? project.getProperty('forceDownloadCore').toBoolean() : false
 // gcc is default for the NDK. It also produces smaller binaries
@@ -15,7 +15,11 @@ ext.stripSymbols = project.hasProperty('stripSymbols') ? project.getProperty('st
 // core source code.
 ext.coreSourcePath = project.hasProperty('coreSourcePath') ? project.getProperty('coreSourcePath') : null
 
-def commonCflags = [ '-Os', '-std=c++11', '-ffunction-sections', '-fdata-sections', '-flto' ]
+def commonCflags = [ '-Os', '-std=c++11' ]
+// LTO and debugging don't play well together
+if (!ext.debugBuild) {
+    commonCflags += [ '-ffunction-sections', '-fdata-sections', '-flto' ]
+}
 
 enum Compiler {
     GCC, CLANG

--- a/realm/realm-jni/project.mk
+++ b/realm/realm-jni/project.mk
@@ -52,7 +52,7 @@ ifeq ($(REALM_ANDROID),)
     endif
   endif
 else
-  PROJECT_CFLAGS += -fvisibility=hidden -DANDROID -ffunction-sections -fdata-sections -flto
+  PROJECT_CFLAGS += -DANDROID
   CFLAGS_OPTIM = -Os -DNDEBUG
 endif
 


### PR DESCRIPTION
Using a locally build core, it is possible to single step into C++. You will have to add the following two lines to `realm.properties`:

    debugBuild=true
    stripSymbols=false

@cmelchior @emanuelez @beeender 