### PR TITLE
Fix wrong usages of StringData.data().

### DIFF
--- a/realm/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm/realm-jni/src/io_realm_internal_table.cpp
@@ -1551,7 +1551,7 @@ bool check_valid_primary_key_column(JNIEnv* env, Table* table, StringData column
                     int64_t next_val = results.get_int(column_index, i);
                     if (val == next_val) {
                         std::ostringstream error_msg;
-                        error_msg << "Field \"" << table->get_column_name(column_index).data() << "\" cannot be a primary key, ";
+                        error_msg << "Field \"" << column_name << "\" cannot be a primary key, ";
                         error_msg << "it already contains duplicate values: " << val;
                         ThrowException(env, IllegalArgument, error_msg.str());
                         return false;
@@ -1570,7 +1570,7 @@ bool check_valid_primary_key_column(JNIEnv* env, Table* table, StringData column
                     string next_str = results.get_string(column_index, i);
                     if (str.compare(next_str) == 0) {
                         std::ostringstream error_msg;
-                        error_msg << "Field \"" << table->get_column_name(column_index).data() << "\" cannot be a primary key, ";
+                        error_msg << "Field \"" << column_name << "\" cannot be a primary key, ";
                         error_msg << "it already contains duplicate values: " << str;
                         ThrowException(env, IllegalArgument, error_msg.str());
                         return false;

--- a/realm/realm-jni/src/util.cpp
+++ b/realm/realm-jni/src/util.cpp
@@ -289,7 +289,7 @@ string string_to_hex(const string& message, StringData& str, const char* in_begi
     ret << "error_code = " << error_code << "; ";
     ret << "retcode = " << retcode << "; ";
     ret << "StringData.size = " << str.size() << "; ";
-    ret << "StringData.data = " << str.data() << "; ";
+    ret << "StringData.data = " << str << "; ";
     ret << "StringData as hex = ";
     for (string::size_type i = 0; i < str.size(); ++i)
         ret << " 0x" << std::hex << std::setfill('0') << std::setw(2) << (int)s[i];

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -342,6 +342,26 @@ public class RealmObjectSchemaTests extends AndroidTestCase {
         }
     }
 
+    public void testAddPrimaryKeyFieldModifier_duplicateValues() {
+        for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
+            final String fieldName = "foo";
+            schema.addField(fieldName, fieldType.getType());
+
+            // create multiple objects those have same value.
+            realm.createObject(schema.getClassName());
+            realm.createObject(schema.getClassName());
+
+            try {
+                schema.addPrimaryKey(fieldName);
+                fail();
+            } catch (IllegalArgumentException e) {
+                // check if message reports correct field name.
+                assertTrue(e.getMessage().contains("\"" + fieldName + "\""));
+            }
+            schema.removeField(fieldName);
+        }
+    }
+
     public void testAddIndexFieldModifier_illegalFieldTypeThrows() {
         String fieldName = "foo";
         for (InvalidIndexFieldType fieldType : InvalidIndexFieldType.values()) {


### PR DESCRIPTION
`StringData.data()` does not guarantee the null termination of returned char array.

We must use `size()` information to properly handle the char array in the StringData like `std::string(str.data(), str.size())`.

Added test case does not fail on my local machine even if this fix was not applied since the next byte of char array happens to be null character.

please review this @realm/java 