### PR TITLE
String setters will throw IllegalArgumentException

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 0.88.0
  * BREAKING CHANGE: DynamicRealm.executeTransaction() now directly throws any RuntimeException instead of wrapping it in a RealmException (#1682).
  * BREAKING CHANGE: DynamicRealm.executeTransaction() now throws IllegalArgumentException instead of silently accepting a null Transaction object.
+ * BREAKING CHANGE: String setters now throws IllegalArgumentException instead of RealmError for invalid surrogates. 
  * Fixed an error occurring during test and connectedCheck of unit test example (#1934).
  * Fixed bug in jsonExample (#2092).
  * Added RealmQuery.isNotEmpty() (#2025). (Thank you @stk1m1)

--- a/realm/realm-jni/src/util.cpp
+++ b/realm/realm-jni/src/util.cpp
@@ -37,15 +37,15 @@ jmethodID java_lang_double_init;
 
 void ConvertException(JNIEnv* env, const char *file, int line)
 {
-    std::ostringstream ss;
+    ostringstream ss;
     try {
         throw;
     }
-    catch (std::bad_alloc& e) {
+    catch (bad_alloc& e) {
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, OutOfMemory, ss.str());
     }
-    catch (realm::CrossTableLinkTarget& e) {
+    catch (CrossTableLinkTarget& e) {
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, CrossTableLink, ss.str());
     }
@@ -53,11 +53,15 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, BadVersion, ss.str());
     }
-    catch (realm::DeletedLinkView& e) {
+    catch (DeletedLinkView& e) {
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, DeletedLinkViewException, ss.str());
     }
-    catch (std::exception& e) {
+    catch (invalid_argument& e) {
+        ss << e.what() << " in " << file << " line " << line;
+        ThrowException(env, IllegalArgument, ss.str());
+    }
+    catch (exception& e) {
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, FatalError, ss.str());
     }
@@ -71,7 +75,7 @@ void ThrowException(JNIEnv* env, ExceptionKind exception, const char *classStr)
 
 void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& classStr, const std::string& itemStr)
 {
-    std::string message;
+    string message;
     jclass jExceptionClass = NULL;
 
     TR_ERR("jni: ThrowingException %d, %s, %s.", exception, classStr.c_str(), itemStr.c_str())
@@ -418,10 +422,10 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
         char* out_end   = m_data.get() + buf_size;
         size_t error_code;
         if (!Xcode::to_utf8(in_begin, in_end, out_begin, out_end, error_code)) {
-            throw runtime_error(string_to_hex("Failure when converting to UTF-8", chars.data(), chars.size(), error_code));
+            throw invalid_argument(string_to_hex("Failure when converting to UTF-8", chars.data(), chars.size(), error_code));
         }
         if (in_begin != in_end) {
-            throw runtime_error(string_to_hex("in_begin != in_end when converting to UTF-8", chars.data(), chars.size(), error_code));
+            throw invalid_argument(string_to_hex("in_begin != in_end when converting to UTF-8", chars.data(), chars.size(), error_code));
         }
         m_size = out_begin - m_data.get();
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -119,7 +119,8 @@ public class RealmObjectTests {
         }
     }
 
-    // invalid surrogate pairs
+    // invalid surrogate pairs:
+    // both high and low should lead to an IllegalArgumentException
     @Test
     public void invalidSurrogates() {
         String high = "Invalid high surrogate \uD83C\uD83C\uDF51";
@@ -134,8 +135,7 @@ public class RealmObjectTests {
             AllTypes highSurrogate = realm.createObject(AllTypes.class);
             highSurrogate.setColumnString(high);
             fail();
-        }
-        catch (IllegalArgumentException ignored) {}
+        } catch (IllegalArgumentException ignored) {}
         realm.cancelTransaction();
 
         realm.beginTransaction();
@@ -143,8 +143,7 @@ public class RealmObjectTests {
             AllTypes lowSurrogate = realm.createObject(AllTypes.class);
             lowSurrogate.setColumnString(low);
             fail();
-        }
-        catch (IllegalArgumentException ignored) {}
+        } catch (IllegalArgumentException ignored) {}
         realm.cancelTransaction();
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -119,6 +119,35 @@ public class RealmObjectTests {
         }
     }
 
+    // invalid surrogate pairs
+    @Test
+    public void invalidSurrogates() {
+        String high = "Invalid high surrogate \uD83C\uD83C\uDF51";
+        String low  = "Invalid low surrogate \uD83C\uDF51\uDF51";
+
+        realm.beginTransaction();
+        realm.clear(AllTypes.class);
+        realm.commitTransaction();
+
+        realm.beginTransaction();
+        try {
+            AllTypes highSurrogate = realm.createObject(AllTypes.class);
+            highSurrogate.setColumnString(high);
+            fail();
+        }
+        catch (IllegalArgumentException ignored) {}
+        realm.cancelTransaction();
+
+        realm.beginTransaction();
+        try {
+            AllTypes lowSurrogate = realm.createObject(AllTypes.class);
+            lowSurrogate.setColumnString(low);
+            fail();
+        }
+        catch (IllegalArgumentException ignored) {}
+        realm.cancelTransaction();
+    }
+
     // removing original object and see if has been removed
     @Test
     public void removeFromRealm() {


### PR DESCRIPTION
As suggested in #1756, `IllegalArgumentException` is better than `RealmError` when trying to store an invalid string.

@realm/java @remeissner