### PR TITLE
RealmQuery 'distinct()' TableView Patch

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
  * Improved .so loading by using ReLinker (https://github.com/KeepSafe/ReLinker).
  * Improved performance of RealmList#contains() (#897).
  * Added RealmQuery.distinct() and RealmResults.distinct() (#1568).
+ * Fixed bug when multiple calls of RealmResults.distinct() causes to return wrong results (#2198).
 
 0.87.4
  * Updated Realm Core to 0.96.0

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -1311,6 +1311,27 @@ public class RealmResultsTests {
     }
 
     @Test
+    public void distinct_restrictedByPreviousDistinct() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        // all objects
+        RealmResults<AnnotationIndexTypes> allResults = realm.where(AnnotationIndexTypes.class).findAll();
+        assertEquals("All Objects Count", numberOfBlocks * numberOfBlocks * numberOfObjects, allResults.size());
+        // distinctive dates
+        RealmResults<AnnotationIndexTypes> distinctDates = allResults.distinct("indexDate");
+        assertEquals("Distinctive Dates", numberOfBlocks, distinctDates.size());
+        // distinctive Booleans
+        RealmResults<AnnotationIndexTypes> distinctBooleans = distinctDates.distinct("indexBoolean");
+        assertEquals("Distinctive Booleans", 2, distinctBooleans.size());
+        // all three results are the same object
+        assertTrue(allResults == distinctDates);
+        assertTrue(allResults == distinctBooleans);
+        assertTrue(distinctDates == distinctBooleans);
+    }
+
+    @Test
     public void distinct_withNull() {
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // must be greater than 1

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -576,22 +576,14 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
     public RealmResults<E> distinct(String fieldName) {
         realm.checkIfValid();
         long columnIndex = getColumnIndex(fieldName);
+
         TableOrView tableOrView = getTable();
-
-        TableView tableView;
         if (tableOrView instanceof Table) {
-            tableView = ((Table) tableOrView).getDistinctView(columnIndex);
+            this.table = ((Table) tableOrView).getDistinctView(columnIndex);
         } else {
-            tableView = ((TableView) tableOrView).getTable().getDistinctView(columnIndex);
+            ((TableView) tableOrView).distinct(columnIndex);
         }
-
-        RealmResults<E> realmResults;
-        if (realm instanceof DynamicRealm) {
-            realmResults =  (RealmResults<E>) RealmResults.createFromDynamicTableOrView(realm, tableView, className);
-        } else {
-            realmResults = RealmResults.createFromTableOrView(realm, tableView, classSpec);
-        }
-        return realmResults;
+        return this;
     }
 
     // Deleting


### PR DESCRIPTION
`RealmResults` gets `distinct()` results from its backing `TableView`.

fixes a bug introduced in #2107 