### PR TITLE
Support multi-arguments distinct() for Realm, DynamicRealm, RealmQuery, and RealmResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * RealmResults.size() now returns Integer.MAX_VALUE when actual size is greater than Integer.MAX_VALUE (#2129).
 * Added RealmQuery.distinctAsync() and RealmResults.distinctAsync() (#2118).
 * Removed allowBackup from AndroidManifest (#2307).
+* Added multi-arguments distinct(...) for Realm, DynamicRealm, RealmQuery, and RealmResults (#2284).
 
 ## 0.87.5
  * Updated Realm Core to 0.96.1

--- a/realm/realm-jni/src/io_realm_internal_TableView.h
+++ b/realm/realm-jni/src/io_realm_internal_TableView.h
@@ -545,6 +545,14 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinct
 
 /*
  * Class:     io_realm_internal_TableView
+ * Method:    nativeMultiDistinct
+ * Signature: (J[J)V
+ */
+JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinctMulti
+  (JNIEnv *, jobject, jlong, jlongArray);
+
+/*
+ * Class:     io_realm_internal_TableView
  * Method:    nativePivot
  * Signature: (JJJIJ)V
  */

--- a/realm/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm/realm-jni/src/io_realm_internal_tableview.cpp
@@ -75,6 +75,39 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinct(
     } CATCH_STD()
 }
 
+JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinctMulti(
+    JNIEnv* env, jobject, jlong nativeViewPtr, jlongArray columnIndexes)
+{
+    if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
+        return;
+    try {
+        JniLongArray indexes(env, columnIndexes);
+        jsize indexes_len = indexes.len();
+        std::vector<size_t> columns;
+        for (int i = 0; i < indexes_len; ++i) {
+            if (!COL_INDEX_VALID(env, TV(nativeViewPtr), indexes[i])) {
+                return;
+            }
+            if (!TV(nativeViewPtr)->get_parent().has_search_index(S(indexes[i]))) {
+                ThrowException(env, IllegalArgument, "The field must be indexed before distinct(...) can be used.");
+                return;
+            }
+            switch (TV(nativeViewPtr)->get_column_type(S(indexes[i]))) {
+                case type_Bool:
+                case type_Int:
+                case type_DateTime:
+                case type_String:
+                    columns.push_back(S(indexes[i]));
+                    break;
+                default:
+                    ThrowException(env, IllegalArgument, "Invalid type - Only String, Date, boolean, byte, short, int, long and their boxed variants are supported.");
+                    return;
+            }
+        }
+        TV(nativeViewPtr)->distinct(columns);
+    } CATCH_STD()
+}
+
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativePivot(
     JNIEnv *env, jobject, jlong dataTablePtr, jlong stringCol, jlong intCol, jint operation, jlong resultTablePtr)
 {

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AnnotationIndexTypes;
 import io.realm.entities.Cat;
@@ -417,6 +418,41 @@ public class DynamicRealmTests {
         }
     }
 
+    private void populateForDistinctInvalidTypesLinked(DynamicRealm realm) {
+        realm.beginTransaction();
+        DynamicRealmObject notEmpty = realm.createObject(AllJavaTypes.CLASS_NAME);
+        notEmpty.setBlob(AllJavaTypes.FIELD_BINARY, new byte[]{1, 2, 3});
+        notEmpty.setObject(AllJavaTypes.FIELD_OBJECT, notEmpty);
+        notEmpty.setList(AllJavaTypes.FIELD_LIST, new RealmList<DynamicRealmObject>(notEmpty));
+        realm.commitTransaction();
+    }
+
+    /*
+     * Fields order test for Chained or Multi-Arguments Distinct()
+     *
+     * The idea is to interweave different values in 2's multiplier and 3's multiplier in a way that
+     * the outcome is different if the order of distinct* operations alternates. More numbers of
+     * fields can be constructed with the combination of multipliers in prime numbers such as 2, 3,
+     * and 5.
+     *
+     * An example is illustrated below.
+     *
+     * Object      : O1| O2| O3| O4| O5| O6
+     * indexString : A | A | B | B | A | A
+     * indexLong   : 1 | 1 | 1 | 2 | 2 | 2
+     */
+    private void populateForDistinctFieldsOrder(DynamicRealm realm, long numberOfBlocks) {
+        realm.beginTransaction();
+        for (int i = 0; i < numberOfBlocks; i++) {
+            for (int j = 0; j < 6; j++) {
+                DynamicRealmObject obj = realm.createObject(AnnotationIndexTypes.CLASS_NAME);
+                obj.setString("indexString", (((j / 2) % 2) == 0) ? "A" : "B");
+                obj.setLong("indexLong", (j < 3) ? 1 : 2);
+            }
+        }
+        realm.commitTransaction();
+    }
+
     @Test
     public void distinct_invalidClassNames() {
         String[] classNames = new String[]{null, "", "foo", "foo.bar"};
@@ -482,6 +518,160 @@ public class DynamicRealmTests {
                 fail(field);
             } catch (IllegalArgumentException ignored) {
             }
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10; // must be greater than 1
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmResults<DynamicRealmObject> distinctMulti = realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.INDEX_FIELDS);
+        assertEquals(numberOfBlocks, distinctMulti.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_switchedFieldsOrder() {
+        final long numberOfBlocks = 25;
+        populateForDistinctFieldsOrder(realm, numberOfBlocks);
+
+        // Regardless of the block size defined above, the output size is expected to be the same, 4 in this case, due to receiving unique combinations of tuples
+        RealmResults<DynamicRealmObject> distinctStringLong = realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_STRING, AnnotationIndexTypes.FIELD_INDEX_LONG);
+        RealmResults<DynamicRealmObject> distinctLongString = realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_LONG, AnnotationIndexTypes.FIELD_INDEX_STRING);
+        assertEquals(4, distinctStringLong.size());
+        assertEquals(4, distinctLongString.size());
+        assertEquals(distinctStringLong.size(), distinctLongString.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_emptyFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        // an empty string field in the middle
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_BOOL, "", AnnotationIndexTypes.FIELD_INDEX_INT);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // an empty string field at the end
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, "");
+        } catch (IllegalArgumentException ignored) {
+        }
+        // a null string field in the middle
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_BOOL, (String)null, AnnotationIndexTypes.FIELD_INDEX_INT);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // a null string field at the end
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // (String)null makes varargs a null array.
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_BOOL, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // Two (String)null for first and varargs fields
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, (String)null, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // "" & (String)null combination
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, "", (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // "" & (String)null combination
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, (String)null, "");
+        } catch (IllegalArgumentException ignored) {
+        }
+        // Two empty fields tests
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, "", "");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_withNullValues() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        RealmResults<DynamicRealmObject> distinctMulti = realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_DATE, AnnotationIndexTypes.FIELD_INDEX_STRING);
+        assertEquals(1, distinctMulti.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_notIndexedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_NOT_INDEX_STRING, AnnotationIndexTypes.NOT_INDEX_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_doesNotExistField() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.FIELD_INDEX_INT, AnnotationIndexTypes.NONEXISTANT_MIX_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_invalidTypesFields() {
+        populateTestRealm();
+
+        try {
+            realm.distinct(AllTypes.CLASS_NAME, AllTypes.FIELD_REALMOBJECT, AllTypes.INVALID_TYPES_FIELDS_FOR_DISTINCT);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_indexedLinkedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.INDEX_LINKED_FIELD_STRING, AnnotationIndexTypes.INDEX_LINKED_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_notIndexedLinkedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        try {
+            realm.distinct(AnnotationIndexTypes.CLASS_NAME, AnnotationIndexTypes.NOT_INDEX_LINKED_FILED_STRING, AnnotationIndexTypes.NOT_INDEX_LINKED_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_invalidTypesLinkedFields() {
+        populateForDistinctInvalidTypesLinked(realm);
+
+        try {
+            realm.distinct(AllJavaTypes.CLASS_NAME, AllJavaTypes.INVALID_LINKED_BINARY_FIELD_FOR_DISTINCT, AllJavaTypes.INVALID_LINKED_TYPES_FIELDS_FOR_DISTINCT);
+        } catch (IllegalArgumentException ignored) {
         }
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -1959,6 +1959,8 @@ public class RealmQueryTests {
         realm.beginTransaction();
         AllJavaTypes notEmpty = new AllJavaTypes();
         notEmpty.setFieldBinary(new byte[]{1, 2, 3});
+        notEmpty.setFieldObject(notEmpty);
+        notEmpty.setFieldList(new RealmList<AllJavaTypes>(notEmpty));
         realm.copyToRealm(notEmpty);
         realm.commitTransaction();
     }
@@ -2278,6 +2280,170 @@ public class RealmQueryTests {
 
         try {
             realm.where(AllJavaTypes.class).distinctAsync(AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_BINARY);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10; // must be greater than 1
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        RealmResults<AnnotationIndexTypes> distinctMulti = query.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.INDEX_FIELDS);
+        assertEquals(numberOfBlocks, distinctMulti.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_switchedFieldsOrder() {
+        final long numberOfBlocks = 25;
+        TestHelper.populateForDistinctFieldsOrder(realm, numberOfBlocks);
+
+        // Regardless of the block size defined above, the output size is expected to be the same, 4 in this case, due to receiving unique combinations of tuples
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        RealmResults<AnnotationIndexTypes> distinctStringLong = query.distinct(AnnotationIndexTypes.FIELD_INDEX_STRING, AnnotationIndexTypes.FIELD_INDEX_LONG);
+        RealmResults<AnnotationIndexTypes> distinctLongString = query.distinct(AnnotationIndexTypes.FIELD_INDEX_LONG, AnnotationIndexTypes.FIELD_INDEX_STRING);
+        assertEquals(4, distinctStringLong.size());
+        assertEquals(4, distinctLongString.size());
+        assertEquals(distinctStringLong.size(), distinctLongString.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_emptyField() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        // an empty string field in the middle
+        try {
+            query.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, "", AnnotationIndexTypes.FIELD_INDEX_INT);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // an empty string field at the end
+        try {
+            query.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, "");
+        } catch (IllegalArgumentException ignored) {
+        }
+        // a null string field in the middle
+        try {
+            query.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, (String)null, AnnotationIndexTypes.FIELD_INDEX_INT);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // a null string field at the end
+        try {
+            query.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // (String)null makes varargs a null array.
+        try {
+            query.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // Two (String)null for first and varargs fields
+        try {
+            query.distinct((String)null, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // "" & (String)null combination
+        try {
+            query.distinct("", (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // "" & (String)null combination
+        try {
+            query.distinct((String)null, "");
+        } catch (IllegalArgumentException ignored) {
+        }
+        // Two empty fields tests
+        try {
+            query.distinct("", "");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_withNullValues() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        RealmResults<AnnotationIndexTypes> distinctMulti = query.distinct(AnnotationIndexTypes.FIELD_INDEX_DATE, AnnotationIndexTypes.FIELD_INDEX_STRING);
+        assertEquals(1, distinctMulti.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_notIndexedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        try {
+            query.distinct(AnnotationIndexTypes.FIELD_NOT_INDEX_STRING, AnnotationIndexTypes.NOT_INDEX_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_doesNotExistField() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        try {
+            query.distinct(AnnotationIndexTypes.FIELD_INDEX_INT, AnnotationIndexTypes.NONEXISTANT_MIX_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_invalidTypesFields() {
+        populateTestRealm();
+
+        RealmQuery<AllTypes> query = realm.where(AllTypes.class);
+        try {
+            query.distinct(AllTypes.FIELD_REALMOBJECT, AllTypes.INVALID_TYPES_FIELDS_FOR_DISTINCT);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_indexedLinkedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        try {
+            query.distinct(AnnotationIndexTypes.INDEX_LINKED_FIELD_STRING, AnnotationIndexTypes.INDEX_LINKED_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_notIndexedLinkedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        RealmQuery<AnnotationIndexTypes> query = realm.where(AnnotationIndexTypes.class);
+        try {
+            query.distinct(AnnotationIndexTypes.NOT_INDEX_LINKED_FILED_STRING, AnnotationIndexTypes.NOT_INDEX_LINKED_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_invalidTypesLinkedFields() {
+        populateForDistinctInvalidTypesLinked(realm);
+
+        RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class);
+        try {
+            query.distinct(AllJavaTypes.INVALID_LINKED_BINARY_FIELD_FOR_DISTINCT, AllJavaTypes.INVALID_LINKED_TYPES_FIELDS_FOR_DISTINCT);
         } catch (IllegalArgumentException ignored) {
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -1305,6 +1305,8 @@ public class RealmResultsTests {
         realm.beginTransaction();
         AllJavaTypes notEmpty = new AllJavaTypes();
         notEmpty.setFieldBinary(new byte[]{1, 2, 3});
+        notEmpty.setFieldObject(notEmpty);
+        notEmpty.setFieldList(new RealmList<AllJavaTypes>(notEmpty));
         realm.copyToRealm(notEmpty);
         realm.commitTransaction();
     }
@@ -1645,6 +1647,170 @@ public class RealmResultsTests {
 
         try {
             realm.where(AllJavaTypes.class).findAll().distinctAsync(AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_BINARY);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10; // must be greater than 1
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        RealmResults<AnnotationIndexTypes> distinctMulti = results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.INDEX_FIELDS);
+        assertEquals(numberOfBlocks, distinctMulti.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_switchedFieldsOrder() {
+        final long numberOfBlocks = 25;
+        TestHelper.populateForDistinctFieldsOrder(realm, numberOfBlocks);
+
+        // Regardless of the block size defined above, the output size is expected to be the same, 4 in this case, due to receiving unique combinations of tuples
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        RealmResults<AnnotationIndexTypes> distinctStringLong = results.distinct(AnnotationIndexTypes.FIELD_INDEX_STRING, AnnotationIndexTypes.FIELD_INDEX_LONG);
+        RealmResults<AnnotationIndexTypes> distinctLongString = results.distinct(AnnotationIndexTypes.FIELD_INDEX_LONG, AnnotationIndexTypes.FIELD_INDEX_STRING);
+        assertEquals(4, distinctStringLong.size());
+        assertEquals(4, distinctLongString.size());
+        assertEquals(distinctStringLong.size(), distinctLongString.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_emptyField() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        // an empty string field in the middle
+        try {
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, "", AnnotationIndexTypes.FIELD_INDEX_INT);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // an empty string field at the end
+        try {
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, "");
+        } catch (IllegalArgumentException ignored) {
+        }
+        // a null string field in the middle
+        try {
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, (String)null, AnnotationIndexTypes.FIELD_INDEX_INT);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // a null string field at the end
+        try {
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // (String)null makes varargs a null array.
+        try {
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // Two (String)null for first and varargs fields
+        try {
+            results.distinct((String)null, (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // "" & (String)null combination
+        try {
+            results.distinct("", (String)null);
+        } catch (IllegalArgumentException ignored) {
+        }
+        // "" & (String)null combination
+        try {
+            results.distinct((String)null, "");
+        } catch (IllegalArgumentException ignored) {
+        }
+        // Two empty fields tests
+        try {
+            results.distinct("", "");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_withNullValues() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        RealmResults<AnnotationIndexTypes> distinctMulti = results.distinct(AnnotationIndexTypes.FIELD_INDEX_DATE, AnnotationIndexTypes.FIELD_INDEX_STRING);
+        assertEquals(1, distinctMulti.size());
+    }
+
+    @Test
+    public void distinctMultiArgs_notIndexedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        try {
+            results.distinct(AnnotationIndexTypes.FIELD_NOT_INDEX_STRING, AnnotationIndexTypes.NOT_INDEX_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_doesNotExistField() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        try {
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_INT, AnnotationIndexTypes.NONEXISTANT_MIX_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_invalidTypesFields() {
+        populateTestRealm();
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        try {
+            results.distinct(AllTypes.FIELD_REALMOBJECT, AllTypes.INVALID_TYPES_FIELDS_FOR_DISTINCT);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_indexedLinkedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        try {
+            results.distinct(AnnotationIndexTypes.INDEX_LINKED_FIELD_STRING, AnnotationIndexTypes.INDEX_LINKED_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_notIndexedLinkedFields() {
+        final long numberOfBlocks = 25;
+        final long numberOfObjects = 10;
+        populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        try {
+            results.distinct(AnnotationIndexTypes.NOT_INDEX_LINKED_FILED_STRING, AnnotationIndexTypes.NOT_INDEX_LINKED_FIELDS);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void distinctMultiArgs_invalidTypesLinkedFields() {
+        populateForDistinctInvalidTypesLinked(realm);
+
+        RealmResults<AnnotationIndexTypes> results = realm.where(AnnotationIndexTypes.class).findAll();
+        try {
+            results.distinct(AllJavaTypes.INVALID_LINKED_BINARY_FIELD_FOR_DISTINCT, AllJavaTypes.INVALID_LINKED_TYPES_FIELDS_FOR_DISTINCT);
         } catch (IllegalArgumentException ignored) {
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import io.realm.entities.AnnotationIndexTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.NullTypes;
 import io.realm.entities.StringOnly;
@@ -633,6 +634,36 @@ public class TestHelper {
         DynamicRealmObject object3 = realm.createObject(AllTypes.CLASS_NAME);
         object3.setLong(AllTypes.FIELD_LONG, 4);
         object3.setString(AllTypes.FIELD_STRING, "Adam");
+        realm.commitTransaction();
+    }
+
+
+    /*
+     * Fields order test for Chained or Multi-Arguments Distinct()
+     *
+     * The idea is to interweave different values in 2's multiplier and 3's multiplier in a way that
+     * the outcome is different if the order of distinct* operations alternates. More numbers of
+     * fields can be constructed with the combination of multipliers in prime numbers such as 2, 3,
+     * and 5.
+     *
+     * An example is illustrated below.
+     *
+     * Object      : O1| O2| O3| O4| O5| O6
+     * indexString : A | A | B | B | A | A
+     * indexLong   : 1 | 1 | 1 | 2 | 2 | 2
+     *
+     * @param realm a {@link Realm} instance.
+     * @param numberOfBlocks number of times set of unique objects should be created.
+     */
+    public static void populateForDistinctFieldsOrder(Realm realm, long numberOfBlocks) {
+        realm.beginTransaction();
+        for (int i = 0; i < numberOfBlocks; i++) {
+            for (int j = 0; j < 6; j++) {
+                AnnotationIndexTypes obj = realm.createObject(AnnotationIndexTypes.class);
+                obj.setIndexString((((j / 2) % 2) == 0) ? "A" : "B");
+                obj.setIndexLong((j < 3) ? 1 : 2);
+            }
+        }
         realm.commitTransaction();
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
@@ -41,6 +41,9 @@ public class AllJavaTypes extends RealmObject{
     public static String FIELD_OBJECT = "fieldObject";
     public static String FIELD_LIST = "fieldList";
 
+    public static final String   INVALID_LINKED_BINARY_FIELD_FOR_DISTINCT = AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_BINARY;
+    public static final String[] INVALID_LINKED_TYPES_FIELDS_FOR_DISTINCT = new String[]{FIELD_OBJECT + "." + FIELD_BINARY, FIELD_OBJECT + "." + FIELD_OBJECT, FIELD_OBJECT + "." + FIELD_LIST};
+
     @Ignore private String fieldIgnored;
     @Index private String fieldString;
     private short fieldShort;

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AllTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AllTypes.java
@@ -35,6 +35,8 @@ public class AllTypes extends RealmObject {
     public static final String FIELD_REALMOBJECT = "columnRealmObject";
     public static final String FIELD_REALMLIST = "columnRealmList";
 
+    public static final String[] INVALID_TYPES_FIELDS_FOR_DISTINCT = new String[]{FIELD_REALMOBJECT, FIELD_REALMLIST, FIELD_DOUBLE, FIELD_FLOAT};
+
     @Required
     private String columnString = "";
     private long columnLong;

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AnnotationIndexTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AnnotationIndexTypes.java
@@ -46,6 +46,11 @@ public class AnnotationIndexTypes extends RealmObject {
 
     public static final String[] INDEX_FIELDS = new String[]{FIELD_INDEX_STRING, FIELD_INDEX_INT, FIELD_INDEX_BYTE, FIELD_INDEX_SHORT, FIELD_INDEX_LONG, FIELD_INDEX_BOOL, FIELD_INDEX_DATE};
     public static final String[] NOT_INDEX_FIELDS = new String[]{FIELD_NOT_INDEX_STRING, FIELD_NOT_INDEX_INT, FIELD_NOT_INDEX_BYTE, FIELD_NOT_INDEX_SHORT, FIELD_NOT_INDEX_LONG, FIELD_NOT_INDEX_BOOL, FIELD_NOT_INDEX_DATE};
+    public static final String   INDEX_LINKED_FIELD_STRING = AnnotationIndexTypes.FIELD_OBJECT + "." + AnnotationIndexTypes.FIELD_INDEX_STRING;
+    public static final String[] INDEX_LINKED_FIELDS = new String[]{FIELD_OBJECT + "." + FIELD_INDEX_STRING, FIELD_OBJECT + "." + FIELD_INDEX_INT};
+    public static final String   NOT_INDEX_LINKED_FILED_STRING = FIELD_OBJECT + "." + FIELD_NOT_INDEX_STRING;
+    public static final String[] NOT_INDEX_LINKED_FIELDS = new String[]{FIELD_OBJECT + "." + FIELD_NOT_INDEX_STRING, FIELD_OBJECT + "." + FIELD_NOT_INDEX_INT};
+    public static final String[] NONEXISTANT_MIX_FIELDS = new String[]{FIELD_INDEX_INT, "doesNotExists", FIELD_INDEX_STRING};
 
     @Index
     private String indexString;

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -279,6 +279,24 @@ public final class DynamicRealm extends BaseRealm {
     }
 
     /**
+     * Returns a distinct set of objects from a specific class. When multiple distinct fields are
+     * given, all unique combinations of values in the fields will be returned. In case of multiple
+     * matches, it is undefined which object is returned. Unless the result is sorted, then the
+     * first object will be returned.
+     *
+     * @param className the Class to get objects of.
+     * @param firstFieldName first field name to use when finding distinct objects.
+     * @param remainingFieldNames remaining field names when determining all unique combinations of field values.
+     * @return a non-null {@link RealmResults} containing the distinct objects.
+     * @throws IllegalArgumentException if field names is empty or {@code null}, does not exist,
+     * is an unsupported type, or points to a linked field.
+     */
+    public RealmResults<DynamicRealmObject> distinct(String className, String firstFieldName, String... remainingFieldNames) {
+        checkIfValid();
+        return where(className).distinct(firstFieldName, remainingFieldNames);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1070,6 +1070,24 @@ public final class Realm extends BaseRealm {
     }
 
     /**
+     * Returns a distinct set of objects from a specific class. When multiple distinct fields are
+     * given, all unique combinations of values in the fields will be returned. In case of multiple
+     * matches, it is undefined which object is returned. Unless the result is sorted, then the
+     * first object will be returned.
+     *
+     * @param clazz the Class to get objects of.
+     * @param firstFieldName first field name to use when finding distinct objects.
+     * @param remainingFieldNames remaining field names when determining all unique combinations of field values.
+     * @return a non-null {@link RealmResults} containing the distinct objects.
+     * @throws IllegalArgumentException if field names is empty or {@code null}, does not exist,
+     * is an unsupported type, or points to a linked field.
+     */
+    public <E extends RealmObject> RealmResults<E> distinct(Class<E> clazz, String firstFieldName, String... remainingFieldNames) {
+        checkIfValid();
+        return where(clazz).distinct(firstFieldName, remainingFieldNames);
+    }
+
+    /**
      * Executes a given transaction on the Realm. {@link #beginTransaction()} and {@link #commitTransaction()} will be
      * called automatically. If any exception is thrown during the transaction {@link #cancelTransaction()} will be
      * called instead of {@link #commitTransaction()}.

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -594,6 +594,22 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
         return where().distinctAsync(fieldName);
     }
 
+    /**
+     * Returns a distinct set of objects from a specific class. When multiple distinct fields are
+     * given, all unique combinations of values in the fields will be returned. In case of multiple
+     * matches, it is undefined which object is returned. Unless the result is sorted, then the
+     * first object will be returned.
+     *
+     * @param firstFieldName first field name to use when finding distinct objects.
+     * @param remainingFieldNames remaining field names when determining all unique combinations of field values.
+     * @return a non-null {@link RealmResults} containing the distinct objects.
+     * @throws IllegalArgumentException if field names is empty or {@code null}, does not exist,
+     * is an unsupported type, or points to a linked field.
+     */
+    public RealmResults<E> distinct(String firstFieldName, String... remainingFieldNames) {
+        return where().distinct(firstFieldName, remainingFieldNames);
+    }
+
     // Deleting
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/internal/TableView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableView.java
@@ -804,6 +804,25 @@ public class TableView implements TableOrView, Closeable {
         nativeDistinct(nativePtr, columnIndex);
     }
 
+    /**
+     * If two rows are indentical (for the given set of distinct-columns), then the last row is
+     * removed unless sorted, in which case the first object is returned.
+     * Each time distinct() gets called, it will first fetch the full original TableView contents
+     * and then apply distinct() on that, invalidating previous distinct().
+     *
+     * @param columnIndexes the column indexes.
+     * @throws IllegalArgumentException if a column is unsupported type, or is not indexed.
+     */
+    public void distinct(List<Long> columnIndexes) {
+        // Execute the disposal of abandoned realm objects each time a new realm object is created
+        this.context.executeDelayedDisposal();
+        long[] indexes = new long[columnIndexes.size()];
+        for (int i = 0; i < columnIndexes.size(); i++) {
+            indexes[i] = columnIndexes.get(i).longValue();
+        }
+        nativeDistinctMulti(nativePtr, indexes);
+    }
+
     @Override
     public long sync() {
         return nativeSync(nativePtr);
@@ -878,5 +897,6 @@ public class TableView implements TableOrView, Closeable {
     private native long nativeWhere(long nativeViewPtr);
     private native void nativePivot(long nativeTablePtr, long stringCol, long intCol, int pivotType, long result);
     private native long nativeDistinct(long nativeViewPtr, long columnIndex);
+    private native long nativeDistinctMulti(long nativeViewPtr, long[] columnIndexes);
     private native long nativeSync(long nativeTablePtr);
 }


### PR DESCRIPTION
Support multi-arguments `distinct(...)` for Realm, DynamicRealm, RealmQuery, and RealmResults.

Supports for issue #1568