### PR TITLE
Deprecate Realm.getInstance(Context)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * BREAKING CHANGE: DynamicRealm.executeTransaction() now throws IllegalArgumentException instead of silently accepting a null Transaction object.
 * BREAKING CHANGE: String setters now throws IllegalArgumentException instead of RealmError for invalid surrogates. 
 * BREAKING CHANGE: DynamicRealm.distinct()/distinctAsync() and Realm.distinct()/distinctAsync() now throw IllegalArgumentException instead of UnsupportedOperationException for invalid type or unindexed field.
+* Deprecated methods: Realm.getInstance(Context). Use Realm.getInstance(RealmConfiguration) or Realm.getDefaultInstance() instead.
 * Fixed an error occurring during test and connectedCheck of unit test example (#1934).
 * Fixed bug in jsonExample (#2092).
 * Added RealmQuery.isNotEmpty() (#2025). (Thank you @stk1m1)

--- a/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/AdapterExampleActivity.java
+++ b/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/AdapterExampleActivity.java
@@ -43,7 +43,9 @@ public class AdapterExampleActivity extends Activity {
 
         RealmConfiguration realmConfig = new RealmConfiguration.Builder(this).build();
         Realm.deleteRealm(realmConfig);
-        realm = Realm.getInstance(realmConfig);
+        // Set the default Realm configuration at the beginning.
+        Realm.setDefaultConfiguration(realmConfig);
+        realm = Realm.getDefaultInstance();
 
         RealmResults<TimeStamp> timeStamps = realm.where(TimeStamp.class).findAll();
         final MyAdapter adapter = new MyAdapter(this, R.id.listView, timeStamps, true);
@@ -70,7 +72,7 @@ public class AdapterExampleActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        workerThread = new WorkerThread(this);
+        workerThread = new WorkerThread();
         workerThread.start();
     }
 

--- a/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerThread.java
+++ b/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerThread.java
@@ -15,7 +15,6 @@
  */
 package io.realm.examples.realmadapters;
 
-import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -25,18 +24,12 @@ public class WorkerThread extends Thread {
 
     public Handler workerHandler;
 
-    private Context context;
-
-    public WorkerThread(Context context) {
-        this.context = context;
-    }
-
     @Override
     public void run() {
         Realm realm = null;
         try {
             Looper.prepare();
-            realm = Realm.getInstance(context);
+            realm = Realm.getDefaultInstance();
             workerHandler = new WorkerHandler(realm);
             Looper.loop();
         } finally {

--- a/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
+++ b/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
@@ -182,22 +182,11 @@ public class IntroExampleActivity extends Activity {
                 dogName = pers.getDog().getName();
             }
             status += "\n" + pers.getName() + ":" + pers.getAge() + " : " + dogName + " : " + pers.getCats().size();
-
-            // The field tempReference is annotated with @Ignore
-            // Though we initially set its value to 42, it has
-            // not been saved as part of the Person RealmObject:
-            if (BuildConfig.DEBUG && pers.getTempReference() != 0) {
-                throw new AssertionError();
-            }
         }
 
         // Sorting
         RealmResults<Person> sortedPersons = realm.allObjects(Person.class);
         sortedPersons.sort("age", Sort.DESCENDING);
-        if (BuildConfig.DEBUG &&
-                !realm.allObjects(Person.class).last().getName().equals(sortedPersons.first().getName())) {
-            throw new AssertionError();
-        }
         status += "\nSorting " + sortedPersons.last().getName() + " == "
                 + realm.allObjects(Person.class).first().getName();
 

--- a/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
+++ b/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
@@ -24,6 +24,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import io.realm.Realm;
+import io.realm.RealmConfiguration;
 import io.realm.RealmResults;
 import io.realm.Sort;
 import io.realm.examples.intro.model.Cat;
@@ -36,6 +37,7 @@ public class IntroExampleActivity extends Activity {
     private LinearLayout rootLayout = null;
 
     private Realm realm;
+    private RealmConfiguration realmConfig;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,8 +49,10 @@ public class IntroExampleActivity extends Activity {
         // These operations are small enough that
         // we can generally safely run them on the UI thread.
 
-        // Open the default Realm for the UI thread.
-        realm = Realm.getInstance(this);
+        // Create the Realm configuration
+        realmConfig = new RealmConfiguration.Builder(this).build();
+        // Open the Realm for the UI thread.
+        realm = Realm.getInstance(realmConfig);
 
         basicCRUD(realm);
         basicQuery(realm);
@@ -139,7 +143,7 @@ public class IntroExampleActivity extends Activity {
 
         // Open the default realm. All threads must use it's own reference to the realm.
         // Those can not be transferred across threads.
-        Realm realm = Realm.getInstance(this);
+        Realm realm = Realm.getInstance(realmConfig);
 
         // Add ten persons in one transaction
         realm.beginTransaction();
@@ -182,14 +186,20 @@ public class IntroExampleActivity extends Activity {
             // The field tempReference is annotated with @Ignore
             // Though we initially set its value to 42, it has
             // not been saved as part of the Person RealmObject:
-            assert(pers.getTempReference() == 0);
+            if (BuildConfig.DEBUG && pers.getTempReference() != 0) {
+                throw new AssertionError();
+            }
         }
 
         // Sorting
         RealmResults<Person> sortedPersons = realm.allObjects(Person.class);
         sortedPersons.sort("age", Sort.DESCENDING);
-        assert(realm.allObjects(Person.class).last().getName() == sortedPersons.first().getName());
-        status += "\nSorting " + sortedPersons.last().getName() + " == " + realm.allObjects(Person.class).first().getName();
+        if (BuildConfig.DEBUG &&
+                !realm.allObjects(Person.class).last().getName().equals(sortedPersons.first().getName())) {
+            throw new AssertionError();
+        }
+        status += "\nSorting " + sortedPersons.last().getName() + " == "
+                + realm.allObjects(Person.class).first().getName();
 
         realm.close();
         return status;
@@ -198,7 +208,7 @@ public class IntroExampleActivity extends Activity {
     private String complexQuery() {
         String status = "\n\nPerforming complex Query operation...";
 
-        Realm realm = Realm.getInstance(this);
+        Realm realm = Realm.getInstance(realmConfig);
         status += "\nNumber of persons: " + realm.allObjects(Person.class).size();
 
         // Find all persons where age between 7 and 9 and name begins with "Person".

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
@@ -40,6 +40,7 @@ public class KotlinExampleActivity : Activity() {
 
     private var rootLayout: LinearLayout by Delegates.notNull()
     private var realm: Realm by Delegates.notNull()
+    private var realmConfig: RealmConfiguration by Delegates.notNull()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,11 +52,11 @@ public class KotlinExampleActivity : Activity() {
         // we can generally safely run them on the UI thread.
 
         // Create configuration and reset Realm.
-        val config = RealmConfiguration.Builder(this).build()
-        Realm.deleteRealm(config)
+        realmConfig = RealmConfiguration.Builder(this).build()
+        Realm.deleteRealm(realmConfig)
 
-        // Open the default realm for the UI thread.
-        realm = Realm.getInstance(this)
+        // Open the realm for the UI thread.
+        realm = Realm.getInstance(realmConfig)
 
         basicCRUD(realm)
         basicQuery(realm)
@@ -143,7 +144,7 @@ public class KotlinExampleActivity : Activity() {
 
         // Open the default realm. All threads must use it's own reference to the realm.
         // Those can not be transferred across threads.
-        val realm = Realm.getInstance(this)
+        val realm = Realm.getInstance(realmConfig)
 
         // Add ten persons in one transaction
         realm.beginTransaction()
@@ -200,7 +201,7 @@ public class KotlinExampleActivity : Activity() {
 
         // Realm implements the Closable interface, therefore we can make use of Kotlin's built-in
         // extension method 'use' (pun intended).
-        Realm.getInstance(this).use {
+        Realm.getInstance(realmConfig).use {
             // 'it' is the implicit lambda parameter of type Realm
             status += "\nNumber of persons: ${it.allObjects(Person::class.java).size}"
 

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
@@ -126,7 +126,7 @@ public class ThreadFragment extends Fragment {
                 // Realm instances cannot be shared between threads, so we need to create a new
                 // instance on the background thread.
                 int redColor = getResources().getColor(R.color.realm_red);
-                Realm backgroundThreadRealm = Realm.getInstance(getActivity());
+                Realm backgroundThreadRealm = Realm.getDefaultInstance();
                 while (!backgroundThread.isInterrupted()) {
                     backgroundThreadRealm.beginTransaction();
 

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
@@ -25,6 +25,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import io.realm.Realm;
+import io.realm.RealmConfiguration;
 import io.realm.RealmResults;
 import io.realm.examples.unittesting.model.Person;
 
@@ -35,6 +36,7 @@ public class ExampleActivity extends Activity {
     private LinearLayout rootLayout = null;
 
     private Realm realm;
+    private static RealmConfiguration realmConfig;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -43,8 +45,10 @@ public class ExampleActivity extends Activity {
         rootLayout = ((LinearLayout) findViewById(R.id.container));
         rootLayout.removeAllViews();
 
+        // Create Realm configuration if it doesn't exist.
+        realmConfig = new RealmConfiguration.Builder(this).build();
         // Open the default Realm for the UI thread.
-        realm = Realm.getInstance(this);
+        realm = Realm.getInstance(realmConfig);
 
         // Clean up from previous run
         cleanUp();
@@ -148,7 +152,7 @@ public class ExampleActivity extends Activity {
     private String complexQuery() {
         String status = "\n\nPerforming complex Query operation...";
 
-        Realm realm = Realm.getInstance(this);
+        Realm realm = Realm.getInstance(realmConfig);
         status += "\nNumber of people in the DB: " + realm.allObjects(Person.class).size();
 
         // Find all persons where age between 1 and 99 and name begins with "J".

--- a/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
+++ b/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.realm.Realm;
+import io.realm.RealmConfiguration;
 import io.realm.RealmObject;
 import io.realm.RealmQuery;
 import io.realm.RealmResults;
@@ -75,8 +76,9 @@ public class ExampleActivityTest {
         // Create the mock
         final Realm mockRealm = mock(Realm.class);
 
-        // Anytime getInstance is called with any context, then return the mockRealm
-        when(Realm.getInstance(any(Context.class))).thenReturn(mockRealm);
+        // Anytime getInstance is called with any configuration, then return the mockRealm
+        // FIXME: Final class Realm cannot be mocked by Mockito! https://github.com/realm/realm-java/issues/2303
+        when(Realm.getInstance(any(RealmConfiguration.class))).thenReturn(mockRealm);
 
         // Anytime we ask Realm to create a Person, return a new instance.
         when(mockRealm.createObject(Person.class)).thenReturn(new Person());
@@ -156,7 +158,7 @@ public class ExampleActivityTest {
 
         // Verify that two Realm.getInstance() calls took place.
         verifyStatic(times(2));
-        Realm.getInstance(any(Context.class));
+        Realm.getInstance(any(RealmConfiguration.class));
 
         // verify that we have four begin and commit transaction calls
         verify(mockRealm, times(4)).beginTransaction();

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -81,14 +81,13 @@ import rx.Observable;
  * <pre>
  * public class RealmApplication extends Application {
  *
- *     private static RealmConfiguration defaultRealmConfig;
- *
  *     \@Override
  *     public void onCreate() {
  *         super.onCreate();
+ *
  *         // The Realm file will be located in package's "files" directory.
- *         defaultRealmConfig = new RealmConfiguration.Builder(this).build();
- *         Realm.setDefaultConfiguration(defaultRealmConfig);
+ *         RealmConfiguration realmConfig = new RealmConfiguration.Builder(this).build();
+ *         Realm.setDefaultConfiguration(realmConfig);
  *     }
  * }
  *

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -79,6 +79,19 @@ import rx.Observable;
  * A standard pattern for working with Realm in Android activities can be seen below:
  * <p>
  * <pre>
+ * public class RealmApplication extends Application {
+ *
+ *     private static RealmConfiguration defaultRealmConfig;
+ *
+ *     \@Override
+ *     public void onCreate() {
+ *         super.onCreate();
+ *         // The Realm file will be located in package's "files" directory.
+ *         defaultRealmConfig = new RealmConfiguration.Builder(this).build();
+ *         Realm.setDefaultConfiguration(defaultRealmConfig);
+ *     }
+ * }
+ *
  * public class RealmActivity extends Activity {
  *
  *   private Realm realm;
@@ -87,7 +100,7 @@ import rx.Observable;
  *   protected void onCreate(Bundle savedInstanceState) {
  *     super.onCreate(savedInstanceState);
  *     setContentView(R.layout.layout_main);
- *     realm = Realm.getInstance(this);
+ *     realm = Realm.getDefaultInstance();
  *   }
  *
  *   \@Override
@@ -157,6 +170,7 @@ public final class Realm extends BaseRealm {
      * @throws RealmMigrationNeededException if the RealmObject classes no longer match the underlying Realm and it must be
      * migrated.
      * @throws RealmIOException if an error happened when accessing the underlying Realm file.
+     * @deprecated use {@link #getDefaultInstance()} or {@link #getInstance(RealmConfiguration)} instead.
      */
     public static Realm getInstance(Context context) {
         return Realm.getInstance(new RealmConfiguration.Builder(context)

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
@@ -39,14 +39,6 @@ public class RealmMigrationNeededException extends RuntimeException {
      * Returns the canonical path to the Realm file that needs to be migrated.
      *
      * This can be used for easy reference during a migration:
-     * FIXME: This example doesn't make too much sense anymore.
-     * <pre>
-     * try {
-     *   Realm.getDefaultInstance();
-     * } catch (RealmMigrationNeededException e) {
-     *   Realm.migrateRealmAtPath(e.getRealmPath(), new CustomMigration());
-     * }
-     * </pre>
      *
      * @return Canonical path to the Realm file.
      * @see File#getCanonicalPath()

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
@@ -39,10 +39,10 @@ public class RealmMigrationNeededException extends RuntimeException {
      * Returns the canonical path to the Realm file that needs to be migrated.
      *
      * This can be used for easy reference during a migration:
-     *
+     * FIXME: This example doesn't make too much sense anymore.
      * <pre>
      * try {
-     *   Realm.getInstance(context);
+     *   Realm.getDefaultInstance();
      * } catch (RealmMigrationNeededException e) {
      *   Realm.migrateRealmAtPath(e.getRealmPath(), new CustomMigration());
      * }


### PR DESCRIPTION
 * Deprecate Realm.getInstance(Context).
 * Replease `Realm.getInstance(Context)` in examples.

 See #2303 , `UnitTestExample` doesn't work even before.
 Realm doc needs to be updated as well.