### PR TITLE
RealmList not returning DynamicRealmObjects of the proper type

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 0.87.3
  * IllegalArgumentException is now properly thrown when calling Realm.copyFromRealm() with a DynamicRealmObject (#2058).
  * Fixed a message in IllegalArgumentException thrown by the accessors of DynamicRealmObject (#2141).
+ * Fixed RealmList not returning DynamicRealmObjects of the correct underlying type (#2143).
  * Updated Realm Core to 0.95.8
    - Fixed a bug where undetected deleted object might lead to seg. fault (#1945).
    - Better performance when deleting objects (#2015).

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTest.java
@@ -18,6 +18,8 @@ package io.realm;
 
 import android.test.AndroidTestCase;
 
+import org.junit.Test;
+
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
@@ -459,9 +461,20 @@ public class DynamicRealmObjectTest extends AndroidTestCase {
 
     // List is not a simple getter, test separately.
     public void testGetList() {
-        RealmList<DynamicRealmObject> list = dObj.getList(AllJavaTypes.FIELD_LIST);
+        realm.beginTransaction();
+        AllTypes obj = realm.createObject(AllTypes.class);
+        Dog dog = realm.createObject(Dog.class);
+        dog.setName("fido");
+        obj.getColumnRealmList().add(dog);
+        realm.commitTransaction();
+
+        DynamicRealmObject dynamicAllTypes = new DynamicRealmObject(obj);
+        RealmList<DynamicRealmObject> list = dynamicAllTypes.getList(AllTypes.FIELD_REALMLIST);
+        DynamicRealmObject listObject = list.get(0);
+
         assertEquals(1, list.size());
-        assertEquals(dObj, list.get(0));
+        assertEquals(Dog.CLASS_NAME, listObject.getType());
+        assertEquals("fido", listObject.getString(Dog.FIELD_NAME));
     }
 
     public void testUntypedGetterSetter() {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTest.java
@@ -162,7 +162,7 @@ public class RealmListTest {
     public void testAddManagedObject_nonManagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         testRealm.beginTransaction();
-        AllTypes managedAllTypes =  testRealm.createObject(AllTypes.class);
+        AllTypes managedAllTypes = testRealm.createObject(AllTypes.class);
         testRealm.commitTransaction();
         list.add(managedAllTypes);
 
@@ -466,7 +466,7 @@ public class RealmListTest {
 
     // Test that set correctly uses Realm.copyToRealmOrUpdate() on standalone objects with a primary key.
     @Test
-    public void  testSetUnmanagedPrimaryKeyObjectToManagedList() {
+    public void testSetUnmanagedPrimaryKeyObjectToManagedList() {
         testRealm.beginTransaction();
         CyclicTypePrimaryKey parent = testRealm.copyToRealm(new CyclicTypePrimaryKey(1, "Parent"));
         RealmList<CyclicTypePrimaryKey> children = parent.getObjects();
@@ -862,7 +862,7 @@ public class RealmListTest {
                             break;
                         case METHOD_MOVE:
                             list.add(new Dog());
-                            list.move(0,1);
+                            list.move(0, 1);
                             break;
                         case METHOD_REMOVE:
                             list.remove(0);

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/Dog.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/Dog.java
@@ -24,6 +24,9 @@ import io.realm.annotations.Index;
 
 public class Dog extends RealmObject {
 
+    public static final String CLASS_NAME = "Dog";
+    public static final String FIELD_NAME = "name";
+
     @Index
     private String name;
     private long age;

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -268,7 +268,7 @@ public final class DynamicRealmObject extends RealmObject {
     public RealmList<DynamicRealmObject> getList(String fieldName) {
         long columnIndex = row.getColumnIndex(fieldName);
         LinkView linkView = row.getLinkList(columnIndex);
-        String className = linkView.getTable().getName().substring(Table.TABLE_PREFIX.length());
+        String className = linkView.getTable().getLinkTarget(columnIndex).getName().substring(Table.TABLE_PREFIX.length());
         return new RealmList<DynamicRealmObject>(className, linkView, realm);
     }
 


### PR DESCRIPTION
RealmLists containing DynamicRealmObjects wrongly sat the type for them as the parent objects types instead of the linkview type. This caused segmentation faults if the wrong fields was accessed as the underlying type didn't match the getter used.

@realm/java

