### PR TITLE
Access to RealmResults based on deleted RealmList

### DIFF
--- a/realm/realm-jni/src/io_realm_internal_Util.cpp
+++ b/realm/realm-jni/src/io_realm_internal_Util.cpp
@@ -169,7 +169,11 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeTestcase(
             if (dotest)
                 ThrowException(env, BadVersion, "parm1", "parm2");
             break;
-
+        case DeletedLinkViewException:
+            expect = "io.realm.internal.DeletedRealmListException: parm1";
+            if (dotest)
+                ThrowException(env, DeletedLinkViewException, "parm1", "parm2");
+            break;
     }
     if (dotest) {
         return NULL;

--- a/realm/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm/realm-jni/src/io_realm_internal_tableview.cpp
@@ -25,20 +25,32 @@
 using namespace realm;
 
 // if you disable the validation, please remember to call sync_in_needed() 
-#define VIEW_VALID_AND_IN_SYNC(env, ptr) view_valid_and_in_sync(env, ptr)
+#define VIEW_VALID_AND_IN_SYNC(env, ptr) (is_view_valid(env, ptr) && is_view_in_sync(env, ptr))
 
-inline bool view_valid_and_in_sync(JNIEnv* env, jlong nativeViewPtr) {
-    bool valid = (TV(nativeViewPtr) != NULL);
-    if (valid) {
-        if (!TV(nativeViewPtr)->is_attached()) {
-            ThrowException(env, TableInvalid, "The Realm has been closed and is no longer accessible.");
-            return false;
-        }
-        TV(nativeViewPtr)->sync_if_needed();
+inline bool is_view_valid(JNIEnv* env, jlong nativeViewPtr) {
+    if (TV(nativeViewPtr) == NULL) {
+        // Should never get here
+        ThrowException(env, FatalError, "Null pointer of table view.");
+        return false;
     }
-    return valid;
+    if (!TV(nativeViewPtr)->is_attached()) {
+        ThrowException(env, TableInvalid, "The Realm has been closed and is no longer accessible.");
+        return false;
+    }
+    return true;
 }
 
+inline bool is_view_in_sync(JNIEnv* /*env*/, jlong nativeViewPtr) {
+    try {
+        TV(nativeViewPtr)->sync_if_needed();
+    } catch (realm::DeletedLinkView&) {
+        // FIXME: Temp fix for https://github.com/realm/realm-core/pull/1434
+        // Better solution would be core only throw the exception when really necessary, methods like size
+        // should just return 0.
+        return false;
+    }
+    return true;
+}
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_createNativeTableView(
     JNIEnv* env, jobject, jobject, jlong)
@@ -105,10 +117,16 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetSourceRowIndex
 (JNIEnv *env, jobject, jlong nativeViewPtr, jlong rowIndex)
 {
     try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return 0;
+        if (!is_view_valid(env, nativeViewPtr)) {
+            return npos;
+        }
+        if (!is_view_in_sync(env, nativeViewPtr)) {
+            TR_ERR("The source LinkView created this TableView has been deleted.");
+            // Let it fall through. Since the size will return 0, an ArrayIndexOutOfBoundsException
+            // will be thrown in ROW_INDEX_VALID check.
+        }
         if (!ROW_INDEX_VALID(env, TV(nativeViewPtr), rowIndex))
-            return 0;
+            return npos;
     } CATCH_STD()
     return TV(nativeViewPtr)->get_source_ndx(S(rowIndex));   // noexcept
 }
@@ -117,7 +135,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetColumnCount
   (JNIEnv *env, jobject, jlong nativeViewPtr)
 {
     try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
+        // No need to sync here.
+        if (!is_view_valid(env, nativeViewPtr))
             return 0;
     } CATCH_STD()
     return TV(nativeViewPtr)->get_column_count();
@@ -127,7 +146,8 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeGetColumnName
   (JNIEnv *env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
     try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) || !COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
+        // No need to sync here.
+        if (!is_view_valid(env, nativeViewPtr) || !COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
             return NULL;
         return to_jstring(env, TV(nativeViewPtr)->get_column_name( S(columnIndex)));
     } CATCH_STD()
@@ -138,8 +158,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetColumnIndex
    (JNIEnv *env, jobject, jlong nativeViewPtr, jstring columnName)
 {
     try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-        return 0;
+        // No need to sync here.
+        if (!is_view_valid(env, nativeViewPtr))
+            return 0;
 
         JStringAccessor columnName2(env, columnName); // throws
         return to_jlong_or_not_found( TV(nativeViewPtr)->get_column_index(columnName2) ); // noexcept
@@ -151,7 +172,8 @@ JNIEXPORT jint JNICALL Java_io_realm_internal_TableView_nativeGetColumnType
   (JNIEnv *env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
     try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) || !COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
+        // No need to sync here.
+        if (!is_view_valid(env, nativeViewPtr) || !COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
             return 0;
     } CATCH_STD()
     return static_cast<int>( TV(nativeViewPtr)->get_column_type( S(columnIndex)) );

--- a/realm/realm-jni/src/util.cpp
+++ b/realm/realm-jni/src/util.cpp
@@ -53,6 +53,10 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, BadVersion, ss.str());
     }
+    catch (realm::DeletedLinkView& e) {
+        ss << e.what() << " in " << file << " line " << line;
+        ThrowException(env, DeletedLinkViewException, ss.str());
+    }
     catch (std::exception& e) {
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, FatalError, ss.str());
@@ -150,6 +154,11 @@ void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& cla
 
         case BadVersion:
             jExceptionClass = env->FindClass("io/realm/internal/async/BadVersionException");
+            message = classStr;
+            break;
+
+        case DeletedLinkViewException:
+            jExceptionClass = env->FindClass("io/realm/internal/DeleteRealmListException");
             message = classStr;
             break;
     }

