### PR TITLE
Removing allow back up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed bug when multiple calls of RealmResults.distinct() causes to return wrong results (#2198).
 * RealmResults.size() now returns Integer.MAX_VALUE when actual size is greater than Integer.MAX_VALUE (#2129).
 * Added RealmQuery.distinctAsync() and RealmResults.distinctAsync() (#2118).
+* Removed allowBackup from AndroidManifest (#2307).
 
 ## 0.87.5
  * Updated Realm Core to 0.96.1

--- a/realm/realm-library/src/main/AndroidManifest.xml
+++ b/realm/realm-library/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.realm" >
-    <application android:allowBackup="true"/>
+
 </manifest>


### PR DESCRIPTION
References: #2227

The consequence of this is that the developer will have ignore the lint warning in their project because we are not setting it. This can be accomplished by adding a `lint.xml` file to the application with the following contents: 

```
<?xml version="1.0" encoding="UTF-8"?>
<lint>
    <issue id="AllowBackup" severity="ignore" />
</lint>
```

Then, in the applications build.gradle add the following lint config in the android block.

```
lintOptions {
    lintConfig file('lint.xml')
}
```

At that point, when `./gradlew lint` is run, the `AllowBackup` warning will be ignored. 

