### PR TITLE
now RealmResults.size() honors the contract of the Collection interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Improved performance of RealmList#contains() (#897).
 * Added RealmQuery.distinct() and RealmResults.distinct() (#1568).
 * Fixed bug when multiple calls of RealmResults.distinct() causes to return wrong results (#2198).
+* RealmResults.size() now returns Integer.MAX_VALUE when actual size is greater than Integer.MAX_VALUE (#2129).
 
 ## 0.87.4
 * Updated Realm Core to 0.96.0

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     androidTestCompile 'com.android.support:support-annotations:23.1.1'
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'
+    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
+    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
 
     androidTestApt project(':realm-annotations-processor')
     androidTestApt project(':realm-annotations')

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import java.util.Date;
 import java.util.List;
@@ -42,6 +43,7 @@ import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.NullTypes;
 import io.realm.entities.Owner;
+import io.realm.internal.Table;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
@@ -993,6 +995,19 @@ public class RealmResultsTests {
         // querying a result with zero objects must give zero objects
         RealmResults<AllTypes> stillNone = none.where().greaterThan(AllTypes.FIELD_LONG, TEST_DATA_SIZE).findAll();
         assertEquals(0, stillNone.size());
+    }
+
+    @Test
+    public void size_returns_Integer_MAX_VALUE_for_huge_results() {
+        final Table table = Mockito.mock(Table.class);
+        final RealmResults<AllTypes> targetResult = TestHelper.newRealmResults(realm, table, AllTypes.class);
+
+        Mockito.when(table.size()).thenReturn(((long) Integer.MAX_VALUE) - 1);
+        assertEquals(Integer.MAX_VALUE - 1, targetResult.size());
+        Mockito.when(table.size()).thenReturn(((long) Integer.MAX_VALUE));
+        assertEquals(Integer.MAX_VALUE, targetResult.size());
+        Mockito.when(table.size()).thenReturn(((long) Integer.MAX_VALUE) + 1);
+        assertEquals(Integer.MAX_VALUE, targetResult.size());
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -26,26 +26,26 @@ import org.junit.Assert;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
-import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.NullTypes;
 import io.realm.entities.StringOnly;
 import io.realm.internal.Table;
+import io.realm.internal.TableOrView;
 import io.realm.internal.log.Logger;
 import io.realm.rule.TestRealmConfigurationFactory;
 
@@ -693,6 +693,35 @@ public class TestHelper {
             looper.quit();
         } else {
             Assert.fail();
+        }
+    }
+
+    /**
+     * Creates a {@link RealmResults} instance.
+     * This helper method is useful to create a mocked {@link RealmResults}.
+     *
+     * @param realm a {@link Realm} or a {@link DynamicRealm} instance.
+     * @param table a {@link Table} or a {@link io.realm.internal.TableView} instance.
+     * @param tableClass a Class of Table.
+     * @return a created {@link RealmResults} instance.
+     */
+    public static <T extends RealmObject> RealmResults<T> newRealmResults(
+            BaseRealm realm, TableOrView table, Class<T> tableClass) {
+        //noinspection TryWithIdenticalCatches
+        try {
+            final Constructor<RealmResults> c = RealmResults.class.getDeclaredConstructor(
+                    BaseRealm.class, TableOrView.class, Class.class);
+            c.setAccessible(true);
+            //noinspection unchecked
+            return c.newInstance(realm, table, tableClass);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -37,6 +37,8 @@ import io.realm.internal.LinkView;
  * useful when dealing with JSON deserializers like GSON or other frameworks that inject values into a class.
  * Non-managed elements in this list can be added to a Realm using the {@link Realm#copyToRealm(Iterable)} method.
  * <p>
+ * {@link RealmList} can contain more elements than {@code Integer.MAX_VALUE}.
+ * In that case, you can access only first {@code Integer.MAX_VALUE} elements in it.
  *
  * @param <E> the class of objects in list.
  */

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -58,6 +58,9 @@ import rx.Observable;
  * If a RealmResults is built on RealmList through {@link RealmList#where()}, it will become invalid when the source
  * RealmList gets deleted. When that happens, the RealmResults will behave like a empty RealmResults, but calling
  * {@link #where()} will throw an {@link IllegalStateException}. Use {@link #isValid} to detect this situation.
+ * <p>
+ * {@link RealmResults} can contain more elements than {@code Integer.MAX_VALUE}.
+ * In that case, you can access only first {@code Integer.MAX_VALUE} elements in it.
  *
  * @param <E> The class of objects in this list.
  * @see RealmQuery#findAll()

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -418,7 +418,8 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
         if (!isLoaded()) {
             return 0;
         } else {
-            return ((Long)getTable().size()).intValue();
+            long size = getTable().size();
+            return (size > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) size;
         }
     }
 


### PR DESCRIPTION
closes #2129 

@realm/java 