### PR TITLE
Convert RealmSchemaTests to JUnit4 + reenable fixed unit test.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
  * IllegalArgumentException is now properly thrown when calling Realm.copyFromRealm() with a DynamicRealmObject (#2058).
  * Fixed a message in IllegalArgumentException thrown by the accessors of DynamicRealmObject (#2141).
  * Fixed RealmList not returning DynamicRealmObjects of the correct underlying type (#2143).
+ * Fixed potential crash when rolling back removal of classes that reference each other (#1829).
  * Updated Realm Core to 0.95.8
    - Fixed a bug where undetected deleted object might lead to seg. fault (#1945).
    - Better performance when deleting objects (#2015).

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
@@ -26,6 +26,7 @@ import io.realm.annotations.PrimaryKey;
 
 public class AllJavaTypes extends RealmObject{
 
+    public static final String CLASS_NAME = "AllJavaTypes";
     public static String FIELD_IGNORED = "fieldIgnored";
     public static String FIELD_STRING = "fieldString";
     public static String FIELD_SHORT = "fieldShort";


### PR DESCRIPTION
Fixes #1829 + re-enables the previously failing unit test (which is now fixed by the new core)

This was actually fixed in 0.87.3, so this PR adds the changelog to that version.

@realm/java 
