### PR TITLE
remove RealmConfiguration.getSchemaMediator() from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * BREAKING CHANGE: String setters now throw IllegalArgumentException instead of RealmError for invalid surrogates.
 * BREAKING CHANGE: DynamicRealm.distinct()/distinctAsync() and Realm.distinct()/distinctAsync() now throw IllegalArgumentException instead of UnsupportedOperationException for invalid type or unindexed field.
 * BREAKING CHANGE: All thread local change listeners are now delayed until the next Looper event instead of being triggered when committing.
+* BREAKING CHANGE: Removed RealmConfiguration.getSchemaMediator() from public API which was deprecated in 0.86.0. Please use RealmConfiguration.getRealmObjectClasses() to obtain the set of model classes (#1797).
 * Deprecated methods: Realm.getInstance(Context). Use Realm.getInstance(RealmConfiguration) or Realm.getDefaultInstance() instead.
 * Fixed an error occurring during test and connectedCheck of unit test example (#1934).
 * Fixed bug in jsonExample (#2092).

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -125,13 +125,10 @@ public class RealmConfiguration {
 
     /**
      * Returns the mediator instance of schema which is defined by this configuration.
-     * This method is left public by mistake and will be removed.
      *
      * @return the mediator of the schema.
-     * @deprecated use {@link #getRealmObjectClasses()} instead if you need to access to the set of model classes.
      */
-    @Deprecated
-    public RealmProxyMediator getSchemaMediator() {
+    RealmProxyMediator getSchemaMediator() {
         return schemaMediator;
     }
 


### PR DESCRIPTION
`RealmConfiguration.getSchemaMediator()` was deprecated in `0.86.0`.
@realm/java 