--- a/realm/realm-jni/src/util.hpp
+++ b/realm/realm-jni/src/util.hpp
@@ -121,7 +121,8 @@ enum ExceptionKind {
     RuntimeError = 12,
     RowInvalid = 13,
     CrossTableLink = 15,
-    BadVersion = 16
+    BadVersion = 16,
+    DeletedLinkViewException = 17
 // NOTE!!!!: Please also add test cases to Util.java when introducing a new exception kind.
 };
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/Dog.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/Dog.java
@@ -24,6 +24,12 @@ import io.realm.annotations.Index;
 
 public class Dog extends RealmObject {
 
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_AGE = "age";
+    public static final String FIELD_HEIGHT = "height";
+    public static final String FIELD_WEIGHT = "weight";
+    public static final String FIELD_BIRTHDAY = "birthday";
+
     @Index
     private String name;
     private long age;

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 
 import io.realm.exceptions.RealmException;
+import io.realm.internal.DeleteRealmListException;
 import io.realm.internal.TableOrView;
 import io.realm.internal.TableQuery;
 import io.realm.internal.TableView;
@@ -51,6 +52,10 @@ import rx.Observable;
  * <p>
  * Notice that a RealmResults is never {@code null} not even in the case where it contains no objects. You should always
  * use the size() method to check if a RealmResults is empty or not.
+ * <p>
+ * If a RealmResults is built on RealmList through {@link RealmList#where()}, it will become invalid when the source
+ * RealmList gets deleted. When that happens, the RealmResults will behave like a empty RealmResults, but calling
+ * {@link #where()} will throw an {@link IllegalStateException}. Use {@link #isValid} to detect this situation.
  *
  * @param <E> The class of objects in this list.
  * @see RealmQuery#findAll()
@@ -65,7 +70,9 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
     private TableOrView table = null;
 
     private static final String TYPE_MISMATCH = "Field '%s': type mismatch - %s expected.";
-    private long currentTableViewVersion = -1;
+    private static final long TABLE_VIEW_VERSION_NONE = -1;
+    private static final long TABLE_VIEW_VERSION_REALM_LIST_DELETED = -2;
+    private long currentTableViewVersion = TABLE_VIEW_VERSION_NONE;
 
     private final TableQuery query;
     private final List<RealmChangeListener> listeners = new CopyOnWriteArrayList<RealmChangeListener>();
@@ -138,7 +145,11 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
      * @return {@code true} if still valid to use, {@code false} otherwise.
      */
     public boolean isValid() {
-        return realm != null && !realm.isClosed();
+        if (realm == null || realm.isClosed()) {
+            return false;
+        }
+
+        return syncToCheckIfValid("Calling isValid on RealmResults whose parent RealmList has been deleted already.");
     }
 
     /**
@@ -146,9 +157,14 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
      *
      * @return a typed RealmQuery.
      * @see io.realm.RealmQuery
+     * @throws IllegalStateException if the RealmList which this RealmResults is created on has been deleted.
      */
     public RealmQuery<E> where() {
         realm.checkIfValid();
+
+        if (!syncToCheckIfValid("Calling where on RealmResults whose parent RealmList has been deleted already.")) {
+            throw new IllegalStateException("The RealmList which this RealmResults is created on has been deleted.");
+        }
         return RealmQuery.createQueryFromResult(this);
     }
 
@@ -856,13 +872,42 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
             //FIXME: still waiting for Core to provide a fix
             //       for crash when calling _sync_if_needed on a cleared View.
             //       https://github.com/realm/realm-core/pull/1390
-            long version = table.sync();
+            long version;
+            try {
+                version = table.sync();
+            } catch (DeleteRealmListException e) {
+                // Although this RealmResults won't be updated anymore, it is good to give user a chance to do update.
+                version = TABLE_VIEW_VERSION_REALM_LIST_DELETED;
+                RealmLog.d("The parent RealmList has been deleted already.");
+            }
             if (currentTableViewVersion != version) {
                 currentTableViewVersion = version;
                 for (RealmChangeListener listener : listeners) {
                     listener.onChange();
                 }
             }
+            // No point to keep those listeners, just clear them.
+            if (version == TABLE_VIEW_VERSION_REALM_LIST_DELETED) {
+                listeners.clear();
+            }
         }
+    }
+
+    // FIXME: This is a temp fix, see https://github.com/realm/realm-core/pull/1434
+    private boolean syncToCheckIfValid(String warningMessage) {
+        if (currentTableViewVersion == TABLE_VIEW_VERSION_REALM_LIST_DELETED) {
+            RealmLog.d(warningMessage);
+            return false;
+        }
+        TableOrView tableOrView = getTable();
+        if (tableOrView instanceof TableView) {
+            try {
+                tableOrView.sync();
+            } catch (DeleteRealmListException e) {
+                RealmLog.d(warningMessage);
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/DeleteRealmListException.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/DeleteRealmListException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.internal;
+
+import io.realm.exceptions.RealmException;
+
+/**
+ *  Triggered from JNI level when access a RealmResults whose parent RealmList has been deleted already.
+ */
+@Keep
+public class DeleteRealmListException extends RealmException {
+    public DeleteRealmListException(String detailMessage) {
+        super(detailMessage);
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/internal/Util.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Util.java
@@ -64,7 +64,8 @@ public class Util {
         Exception_RowInvalid(13),
         Exception_EncryptionNotSupported(14),
         Exception_CrossTableLink(15),
-        Exception_BadVersion(16);
+        Exception_BadVersion(16),
+        Exception_DeletedLinkView(17);
 
         private final int nativeTestcase;
         Testcase(int nativeValue) {


### PR DESCRIPTION
* When the original RealmList is deleted, for most methods of
  RealmResults should just work without crash by just treat it like an
  empty RealmResults.
* RealmResults.where() return null in this case.

Close 1945