### PR TITLE
add dontCleanJniFiles option to clean task

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ That command will generate:
  * `./gradlew javadoc` will generate the Javadocs
  * `./gradlew monkeyExamples` will run the monkey tests on all the examples
  * `./gradlew installRealmJava` will install the Realm library and plugin to mavenLocal()
+ * `./gradlew clean -PdontCleanJniFiles` will remove all generated files except for JNI related files. This saves recompilation time a lot.
 
 Generating the Javadoc using the command above will report a large number of warnings. The Javadoc is generated, and we will fix the issue in the near future.
 

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,9 @@ task cleanRealm(type:GradleBuild) {
     group = 'Clean'
     buildFile = file('realm/build.gradle')
     tasks = ['clean']
+    if (project.hasProperty('dontCleanJniFiles')) {
+        startParameter.projectProperties = [dontCleanJniFiles: ""]
+    }
 }
 
 task cleanGradlePlugin(type:GradleBuild) {

--- a/realm/realm-jni/build.gradle
+++ b/realm/realm-jni/build.gradle
@@ -316,6 +316,10 @@ task buildAndroidJni(group: 'build', description: 'Build the Android JNI shared 
 }
 
 task clean(type: Delete) {
+    outputs.upToDateWhen {
+        project.hasProperty('dontCleanJniFiles')
+    }
+
     delete project.buildDir
 
     delete fileTree(dir: "${projectDir}/../realm-library/src/main/jniLibs/", include: '**/librealm-jni*.so')


### PR DESCRIPTION
`./gradlew clean -PdontCleanJniFiles` removes all generated files except for JNI related files.

@realm/java 