### PR TITLE
Notify listeners of async RealmObject even if the result is empty

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
@@ -539,7 +539,11 @@ public class TypeBasedNotificationsTests {
             @Override
             public void onChange() {
                 switch (typebasedCommitInvocations.incrementAndGet()) {
-                    case 1: {
+                    case 1:
+                        assertTrue(dog.isLoaded());
+                        assertFalse(dog.isValid());
+                        break;
+                    case 2:
                         assertEquals("Akamaru", dog.getName());
                         realm.handler.post(new Runnable() {
                             @Override
@@ -551,8 +555,7 @@ public class TypeBasedNotificationsTests {
                             }
                         });
                         break;
-                    }
-                    case 2: {
+                    case 3:
                         assertEquals("Akamaru", dog.getName());
                         assertEquals(17, dog.getAge());
                         // posting as an event will give the handler a chance
@@ -562,12 +565,11 @@ public class TypeBasedNotificationsTests {
                             @Override
                             public void run() {
                                 assertEquals(3, globalCommitInvocations.get());
-                                assertEquals(2, typebasedCommitInvocations.get());
+                                assertEquals(3, typebasedCommitInvocations.get());
                                 looperThread.testComplete();
                             }
                         });
                         break;
-                    }
                 }
             }
         });
@@ -619,7 +621,12 @@ public class TypeBasedNotificationsTests {
             @Override
             public void onChange() {
                 switch (typebasedCommitInvocations.incrementAndGet()) {
-                    case 1: {
+                    case 1:  // triggered by COMPLETED_ASYNC_REALM_OBJECT
+                    case 2: // triggered by the irrelevant commit (not affecting Dog table)
+                        assertTrue(dog.isLoaded());
+                        assertFalse(dog.isValid());
+                        break;
+                    case 3:
                         assertEquals("Akamaru", dog.getName());
                         realm.handler.post(new Runnable() {
                             @Override
@@ -639,8 +646,7 @@ public class TypeBasedNotificationsTests {
                             }
                         });
                         break;
-                    }
-                    case 2: {
+                    case 4:
                         assertEquals("Akamaru", dog.getName());
                         assertEquals(17, dog.getAge());
                         // posting as an event will give the handler a chance
@@ -650,7 +656,7 @@ public class TypeBasedNotificationsTests {
                             @Override
                             public void run() {
                                 assertEquals(3, globalCommitInvocations.get());
-                                assertEquals(2, typebasedCommitInvocations.get());
+                                assertEquals(4, typebasedCommitInvocations.get());
                                 looperThread1.quit();
                                 looperThread2.quit();
                                 looperThread3.quit();
@@ -661,7 +667,6 @@ public class TypeBasedNotificationsTests {
                             }
                         });
                         break;
-                    }
                 }
             }
         });
@@ -711,7 +716,13 @@ public class TypeBasedNotificationsTests {
             @Override
             public void onChange() {
                 switch (typebasedCommitInvocations.incrementAndGet()) {
-                    case 1: {
+                    case 1:  // triggered by COMPLETED_ASYNC_REALM_OBJECT
+                    case 2: {// triggered by the irrelevant commit (not affecting Dog table)
+                        assertTrue(dog.isLoaded());
+                        assertFalse(dog.isValid());
+                        break;
+                    }
+                    case 3: {
                         assertEquals("Akamaru", dog.getName());
                         realm.handler.postDelayed(new Runnable() {
                             @Override
@@ -732,7 +743,7 @@ public class TypeBasedNotificationsTests {
                         }, TimeUnit.SECONDS.toMillis(0));
                         break;
                     }
-                    case 2: {
+                    case 4: {
                         assertEquals("Akamaru", dog.getName());
                         assertEquals(17, dog.getAge());
                         // posting as an event will give the handler a chance
@@ -742,7 +753,7 @@ public class TypeBasedNotificationsTests {
                             @Override
                             public void run() {
                                 assertEquals(3, globalCommitInvocations.get());
-                                assertEquals(2, typebasedCommitInvocations.get());
+                                assertEquals(4, typebasedCommitInvocations.get());
                                 looperThread.testComplete();
                             }
                         });

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1822,7 +1822,9 @@ public class RealmQuery<E extends RealmObject> {
      * @return immediately an empty {@link RealmObject}. Trying to access any field on the returned object
      * before it is loaded will throw an {@code IllegalStateException}. Use {@link RealmObject#isLoaded()} to check if
      * the object is fully loaded or register a listener {@link io.realm.RealmObject#addChangeListener}
-     * to be notified when the query completes.
+     * to be notified when the query completes. If no RealmObject was found after the query completed, the returned
+     * RealmObject will have {@link RealmObject#isLoaded()} set to {@code true} and {@link RealmObject#isValid()} set to
+     * {@code false}.
      */
     public E findFirstAsync() {
         checkQueryIsNotReused();

--- a/realm/realm-library/src/main/java/io/realm/internal/Row.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Row.java
@@ -120,7 +120,7 @@ public interface Row {
 
     Row EMPTY_ROW = new Row() {
         private final static String UNLOADED_ROW_MESSAGE = "Can't access a row that hasn't been loaded, make sure the instance" +
-                " is loaded by calling RealmObject.isLoaded";
+                " is loaded by calling RealmObject.isLoaded().";
 
         @Override
         public long getColumnCount() {


### PR DESCRIPTION
Fixes #2218 #2200
