### PR TITLE
add environment variable to specify the location of core's archive files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Prerequisites:
     launchctl setenv NDK_HOME "$NDK_HOME"
     ```
 
+ * And if you'd like to specify the location to store the archives of Realm's core, set `REALM_CORE_DOWNLOAD_DIR` environment variable. It enables you to keep core's archive when executing `git clean -xfd`.
+
+   ```
+   export REALM_CORE_DOWNLOAD_DIR=~/.realmCore
+   ```
+
 Once you have completed all the pre-requisites building Realm is done with a simple command
 
 ```

--- a/realm/realm-jni/build.gradle
+++ b/realm/realm-jni/build.gradle
@@ -14,6 +14,8 @@ ext.stripSymbols = project.hasProperty('stripSymbols') ? project.getProperty('st
 // Set the core source code path. By setting this, the core will be built from source. And coreVersion will be read from
 // core source code.
 ext.coreSourcePath = project.hasProperty('coreSourcePath') ? project.getProperty('coreSourcePath') : null
+// The location of core archive.
+ext.coreArchiveDir = System.getenv("REALM_CORE_DOWNLOAD_DIR")
 
 def commonCflags = [ '-Os', '-std=c++11' ]
 // LTO and debugging don't play well together
@@ -123,7 +125,10 @@ def getDebugExt() {
     return debugBuild ? "-dbg" : ""
 }
 
-ext.coreArchiveFile = rootProject.file("../core-android-${project.coreVersion}.tar.gz")
+if (!ext.coreArchiveDir) {
+    ext.coreArchiveDir = ".."
+}
+ext.coreArchiveFile = rootProject.file("${ext.coreArchiveDir}/core-android-${project.coreVersion}.tar.gz")
 ext.coreDir = file("${buildDir}/core-${project.coreVersion}")
 
 def coreDownloaded = false


### PR DESCRIPTION
This enables us to keep archive files when executing 'git clean -xfd'.

usage: add following line to your ~/.profile

```
export REALM_CORE_DOWNLOAD_DIR=~/.realmCore
```

@realm/java 