### PR TITLE
Update Kotlin used in example to 1.0-RC

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.0-beta-4589'
+    ext.kotlin_version = '1.0.0-rc-1036'
     repositories {
         jcenter()
     }
@@ -45,11 +45,16 @@ android {
     }
 }
 
+repositories {
+    // for ReLinker
+    maven { url 'https://jitpack.io/'}
+}
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
-    compile 'org.jetbrains.anko:anko-sdk15:0.7.2'
-    compile "io.realm:realm-android-library:${version}@aar"
+    compile 'org.jetbrains.anko:anko-sdk15:0.8.2'
+    compile "io.realm:realm-android-library:${version}"
     compile "io.realm:realm-annotations:${version}"
     kapt "io.realm:realm-annotations:${version}"
     kapt "io.realm:realm-annotations-processor:${version}"


### PR DESCRIPTION
We should migrate to realm gradle plugin. I'll do that after merging of better objects PR since that PR includes changes for Kotlin.

please review this @realm/java 