### PR TITLE
RealmCollection API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 ## 0.89.0
 
-### Enhancements
+### Breaking changes
 
+* RealmResults.clear() now throws UnsupportedOperationException. Use RealmResults.deleteAllFromRealm() instead.
+* RealmResults.remove(int) now throws UnsupportedOperationException. Use RealmResults.deleteFromRealm() instead.
+
+### Deprecated
+
+* RealmObject.removeFromRealm() in place of RealmObject.deleteFromRealm()
+* Realm.clear(Class) in favour of Realm.delete(Class).
+* DynamicRealm.clear(Class) in place of DynamicRealm.delete(Class).
+
+### Enhancements
+* RealmCollection and OrderedRealmCollection have been added. RealmList and RealmResults both implement these interfaces.
+* RealmBaseAdapter now accept an OrderedRealmCollection instead of only RealmResults.
 * RealmObjectSchema.isPrimaryKey(String) (#2440)
 
 ### Bug fixes

--- a/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/AdapterExampleActivity.java
+++ b/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/AdapterExampleActivity.java
@@ -54,7 +54,7 @@ public class AdapterExampleActivity extends Activity {
         listView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> adapterView, View view, int i, long l) {
-                TimeStamp timeStamp = adapter.getRealmResults().get(i);
+                TimeStamp timeStamp = adapter.getAdapterData().get(i);
                 Message message = buildMessage(WorkerHandler.REMOVE_TIMESTAMP, timeStamp.getTimeStamp());
 
                 workerThread.workerHandler.sendMessage(message);
@@ -66,7 +66,7 @@ public class AdapterExampleActivity extends Activity {
     @Override
     protected void onPause() {
         super.onPause();
-        workerThread.workerHandler.getLooper().quit();
+        workerThread.quit();
     }
 
     @Override

--- a/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/MyAdapter.java
+++ b/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/MyAdapter.java
@@ -22,6 +22,7 @@ import android.view.ViewGroup;
 import android.widget.ListAdapter;
 import android.widget.TextView;
 
+import io.realm.OrderedRealmCollection;
 import io.realm.RealmBaseAdapter;
 import io.realm.RealmResults;
 import io.realm.examples.realmadapters.models.TimeStamp;
@@ -32,7 +33,7 @@ public class MyAdapter extends RealmBaseAdapter<TimeStamp> implements ListAdapte
         TextView timestamp;
     }
 
-    public MyAdapter(Context context, int resId, RealmResults<TimeStamp> realmResults, boolean automaticUpdate) {
+    public MyAdapter(Context context, int resId, OrderedRealmCollection<TimeStamp> realmResults, boolean automaticUpdate) {
         super(context, realmResults, automaticUpdate);
     }
 
@@ -48,12 +49,12 @@ public class MyAdapter extends RealmBaseAdapter<TimeStamp> implements ListAdapte
             viewHolder = (ViewHolder) convertView.getTag();
         }
 
-        TimeStamp item = realmResults.get(position);
+        TimeStamp item = adapterData.get(position);
         viewHolder.timestamp.setText(item.getTimeStamp());
         return convertView;
     }
 
-    public RealmResults<TimeStamp> getRealmResults() {
-        return realmResults;
+    public OrderedRealmCollection<TimeStamp> getAdapterData() {
+        return adapterData;
     }
 }

--- a/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerHandler.java
+++ b/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerHandler.java
@@ -51,7 +51,7 @@ public class WorkerHandler extends Handler {
                 break;
             case REMOVE_TIMESTAMP:
                 realm.beginTransaction();
-                realm.where(TimeStamp.class).equalTo("timeStamp", timestamp).findAll().clear();
+                realm.where(TimeStamp.class).equalTo("timeStamp", timestamp).findAll().deleteAllFromRealm();
                 realm.commitTransaction();
                 break;
         }

--- a/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerThread.java
+++ b/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerThread.java
@@ -18,11 +18,15 @@ package io.realm.examples.realmadapters;
 import android.os.Handler;
 import android.os.Looper;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import io.realm.Realm;
 
 public class WorkerThread extends Thread {
 
     public Handler workerHandler;
+    private CountDownLatch realmOpen;
 
     @Override
     public void run() {
@@ -30,12 +34,23 @@ public class WorkerThread extends Thread {
         try {
             Looper.prepare();
             realm = Realm.getDefaultInstance();
+            realmOpen = new CountDownLatch(1);
             workerHandler = new WorkerHandler(realm);
             Looper.loop();
         } finally {
             if (realm != null) {
                 realm.close();
+                realmOpen.countDown();
             }
+        }
+    }
+
+    public void quit() {
+        workerHandler.getLooper().quit();
+        try {
+            realmOpen.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
+++ b/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
@@ -116,7 +116,7 @@ public class IntroExampleActivity extends Activity {
 
         // Delete all persons
         realm.beginTransaction();
-        realm.allObjects(Person.class).clear();
+        realm.allObjects(Person.class).deleteAllFromRealm();
         realm.commitTransaction();
     }
 

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
@@ -66,7 +66,7 @@ public class KotlinExampleActivity : Activity() {
         // Using executeTransaction with a lambda reduces code size and makes it impossible
         // to forget to commit the transaction.
         realm.executeTransaction {
-            realm.allObjects(Person::class.java).clear()
+            realm.allObjects(Person::class.java).deleteAllFromRealm()
         }
 
         // More complex operations can be executed on another thread, for example using

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
@@ -86,7 +86,7 @@ public class ExampleActivity extends Activity {
     private void cleanUp() {
         // Delete all persons
         realm.beginTransaction();
-        realm.allObjects(Person.class).clear();
+        realm.allObjects(Person.class).deleteAllFromRealm();
         realm.commitTransaction();
     }
 

--- a/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
+++ b/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
@@ -39,7 +39,6 @@ import io.realm.RealmConfiguration;
 import io.realm.RealmObject;
 import io.realm.RealmQuery;
 import io.realm.RealmResults;
-import io.realm.examples.unittesting.ExampleActivity;
 import io.realm.examples.unittesting.model.Person;
 import io.realm.internal.RealmCore;
 
@@ -197,7 +196,7 @@ public class ExampleActivityTest {
 
         // Verify that the clear method was called. Clear is also called in the start of the
         // activity to ensure we start with a clean db.
-        verify(people, times(2)).clear();
+        verify(people, times(2)).deleteAllFromRealm();
 
         // Call the destroy method so we can verify that the .close() method was called (below)
         controller.destroy();

--- a/realm/realm-jni/src/io_realm_internal_LinkView.cpp
+++ b/realm/realm-jni/src/io_realm_internal_LinkView.cpp
@@ -214,3 +214,15 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetTable
     return reinterpret_cast<jlong>(pTable);
 }
 
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveTargetRow
+  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong pos)
+{
+    TR_ENTER_PTR(nativeLinkViewPtr)
+    LinkView *lv = LV(nativeLinkViewPtr);
+    if (!ROW_INDEX_VALID(env, lv, pos)) {
+        return;
+    }
+    try {
+        return lv->remove_target_row( S(pos) );
+    } CATCH_STD()
+}

--- a/realm/realm-jni/src/io_realm_internal_LinkView.h
+++ b/realm/realm-jni/src/io_realm_internal_LinkView.h
@@ -121,6 +121,14 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeFind
 
 /*
  * Class:     io_realm_internal_LinkView
+ * Method:    nativeRemoveTargetRow
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveTargetRow
+  (JNIEnv *, jobject, jlong, jlong);
+
+/*
+ * Class:     io_realm_internal_LinkView
  * Method:    nativeRemoveAllTargetRows
  * Signature: (J)V
  */

--- a/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import io.realm.entities.AllJavaTypes;
+import io.realm.entities.CyclicType;
+import io.realm.entities.NonLatinFieldNames;
+import io.realm.entities.NullTypes;
+
+/**
+ * Super class for all RealmCollection related tests.
+ * This class only contains configuration and helper methods.
+ */
+public abstract class CollectionTests {
+
+    protected final static long YEAR_MILLIS = TimeUnit.DAYS.toMillis(365);
+
+    // Enumerate all known collection classes from the Realm API.
+    protected enum CollectionClass {
+        MANAGED_REALMLIST, UNMANAGED_REALMLIST, REALMRESULTS
+    }
+
+    // Enumerate all current supported collections that can be in un-managed mode.
+    protected enum UnManagedCollection {
+        UNMANAGED_REALMLIST
+    }
+
+    // Enumerate all current supported collections that can be managed by Realm.
+    protected enum ManagedCollection {
+        MANAGED_REALMLIST, REALMRESULTS
+    }
+
+    // Enumerate all methods from the RealmCollection interface that depend on Realm API's.
+    protected enum RealmCollectionMethod {
+        WHERE, MIN, MAX, SUM, AVERAGE, MIN_DATE, MAX_DATE, DELETE_ALL_FROM_REALM, IS_VALID
+    }
+
+    // Enumerate all methods from the Collection interface
+    protected enum CollectionMethod {
+        ADD_OBJECT, ADD_ALL_OBJECTS, CLEAR, CONTAINS, CONTAINS_ALL, EQUALS, HASHCODE, IS_EMPTY, ITERATOR, REMOVE_OBJECT,
+        REMOVE_ALL, RETAIN_ALL, SIZE, TO_ARRAY, TO_ARRAY_INPUT
+    }
+
+    // Enumerate all methods on the List interface and OrderedRealmCollection interface that doesn't depend on Realm
+    // API's.
+    protected enum ListMethod {
+        FIRST, LAST, ADD_INDEX, ADD_ALL_INDEX, GET_INDEX, INDEX_OF, LAST_INDEX_OF, LIST_ITERATOR, LIST_ITERATOR_INDEX, REMOVE_INDEX,
+        SET, SUBLIST
+    }
+
+    // Enumerate all methods from the OrderedRealmCollection interface that depend on Realm API's.
+    protected enum OrderedRealmCollectionMethod {
+        DELETE_INDEX, DELETE_FIRST, DELETE_LAST, SORT, SORT_FIELD, SORT_2FIELDS, SORT_MULTI
+    }
+
+    // Enumerate all methods that can mutate a RealmCollection
+    protected enum CollectionMutatorMethod {
+        DELETE_ALL, ADD_OBJECT, ADD_ALL_OBJECTS, CLEAR, REMOVE_OBJECT, REMOVE_ALL, RETAIN_ALL
+    }
+
+    // Enumerate all methods that can mutate a RealmOrderedCollection
+    protected enum OrderedCollectionMutatorMethod {
+        DELETE_INDEX, DELETE_FIRST, DELETE_LAST, ADD_INDEX, ADD_ALL_INDEX, SET, REMOVE_INDEX
+    }
+
+    protected void populateRealm(Realm realm, int objects) {
+        realm.beginTransaction();
+        realm.delete(AllJavaTypes.class);
+        realm.delete(NonLatinFieldNames.class);
+        for (int i = 0; i < objects; i++) {
+            AllJavaTypes obj = realm.createObject(AllJavaTypes.class, i);
+            fillObject(i, objects, obj);
+            NonLatinFieldNames nonLatinFieldNames = realm.createObject(NonLatinFieldNames.class);
+            nonLatinFieldNames.set델타(i);
+            nonLatinFieldNames.setΔέλτα(i);
+        }
+
+        // Add all items to the RealmList on the first object
+        AllJavaTypes firstObj = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_LONG, 0).findFirst();
+        RealmResults<AllJavaTypes> listData = realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
+        RealmList<AllJavaTypes> list = firstObj.getFieldList();
+        for (int i = 0; i < listData.size(); i++) {
+            list.add(listData.get(i));
+        }
+        realm.commitTransaction();
+    }
+
+    protected RealmList<AllJavaTypes> populateInMemoryList(int objects) {
+        RealmList<AllJavaTypes> list = new RealmList<AllJavaTypes>();
+        for (int i = 0; i < objects; i++) {
+            AllJavaTypes obj = new AllJavaTypes();
+            fillObject(i, objects, obj);
+            list.add(obj);
+        }
+        return list;
+    }
+
+    private void fillObject(int index, int totalObjects, AllJavaTypes obj) {
+        obj.setFieldLong(index);
+        obj.setFieldInt(index);
+        obj.setFieldBoolean(((index % 2) == 0));
+        obj.setFieldBinary(new byte[]{1, 2, 3});
+        obj.setFieldDate(new Date(YEAR_MILLIS * 20 * (index - totalObjects / 2)));
+        obj.setFieldDouble(3.1415 + index);
+        obj.setFieldFloat(1.234567f + index);
+        obj.setFieldString("test data " + index);
+    }
+
+    // Creates a collection that is based on a RealmList that was deleted.
+    protected OrderedRealmCollection<CyclicType> populateCollectionOnDeletedLinkView(Realm realm, ManagedCollection collectionClass) {
+        realm.beginTransaction();
+        CyclicType parent = realm.createObject(CyclicType.class);
+        for (int i = 0; i < 10; i++) {
+            CyclicType child = new CyclicType();
+            child.setName("name_" + i);
+            child.setObject(parent);
+            parent.getObjects().add(child);
+        }
+        realm.commitTransaction();
+
+        OrderedRealmCollection<CyclicType> result;
+        switch(collectionClass) {
+            case MANAGED_REALMLIST:
+                result = parent.getObjects();
+                break;
+            case REALMRESULTS:
+                result = parent.getObjects().where().equalTo(CyclicType.FIELD_NAME, "name_0").findAll();
+                break;
+            default:
+                throw new AssertionError("Unknown collection: " + collectionClass);
+        }
+
+        realm.beginTransaction();
+        parent.deleteFromRealm();
+        realm.commitTransaction();
+        return result;
+    }
+
+    // Create a number of objects that mix null and real values for number type fields.
+    protected void populatePartialNullRowsForNumericTesting(Realm realm) {
+        NullTypes nullTypes1 = new NullTypes();
+        nullTypes1.setId(1);
+        nullTypes1.setFieldIntegerNull(1);
+        nullTypes1.setFieldFloatNull(2F);
+        nullTypes1.setFieldDoubleNull(3D);
+        nullTypes1.setFieldBooleanNull(true);
+        nullTypes1.setFieldStringNull("4");
+        nullTypes1.setFieldDateNull(new Date(12345));
+
+        NullTypes nullTypes2 = new NullTypes();
+        nullTypes2.setId(2);
+
+        NullTypes nullTypes3 = new NullTypes();
+        nullTypes3.setId(3);
+        nullTypes3.setFieldIntegerNull(0);
+        nullTypes3.setFieldFloatNull(0F);
+        nullTypes3.setFieldDoubleNull(0D);
+        nullTypes3.setFieldBooleanNull(false);
+        nullTypes3.setFieldStringNull("0");
+        nullTypes3.setFieldDateNull(new Date(0));
+
+        realm.beginTransaction();
+        realm.copyToRealm(nullTypes1);
+        realm.copyToRealm(nullTypes2);
+        realm.copyToRealm(nullTypes3);
+        realm.commitTransaction();
+    }
+
+    // Create a list of AllJavaTypes with its `fieldString` field set to a given value.
+    protected OrderedRealmCollection<AllJavaTypes> createStringCollection(Realm realm, ManagedCollection collectionClass, String... args) {
+        realm.beginTransaction();
+        realm.deleteAll();
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                int id = 0;
+                for (String arg : args) {
+                    AllJavaTypes obj = realm.createObject(AllJavaTypes.class, id++);
+                    obj.setFieldString(arg);
+                }
+                realm.commitTransaction();
+                return realm.allObjects(AllJavaTypes.class);
+
+            case REALMRESULTS:
+                AllJavaTypes first = realm.createObject(AllJavaTypes.class);
+                first.setFieldString(args[0]);
+                first.getFieldList().add(first);
+                for (int i = 1; i < args.length; i++) {
+                    AllJavaTypes obj = realm.createObject(AllJavaTypes.class, i);
+                    obj.setFieldString(args[i]);
+                    first.getFieldList().add(obj);
+                }
+                realm.commitTransaction();
+                return first.getFieldList();
+
+            default:
+                throw new AssertionError("Unknown collection: " + collectionClass);
+        }
+    }
+
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -116,7 +116,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void constructor_deletedObjectThrows() {
         realm.beginTransaction();
-        typedObj.removeFromRealm();
+        typedObj.deleteFromRealm();
         realm.commitTransaction();
         thrown.expect(IllegalArgumentException.class);
         new DynamicRealmObject(typedObj);

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -85,7 +85,7 @@ public class DynamicRealmTests {
             realm.setAutoRefresh(false);
         }
         realm.beginTransaction();
-        realm.allObjects(AllTypes.CLASS_NAME).clear();
+        realm.deleteAll();
         for (int i = 0; i < objects; ++i) {
             DynamicRealmObject allTypes = realm.createObject(AllTypes.CLASS_NAME);
             allTypes.setBoolean(AllTypes.FIELD_BOOLEAN, (i % 3) == 0);
@@ -200,25 +200,25 @@ public class DynamicRealmTests {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void clear_invalidName() {
+    public void delete_type_invalidName() {
         realm.beginTransaction();
-        realm.clear("I don't exist");
+        realm.delete("I don't exist");
     }
 
     @Test(expected = IllegalStateException.class)
-    public void clear_outsideTransactionClearOutsideTransactionThrows() {
-        realm.clear(AllTypes.CLASS_NAME);
+    public void delete_type_outsideTransactionClearOutsideTransactionThrows() {
+        realm.delete(AllTypes.CLASS_NAME);
     }
 
     @Test
-    public void clear() {
+    public void delete_type() {
         realm.beginTransaction();
         realm.createObject(AllTypes.CLASS_NAME);
         realm.commitTransaction();
 
         assertEquals(1, realm.where(AllTypes.CLASS_NAME).count());
         realm.beginTransaction();
-        realm.clear(AllTypes.CLASS_NAME);
+        realm.delete(AllTypes.CLASS_NAME);
         realm.commitTransaction();
         assertEquals(0, realm.where(AllTypes.CLASS_NAME).count());
     }
@@ -757,7 +757,7 @@ public class DynamicRealmTests {
 
         dynamicRealm.setAutoRefresh(false);
         dynamicRealm.beginTransaction();
-        dynamicRealm.clear(AllTypes.CLASS_NAME);
+        dynamicRealm.delete(AllTypes.CLASS_NAME);
         for (int i = 0; i < 5; ) {
             DynamicRealmObject allTypes = dynamicRealm.createObject(AllTypes.CLASS_NAME);
             allTypes.set(AllTypes.FIELD_LONG, i);
@@ -957,7 +957,7 @@ public class DynamicRealmTests {
     }
 
     @Test
-    public void clear_all() {
+    public void deleteAll() {
         realm.beginTransaction();
         realm.createObject(AllTypes.CLASS_NAME);
         DynamicRealmObject cat = realm.createObject(Cat.CLASS_NAME);

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedOrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedOrderedRealmCollectionTests.java
@@ -1,0 +1,762 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import io.realm.entities.AllJavaTypes;
+import io.realm.entities.Cat;
+import io.realm.entities.Dog;
+import io.realm.entities.NullTypes;
+import io.realm.entities.Owner;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for all methods specific to OrderedRealmCollections that are not implementation specific.
+ *
+ * Methods tested in this class:
+ *
+ * # OrderedRealmCollection
+ *
+ * - E first()
+ * - E last()
+ * + void sort(String field)
+ * + void sort(String field, Sort sortOrder)
+ * + void sort(String field1, Sort sortOrder1, String field2, Sort sortOrder2)
+ * + void sort(String[] fields, Sort[] sortOrders)
+ * + void deleteFromRealm(int location)
+ * + void deleteFirstFromRealm()
+ * + void deleteLastFromRealm();
+ *
+ * # List
+ *
+ *  - void add(int location, E object);
+ *  - boolean addAll(int location, Collection<? extends E> collection);
+ *  - E get(int location);
+ *  - int indexOf(Object object);
+ *  - int lastIndexOf(Object object);
+ *  - ListIterator<E> listIterator();
+ *  - ListIterator<E> listIterator(int location);
+ *  - E remove(int location);
+ *  - E set(int location, E object);
+ *  - List<E> subList(int start, int end);
+ *
+ * # RealmCollection
+ *
+ * - RealmQuery<E> where();
+ * - Number min(String fieldName);
+ * - Number max(String fieldName);
+ * - Number sum(String fieldName);
+ * - double average(String fieldName);
+ * - Date maxDate(String fieldName);
+ * - Date minDate(String fieldName);
+ * - void deleteAllFromRealm();
+ * - boolean isLoaded();
+ * - boolean load();
+ * - boolean isValid();
+ * - BaseRealm getRealm();
+ *
+ * # Collection
+ *
+ * - public boolean add(E object);
+ * - public boolean addAll(Collection<? extends E> collection);
+ * - public void deleteAll();
+ * - public boolean contains(Object object);
+ * - public boolean containsAll(Collection<?> collection);
+ * - public boolean equals(Object object);
+ * - public int hashCode();
+ * - public boolean isEmpty();
+ * - public Iterator<E> iterator();
+ * - public boolean remove(Object object);
+ * - public boolean removeAll(Collection<?> collection);
+ * - public boolean retainAll(Collection<?> collection);
+ * - public int size();
+ * - public Object[] toArray();
+ * - public <T> T[] toArray(T[] array);
+ *
+ * @see RealmCollectionTests
+ * @see ManagedRealmCollectionTests
+ * @see UnManagedRealmCollectionTests
+ */
+
+@RunWith(Parameterized.class)
+public class ManagedOrderedRealmCollectionTests extends CollectionTests {
+
+    private static final int TEST_SIZE = 10;
+    private final static int TEST_DATA_FIRST_HALF = (int) ((TEST_SIZE / 2.0D) - 1);
+    private final static int TEST_DATA_LAST_HALF = (int) ((TEST_SIZE / 2.0D) + 1);
+
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private final ManagedCollection collectionClass;
+    private Realm realm;
+    private OrderedRealmCollection<AllJavaTypes> collection;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<ManagedCollection> data() {
+        return Arrays.asList(ManagedCollection.values());
+    }
+
+    public ManagedOrderedRealmCollectionTests(ManagedCollection collectionType) {
+        this.collectionClass = collectionType;
+    }
+
+    @Before
+    public void setup() {
+        realm = Realm.getInstance(configFactory.createConfiguration());
+        populateRealm(realm, TEST_SIZE);
+        collection = createCollection(collectionClass);
+    }
+
+    OrderedRealmCollection<AllJavaTypes> createCollection(ManagedCollection collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                return realm.where(AllJavaTypes.class)
+                        .equalTo(AllJavaTypes.FIELD_LONG, 0)
+                        .findFirst()
+                        .getFieldList();
+
+            case REALMRESULTS:
+                return realm.allObjects(AllJavaTypes.class);
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    private OrderedRealmCollection<NullTypes> createEmptyCollection(Realm realm, ManagedCollection collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                realm.beginTransaction();
+                NullTypes obj = realm.createObject(NullTypes.class);
+                realm.commitTransaction();
+                return obj.getFieldListNull();
+
+            case REALMRESULTS:
+                return realm.where(NullTypes.class).findAll();
+        }
+
+        throw new AssertionError("Unknown collection: " + collectionClass);
+    }
+
+    @After
+    public void tearDown() {
+        realm.close();
+    }
+
+    @Test
+    public void sort_twoFields() {
+        OrderedRealmCollection<AllJavaTypes> sortedList = collection.sort(AllJavaTypes.FIELD_BOOLEAN, Sort.ASCENDING, AllJavaTypes.FIELD_LONG, Sort.DESCENDING);
+        AllJavaTypes obj = sortedList.first();
+        assertFalse(obj.isFieldBoolean());
+        assertEquals(TEST_SIZE - 1, obj.getFieldLong());
+    }
+
+    @Test
+    public void sort_boolean() {
+        OrderedRealmCollection<AllJavaTypes> sortedList = collection.sort(AllJavaTypes.FIELD_BOOLEAN, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals(false, sortedList.last().isFieldBoolean());
+        assertEquals(true, sortedList.first().isFieldBoolean());
+        assertEquals(true, sortedList.get(TEST_DATA_FIRST_HALF).isFieldBoolean());
+        assertEquals(false, sortedList.get(TEST_DATA_LAST_HALF).isFieldBoolean());
+
+        RealmResults<AllJavaTypes> reverseList = sortedList.sort(AllJavaTypes.FIELD_BOOLEAN, Sort.ASCENDING);
+        assertEquals(TEST_SIZE, reverseList.size());
+        assertEquals(true, reverseList.last().isFieldBoolean());
+        assertEquals(false, reverseList.first().isFieldBoolean());
+        assertEquals(false, reverseList.get(TEST_DATA_FIRST_HALF).isFieldBoolean());
+        assertEquals(true, reverseList.get(TEST_DATA_LAST_HALF).isFieldBoolean());
+
+        RealmResults<AllJavaTypes> reserveSortedList = reverseList.sort(AllJavaTypes.FIELD_BOOLEAN, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, reserveSortedList.size());
+        assertEquals(reserveSortedList.first(), sortedList.first());
+    }
+
+    @Test
+    public void sort_string() {
+        OrderedRealmCollection<AllJavaTypes> resultList = collection;
+        OrderedRealmCollection<AllJavaTypes> sortedList = createCollection(collectionClass);
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_STRING, Sort.DESCENDING);
+
+        assertEquals(resultList.size(), sortedList.size());
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals(resultList.first().getFieldString(), sortedList.last().getFieldString());
+
+        RealmResults<AllJavaTypes> reverseList = sortedList.sort(AllJavaTypes.FIELD_STRING, Sort.ASCENDING);
+        assertEquals(TEST_SIZE, reverseList.size());
+        assertEquals(resultList.first().getFieldString(), reverseList.first().getFieldString());
+
+        int numberOfDigits = 1 + ((int) Math.log10(TEST_SIZE));
+        int largestNumber = 1;
+        largestNumber = (int) (largestNumber * Math.pow(10, numberOfDigits - 1));
+        largestNumber = largestNumber - 1;
+        assertEquals(resultList.get(largestNumber).getFieldString(), reverseList.last().getFieldString());
+        RealmResults<AllJavaTypes> reverseSortedList = reverseList.sort(AllJavaTypes.FIELD_STRING, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, reverseSortedList.size());
+    }
+
+    @Test
+    public void sort_double() {
+        OrderedRealmCollection<AllJavaTypes> resultList = collection;
+        OrderedRealmCollection<AllJavaTypes> sortedList = createCollection(collectionClass);
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_DOUBLE, Sort.DESCENDING);
+        assertEquals(resultList.size(), sortedList.size());
+        assertEquals(TEST_SIZE, sortedList.size());
+            assertEquals(resultList.first().getFieldDouble(), sortedList.last().getFieldDouble(), 0D);
+
+        RealmResults<AllJavaTypes> reverseList = sortedList.sort(AllJavaTypes.FIELD_DOUBLE, Sort.ASCENDING);
+        assertEquals(TEST_SIZE, reverseList.size());
+        assertEquals(resultList.first().getFieldDouble(), reverseList.first().getFieldDouble(), 0D);
+        assertEquals(resultList.last().getFieldDouble(), reverseList.last().getFieldDouble(), 0D);
+
+        RealmResults<AllJavaTypes> reverseSortedList = reverseList.sort(AllJavaTypes.FIELD_DOUBLE, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, reverseSortedList.size());
+    }
+
+    @Test
+    public void sort_float() {
+        OrderedRealmCollection<AllJavaTypes> resultList = collection;
+        OrderedRealmCollection<AllJavaTypes> sortedList = createCollection(collectionClass);
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_FLOAT, Sort.DESCENDING);
+        assertEquals(resultList.size(), sortedList.size());
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals(resultList.first().getFieldFloat(), sortedList.last().getFieldFloat(), 0D);
+
+        RealmResults<AllJavaTypes> reverseList = sortedList.sort(AllJavaTypes.FIELD_FLOAT, Sort.ASCENDING);
+        assertEquals(TEST_SIZE, reverseList.size());
+        assertEquals(resultList.first().getFieldFloat(), reverseList.first().getFieldFloat(), 0D);
+        assertEquals(resultList.last().getFieldFloat(), reverseList.last().getFieldFloat(), 0D);
+
+        RealmResults<AllJavaTypes> reverseSortedList = reverseList.sort(AllJavaTypes.FIELD_FLOAT, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, reverseSortedList.size());
+    }
+
+    private void doTestSortOnColumnWithPartialNullValues(String fieldName,
+                                                         OrderedRealmCollection<NullTypes> original,
+                                                         OrderedRealmCollection<NullTypes> copy) {
+
+        RealmResults<NullTypes> sortedList = copy.sort(fieldName, Sort.ASCENDING);
+        assertEquals("Should have same size", original.size(), sortedList.size());
+        // Null should always be the first one in the ascending sorted list
+        assertEquals(2, sortedList.first().getId());
+        assertEquals(1, sortedList.last().getId());
+
+        // Descending
+        sortedList = sortedList.sort(fieldName, Sort.DESCENDING);
+        assertEquals("Should have same size", original.size(), sortedList.size());
+        assertEquals(1, sortedList.first().getId());
+        // Null should always be the last one in the descending sorted list
+        assertEquals(2, sortedList.last().getId());
+    }
+
+    // Test sort on nullable fields with null values partially
+    @Test
+    public void sort_rowsWithPartialNullValues() {
+        populatePartialNullRowsForNumericTesting(realm);
+        OrderedRealmCollection<NullTypes> original;
+        OrderedRealmCollection<NullTypes> copy;
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                realm.beginTransaction();
+                RealmResults<NullTypes> objects = realm.allObjects(NullTypes.class);
+                NullTypes parent = realm.createObject(NullTypes.class, 0);
+                for (int i = 0; i < objects.size(); i++) {
+                    NullTypes object = objects.get(i);
+                    if (object.getId() != 0) {
+                        parent.getFieldListNull().add(object);
+                    }
+                }
+                realm.commitTransaction();
+                original = parent.getFieldListNull().where().findAll();
+                copy = parent.getFieldListNull();
+                break;
+
+            case REALMRESULTS:
+                original = realm.allObjects(NullTypes.class);
+                copy = realm.allObjects(NullTypes.class);
+                break;
+
+            default:
+                throw new AssertionError("Unknown collection class: " + collectionClass);
+        }
+
+        // 1 String
+        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_STRING_NULL, original, copy);
+
+        // 3 Boolean
+        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_BOOLEAN_NULL, original, copy);
+
+        // 6 Integer
+        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_INTEGER_NULL, original, copy);
+
+        // 7 Float
+        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_FLOAT_NULL, original, copy);
+
+        // 8 Double
+        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_DOUBLE_NULL, original, copy);
+
+        // 10 Date
+        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_DATE_NULL, original, copy);
+    }
+
+    @Test
+    public void sort_nonExistingColumn() {
+        RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
+        thrown.expect(IllegalArgumentException.class);
+        resultList.sort("Non-existing");
+    }
+
+    @Test
+    public void sort_danishCharacters() {
+        OrderedRealmCollection<AllJavaTypes> collection = createStringCollection(realm, collectionClass,
+                "Æble",
+                "Øl",
+                "Århus"
+        );
+
+        collection = collection.sort(AllJavaTypes.FIELD_STRING);
+
+        assertEquals(3, collection.size());
+        assertEquals("Æble", collection.get(0).getFieldString());
+        assertEquals("Øl", collection.get(1).getFieldString());
+        assertEquals("Århus", collection.get(2).getFieldString());
+
+        collection = collection.sort(AllJavaTypes.FIELD_STRING, Sort.DESCENDING);
+        assertEquals(3, collection.size());
+        assertEquals("Århus", collection.get(0).getFieldString());
+        assertEquals("Øl", collection.get(1).getFieldString());
+        assertEquals("Æble", collection.get(2).getFieldString());
+    }
+
+    @Test
+    public void sort_russianCharacters() {
+        OrderedRealmCollection<AllJavaTypes> collection = createStringCollection(realm, collectionClass,
+                "Санкт-Петербург",
+                "Москва",
+                "Новороссийск"
+        );
+
+        collection = collection.sort(AllJavaTypes.FIELD_STRING);
+
+        assertEquals(3, collection.size());
+        assertEquals("Москва", collection.get(0).getFieldString());
+        assertEquals("Новороссийск", collection.get(1).getFieldString());
+        assertEquals("Санкт-Петербург", collection.get(2).getFieldString());
+
+        collection = collection.sort(AllJavaTypes.FIELD_STRING, Sort.DESCENDING);
+        assertEquals(3, collection.size());
+        assertEquals("Санкт-Петербург", collection.get(0).getFieldString());
+        assertEquals("Новороссийск", collection.get(1).getFieldString());
+        assertEquals("Москва", collection.get(2).getFieldString());
+    }
+
+    @Test
+    public void sort_greekCharacters() {
+        OrderedRealmCollection<AllJavaTypes> collection = createStringCollection(realm, collectionClass,
+                "αύριο",
+                "ημέρες",
+                "δοκιμές"
+        );
+
+        collection = collection.sort(AllJavaTypes.FIELD_STRING);
+
+        assertEquals(3, collection.size());
+        assertEquals("αύριο", collection.get(0).getFieldString());
+        assertEquals("δοκιμές", collection.get(1).getFieldString());
+        assertEquals("ημέρες", collection.get(2).getFieldString());
+
+        collection = collection.sort(AllJavaTypes.FIELD_STRING, Sort.DESCENDING);
+        assertEquals(3, collection.size());
+        assertEquals("ημέρες", collection.get(0).getFieldString());
+        assertEquals("δοκιμές", collection.get(1).getFieldString());
+        assertEquals("αύριο", collection.get(2).getFieldString());
+    }
+
+    //No sorting order defined. There are Korean, Arabic and Chinese characters.
+    @Test
+    public void sort_manyDifferentCharacters() {
+        OrderedRealmCollection<AllJavaTypes> collection = createStringCollection(realm, collectionClass,
+                "단위",
+                "테스트",
+                "وحدة",
+                "اختبار",
+                "单位",
+                "试验",
+                "單位",
+                "測試"
+        );
+
+        collection.sort(AllJavaTypes.FIELD_STRING);
+        assertEquals(8, collection.size());
+
+        collection.sort(AllJavaTypes.FIELD_STRING, Sort.DESCENDING);
+        assertEquals(8, collection.size());
+    }
+
+    @Test
+    public void sort_twoLanguages() {
+        OrderedRealmCollection<AllJavaTypes> collection = createStringCollection(realm, collectionClass,
+                "test",
+                "αύριο",
+                "work"
+        );
+
+        try {
+            collection.sort(AllJavaTypes.FIELD_STRING);
+        } catch (IllegalArgumentException e) {
+            fail("Failed to sort with two kinds of alphabets");
+        }
+    }
+
+    @Test
+    public void sort_usingChildObject() {
+        realm.beginTransaction();
+        Owner owner = realm.createObject(Owner.class);
+        owner.setName("owner");
+        Cat cat = realm.createObject(Cat.class);
+        cat.setName("cat");
+        owner.setCat(cat);
+        realm.commitTransaction();
+
+        RealmQuery<Owner> query = realm.where(Owner.class);
+        RealmResults<Owner> owners = query.findAll();
+
+        try {
+            owners.sort("cat.name");
+            fail("Sorting by child object properties should result in a IllegalArgumentException");
+        } catch (IllegalArgumentException ignore) {
+        }
+    }
+
+    @Test
+    public void sort_nullArguments() {
+        OrderedRealmCollection<AllJavaTypes> result = collection;
+        try {
+            result.sort(null);
+            fail("Sorting with a null field name should throw an IllegalArgumentException");
+        } catch (IllegalArgumentException ignored) {
+        }
+        try {
+            result.sort((String) null, null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void sort_emptyResults() {
+        OrderedRealmCollection<NullTypes> collection = createEmptyCollection(realm, collectionClass);
+        assertEquals(0, collection.size());
+        collection.sort(NullTypes.FIELD_STRING_NULL);
+        assertEquals(0, collection.size());
+    }
+
+    @Test
+    public void sort_singleField() {
+        RealmResults<AllJavaTypes> sortedList = collection.sort(new String[]{AllJavaTypes.FIELD_LONG}, new Sort[]{Sort.DESCENDING});
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals(TEST_SIZE - 1, sortedList.first().getFieldLong());
+        assertEquals(0, sortedList.last().getFieldLong());
+    }
+
+    @Test
+    public void sort_date() {
+        OrderedRealmCollection<AllJavaTypes> resultList = collection;
+        OrderedRealmCollection<AllJavaTypes> sortedList = createCollection(collectionClass);
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_DATE, Sort.DESCENDING);
+        assertEquals(resultList.size(), sortedList.size());
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals(resultList.first().getFieldDate(), sortedList.last().getFieldDate());
+
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_DATE, Sort.ASCENDING);
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals(resultList.first().getFieldDate(), sortedList.first().getFieldDate());
+        assertEquals(resultList.last().getFieldDate(), sortedList.last().getFieldDate());
+
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_DATE, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, sortedList.size());
+    }
+
+    @Test
+    public void sort_long() {
+        OrderedRealmCollection<AllJavaTypes> resultList = collection;
+        OrderedRealmCollection<AllJavaTypes> sortedList = createCollection(collectionClass);
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_LONG, Sort.DESCENDING);
+        assertEquals("Should have same size", resultList.size(), sortedList.size());
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals("First excepted to be last", resultList.first().getFieldLong(), sortedList.last().getFieldLong());
+
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
+        assertEquals(TEST_SIZE, sortedList.size());
+        assertEquals("First excepted to be first", resultList.first().getFieldLong(), sortedList.first().getFieldLong());
+        assertEquals("Last excepted to be last", resultList.last().getFieldLong(), sortedList.last().getFieldLong());
+
+        sortedList = sortedList.sort(AllJavaTypes.FIELD_LONG, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, sortedList.size());
+    }
+
+    @Test
+    public void deleteFromRealm() {
+        OrderedRealmCollection<Dog> collection = createNonCyclicCollection(realm, collectionClass);
+        assertEquals(1, collection.get(1).getAge());
+        realm.beginTransaction();
+        collection.deleteFromRealm(0);
+        realm.commitTransaction();
+        assertEquals(TEST_SIZE - 1, collection.size());
+        assertEquals(2, collection.get(1).getAge());
+    }
+
+    @Test
+    public void deleteFromRealm_invalidIndex() {
+        Integer[] indexes = new Integer[] { Integer.MIN_VALUE, -1, TEST_SIZE, Integer.MAX_VALUE };
+        for (Integer index : indexes) {
+            try {
+                realm.beginTransaction();
+                collection.deleteFromRealm(index);
+                fail("Index should have thrown exception: " + index);
+            } catch (ArrayIndexOutOfBoundsException ignored) {
+            } finally {
+                realm.cancelTransaction();
+            }
+        }
+    }
+
+    @Test
+    public void deleteFirstFromRealm() {
+        OrderedRealmCollection<Dog> collection = createNonCyclicCollection(realm, collectionClass);
+        assertEquals(0, collection.get(0).getAge());
+
+        realm.beginTransaction();
+        assertTrue(collection.deleteFirstFromRealm());
+        realm.commitTransaction();
+        assertEquals(TEST_SIZE - 1, collection.size());
+        assertEquals(1, collection.get(0).getAge());
+    }
+
+    private OrderedRealmCollection<Dog> createNonCyclicCollection(Realm realm, ManagedCollection collectionClass) {
+        realm.beginTransaction();
+        realm.deleteAll();
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                Owner owner = realm.createObject(Owner.class);
+                RealmList<Dog> dogs = owner.getDogs();
+                for (int i = 0; i < TEST_SIZE; i++) {
+                    Dog dog = realm.createObject(Dog.class);
+                    dog.setName("Dog " + i);
+                    dog.setAge(i);
+                    dogs.add(dog);
+                }
+                realm.commitTransaction();
+                return dogs;
+
+            case REALMRESULTS:
+                for (int i = 0; i < TEST_SIZE; i++) {
+                    Dog dog = realm.createObject(Dog.class);
+                    dog.setAge(i);
+                    dog.setName("Dog " + i);
+                }
+                realm.commitTransaction();
+                return realm.allObjects(Dog.class);
+
+            default:
+                throw new AssertionError("Unknown collection class: " + collectionClass);
+        }
+
+    }
+
+    @Test
+    public void deleteFirstFromRealm_emptyCollection() {
+        OrderedRealmCollection<NullTypes> collection = createEmptyCollection(realm, collectionClass);
+        realm.beginTransaction();
+        assertFalse(collection.deleteFirstFromRealm());
+        realm.commitTransaction();
+        assertEquals(0, collection.size());
+    }
+
+    @Test
+    public void deleteLastFromRealm() {
+        assertEquals(TEST_SIZE - 1, collection.last().getFieldLong());
+        realm.beginTransaction();
+        assertTrue(collection.deleteLastFromRealm());
+        realm.commitTransaction();
+        assertEquals(TEST_SIZE - 1, collection.size());
+        assertEquals(TEST_SIZE - 2, collection.last().getFieldLong());
+    }
+
+    @Test
+    public void deleteLastFromRealm_emptyCollection() {
+        OrderedRealmCollection<NullTypes> collection = createEmptyCollection(realm, collectionClass);
+        realm.beginTransaction();
+        assertFalse(collection.deleteLastFromRealm());
+        realm.commitTransaction();
+        assertEquals(0, collection.size());
+    }
+
+    // Test all methods that mutate data throw correctly if not inside an transaction.
+    // Due to implementation details both UnsupportedOperation and IllegalState is accepted at this level
+    @Test
+    public void mutableMethodsOutsideTransactions() {
+
+        for (OrderedCollectionMutatorMethod method : OrderedCollectionMutatorMethod.values()) {
+
+            // Define expected exception
+            Class<? extends Throwable> expected = IllegalStateException.class;
+            if (collectionClass == ManagedCollection.REALMRESULTS) {
+                switch (method) {
+                    case ADD_INDEX:
+                    case ADD_ALL_INDEX:
+                    case SET:
+                    case REMOVE_INDEX:
+                        expected = UnsupportedOperationException.class;
+                        break;
+                    default:
+                        // Use default exception
+                }
+            }
+
+            try {
+                switch (method) {
+                    case DELETE_INDEX: collection.deleteFromRealm(0); break;
+                    case DELETE_FIRST: collection.deleteFirstFromRealm(); break;
+                    case DELETE_LAST: collection.deleteLastFromRealm(); break;
+                    case ADD_INDEX: collection.add(0, new AllJavaTypes()); break;
+                    case ADD_ALL_INDEX: collection.addAll(0, Collections.singletonList(new AllJavaTypes())); break;
+                    case SET: collection.set(0, new AllJavaTypes()); break;
+                    case REMOVE_INDEX: collection.remove(0); break;
+                }
+                fail("Unknown method or it failed to throw: " + method);
+            } catch (Throwable t) {
+                if (!t.getClass().equals(expected)) {
+                    fail(method + " didn't throw the expected exception. Was: " + t + ", expected: " + expected);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void methodsThrowOnWrongThread() throws ExecutionException, InterruptedException {
+        for (OrderedRealmCollectionMethod method : OrderedRealmCollectionMethod.values()) {
+            assertTrue(method + " failed" , runMethodOnWrongThread(method));
+        }
+
+        for (ListMethod method : ListMethod.values()) {
+            assertTrue(method + " failed" , runMethodOnWrongThread(method));
+        }
+    }
+
+    private boolean runMethodOnWrongThread(final OrderedRealmCollectionMethod method) throws ExecutionException, InterruptedException {
+        realm.beginTransaction();
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                try {
+                    switch (method) {
+                        case DELETE_INDEX: collection.deleteFromRealm(0); break;
+                        case DELETE_FIRST: collection.deleteFirstFromRealm(); break;
+                        case DELETE_LAST: collection.deleteLastFromRealm(); break;
+                        case SORT: collection.sort(AllJavaTypes.FIELD_STRING); break;
+                        case SORT_FIELD: collection.sort(AllJavaTypes.FIELD_STRING, Sort.ASCENDING); break;
+                        case SORT_2FIELDS: collection.sort(AllJavaTypes.FIELD_STRING, Sort.ASCENDING, AllJavaTypes.FIELD_LONG, Sort.DESCENDING); break;
+                        case SORT_MULTI: collection.sort(new String[] { AllJavaTypes.FIELD_STRING }, new Sort[] { Sort.ASCENDING }); break;
+                    }
+                    return false;
+                } catch (IllegalStateException ignored) {
+                    return true;
+                }
+            }
+        });
+        Boolean result = future.get();
+        realm.cancelTransaction();
+        return result;
+    }
+
+    private boolean runMethodOnWrongThread(final ListMethod method) throws ExecutionException, InterruptedException {
+        realm.beginTransaction();
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                // Define expected exception
+                Class<? extends Throwable> expected = IllegalStateException.class;
+                if (collectionClass == ManagedCollection.REALMRESULTS) {
+                    switch (method) {
+                        case ADD_INDEX:
+                        case ADD_ALL_INDEX:
+                        case SET:
+                        case REMOVE_INDEX:
+                            expected = UnsupportedOperationException.class;
+                            break;
+                        default:
+                            // Use default exception
+                    }
+                }
+
+                try {
+                    switch (method) {
+                        case FIRST: collection.first(); break;
+                        case LAST: collection.last(); break;
+                        case ADD_INDEX: collection.add(0, new AllJavaTypes()); break;
+                        case ADD_ALL_INDEX: collection.addAll(0, Collections.singletonList(new AllJavaTypes())); break;
+                        case GET_INDEX: collection.get(0); break;
+                        case INDEX_OF: collection.indexOf(new AllJavaTypes()); break;
+                        case LAST_INDEX_OF: collection.lastIndexOf(new AllJavaTypes()); break;
+                        case LIST_ITERATOR: collection.listIterator(); break;
+                        case LIST_ITERATOR_INDEX: collection.listIterator(0); break;
+                        case REMOVE_INDEX: collection.remove(0); break;
+                        case SET: collection.set(0, new AllJavaTypes()); break;
+                        case SUBLIST: collection.subList(0, 1); break;
+                    }
+                    return false;
+                } catch (Throwable t) {
+                    if (!t.getClass().equals(expected)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        });
+        Boolean result = future.get();
+        realm.cancelTransaction();
+        return result;
+    }
+
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
@@ -1,0 +1,785 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import io.realm.entities.AllJavaTypes;
+import io.realm.entities.NonLatinFieldNames;
+import io.realm.entities.NullTypes;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for all methods part of the the {@link RealmCollection} interface.
+ * This class only tests collections that are managed by Realm. See {@link UnManagedRealmCollectionTests} for
+ * all tests targeting un-managed collections.
+ *
+ * Methods tested in this class:
+ *
+ * # RealmCollection
+ *
+ * + RealmQuery<E> where();
+ * + Number min(String fieldName);
+ * + Number max(String fieldName);
+ * + Number sum(String fieldName);
+ * + double average(String fieldName);
+ * + Date maxDate(String fieldName);
+ * + Date minDate(String fieldName);
+ * + void deleteAllFromRealm();
+ * + boolean isLoaded();
+ * + boolean load();
+ * + boolean isValid();
+ * + BaseRealm getRealm();
+ *
+ * # Collection
+ *
+ * - public boolean add(E object);
+ * - public boolean addAll(Collection<? extends E> collection);
+ * - public void deleteAll();
+ * - public boolean contains(Object object);
+ * - public boolean containsAll(Collection<?> collection);
+ * - public boolean equals(Object object);
+ * - public int hashCode();
+ * - public boolean isEmpty();
+ * - public Iterator<E> iterator();
+ * - public boolean remove(Object object);
+ * - public boolean removeAll(Collection<?> collection);
+ * - public boolean retainAll(Collection<?> collection);
+ * - public int size();
+ * - public Object[] toArray();
+ * - public <T> T[] toArray(T[] array);
+ */
+@RunWith(Parameterized.class)
+public class ManagedRealmCollectionTests extends CollectionTests {
+
+    private static final int TEST_SIZE = 10;
+
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+
+    private final ManagedCollection collectionClass;
+    private Realm realm;
+
+    // Collections used for testing
+    private RealmCollection<AllJavaTypes> collection;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<ManagedCollection> data() {
+        return Arrays.asList(ManagedCollection.values());
+    }
+
+    public ManagedRealmCollectionTests(ManagedCollection collectionType) {
+        this.collectionClass = collectionType;
+    }
+
+    @Before
+    public void setup() {
+        realm = Realm.getInstance(configFactory.createConfiguration());
+        populateRealm(realm, TEST_SIZE);
+        collection = createCollection(collectionClass);
+    }
+
+    @After
+    public void tearDown() {
+        realm.close();
+    }
+
+    private OrderedRealmCollection<AllJavaTypes> createCollection(ManagedCollection collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                return realm.where(AllJavaTypes.class)
+                        .equalTo(AllJavaTypes.FIELD_LONG, 0)
+                        .findFirst()
+                        .getFieldList();
+
+            case REALMRESULTS:
+                return realm.allObjects(AllJavaTypes.class);
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    private OrderedRealmCollection<NullTypes> createEmptyCollection(Realm realm, ManagedCollection collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                realm.beginTransaction();
+                NullTypes obj = realm.createObject(NullTypes.class);
+                realm.commitTransaction();
+                return obj.getFieldListNull();
+
+            case REALMRESULTS:
+                return realm.where(NullTypes.class).findAll();
+        }
+
+        throw new AssertionError("Unknown collection: " + collectionClass);
+    }
+
+    private OrderedRealmCollection<NullTypes> createAllNullRowsForNumericTesting(Realm realm, ManagedCollection collectionClass) {
+        TestHelper.populateAllNullRowsForNumericTesting(realm);
+        switch(collectionClass) {
+            case MANAGED_REALMLIST:
+                RealmResults<NullTypes> results = realm.allObjects(NullTypes.class);
+                RealmList<NullTypes> list = results.get(0).getFieldListNull();
+                realm.beginTransaction();
+                for (int i = 0; i < results.size(); i++) {
+                    list.add(results.get(i));
+                }
+                realm.commitTransaction();
+                return list;
+
+            case REALMRESULTS:
+                return realm.where(NullTypes.class).findAll();
+        }
+        throw new AssertionError("Unknown collection: " + collectionClass);
+    }
+
+    private OrderedRealmCollection<NullTypes> createPartialNullRowsForNumericTesting(Realm realm, ManagedCollection collectionClass) {
+        populatePartialNullRowsForNumericTesting(realm);
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                RealmResults<NullTypes> results = realm.allObjects(NullTypes.class);
+                RealmList<NullTypes> list = results.get(0).getFieldListNull();
+                realm.beginTransaction();
+                int size = results.size();
+                for (int i = 0; i < size; i++) {
+                    list.add(results.get(i));
+                }
+                realm.commitTransaction();
+                return list;
+
+            case REALMRESULTS:
+                return realm.where(NullTypes.class).findAll();
+        }
+        throw new AssertionError("Unknown collection: " + collectionClass);
+    }
+
+    // PRE-CONDITION: populateRealm() was called as part of setUp()
+    private OrderedRealmCollection<NonLatinFieldNames> createNonLatinCollection(Realm realm, ManagedCollection collectionClass) {
+        switch (collectionClass) {
+
+            case MANAGED_REALMLIST:
+                realm.beginTransaction();
+                RealmResults<NonLatinFieldNames> results = realm.allObjects(NonLatinFieldNames.class);
+                RealmList<NonLatinFieldNames> list = results.get(0).getChildren();
+                for (int i = 0; i < results.size(); i++) {
+                    list.add(results.get(i));
+                }
+                realm.commitTransaction();
+                return list;
+
+            case REALMRESULTS:
+                return realm.allObjects(NonLatinFieldNames.class);
+
+            default:
+                throw new AssertionError("Unknown collection: " + collectionClass);
+        }
+    }
+
+    @Test
+    public void where() {
+        RealmResults<AllJavaTypes> results = collection.where().findAll();
+        assertEquals(TEST_SIZE, results.size());
+    }
+
+    @Test
+    public void where_contains() {
+        RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class).findAll().where();
+        AllJavaTypes item = query.findFirst();
+        assertTrue("Item should exist in results.", query.findAll().contains(item));
+    }
+
+    @Test
+    public void where_contains_null() {
+        RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class).findAll().where();
+        assertFalse("Should not contain a null item.", query.findAll().contains(null));
+    }
+
+    @Test
+    public void where_shouldNotContainRemovedItem() {
+        RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class).findAll().where();
+        AllJavaTypes item = realm.where(AllJavaTypes.class).findFirst();
+        realm.beginTransaction();
+        item.deleteFromRealm();
+        realm.commitTransaction();
+        assertFalse("Should not contain a removed item.", query.findAll().contains(item));
+    }
+
+    /**
+     * Test to see if a particular item that does exist in the same Realm does not
+     * exist in the result set of another query.
+     */
+    @Test
+    public void where_lessThanGreaterThan() {
+        RealmResults<AllJavaTypes> items = realm.where(AllJavaTypes.class).lessThan(AllJavaTypes.FIELD_LONG, 1000).findAll();
+        AllJavaTypes anotherType = realm.where(AllJavaTypes.class).greaterThan(AllJavaTypes.FIELD_LONG, 1000).findFirst();
+        assertFalse("Should not be able to find item in another result list.", items.contains(anotherType));
+    }
+
+    @Test
+    public void where_equalTo_manyConditions() {
+        RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class);
+        query.equalTo(AllJavaTypes.FIELD_LONG, 0);
+        for (int i = 1; i < TEST_SIZE; i++) {
+            query.or().equalTo(AllJavaTypes.FIELD_LONG, i);
+        }
+        RealmResults<AllJavaTypes> allTypesRealmResults = query.findAll();
+        assertEquals(TEST_SIZE, allTypesRealmResults.size());
+    }
+
+    @Test
+    public void where_findAll_size() {
+        RealmResults<AllJavaTypes> results = realm.where(AllJavaTypes.class).findAll();
+        assertEquals(TEST_SIZE, results.size());
+
+        // querying a RealmResults should find objects that fulfill the condition
+        RealmResults<AllJavaTypes> onedigits = results.where().lessThan(AllJavaTypes.FIELD_LONG, 10).findAll();
+        assertEquals(Math.min(10, TEST_SIZE), onedigits.size());
+
+        // if no objects fulfill conditions, the result has zero objects
+        RealmResults<AllJavaTypes> none = results.where().greaterThan(AllJavaTypes.FIELD_LONG, TEST_SIZE).findAll();
+        assertEquals(0, none.size());
+
+        // querying a result with zero objects must give zero objects
+        RealmResults<AllJavaTypes> stillNone = none.where().greaterThan(AllJavaTypes.FIELD_LONG, TEST_SIZE).findAll();
+        assertEquals(0, stillNone.size());
+    }
+
+    @Test
+    public void where_findAllSorted() {
+        RealmResults<AllJavaTypes> results = realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
+        assertEquals(TEST_SIZE, results.size());
+        //noinspection ConstantConditions
+        assertEquals(0, results.first().getFieldLong());
+        //noinspection ConstantConditions
+        assertEquals(TEST_SIZE - 1, results.last().getFieldLong());
+
+        RealmResults<AllJavaTypes> reverseList = realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_LONG, Sort.DESCENDING);
+        assertEquals(TEST_SIZE, reverseList.size());
+        //noinspection ConstantConditions
+        assertEquals(0, reverseList.last().getFieldLong());
+        //noinspection ConstantConditions
+        assertEquals(TEST_SIZE - 1, reverseList.first().getFieldLong());
+
+        try {
+            realm.where(AllJavaTypes.class).findAllSorted("invalid",
+                    Sort.DESCENDING);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void where_queryDateField() {
+        RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_DATE, new Date(YEAR_MILLIS * 20));
+        RealmResults<AllJavaTypes> all = query.findAll();
+        assertEquals(1, query.count());
+        assertEquals(1, all.size());
+
+        // before 1901
+        query = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_DATE, new Date(YEAR_MILLIS * -100));
+        all = query.findAll();
+        assertEquals(1, query.count());
+        assertEquals(1, all.size());
+
+        // after 2038
+        query = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_DATE, new Date(YEAR_MILLIS * 80));
+        all = query.findAll();
+        assertEquals(1, query.count());
+        assertEquals(1, all.size());
+    }
+
+    @Test
+    public void min() {
+        Number minimum = collection.min(AllJavaTypes.FIELD_LONG);
+        assertEquals(0, minimum.intValue());
+    }
+
+    // Test min on empty columns
+    @Test
+    public void min_emptyNonNullFields() {
+        OrderedRealmCollection<NullTypes> results = createEmptyCollection(realm, collectionClass);
+        assertNull(results.min(NullTypes.FIELD_INTEGER_NOT_NULL));
+        assertNull(results.min(NullTypes.FIELD_FLOAT_NOT_NULL));
+        assertNull(results.min(NullTypes.FIELD_DOUBLE_NOT_NULL));
+        assertNull(results.minDate(NullTypes.FIELD_DATE_NOT_NULL));
+    }
+
+    // Test min on nullable rows with all null values
+    @Test
+    public void min_emptyNullFields() {
+        OrderedRealmCollection<NullTypes> results = createAllNullRowsForNumericTesting(realm, collectionClass);
+        assertNull(results.max(NullTypes.FIELD_INTEGER_NULL));
+        assertNull(results.max(NullTypes.FIELD_FLOAT_NULL));
+        assertNull(results.max(NullTypes.FIELD_DOUBLE_NULL));
+        assertNull(results.maxDate(NullTypes.FIELD_DATE_NULL));
+    }
+
+    // Test min on nullable rows with partial null values
+    @Test
+    public void min_partialNullRows() {
+        OrderedRealmCollection<NullTypes> results = createPartialNullRowsForNumericTesting(realm, collectionClass);
+        assertEquals(0, results.min(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(0f, results.min(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
+        assertEquals(0d, results.min(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+    }
+
+    @Test
+    public void max() {
+        Number maximum = collection.max(AllJavaTypes.FIELD_LONG);
+        assertEquals(TEST_SIZE - 1, maximum.intValue());
+    }
+
+    // Test max on empty columns
+    @Test
+    public void max_emptyNonNullFields() {
+        OrderedRealmCollection<NullTypes> results = createEmptyCollection(realm, collectionClass);
+        assertNull(results.max(NullTypes.FIELD_INTEGER_NOT_NULL));
+        assertNull(results.max(NullTypes.FIELD_FLOAT_NOT_NULL));
+        assertNull(results.max(NullTypes.FIELD_DOUBLE_NOT_NULL));
+        assertNull(results.maxDate(NullTypes.FIELD_DATE_NOT_NULL));
+    }
+
+    // Test max on nullable rows with all null values
+    @Test
+    public void max_emptyNullFields() {
+        OrderedRealmCollection<NullTypes> results = createAllNullRowsForNumericTesting(realm, collectionClass);
+        assertNull(results.max(NullTypes.FIELD_INTEGER_NULL));
+        assertNull(results.max(NullTypes.FIELD_FLOAT_NULL));
+        assertNull(results.max(NullTypes.FIELD_DOUBLE_NULL));
+        assertNull(results.maxDate(NullTypes.FIELD_DATE_NULL));
+    }
+
+    // Test max on nullable rows with partial null values
+    @Test
+    public void max_partialNullRows() {
+        OrderedRealmCollection<NullTypes> results = createPartialNullRowsForNumericTesting(realm, collectionClass);
+        assertEquals(1, results.max(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(2f, results.max(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
+        assertEquals(3d, results.max(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+    }
+
+    @Test
+    public void sum() {
+        Number sum = collection.sum(AllJavaTypes.FIELD_LONG);
+        // Sum of numbers 0 to M-1: (M-1)*M/2
+        assertEquals((TEST_SIZE - 1) * TEST_SIZE/ 2, sum.intValue());
+    }
+
+    // Test sum on nullable rows with all null values
+    @Test
+    public void sum_nullRows() {
+        OrderedRealmCollection<NullTypes> resultList = createAllNullRowsForNumericTesting(realm, collectionClass);
+        assertEquals(0, resultList.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(0f, resultList.sum(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
+        assertEquals(0d, resultList.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+    }
+
+    // Test sum on nullable rows with partial null values
+    @Test
+    public void sum_partialNullRows() {
+        OrderedRealmCollection<NullTypes> resultList = createPartialNullRowsForNumericTesting(realm, collectionClass);
+
+        assertEquals(1, resultList.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
+        assertEquals(2f, resultList.sum(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
+        assertEquals(3d, resultList.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
+    }
+
+    @Test
+    public void sum_nonLatinColumnNames() {
+        OrderedRealmCollection<NonLatinFieldNames> resultList = createNonLatinCollection(realm, collectionClass);
+
+        Number sum = resultList.sum(NonLatinFieldNames.FIELD_LONG_KOREAN_CHAR);
+        // Sum of numbers 0 to M-1: (M-1)*M/2
+        assertEquals((TEST_SIZE - 1) * TEST_SIZE / 2, sum.intValue());
+
+        sum = resultList.sum(NonLatinFieldNames.FIELD_LONG_GREEK_CHAR);
+        // Sum of numbers 0 to M-1: (M-1)*M/2
+        assertEquals((TEST_SIZE - 1) * TEST_SIZE / 2, sum.intValue());
+    }
+
+    @Test
+    public void avg() {
+        double N = (double) TEST_SIZE;
+
+        // Sum of numbers 1 to M: M*(M+1)/2
+        // See setUp() for values of fields
+        // N = TEST_DATA_SIZE
+
+        // Type: double; a = 3.1415
+        // a, a+1, ..., a+i, ..., a+N-1
+        // sum = 3.1415*N + N*(N-1)/2
+        // average = sum/N = 3.1415+(N-1)/2
+        double average = 3.1415 + (N - 1.0) * 0.5;
+        assertEquals(average, collection.average(AllJavaTypes.FIELD_DOUBLE), 0.0001);
+
+        // Type: long
+        // 0, 1, ..., N-1
+        // sum = N*(N-1)/2
+        // average = sum/N = (N-1)/2
+        assertEquals(0.5 * (N - 1), collection.average(AllJavaTypes.FIELD_LONG), 0.0001);
+
+        // Type: float; b = 1.234567
+        // b, b+1, ..., b+i, ..., b+N-1
+        // sum = b*N + N*(N-1)/2
+        // average = sum/N = b + (N-1)/2
+        assertEquals(1.234567 + 0.5 * (N - 1.0), collection.average(AllJavaTypes.FIELD_FLOAT), 0.0001);
+    }
+
+    // Test average on empty columns
+    @Test
+    public void avg_emptyNonNullFields() {
+        OrderedRealmCollection<NullTypes> resultList = createEmptyCollection(realm, collectionClass);
+        assertEquals(0d, resultList.average(NullTypes.FIELD_INTEGER_NOT_NULL), 0d);
+        assertEquals(0d, resultList.average(NullTypes.FIELD_FLOAT_NOT_NULL), 0d);
+        assertEquals(0d, resultList.average(NullTypes.FIELD_DOUBLE_NOT_NULL), 0d);
+    }
+
+    // Test average on nullable rows with all null values
+    @Test
+    public void avg_emptyNullFields() {
+        OrderedRealmCollection<NullTypes> resultList = createEmptyCollection(realm, collectionClass);
+        assertEquals(0d, resultList.average(NullTypes.FIELD_INTEGER_NULL), 0d);
+        assertEquals(0d, resultList.average(NullTypes.FIELD_FLOAT_NULL), 0d);
+        assertEquals(0d, resultList.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
+    }
+
+    // Test average on nullable rows with partial null values
+    @Test
+    public void avg_partialNullRows() {
+        OrderedRealmCollection<NullTypes> resultList = createPartialNullRowsForNumericTesting(realm, collectionClass);
+        assertEquals(0.5d, resultList.average(NullTypes.FIELD_INTEGER_NULL), 0d);
+        assertEquals(1.0d, resultList.average(NullTypes.FIELD_FLOAT_NULL), 0d);
+        assertEquals(1.5d, resultList.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
+    }
+
+    @Test
+    public void maxDate() {
+        assertEquals(new Date(YEAR_MILLIS * 20 * 4), collection.maxDate(AllJavaTypes.FIELD_DATE));
+    }
+
+    @Test
+    public void minDate() {
+        assertEquals(new Date(YEAR_MILLIS * 20 * -5), collection.minDate(AllJavaTypes.FIELD_DATE));
+    }
+
+    @Test
+    public void realmMethods_invalidFieldNames() {
+        String[] fieldNames = new String[] {
+                null, "", "foo", AllJavaTypes.FIELD_STRING + ".foo", TestHelper.getRandomString(65)
+        };
+
+        for (RealmCollectionMethod realmMethod : RealmCollectionMethod.values()) {
+            for (String fieldName : fieldNames) {
+                try {
+                    switch (realmMethod) {
+                        case MIN: collection.min(fieldName); break;
+                        case MAX: collection.max(fieldName); break;
+                        case SUM: collection.sum(fieldName); break;
+                        case AVERAGE: collection.average(fieldName); break;
+                        case MIN_DATE: collection.minDate(fieldName); break;
+                        case MAX_DATE: collection.maxDate(fieldName); break;
+
+                        // These methods doesn't take any arguments.
+                        // Just skip them.
+                        case WHERE:
+                        case DELETE_ALL_FROM_REALM:
+                        case IS_VALID:
+                            continue;
+
+                        default:
+                            fail("Unknown method: " + realmMethod);
+
+                    }
+                    fail(realmMethod + " did not throw an exception for input: " + fieldName);
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+        }
+    }
+
+    @Test
+    public void realmMethods_invalidFieldType() {
+        String fieldName = AllJavaTypes.FIELD_STRING;
+        for (RealmCollectionMethod realmMethod : RealmCollectionMethod.values()) {
+            try {
+                switch (realmMethod) {
+                    case MIN: collection.min(fieldName); break;
+                    case MAX: collection.max(fieldName); break;
+                    case SUM: collection.sum(fieldName); break;
+                    case AVERAGE: collection.average(fieldName); break;
+                    case MIN_DATE: collection.minDate(fieldName); break;
+                    case MAX_DATE: collection.maxDate(fieldName); break;
+
+                    // These methods doesn't take any arguments.
+                    // Just skip them.
+                    case WHERE:
+                    case DELETE_ALL_FROM_REALM:
+                    case IS_VALID:
+                        continue;
+
+                    default:
+                        fail("Unknown method: " + realmMethod);
+
+                }
+                fail(realmMethod + " did not throw an exception for input: " + fieldName);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void deleteAllFromRealm() {
+        // If we have a self-referencing collection, removing all objects will crash
+        // any following method. To avoid that scenario we make sure to use a collection
+        // without cycles.
+        int size = TEST_SIZE;
+        if (collectionClass == ManagedCollection.MANAGED_REALMLIST) {
+            RealmList list = (RealmList) collection;
+            realm.beginTransaction();
+            list.remove(0); // Break the cycle
+            realm.commitTransaction();
+            size = TEST_SIZE - 1;
+        }
+
+        assertEquals(size, collection.size());
+        realm.beginTransaction();
+        assertTrue(collection.deleteAllFromRealm());
+        realm.commitTransaction();
+        assertEquals(0, collection.size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void deleteAllFromRealm_outsideTransaction() {
+        collection.deleteAllFromRealm();
+    }
+
+    @Test
+    public void deleteAllFromRealm_emptyList() {
+        OrderedRealmCollection<NullTypes> collection = createEmptyCollection(realm, collectionClass);
+
+        realm.beginTransaction();
+        assertFalse(collection.deleteAllFromRealm());
+        realm.commitTransaction();
+        assertEquals(0, collection.size());
+    }
+
+    @Test
+    public void deleteAllFromRealm_invalidList() {
+        realm.close();
+        try {
+            collection.deleteAllFromRealm();
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    @Test
+    public void isLoaded() {
+        // RealmCollections are currently always loaded. Only exception is RealmResults.
+        // See RealmResultsTests for extended tests on this.
+        assertTrue(collection.isLoaded());
+    }
+
+    @Test
+    public void load() {
+        // RealmCollections are currently always loaded, so this just returns true. Only exception is RealmResults.
+        // See RealmResultsTests for extended tests on this.
+        assertTrue(collection.load());
+    }
+
+    @Test
+    public void isValid() {
+        assertTrue(collection.isValid());
+    }
+
+    @Test
+    public void isValid_realmClosed() {
+        realm.close();
+        assertFalse(collection.isValid());
+    }
+
+    @Test
+    public void contains_deletedRealmObject() {
+        AllJavaTypes obj = collection.iterator().next();
+        realm.beginTransaction();
+        obj.deleteFromRealm();
+        realm.commitTransaction();
+
+        assertFalse(collection.contains(obj));
+    }
+
+    @Test
+    public void equals_sameRealmObjectsDifferentCollection() {
+        assertTrue(collection.equals(createCollection(collectionClass)));
+    }
+
+    // Test all methods that mutate data throw correctly if not inside an transaction.
+    // Due to implementation details both UnsupportedOperation and IllegalState is accepted at this level
+    @Test
+    public void mutableMethodsOutsideTransactions() {
+        for (CollectionMutatorMethod method : CollectionMutatorMethod.values()) {
+
+            // Define expected exception
+            Class<? extends Throwable> expected = IllegalStateException.class;
+            if (collectionClass == ManagedCollection.REALMRESULTS) {
+                switch (method) {
+                    case ADD_OBJECT:
+                    case ADD_ALL_OBJECTS:
+                    case CLEAR:
+                    case REMOVE_OBJECT:
+                    case REMOVE_ALL:
+                    case RETAIN_ALL:
+                        expected = UnsupportedOperationException.class;
+                }
+            }
+
+            try {
+                switch (method) {
+                    case DELETE_ALL: collection.deleteAllFromRealm(); break;
+                    case ADD_OBJECT: collection.add(new AllJavaTypes());
+                    case ADD_ALL_OBJECTS: collection.addAll(Collections.singletonList(new AllJavaTypes())); break;
+                    case CLEAR: collection.clear(); break;
+                    case REMOVE_OBJECT: collection.remove(new AllJavaTypes()); break;
+                    case REMOVE_ALL: collection.removeAll(Collections.singletonList(new AllJavaTypes())); break;
+                    case RETAIN_ALL: collection.retainAll(Collections.singletonList(new AllJavaTypes())); break;
+                }
+                fail("Unknown method or it failed to throw: " + method);
+            } catch (Throwable t) {
+                if (!t.getClass().equals(expected)) {
+                    fail(method + " didn't throw the expected exception. Was: " + t + ", expected: " + expected);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void methodsThrowOnWrongThread() throws ExecutionException, InterruptedException {
+        for (RealmCollectionMethod method : RealmCollectionMethod.values()) {
+            assertTrue(method + " failed" , runMethodOnWrongThread(method));
+        }
+        for (CollectionMethod method : CollectionMethod.values()) {
+            assertTrue(method + " failed" , runMethodOnWrongThread(method));
+        }
+    }
+
+    private boolean runMethodOnWrongThread(final RealmCollectionMethod method) throws ExecutionException, InterruptedException {
+        realm.beginTransaction();
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                try {
+                    switch (method) {
+                        case WHERE: collection.where(); break;
+                        case MIN: collection.min(AllJavaTypes.FIELD_LONG); break;
+                        case MAX: collection.min(AllJavaTypes.FIELD_LONG); break;
+                        case SUM: collection.sum(AllJavaTypes.FIELD_LONG); break;
+                        case AVERAGE: collection.average(AllJavaTypes.FIELD_LONG); break;
+                        case MIN_DATE: collection.minDate(AllJavaTypes.FIELD_DATE); break;
+                        case MAX_DATE: collection.maxDate(AllJavaTypes.FIELD_DATE); break;
+                        case DELETE_ALL_FROM_REALM: collection.deleteAllFromRealm(); break;
+                        case IS_VALID: collection.isValid(); break;
+                    }
+                    return false;
+                } catch (IllegalStateException ignored) {
+                    return true;
+                }
+            }
+        });
+        Boolean result = future.get();
+        realm.cancelTransaction();
+        return result;
+    }
+
+    private boolean runMethodOnWrongThread(final CollectionMethod method) throws ExecutionException, InterruptedException {
+        realm.beginTransaction();
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+
+                // Define expected exception
+                Class<? extends Throwable> expected = IllegalStateException.class;
+                if (collectionClass == ManagedCollection.REALMRESULTS) {
+                    switch (method) {
+                        case ADD_OBJECT:
+                        case ADD_ALL_OBJECTS:
+                        case CLEAR:
+                        case REMOVE_OBJECT:
+                        case REMOVE_ALL:
+                        case RETAIN_ALL:
+                            expected = UnsupportedOperationException.class;
+                    }
+                }
+
+                try {
+                    switch (method) {
+                        case ADD_OBJECT: collection.add(new AllJavaTypes()); break;
+                        case ADD_ALL_OBJECTS: collection.addAll(Collections.singletonList(new AllJavaTypes())); break;
+                        case CLEAR: collection.clear(); case CONTAINS:
+                        case CONTAINS_ALL: collection.containsAll(Collections.singletonList(new AllJavaTypes())); break;
+                        case EQUALS: collection.equals(createCollection(collectionClass)); break;
+                        case HASHCODE:
+                            //noinspection ResultOfMethodCallIgnored
+                            collection.hashCode();
+                            break;
+                        case IS_EMPTY: collection.isEmpty(); break;
+                        case ITERATOR: return true; // Creating an iterator should be safe. Accessing it will fail, but tested elsewhere.
+                        case REMOVE_OBJECT: collection.remove(new AllJavaTypes()); break;
+                        case REMOVE_ALL: collection.removeAll(Collections.singletonList(new AllJavaTypes())); break;
+                        case RETAIN_ALL: collection.retainAll(Collections.singletonList(new AllJavaTypes())); break;
+                        case SIZE: collection.size(); break;
+                        case TO_ARRAY: collection.toArray(); break;
+                        case TO_ARRAY_INPUT: collection.toArray(new Object[collection.size()]); break;
+                    }
+                    return false;
+                } catch (Throwable t) {
+                    if (!t.getClass().equals(expected)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        });
+        Boolean result = future.get();
+        realm.cancelTransaction();
+        return result;
+    }
+
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import android.util.Pair;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.realm.entities.AllJavaTypes;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for all methods specific to OrderedRealmCollections no matter if they are managed or un-managed.
+ *
+ * Methods tested in this class:
+ *
+ * # RealmOrderedCollection
+ *
+ * + E first()
+ * + E last()
+ * - void sort(String field)
+ * - void sort(String field, Sort sortOrder)
+ * - void sort(String field1, Sort sortOrder1, String field2, Sort sortOrder2)
+ * - void sort(String[] fields, Sort[] sortOrders)
+ * - void deleteFromRealm(int location)
+ * - void deleteFirstFromRealm()
+ * - void deleteLastFromRealm();
+ *
+ * # List
+ *
+ *  - void add(int location, E object);
+ *  - boolean addAll(int location, Collection<? extends E> collection);
+ *  + E get(int location);
+ *  + int indexOf(Object object);
+ *  + int lastIndexOf(Object object);
+ *  - ListIterator<E> listIterator();
+ *  - ListIterator<E> listIterator(int location);
+ *  - E remove(int location);
+ *  - E set(int location, E object);
+ *  + List<E> subList(int start, int end);
+ *
+ * # RealmCollection
+ *
+ * - RealmQuery<E> where();
+ * - Number min(String fieldName);
+ * - Number max(String fieldName);
+ * - Number sum(String fieldName);
+ * - double average(String fieldName);
+ * - Date maxDate(String fieldName);
+ * - Date minDate(String fieldName);
+ * - void deleteAllFromRealm();
+ * - boolean isLoaded();
+ * - boolean load();
+ * - boolean isValid();
+ * - BaseRealm getRealm();
+ *
+ * # Collection
+ *
+ * - public boolean add(E object);
+ * - public boolean addAll(Collection<? extends E> collection);
+ * - public void deleteAll();
+ * - public boolean contains(Object object);
+ * - public boolean containsAll(Collection<?> collection);
+ * - public boolean equals(Object object);
+ * - public int hashCode();
+ * - public boolean isEmpty();
+ * - public Iterator<E> iterator();
+ * - public boolean remove(Object object);
+ * - public boolean removeAll(Collection<?> collection);
+ * - public boolean retainAll(Collection<?> collection);
+ * - public int size();
+ * - public Object[] toArray();
+ * - public <T> T[] toArray(T[] array);
+ *
+ * @see RealmCollectionTests
+ * @see ManagedRealmCollectionTests
+ * @see UnManagedRealmCollectionTests
+ */
+@RunWith(Parameterized.class)
+public class OrderedRealmCollectionTests extends CollectionTests {
+
+    private static final int TEST_SIZE = 10;
+
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private final CollectionClass collectionClass;
+    private Realm realm;
+    private OrderedRealmCollection<AllJavaTypes> collection;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<CollectionClass> data() {
+        return Arrays.asList(CollectionClass.values());
+    }
+
+    public OrderedRealmCollectionTests(CollectionClass collectionType) {
+        this.collectionClass = collectionType;
+    }
+
+    @Before
+    public void setup() {
+        realm = Realm.getInstance(configFactory.createConfiguration());
+        collection = createCollection(realm, collectionClass);
+    }
+
+    private OrderedRealmCollection<AllJavaTypes> createCollection(Realm realm, CollectionClass collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                populateRealm(realm, TEST_SIZE);
+                return realm.where(AllJavaTypes.class)
+                        .equalTo(AllJavaTypes.FIELD_LONG, 0)
+                        .findFirst()
+                        .getFieldList();
+
+            case UNMANAGED_REALMLIST:
+                return populateInMemoryList(TEST_SIZE);
+
+            case REALMRESULTS:
+                populateRealm(realm, TEST_SIZE);
+                return realm.allObjects(AllJavaTypes.class);
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    private OrderedRealmCollection<AllJavaTypes> createEmptyCollection(Realm realm, CollectionClass collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                return realm.where(AllJavaTypes.class)
+                        .equalTo(AllJavaTypes.FIELD_LONG, 1)
+                        .findFirst()
+                        .getFieldList();
+
+            case UNMANAGED_REALMLIST:
+                return new RealmList<AllJavaTypes>();
+
+            case REALMRESULTS:
+                return realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_LONG, -1).findAll();
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    private Pair<AllJavaTypes, OrderedRealmCollection<AllJavaTypes>> createCollectionWithMultipleCopies(Realm realm, CollectionClass collectionClass) {
+
+        AllJavaTypes obj;
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                obj = realm.where(AllJavaTypes.class)
+                        .equalTo(AllJavaTypes.FIELD_LONG, 1)
+                        .findFirst();
+                RealmList<AllJavaTypes> list = obj.getFieldList();
+                realm.beginTransaction();
+                list.add(obj);
+                realm.commitTransaction();
+                return new Pair<AllJavaTypes, OrderedRealmCollection<AllJavaTypes>>(obj, list);
+
+            case UNMANAGED_REALMLIST:
+                obj = new AllJavaTypes(1);
+                return new Pair<AllJavaTypes, OrderedRealmCollection<AllJavaTypes>>(obj, new RealmList<AllJavaTypes>(obj, obj));
+
+            case REALMRESULTS:
+                RealmResults<AllJavaTypes> result = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_LONG, 1).findAll();
+                obj = result.first();
+                return new Pair<AllJavaTypes, OrderedRealmCollection<AllJavaTypes>>(obj, result);
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        realm.close();
+    }
+
+    @Test
+    public void first() {
+        assertEquals(collection.get(0), collection.first());
+    }
+
+    @Test
+    public void first_emptyCollection() {
+        collection = createEmptyCollection(realm, collectionClass);
+        try {
+            collection.first();
+            fail();
+        } catch (IndexOutOfBoundsException ignored) {
+        }
+    }
+
+    @Test
+    public void last() {
+        assertEquals(collection.get(TEST_SIZE - 1), collection.last());
+    }
+
+    @Test
+    public void last_emptyCollection() {
+        collection = createEmptyCollection(realm, collectionClass);
+        try {
+            collection.last();
+            fail();
+        } catch (IndexOutOfBoundsException ignored) {
+        }
+    }
+
+    @Test
+    public void get_validIndex() {
+        AllJavaTypes first = collection.get(0);
+        assertEquals(0, first.getFieldInt());
+
+        AllJavaTypes last = collection.get(TEST_SIZE - 1);
+        assertEquals(TEST_SIZE - 1, last.getFieldInt());
+    }
+
+    @Test
+    public void get_indexOutOfBounds() {
+        List<Integer> indexes = Arrays.asList(-1, TEST_SIZE, Integer.MAX_VALUE, Integer.MIN_VALUE);
+        for (Integer index : indexes) {
+            try {
+                collection.get(index);
+                fail(index +  " did not throw the expected Exception.");
+            } catch (IndexOutOfBoundsException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void indexOf() {
+        AllJavaTypes obj = collection.get(1);
+        assertEquals(1, collection.indexOf(obj));
+    }
+
+    @Test
+    public void indexOf_null() {
+        assertEquals(-1, collection.indexOf(null));
+    }
+
+    @Test
+    public void indexOf_objectNotInRealm() {
+        assertEquals(-1, collection.indexOf(new AllJavaTypes()));
+    }
+
+    @Test
+    public void lastIndexOf() {
+        Pair<AllJavaTypes, OrderedRealmCollection<AllJavaTypes>> data = createCollectionWithMultipleCopies(realm, collectionClass);
+        AllJavaTypes obj = data.first;
+        collection = data.second;
+        int lastIndex = collection.lastIndexOf(obj);
+        assertEquals(collection.size() - 1, lastIndex);
+    }
+
+    @Test
+    public void lastIndexOf_null() {
+        assertEquals(-1, collection.lastIndexOf(null));
+    }
+
+    @Test
+    public void lastIndexOf_objectNotInRealm() {
+        assertEquals(-1, collection.lastIndexOf(new AllJavaTypes()));
+    }
+
+    @Test
+    public void subList() {
+        List<AllJavaTypes> list = collection.subList(0, 5);
+        assertEquals(5, list.size());
+        assertEquals(list.get(0), collection.get(0));
+        assertEquals(list.get(4), collection.get(4));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void subList_invalidStartIndex() {
+        collection.subList(-1, TEST_SIZE);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void subList_invalidEnd() {
+        collection.subList(0, TEST_SIZE + 1);
+    }
+
+    // Check that all releveant methods throw a correct IndexOutOfBounds
+    @Test
+    public void methods_indexOutOfBounds() {
+        collection = createEmptyCollection(realm, collectionClass);
+
+        for (ListMethod method : ListMethod.values()) {
+            realm.beginTransaction();
+            try {
+                switch (method) {
+                    case ADD_INDEX: collection.add(1, new AllJavaTypes()); break;
+                    case ADD_ALL_INDEX: collection.addAll(1, Collections.singleton(new AllJavaTypes())); break;
+                    case GET_INDEX: collection.get(1); break;
+                    case LIST_ITERATOR_INDEX: collection.listIterator(1); break;
+                    case REMOVE_INDEX: collection.remove(1);
+                    case SET: collection.set(1, new AllJavaTypes());
+                    case SUBLIST: collection.subList(1, 2);
+
+                    // Cannot fail with IndexOutOfBounds
+                    case FIRST:
+                    case LAST:
+                    case INDEX_OF:
+                    case LAST_INDEX_OF:
+                    case LIST_ITERATOR:
+                        continue;
+                }
+                fail(method + " did not throw an exception");
+            } catch (IndexOutOfBoundsException ignored) {
+            } catch (UnsupportedOperationException ignored) {
+            } finally {
+                realm.cancelTransaction();
+            }
+        }
+
+        for (OrderedRealmCollectionMethod method : OrderedRealmCollectionMethod.values()) {
+            realm.beginTransaction();
+            try {
+                switch (method) {
+                    case DELETE_INDEX: collection.deleteFromRealm(1); break;
+
+                    // Cannot fail with IndexOutOfBounds
+                    case DELETE_FIRST:
+                    case DELETE_LAST:
+                    case SORT:
+                    case SORT_FIELD:
+                    case SORT_2FIELDS:
+                    case SORT_MULTI:
+                        continue;
+                }
+                fail(method + " did not throw an exception");
+            } catch (IndexOutOfBoundsException ignored) {
+            } catch (UnsupportedOperationException ignored) {
+            } finally {
+                realm.cancelTransaction();
+            }
+        }
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAdapterTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAdapterTest.java
@@ -109,7 +109,7 @@ public class RealmAdapterTest {
         RealmAdapter realmAdapter = new RealmAdapter(context, resultList, automaticUpdate);
 
         testRealm.beginTransaction();
-        realmAdapter.getRealmResults().clear();
+        realmAdapter.getRealmResults().deleteAllFromRealm();
         testRealm.commitTransaction();
 
         assertEquals(0, realmAdapter.getCount());
@@ -123,7 +123,7 @@ public class RealmAdapterTest {
         RealmAdapter realmAdapter = new RealmAdapter(context, resultList, automaticUpdate);
 
         testRealm.beginTransaction();
-        realmAdapter.getRealmResults().remove(0);
+        realmAdapter.getRealmResults().deleteFromRealm(0);
         testRealm.commitTransaction();
         assertEquals(TEST_DATA_SIZE - 1, realmAdapter.getCount());
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
@@ -232,7 +232,7 @@ public class RealmAnnotationTests {
     @Test
     public void namingConvention() {
         realm.beginTransaction();
-        realm.clear(AnnotationNameConventions.class);
+        realm.delete(AnnotationNameConventions.class);
         AnnotationNameConventions anc1 = realm.createObject(AnnotationNameConventions.class);
         anc1.setHasObject(true);
         anc1.setId_object(1);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -462,7 +462,7 @@ public class RealmAsyncQueryTests {
                         if (intercepts == 1) {
                             // We advance the Realm so we can simulate a retry
                             realm.beginTransaction();
-                            realm.clear(AllTypes.class);
+                            realm.delete(AllTypes.class);
                             realm.commitTransaction();
                         }
                 }
@@ -918,7 +918,7 @@ public class RealmAsyncQueryTests {
                         if (intercepts == 1) {
                             // we advance the Realm so we can simulate a retry
                             realm.beginTransaction();
-                            realm.clear(AllTypes.class);
+                            realm.delete(AllTypes.class);
                             AllTypes object = realm.createObject(AllTypes.class);
                             object.setColumnString("The Endless River");
                             object.setColumnLong(5);
@@ -1015,7 +1015,7 @@ public class RealmAsyncQueryTests {
                             // We advance the Realm so we can simulate a retry before listeners are
                             // called.
                             realm.beginTransaction();
-                            realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 8).findFirst().removeFromRealm();
+                            realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 8).findFirst().deleteFromRealm();
                             realm.commitTransaction();
                         }
                         break;
@@ -1952,8 +1952,7 @@ public class RealmAsyncQueryTests {
     private void populateTestRealm(final Realm testRealm, int objects) {
         testRealm.setAutoRefresh(false);
         testRealm.beginTransaction();
-        testRealm.allObjects(AllTypes.class).clear();
-        testRealm.allObjects(NonLatinFieldNames.class).clear();
+        testRealm.deleteAll();
         for (int i = 0; i < objects; ++i) {
             AllTypes allTypes = testRealm.createObject(AllTypes.class);
             allTypes.setColumnBoolean((i % 3) == 0);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
@@ -1,0 +1,232 @@
+package io.realm;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import io.realm.entities.AllJavaTypes;
+import io.realm.entities.Dog;
+import io.realm.entities.NullTypes;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for all methods part of the the {@link RealmCollection} interface.
+ * This class only tests methods that have the same behavior no matter if the collection is managed or not.
+ *
+ * Methods tested in this class:
+ *
+ * # RealmCollection
+ *
+ * - RealmQuery<E> where();
+ * - Number min(String fieldName);
+ * - Number max(String fieldName);
+ * - Number sum(String fieldName);
+ * - double average(String fieldName);
+ * - Date maxDate(String fieldName);
+ * - Date minDate(String fieldName);
+ * - void deleteAllFromRealm();
+ * - boolean isLoaded();
+ * - boolean load();
+ * - boolean isValid();
+ * - BaseRealm getRealm();
+ *
+ * # Collection
+ *
+ * - public boolean add(E object);
+ * - public boolean addAll(Collection<? extends E> collection);
+ * - public void deleteAll();
+ * + public boolean contains(Object object);
+ * + public boolean containsAll(Collection<?> collection);
+ * + public boolean equals(Object object);
+ * + public int hashCode();
+ * + public boolean isEmpty();
+ * - public Iterator<E> iterator();
+ * + public boolean remove(Object object);
+ * + public boolean removeAll(Collection<?> collection);
+ * + public boolean retainAll(Collection<?> collection);
+ * + public int size();
+ * + public Object[] toArray();
+ * + public <T> T[] toArray(T[] array);
+ **
+ * @see ManagedRealmCollectionTests
+ * @see UnManagedRealmCollectionTests
+ */
+@RunWith(Parameterized.class)
+public class RealmCollectionTests extends CollectionTests {
+
+    private static final int TEST_SIZE = 10;
+
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+
+    private final CollectionClass collectionClass;
+    private Realm realm;
+    private RealmCollection<AllJavaTypes> collection;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<CollectionClass> data() {
+        return Arrays.asList(CollectionClass.values());
+    }
+
+    public RealmCollectionTests(CollectionClass collectionType) {
+        this.collectionClass = collectionType;
+    }
+
+    @Before
+    public void setup() {
+        realm = Realm.getInstance(configFactory.createConfiguration());
+        collection = createCollection(collectionClass);
+    }
+
+    private RealmCollection<AllJavaTypes> createCollection(CollectionClass collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                populateRealm(realm, TEST_SIZE);
+                return realm.where(AllJavaTypes.class)
+                        .equalTo(AllJavaTypes.FIELD_LONG, 0)
+                        .findFirst()
+                        .getFieldList();
+
+            case UNMANAGED_REALMLIST:
+                return populateInMemoryList(TEST_SIZE);
+
+            case REALMRESULTS:
+                populateRealm(realm, TEST_SIZE);
+                return realm.allObjects(AllJavaTypes.class);
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    private OrderedRealmCollection<NullTypes> createEmptyCollection(Realm realm, CollectionClass collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                realm.beginTransaction();
+                NullTypes obj = realm.createObject(NullTypes.class);
+                realm.commitTransaction();
+                return obj.getFieldListNull();
+
+            case UNMANAGED_REALMLIST:
+                return new RealmList<NullTypes>();
+
+            case REALMRESULTS:
+                return realm.where(NullTypes.class).findAll();
+        }
+
+        throw new AssertionError("Unknown collection: " + collectionClass);
+    }
+
+
+    @After
+    public void tearDown() {
+        realm.close();
+    }
+
+    @Test
+    public void contains() {
+        AllJavaTypes obj = collection.iterator().next();
+        assertTrue(collection.contains(obj));
+    }
+
+    @Test
+    public void contains_realmObjectFromOtherRealm() {
+        Realm realm2 = Realm.getInstance(configFactory.createConfiguration("other_realm.realm"));
+        populateRealm(realm2, TEST_SIZE);
+        AllJavaTypes otherRealmObj = realm2.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_LONG, 0).findFirst();
+
+        try {
+            assertFalse(collection.contains(otherRealmObj));
+        } finally {
+            realm2.close();
+        }
+    }
+
+    @Test
+    public void contains_wrongType() {
+        //noinspection SuspiciousMethodCalls
+        assertFalse(collection.contains(new Dog()));
+    }
+
+    @Test
+    public void contains_null() {
+        assertFalse(collection.contains(null));
+    }
+
+    @Test
+    public void containsAll() {
+        Iterator<AllJavaTypes> it = collection.iterator();
+        List<AllJavaTypes> list = Arrays.asList(it.next(), it.next());
+        assertTrue(collection.containsAll(list));
+    }
+
+    @Test
+    public void containsAll_emptyInput() {
+        assertTrue(collection.containsAll(Collections.emptyList()));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void containsAll_nullInput() {
+        collection.containsAll(null);
+    }
+
+    @Test
+    public void equals() {
+        ArrayList<AllJavaTypes> newList = new ArrayList<AllJavaTypes>();
+        newList.addAll(collection);
+
+        assertTrue(collection.equals(collection));
+        assertTrue(collection.equals(newList));
+        assertFalse(collection.equals(Collections.emptyList()));
+        assertFalse(collection.equals(null));
+    }
+
+    @Test
+    public void hashCode_allObjects() {
+        ArrayList<AllJavaTypes> newList = new ArrayList<AllJavaTypes>();
+        newList.addAll(collection);
+
+        assertTrue(collection.hashCode() == newList.hashCode());
+        assertFalse(collection.hashCode() == Collections.emptyList().hashCode());
+    }
+
+    @Test
+    public void isEmpty() {
+        assertFalse(collection.isEmpty());
+        RealmCollection<NullTypes> collection = createEmptyCollection(realm, collectionClass);
+        assertTrue(collection.isEmpty());
+    }
+
+    @Test
+    public void size() {
+        assertEquals(TEST_SIZE, collection.size());
+    }
+
+    @Test
+    public void toArray() {
+        Object[] array = collection.toArray();
+        assertEquals(TEST_SIZE, array.length);
+        assertEquals(collection.iterator().next(), array[0]);
+    }
+
+    @Test
+    public void toArray_inputArray() {
+        AllJavaTypes[] array = new AllJavaTypes[collection.size()];
+        collection.toArray(array);
+        assertEquals(TEST_SIZE, array.length);
+        assertEquals(collection.iterator().next(), array[0]);
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
@@ -35,9 +35,9 @@ public class RealmLinkTests extends AndroidTestCase {
         testRealm = Realm.getInstance(realmConfig);
 
         testRealm.beginTransaction();
-        testRealm.clear(Dog.class);
-        testRealm.clear(Cat.class);
-        testRealm.clear(Owner.class);
+        testRealm.delete(Dog.class);
+        testRealm.delete(Cat.class);
+        testRealm.delete(Owner.class);
 
         Dog dog1 = testRealm.createObject(Dog.class);
         dog1.setName("Pluto");
@@ -496,7 +496,7 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(0, owners1.size());
 
         testRealm.beginTransaction();
-        testRealm.clear(Cat.class);
+        testRealm.delete(Cat.class);
         testRealm.commitTransaction();
 
         RealmResults<Owner> owners2 = testRealm.where(Owner.class).isNull("cat").findAll();
@@ -508,7 +508,7 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(1, owners1.size());
 
         testRealm.beginTransaction();
-        testRealm.clear(Cat.class);
+        testRealm.delete(Cat.class);
         testRealm.commitTransaction();
 
         RealmResults<Owner> owners2 = testRealm.where(Owner.class).isNotNull("cat").findAll();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -25,13 +25,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.concurrent.Callable;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.Cat;
@@ -39,107 +36,90 @@ import io.realm.entities.CyclicType;
 import io.realm.entities.CyclicTypePrimaryKey;
 import io.realm.entities.Dog;
 import io.realm.entities.Owner;
-import io.realm.exceptions.RealmException;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Unit tests specific for RealmList that cannot be covered by {@link OrderedRealmCollectionTests},
+ * {@link ManagedRealmCollectionTests}, {@link UnManagedRealmCollectionTests} or {@link RealmCollectionTests}.
+ */
 @RunWith(AndroidJUnit4.class)
-public class RealmListTests {
+public class RealmListTests extends CollectionTests {
+
+    private static final int TEST_SIZE = 10;
 
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private static final int TEST_OBJECTS = 10;
-    private Realm testRealm;
+    private Realm realm;
+    private RealmList<Dog> collection;
 
     @Before
     public void setUp() throws Exception {
         RealmConfiguration realmConfig = configFactory.createConfiguration();
-        testRealm = Realm.getInstance(realmConfig);
+        realm = Realm.getInstance(realmConfig);
 
-        testRealm.beginTransaction();
-        Owner owner = testRealm.createObject(Owner.class);
+        realm.beginTransaction();
+        Owner owner = realm.createObject(Owner.class);
         owner.setName("Owner");
-        for (int i = 0; i < TEST_OBJECTS; i++) {
-            Dog dog = testRealm.createObject(Dog.class);
+        for (int i = 0; i < TEST_SIZE; i++) {
+            Dog dog = realm.createObject(Dog.class);
             dog.setName("Dog " + i);
             owner.getDogs().add(dog);
         }
-        testRealm.commitTransaction();
+        realm.commitTransaction();
+        collection = owner.getDogs();
     }
 
     @After
     public void tearDown() throws Exception {
-        if (testRealm != null) {
-            testRealm.close();
+        if (realm != null) {
+            realm.close();
         }
     }
 
     private RealmList<Dog> createNonManagedDogList() {
         RealmList<Dog> list = new RealmList<Dog>();
-        for (int i = 0; i < TEST_OBJECTS; i++) {
+        for (int i = 0; i < TEST_SIZE; i++) {
             list.add(new Dog("Dog " + i));
         }
         return list;
     }
 
     private RealmList<Dog> createDeletedRealmList() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
 
-        testRealm.beginTransaction();
-        owner.removeFromRealm();
-        testRealm.commitTransaction();
+        realm.beginTransaction();
+        owner.deleteFromRealm();
+        realm.commitTransaction();
         return dogs;
     }
 
-    // Check that all methods work correctly on a empty RealmList
-    private void checkMethodsOnEmptyList(Realm realm, RealmList<Dog> list) {
-        realm.beginTransaction();
-        for (int i = 0; i < 4; i++) {
             //noinspection TryWithIdenticalCatches
-            try {
-                switch (i) {
-                    case 0: list.get(0); break;
-                    case 1: list.remove(0); break;
-                    case 2: list.set(0, new Dog()); break;
-                    case 3: list.move(0, 0); break;
-                    default: break;
-                }
-                fail();
-            } catch (IndexOutOfBoundsException ignored) {
-            } catch (RealmException ignored) {
-            }
-        }
-        realm.cancelTransaction();
-
-        assertEquals(0, list.size());
-        assertNull(list.first());
-        assertNull(list.last());
-    }
-
     /*********************************************************
-     * Non-Managed mode tests                                *
+     * Un-managed mode tests                                *
      *********************************************************/
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_nonManaged_null() {
+        AllTypes[] args = null;
+        //noinspection ConstantConditions
+        new RealmList<AllTypes>(args);
+    }
 
     @Test
     public void isValid_nonManagedMode() {
         //noinspection MismatchedQueryAndUpdateOfCollection
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         assertFalse(list.isValid());
-    }
-
-    @Test (expected = RealmException.class)
-    public void where_nonManagedMode() {
-        new RealmList<AllTypes>().where();
     }
 
     @Test
@@ -160,9 +140,9 @@ public class RealmListTests {
     @Test
     public void add_managedObjectInNonManagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
-        testRealm.beginTransaction();
-        AllTypes managedAllTypes = testRealm.createObject(AllTypes.class);
-        testRealm.commitTransaction();
+        realm.beginTransaction();
+        AllTypes managedAllTypes = realm.createObject(AllTypes.class);
+        realm.commitTransaction();
         list.add(managedAllTypes);
 
         assertEquals(managedAllTypes, list.get(0));
@@ -179,15 +159,25 @@ public class RealmListTests {
     }
 
     @Test
-    public void add_ManagedObjectAtIndexInNonManagedMode() {
+    public void add_managedObjectAtIndexInNonManagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         list.add(new AllTypes());
-        testRealm.beginTransaction();
-        AllTypes managedAllTypes = testRealm.createObject(AllTypes.class);
-        testRealm.commitTransaction();
+        realm.beginTransaction();
+        AllTypes managedAllTypes = realm.createObject(AllTypes.class);
+        realm.commitTransaction();
         list.add(0, managedAllTypes);
 
         assertEquals(managedAllTypes, list.get(0));
+    }
+
+    @Test
+    public void add_objectAtIndexInManagedMode() {
+        realm.beginTransaction();
+        Dog obj = collection.get(0);
+        collection.add(0, new Dog("Dog 42"));
+        realm.commitTransaction();
+        assertEquals(obj.getName(), collection.get(1).getName());
+        assertEquals("Dog 42", collection.get(0).getName());
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -207,18 +197,18 @@ public class RealmListTests {
 
     @Test
     public void set_managedMode() {
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         try {
-            RealmList<Dog> list = testRealm.createObject(Owner.class).getDogs();
-            Dog dog1 = testRealm.createObject(Dog.class);
+            RealmList<Dog> list = realm.createObject(Owner.class).getDogs();
+            Dog dog1 = realm.createObject(Dog.class);
             dog1.setName("dog1");
-            Dog dog2 = testRealm.createObject(Dog.class);
+            Dog dog2 = realm.createObject(Dog.class);
             dog2.setName("dog2");
             list.add(dog1);
             assertEquals(dog1, list.set(0, dog2));
             assertEquals(1, list.size());
         } finally {
-            testRealm.cancelTransaction();
+            realm.cancelTransaction();
         }
     }
 
@@ -235,9 +225,9 @@ public class RealmListTests {
     public void set_managedObjectInNonManagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         list.add(new AllTypes());
-        testRealm.beginTransaction();
-        AllTypes managedAllTypes = testRealm.createObject(AllTypes.class);
-        testRealm.commitTransaction();
+        realm.beginTransaction();
+        AllTypes managedAllTypes = realm.createObject(AllTypes.class);
+        realm.commitTransaction();
         list.set(0, managedAllTypes);
 
         assertEquals(managedAllTypes, list.get(0));
@@ -261,30 +251,14 @@ public class RealmListTests {
         assertEquals(object1, object2);
     }
 
-    @Test
-    public void get_nonManagedMode() {
-        RealmList<AllTypes> list = new RealmList<AllTypes>();
-        AllTypes object1 = new AllTypes();
-        list.add(object1);
-        AllTypes object2 = list.get(0);
-        assertEquals(object1, object2);
-    }
-
-    @Test
-    public void size_nonManagedMode() {
-        RealmList<AllTypes> list = new RealmList<AllTypes>();
-        list.add(new AllTypes());
-        assertEquals(1, list.size());
-    }
-
     // Test move where oldPosition > newPosition
     @Test
     public void move_down() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         Dog dog1 = owner.getDogs().get(1);
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         owner.getDogs().move(1, 0);
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
         assertEquals(0, owner.getDogs().indexOf(dog1));
     }
@@ -292,44 +266,16 @@ public class RealmListTests {
     // Test move where oldPosition < newPosition
     @Test
     public void move_up() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        int oldIndex = TEST_OBJECTS / 2;
+        Owner owner = realm.where(Owner.class).findFirst();
+        int oldIndex = TEST_SIZE / 2;
         int newIndex = oldIndex + 1;
         Dog dog = owner.getDogs().get(oldIndex);
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         owner.getDogs().move(oldIndex, newIndex); // This doesn't do anything as oldIndex is now empty so the index's above gets shifted to the left.
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
-        assertEquals(TEST_OBJECTS, owner.getDogs().size());
+        assertEquals(TEST_SIZE, owner.getDogs().size());
         assertEquals(newIndex, owner.getDogs().indexOf(dog));
-    }
-
-    @Test
-    public void first_nonManagedMode() {
-        RealmList<AllTypes> list = new RealmList<AllTypes>();
-        AllTypes object1 = new AllTypes();
-        AllTypes object2 = new AllTypes();
-        list.add(object1);
-        list.add(object2);
-
-        assertEquals(object1, list.first());
-    }
-
-    @Test
-    public void last_nonManagedMode() {
-        RealmList<AllTypes> list = new RealmList<AllTypes>();
-        AllTypes object1 = new AllTypes();
-        AllTypes object2 = new AllTypes();
-        list.add(object1);
-        list.add(object2);
-
-        assertEquals(object2, list.last());
-    }
-
-    @Test
-    public void allMethods_emptyListInNonManagedMode() {
-        RealmList<Dog> list = new RealmList<Dog>();
-        checkMethodsOnEmptyList(testRealm, list);
     }
 
     // Test move where oldPosition > newPosition
@@ -346,12 +292,12 @@ public class RealmListTests {
     @Test
     public void move_upInNonManagedMode() {
         RealmList<Dog> dogs = createNonManagedDogList();
-        int oldIndex = TEST_OBJECTS / 2;
+        int oldIndex = TEST_SIZE / 2;
         int newIndex = oldIndex + 1;
         Dog dog = dogs.get(oldIndex);
         dogs.move(oldIndex, newIndex); // This doesn't do anything as oldIndex is now empty so the index's above gets shifted to the left.
 
-        assertEquals(TEST_OBJECTS, dogs.size());
+        assertEquals(TEST_SIZE, dogs.size());
         assertEquals(oldIndex, dogs.indexOf(dog));
     }
 
@@ -361,23 +307,23 @@ public class RealmListTests {
 
     @Test
     public void isValid() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
 
         assertTrue(dogs.isValid());
 
-        testRealm.close();
+        realm.close();
         assertFalse(dogs.isValid());
     }
 
     @Test
     public void isValid_whenParentRemoved() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
 
-        testRealm.beginTransaction();
-        owner.removeFromRealm();
-        testRealm.commitTransaction();
+        realm.beginTransaction();
+        owner.deleteFromRealm();
+        realm.commitTransaction();
 
         // RealmList contained in removed object is invalid.
         assertFalse(dogs.isValid());
@@ -385,121 +331,121 @@ public class RealmListTests {
 
     @Test
     public void move_outOfBoundsLowerThrows() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        testRealm.beginTransaction();
+        Owner owner = realm.where(Owner.class).findFirst();
+        realm.beginTransaction();
         try {
             owner.getDogs().move(0, -1);
             fail("Indexes < 0 should throw an exception");
         } catch (IndexOutOfBoundsException ignored) {
         } finally {
-            testRealm.cancelTransaction();
+            realm.cancelTransaction();
         }
     }
 
     @Test
     public void move_outOfBoundsHigherThrows() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        testRealm.beginTransaction();
+        Owner owner = realm.where(Owner.class).findFirst();
+        realm.beginTransaction();
         try {
-            int lastIndex = TEST_OBJECTS - 1;
-            int outOfBoundsIndex = TEST_OBJECTS;
+            int lastIndex = TEST_SIZE - 1;
+            int outOfBoundsIndex = TEST_SIZE;
             owner.getDogs().move(lastIndex, outOfBoundsIndex);
             fail("Indexes >= size() should throw an exception");
         } catch (IndexOutOfBoundsException ignored) {
             ignored.printStackTrace();
         } finally {
-            testRealm.cancelTransaction();
+            realm.cancelTransaction();
         }
     }
 
     @Test
     public void add_managedObjectToManagedList() {
-        testRealm.beginTransaction();
-        testRealm.clear(Owner.class);
-        Owner owner = testRealm.createObject(Owner.class);
-        Dog dog = testRealm.createObject(Dog.class);
+        realm.beginTransaction();
+        realm.delete(Owner.class);
+        Owner owner = realm.createObject(Owner.class);
+        Dog dog = realm.createObject(Dog.class);
         owner.getDogs().add(dog);
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
-        assertEquals(1, testRealm.where(Owner.class).findFirst().getDogs().size());
+        assertEquals(1, realm.where(Owner.class).findFirst().getDogs().size());
     }
 
     // Test that add correctly uses Realm.copyToRealm() on standalone objects.
     @Test
     public void add_nonManagedObjectToManagedList() {
-        testRealm.beginTransaction();
-        CyclicType parent = testRealm.createObject(CyclicType.class);
+        realm.beginTransaction();
+        CyclicType parent = realm.createObject(CyclicType.class);
         RealmList<CyclicType> children = parent.getObjects();
         children.add(new CyclicType());
-        testRealm.commitTransaction();
-        assertEquals(1, testRealm.where(CyclicType.class).findFirst().getObjects().size());
+        realm.commitTransaction();
+        assertEquals(1, realm.where(CyclicType.class).findFirst().getObjects().size());
     }
 
     // Make sure that standalone objects with a primary key are added using copyToRealmOrUpdate
     @Test
     public void add_nonManagedPrimaryKeyObjectToManagedList() {
-        testRealm.beginTransaction();
-        testRealm.copyToRealm(new CyclicTypePrimaryKey(2, "original"));
-        RealmList<CyclicTypePrimaryKey> children = testRealm.copyToRealm(new CyclicTypePrimaryKey(1)).getObjects();
+        realm.beginTransaction();
+        realm.copyToRealm(new CyclicTypePrimaryKey(2, "original"));
+        RealmList<CyclicTypePrimaryKey> children = realm.copyToRealm(new CyclicTypePrimaryKey(1)).getObjects();
         children.add(new CyclicTypePrimaryKey(2, "new"));
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
-        assertEquals(1, testRealm.where(CyclicTypePrimaryKey.class).equalTo("id", 1).findFirst().getObjects().size());
-        assertEquals("new", testRealm.where(CyclicTypePrimaryKey.class).equalTo("id", 2).findFirst().getName());
+        assertEquals(1, realm.where(CyclicTypePrimaryKey.class).equalTo("id", 1).findFirst().getObjects().size());
+        assertEquals("new", realm.where(CyclicTypePrimaryKey.class).equalTo("id", 2).findFirst().getName());
     }
 
     // Test that set correctly uses Realm.copyToRealm() on standalone objects.
     @Test
     public void set_nonManagedObjectToManagedList() {
-        testRealm.beginTransaction();
-        CyclicType parent = testRealm.copyToRealm(new CyclicType("Parent"));
+        realm.beginTransaction();
+        CyclicType parent = realm.copyToRealm(new CyclicType("Parent"));
         RealmList<CyclicType> children = parent.getObjects();
         children.add(new CyclicType());
         children.add(new CyclicType("original"));
         children.add(new CyclicType());
         children.set(1, new CyclicType("updated"));
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
-        RealmList<CyclicType> list = testRealm.where(CyclicType.class).findFirst().getObjects();
+        RealmList<CyclicType> list = realm.where(CyclicType.class).findFirst().getObjects();
         assertEquals(3, list.size());
         assertEquals("updated", list.get(1).getName());
-        assertEquals(5, testRealm.where(CyclicType.class).count());
+        assertEquals(5, realm.where(CyclicType.class).count());
     }
 
     // Test that set correctly uses Realm.copyToRealmOrUpdate() on standalone objects with a primary key.
     @Test
     public void  set_nonManagedPrimaryKeyObjectToManagedList() {
-        testRealm.beginTransaction();
-        CyclicTypePrimaryKey parent = testRealm.copyToRealm(new CyclicTypePrimaryKey(1, "Parent"));
+        realm.beginTransaction();
+        CyclicTypePrimaryKey parent = realm.copyToRealm(new CyclicTypePrimaryKey(1, "Parent"));
         RealmList<CyclicTypePrimaryKey> children = parent.getObjects();
         children.add(new CyclicTypePrimaryKey(2));
         children.add(new CyclicTypePrimaryKey(3, "original"));
         children.add(new CyclicTypePrimaryKey(4));
         children.set(1, new CyclicTypePrimaryKey(3, "updated"));
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
-        RealmList<CyclicTypePrimaryKey> list = testRealm.where(CyclicTypePrimaryKey.class).findFirst().getObjects();
+        RealmList<CyclicTypePrimaryKey> list = realm.where(CyclicTypePrimaryKey.class).findFirst().getObjects();
         assertEquals(3, list.size());
         assertEquals("updated", list.get(1).getName());
     }
 
     @Test
     public void add_nullToManagedListThrows() {
-        testRealm.beginTransaction();
-        Owner owner = testRealm.createObject(Owner.class);
+        realm.beginTransaction();
+        Owner owner = realm.createObject(Owner.class);
         thrown.expect(IllegalArgumentException.class);
         owner.getDogs().add(null);
     }
 
     @Test
     public void size() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        assertEquals(TEST_OBJECTS, owner.getDogs().size());
+        Owner owner = realm.where(Owner.class).findFirst();
+        assertEquals(TEST_SIZE, owner.getDogs().size());
     }
 
     @Test
     public void getObjects() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
 
         assertNotNull(dogs);
@@ -507,53 +453,37 @@ public class RealmListTests {
     }
 
     @Test
-    public void first() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        RealmList<Dog> dogs = owner.getDogs();
-
-        assertEquals("Dog 0", dogs.first().getName());
-    }
-
-    @Test
-    public void last() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        RealmList<Dog> dogs = owner.getDogs();
-
-        assertEquals("Dog " + (TEST_OBJECTS - 1), dogs.last().getName());
-    }
-
-    @Test
     public void remove_byIndex() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         Dog dog5 = dogs.get(5);
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         Dog removedDog = dogs.remove(5);
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
         assertEquals(dog5, removedDog);
-        assertEquals(TEST_OBJECTS - 1, dogs.size());
+        assertEquals(TEST_SIZE - 1, dogs.size());
     }
 
     @Test
     public void remove_last() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
 
-        testRealm.beginTransaction();
-        dogs.remove(TEST_OBJECTS - 1);
-        testRealm.commitTransaction();
+        realm.beginTransaction();
+        dogs.remove(TEST_SIZE - 1);
+        realm.commitTransaction();
 
-        assertEquals(TEST_OBJECTS - 1, dogs.size());
+        assertEquals(TEST_SIZE - 1, dogs.size());
     }
 
     @Test
     public void remove_fromEmptyListThrows() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         dogs.clear();
         thrown.expect(IndexOutOfBoundsException.class);
         dogs.remove(0);
@@ -561,24 +491,24 @@ public class RealmListTests {
 
     @Test
     public void remove_byObject() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         Dog dog = dogs.get(0);
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         boolean result = dogs.remove(dog);
-        testRealm.commitTransaction();
+        realm.commitTransaction();
 
         assertTrue(result);
-        assertEquals(TEST_OBJECTS - 1, dogs.size());
+        assertEquals(TEST_SIZE - 1, dogs.size());
     }
 
     @Test
     public void add_atAfterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
-        Dog dog = testRealm.createObject(Dog.class);
+        realm.beginTransaction();
+        Dog dog = realm.createObject(Dog.class);
         dog.setName("Dog");
         thrown.expect(IllegalStateException.class);
         dogs.add(0, dog);
@@ -588,8 +518,8 @@ public class RealmListTests {
     public void add_afterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
-        Dog dog = testRealm.createObject(Dog.class);
+        realm.beginTransaction();
+        Dog dog = realm.createObject(Dog.class);
         dog.setName("Dog");
         thrown.expect(IllegalStateException.class);
         dogs.add(dog);
@@ -599,8 +529,8 @@ public class RealmListTests {
     public void set_afterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
-        Dog dog = testRealm.createObject(Dog.class);
+        realm.beginTransaction();
+        Dog dog = realm.createObject(Dog.class);
         dog.setName("Dog");
         thrown.expect(IllegalStateException.class);
         dogs.set(0, dog);
@@ -610,7 +540,7 @@ public class RealmListTests {
     public void move_afterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         thrown.expect(IllegalStateException.class);
         dogs.move(0, 1);
     }
@@ -619,7 +549,7 @@ public class RealmListTests {
     public void clear_afterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         thrown.expect(IllegalStateException.class);
         dogs.clear();
     }
@@ -628,29 +558,51 @@ public class RealmListTests {
     public void remove_atAfterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
-        Dog dog = testRealm.createObject(Dog.class);
+        realm.beginTransaction();
+        Dog dog = realm.createObject(Dog.class);
         dog.setName("Dog");
         thrown.expect(IllegalStateException.class);
         dogs.remove(0);
     }
 
     @Test
-    public void remove_bbjectAfterContainerObjectRemoved() {
+    public void remove_objectAfterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
-        Dog dog = testRealm.createObject(Dog.class);
+        realm.beginTransaction();
+        Dog dog = realm.createObject(Dog.class);
         dog.setName("Dog");
         thrown.expect(IllegalStateException.class);
         dogs.remove(dog);
     }
 
     @Test
+    public void removeAll_managedMode() {
+        realm.beginTransaction();
+        List<Dog> objectsToRemove = Arrays.asList(collection.get(0));
+        assertTrue(collection.removeAll(objectsToRemove));
+        assertFalse(collection.contains(objectsToRemove.get(0)));
+    }
+
+    @Test
+    public void removeAll_managedMode_wrongClass() {
+        realm.beginTransaction();
+        //noinspection SuspiciousMethodCalls
+        assertFalse(collection.removeAll(Collections.singletonList(new Cat())));
+    }
+
+    @Test
+    public void removeAll_unmanaged_wrongClass() {
+        RealmList<Dog> list = createNonManagedDogList();
+        //noinspection SuspiciousMethodCalls
+        assertFalse(list.removeAll(Collections.singletonList(new Cat())));
+    }
+
+    @Test
     public void remove_allAfterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         thrown.expect(IllegalStateException.class);
         dogs.removeAll(Collections.<Dog>emptyList());
     }
@@ -697,13 +649,25 @@ public class RealmListTests {
     @Test
     public void toString_AfterContainerObjectRemoved() {
         RealmList<Dog> dogs = createDeletedRealmList();
-
         assertEquals("Dog@[invalid]", dogs.toString());
     }
 
     @Test
+    public void toString_managedMode() {
+        StringBuilder sb = new StringBuilder("Dog@[");
+        for (int i = 0; i < collection.size() - 1; i++) {
+            sb.append(collection.get(i).row.getIndex());
+            sb.append(",");
+        }
+        sb.append(collection.get(TEST_SIZE - 1).row.getIndex());
+        sb.append("]");
+
+        assertEquals(sb.toString(), collection.toString());
+    }
+
+    @Test
     public void query() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         Dog firstDog = dogs.where().equalTo("name", "Dog 0").findFirst();
 
@@ -711,309 +675,131 @@ public class RealmListTests {
     }
 
     @Test
-    public void allMethods_emptyListInManagedMode() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        testRealm.beginTransaction();
-        owner.getDogs().clear();
-        testRealm.commitTransaction();
-
-        checkMethodsOnEmptyList(testRealm, owner.getDogs());
-    }
-
-    @Test
     public void clear() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        testRealm.beginTransaction();
-        assertEquals(TEST_OBJECTS, owner.getDogs().size());
+        Owner owner = realm.where(Owner.class).findFirst();
+        realm.beginTransaction();
+        assertEquals(TEST_SIZE, owner.getDogs().size());
         owner.getDogs().clear();
         assertEquals(0, owner.getDogs().size());
-        testRealm.commitTransaction();
+        realm.commitTransaction();
     }
 
     @Test
-    public void clear_NotDeleting() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        testRealm.beginTransaction();
-        assertEquals(TEST_OBJECTS, testRealm.allObjects(Dog.class).size());
+    public void clear_notDeleting() {
+        Owner owner = realm.where(Owner.class).findFirst();
+        realm.beginTransaction();
+        assertEquals(TEST_SIZE, realm.allObjects(Dog.class).size());
         owner.getDogs().clear();
-        assertEquals(TEST_OBJECTS, testRealm.allObjects(Dog.class).size());
-        testRealm.commitTransaction();
+        assertEquals(TEST_SIZE, realm.allObjects(Dog.class).size());
+        realm.commitTransaction();
     }
 
     @Test
-    public void contains() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        Dog dog = owner.getDogs().get(0);
-        assertTrue("Should contain a particular dog.", owner.getDogs().contains(dog));
-    }
+    public void setList_clearsOldItems() {
+        realm.beginTransaction();
+        CyclicType one = realm.copyToRealm(new CyclicType());
+        CyclicType two = realm.copyToRealm(new CyclicType());
 
-    /**
-     * Test to see if a particular item that does exist in the same Realm does not
-     * exist in a query that excludes said item.
-     */
-    @Test
-    public void contains_sameRealmNotContained() {
-        RealmResults<Dog> dogs = testRealm.where(Dog.class)
-                .equalTo("name", "Dog 1").or().equalTo("name", "Dog 2").findAll();
-        Dog thirdDog = testRealm.where(Dog.class)
-                .equalTo("name", "Dog 3").findFirst();
-        assertFalse("Should not contain a particular dog.", dogs.contains(thirdDog));
-    }
-
-    @Test
-    public void contains_inNonManagedList() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        RealmList<Dog> managedDogs = owner.getDogs();
-        // Create a non-managed RealmList
-        RealmList<Dog> nonManagedDogs
-                = new RealmList<Dog>(managedDogs.toArray(new Dog[managedDogs.size()]));
-        Dog dog = managedDogs.get(0);
-        assertTrue("Should contain a particular dog", nonManagedDogs.contains(dog));
-    }
-
-    @Test
-    public void contains_null() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        assertFalse("Should not contain a null item.", owner.getDogs().contains(null));
-    }
-
-    /**
-     * Test that the {@link Realm#contains(Class)} method of one Realm will not contain a
-     * {@link RealmObject} from another Realm.
-     */
-    @Test
-    public void contains_doesNotContainAnItem() {
-        RealmConfiguration realmConfig = configFactory.createConfiguration("contains_test.realm");
-        Realm testRealmTwo = Realm.getInstance(realmConfig);
-        try {
-            // Set up the test realm
-            testRealmTwo.beginTransaction();
-            Owner owner2 = testRealmTwo.createObject(Owner.class);
-            owner2.setName("Owner");
-            for (int i = 0; i < TEST_OBJECTS; i++) {
-                Dog dog = testRealmTwo.createObject(Dog.class);
-                dog.setName("Dog " + i);
-                owner2.getDogs().add(dog);
-            }
-            testRealmTwo.commitTransaction();
-
-            // Get a dog from the test realm.
-            Dog dog2 = testRealmTwo.where(Owner.class).findFirst().getDogs().get(0);
-
-            // Access the original Realm. Then see if the above dog object is contained. (It shouldn't).
-            Owner owner1 = testRealm.where(Owner.class).findFirst();
-
-            assertFalse("Should not be able to find one object in another Realm via contains",
-                    owner1.getDogs().contains(dog2));
-        } finally {
-            if (testRealmTwo != null && !testRealmTwo.isClosed()) {
-                testRealmTwo.close();
-            }
-        }
-    }
-
-    @Test
-    public void contains_shouldNotContainDeletedRealmObject() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        RealmList<Dog> dogs = owner.getDogs();
-        Dog dog1 = dogs.get(0);
-        testRealm.beginTransaction();
-        dog1.removeFromRealm();
-        testRealm.commitTransaction();
-        assertFalse("Should not contain a deleted RealmObject", dogs.contains(dog1));
-    }
-
-    // Test that all methods that require a transaction (ie. any function that mutates Realm data)
-    @Test
-    public void mutableMethods_OutsideTransactions() {
-        testRealm.beginTransaction();
-        RealmList<Dog> list = testRealm.createObject(AllTypes.class).getColumnRealmList();
-        Dog dog = testRealm.createObject(Dog.class);
-        list.add(dog);
-        testRealm.commitTransaction();
-
-        try { list.add(dog);    fail(); } catch (IllegalStateException ignored) {}
-        try { list.add(0, dog); fail(); } catch (IllegalStateException ignored) {}
-        try { list.clear();     fail(); } catch (IllegalStateException ignored) {}
-        try { list.move(0, 1);  fail(); } catch (IllegalStateException ignored) {}
-        try { list.remove(0);   fail(); } catch (IllegalStateException ignored) {}
-        try { list.set(0, dog); fail(); } catch (IllegalStateException ignored) {}
-    }
-
-    private enum Method {
-        METHOD_ADD,
-        METHOD_ADD_AT,
-        METHOD_CLEAR,
-        METHOD_MOVE,
-        METHOD_REMOVE,
-        METHOD_SET
-    }
-
-    // Calling methods from the wrong thread should fail
-    private boolean methodWrongThread(final Method method) throws InterruptedException, ExecutionException {
-        testRealm.beginTransaction();
-        testRealm.clear(AllTypes.class);
-        testRealm.clear(Dog.class);
-        final RealmList<Dog> list = testRealm.createObject(AllTypes.class).getColumnRealmList();
-        Dog dog = testRealm.createObject(Dog.class);
-        list.add(dog);
-        testRealm.commitTransaction();
-
-        testRealm.beginTransaction(); // Make sure that a valid transaction has begun on the correct thread
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                try {
-                    switch (method) {
-                        case METHOD_ADD:
-                            list.add(new Dog());
-                            break;
-                        case METHOD_ADD_AT:
-                            list.add(1, new Dog());
-                            break;
-                        case METHOD_CLEAR:
-                            list.clear();
-                            break;
-                        case METHOD_MOVE:
-                            list.add(new Dog());
-                            list.move(0, 1);
-                            break;
-                        case METHOD_REMOVE:
-                            list.remove(0);
-                            break;
-                        case METHOD_SET:
-                            list.set(0, new Dog());
-                            break;
-                    }
-                    return false;
-                } catch (IllegalStateException ignored) {
-                    return true;
-                }
-            }
-        });
-
-        boolean result = future.get();
-        testRealm.cancelTransaction();
-        return result;
-    }
-
-    @Test
-    public void methods_ThrowOnWrongThread() throws ExecutionException, InterruptedException {
-        for (Method method : Method.values()) {
-            assertTrue(method.toString(), methodWrongThread(method));
-        }
-    }
-
-    @Test
-    public void setList_ClearsOldItems() {
-        testRealm.beginTransaction();
-        CyclicType one = testRealm.copyToRealm(new CyclicType());
-        CyclicType two = testRealm.copyToRealm(new CyclicType());
+        assertEquals(0, two.getObjects().size());
         two.setObjects(new RealmList<CyclicType>(one));
-        two.setObjects(new RealmList<CyclicType>(one));
-        testRealm.commitTransaction();
-
         assertEquals(1, two.getObjects().size());
+        two.setObjects(new RealmList<CyclicType>(one, two));
+        assertEquals(2, two.getObjects().size());
+    }
+
+    @Test
+    public void realmMethods_onDeletedLinkView() {
+        OrderedRealmCollection<CyclicType> results = populateCollectionOnDeletedLinkView(realm, ManagedCollection.MANAGED_REALMLIST);
+
+        for (RealmCollectionMethod method : RealmCollectionMethod.values()) {
+            try {
+                switch (method) {
+                    case WHERE: results.where(); break;
+                    case MIN: results.min(CyclicType.FIELD_ID); break;
+                    case MAX: results.max(CyclicType.FIELD_ID); break;
+                    case SUM: results.sum(CyclicType.FIELD_ID); break;
+                    case AVERAGE: results.average(CyclicType.FIELD_ID); break;
+                    case MIN_DATE: results.minDate(CyclicType.FIELD_DATE); break;
+                    case MAX_DATE: results.maxDate(CyclicType.FIELD_DATE); break;
+                    case DELETE_ALL_FROM_REALM: results.deleteAllFromRealm(); break;
+                    case IS_VALID: continue; // Does not throw
+                }
+                fail(method + " should have thrown an Exception.");
+            } catch (IllegalStateException ignored) {
+            }
+        }
+
+        for (OrderedRealmCollectionMethod method : OrderedRealmCollectionMethod.values()) {
+            realm.beginTransaction();
+            try {
+                switch (method) {
+                    case DELETE_INDEX: results.deleteFromRealm(0); break;
+                    case DELETE_FIRST: results.deleteFirstFromRealm(); break;
+                    case DELETE_LAST: results.deleteLastFromRealm(); break;
+                    case SORT: results.sort(CyclicType.FIELD_NAME); break;
+                    case SORT_FIELD: results.sort(CyclicType.FIELD_NAME, Sort.ASCENDING); break;
+                    case SORT_2FIELDS: results.sort(CyclicType.FIELD_NAME, Sort.ASCENDING, CyclicType.FIELD_DATE, Sort.DESCENDING); break;
+                    case SORT_MULTI: results.sort(new String[] { CyclicType.FIELD_NAME, CyclicType.FIELD_DATE }, new Sort[] { Sort.ASCENDING, Sort.DESCENDING});
+                }
+                fail(method + " should have thrown an Exception");
+            } catch (IllegalStateException ignored) {
+            } finally {
+                realm.cancelTransaction();
+            }
+        }
     }
 
     @Test
     public void removeAllFromRealm() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
-        assertEquals(TEST_OBJECTS, dogs.size());
+        assertEquals(TEST_SIZE, dogs.size());
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         dogs.deleteAllFromRealm();
-        testRealm.commitTransaction();
+        realm.commitTransaction();
         assertEquals(0, dogs.size());
-        assertEquals(0, testRealm.where(Dog.class).count());
-    }
-
-    @Test
-    public void removeAllFromRealm_notManagedList() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
-        RealmList<Dog> dogs = owner.getDogs();
-        assertEquals(TEST_OBJECTS, dogs.size());
-
-        RealmList<Dog> notManagedDogs = new RealmList<Dog>();
-        for (Dog dog : dogs) {
-            notManagedDogs.add(dog);
-        }
-
-        testRealm.beginTransaction();
-        notManagedDogs.deleteAllFromRealm();
-        testRealm.commitTransaction();
-        assertEquals(0, dogs.size());
-        assertEquals(0, notManagedDogs.size());
-        assertEquals(0, testRealm.where(Dog.class).count());
+        assertEquals(0, realm.where(Dog.class).count());
     }
 
     @Test
     public void removeAllFromRealm_outsideTransaction() {
-        Owner owner = testRealm.where(Owner.class).findFirst();
+        Owner owner = realm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         try {
             dogs.deleteAllFromRealm();
             fail("removeAllFromRealm should be called in a transaction.");
         } catch (IllegalStateException e) {
-            assertEquals("Changing Realm data can only be done from inside a transaction.", e.getMessage());
+            assertEquals("Changing Realm data can only be done from inside a write transaction.", e.getMessage());
         }
-    }
-
-    @Test
-    public void removeAllFromRealm_listWithStandaloneObjectShouldThrow() {
-        final RealmList<Dog> list = new RealmList<Dog>();
-
-        testRealm.beginTransaction();
-        Dog dog1 = testRealm.where(Dog.class).findFirst();
-        testRealm.commitTransaction();
-        Dog dog2 = new Dog();
-
-        list.add(dog1);
-        list.add(dog2);
-
-        testRealm.beginTransaction();
-        try {
-            list.deleteAllFromRealm();
-            fail("Cannot remove a list with a standalone object in it!");
-        } catch (IllegalStateException e) {
-            assertEquals("Object malformed: missing object in Realm. Make sure to instantiate RealmObjects with" +
-                    " Realm.createObject()", e.getMessage());
-        } finally {
-            testRealm.cancelTransaction();
-        }
-
-        assertEquals(TEST_OBJECTS, testRealm.where(Dog.class).count());
-        assertEquals(2, list.size());
     }
 
     @Test
     public void removeAllFromRealm_emptyList() {
-        RealmList<Dog> dogs = testRealm.where(Owner.class).findFirst().getDogs();
-        assertEquals(TEST_OBJECTS, dogs.size());
+        RealmList<Dog> dogs = realm.where(Owner.class).findFirst().getDogs();
+        assertEquals(TEST_SIZE, dogs.size());
 
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         dogs.deleteAllFromRealm();
-        testRealm.commitTransaction();
+        realm.commitTransaction();
         assertEquals(0, dogs.size());
-        assertEquals(0, testRealm.where(Dog.class).count());
+        assertEquals(0, realm.where(Dog.class).count());
 
         // The dogs is empty now.
-        testRealm.beginTransaction();
+        realm.beginTransaction();
         dogs.deleteAllFromRealm();
-        testRealm.commitTransaction();
+        realm.commitTransaction();
         assertEquals(0, dogs.size());
-        assertEquals(0, testRealm.where(Dog.class).count());
+        assertEquals(0, realm.where(Dog.class).count());
 
     }
 
     @Test
     public void removeAllFromRealm_invalidListShouldThrow() {
-        RealmList<Dog> dogs = testRealm.where(Owner.class).findFirst().getDogs();
-        assertEquals(TEST_OBJECTS, dogs.size());
-        testRealm.close();
-        testRealm = null;
+        RealmList<Dog> dogs = realm.where(Owner.class).findFirst().getDogs();
+        assertEquals(TEST_SIZE, dogs.size());
+        realm.close();
+        realm = null;
 
         try {
             dogs.deleteAllFromRealm();
@@ -1026,13 +812,13 @@ public class RealmListTests {
     @Test
     public void add_set_objectFromOtherThread() {
         final CountDownLatch finishedLatch = new CountDownLatch(1);
-        final Dog dog = testRealm.where(Dog.class).findFirst();
+        final Dog dog = realm.where(Dog.class).findFirst();
         final String expectedMsg = "Cannot copy an object from another Realm instance.";
 
         new Thread(new Runnable() {
             @Override
             public void run() {
-                Realm realm = Realm.getInstance(testRealm.getConfiguration());
+                Realm realm = Realm.getInstance(RealmListTests.this.realm.getConfiguration());
                 realm.beginTransaction();
                 RealmList<Dog> list = realm.createObject(Owner.class).getDogs();
                 list.add(realm.createObject(Dog.class));
@@ -1068,14 +854,14 @@ public class RealmListTests {
     @Test
     public void add_set_dynamicObjectFromOtherThread() {
         final CountDownLatch finishedLatch = new CountDownLatch(1);
-        DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
         final DynamicRealmObject dynDog = dynamicRealm.where(Dog.CLASS_NAME).findFirst();
         final String expectedMsg = "Cannot copy an object to a Realm instance created in another thread.";
 
         new Thread(new Runnable() {
             @Override
             public void run() {
-                DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+                DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
                 dynamicRealm.beginTransaction();
                 RealmList<DynamicRealmObject> list = dynamicRealm.createObject(Owner.CLASS_NAME)
                         .getList(Owner.FIELD_DOGS);
@@ -1115,7 +901,7 @@ public class RealmListTests {
     public void add_set_withWrongDynamicObjectType() {
         final String expectedMsg = "The object has a different type from list's. Type of the list is 'Dog'," +
                         " type of object is 'Cat'.";
-        DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
 
         dynamicRealm.beginTransaction();
         RealmList<DynamicRealmObject> list = dynamicRealm.createObject(Owner.CLASS_NAME)
@@ -1153,8 +939,8 @@ public class RealmListTests {
     @Test
     public void add_set_dynamicObjectCreatedFromTypedRealm() {
         final String expectedMsg = "Cannot copy DynamicRealmObject between Realm instances.";
-        DynamicRealmObject dynDog = new DynamicRealmObject(testRealm.where(Dog.class).findFirst());
-        DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+        DynamicRealmObject dynDog = new DynamicRealmObject(realm.where(Dog.class).findFirst());
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
 
         dynamicRealm.beginTransaction();
         RealmList<DynamicRealmObject> list = dynamicRealm.createObject(Owner.CLASS_NAME)

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Calendar;
 import java.util.Date;
@@ -104,7 +103,7 @@ public class RealmObjectTests {
         String[] strings = {"ABCD", "ÆØÅ", "Ö∫Ë", "ΠΑΟΚ", "Здравей"};
 
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
 
         for (String str : strings) {
             AllTypes obj1 = realm.createObject(AllTypes.class);
@@ -130,7 +129,7 @@ public class RealmObjectTests {
         String low  = "Invalid low surrogate \uD83C\uDF51\uDF51";
 
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         realm.commitTransaction();
 
         realm.beginTransaction();
@@ -152,7 +151,7 @@ public class RealmObjectTests {
 
     // removing original object and see if has been removed
     @Test
-    public void removeFromRealm() {
+    public void deleteFromRealm() {
         realm.beginTransaction();
         Dog rex = realm.createObject(Dog.class);
         rex.setName("Rex");
@@ -164,7 +163,7 @@ public class RealmObjectTests {
         assertEquals(1, allDogsBefore.size());
 
         realm.beginTransaction();
-        rex.removeFromRealm();
+        rex.deleteFromRealm();
         realm.commitTransaction();
 
         RealmResults<Dog> allDogsAfter = realm.where(Dog.class).equalTo("name", "Rex").findAll();
@@ -180,7 +179,7 @@ public class RealmObjectTests {
         // deleting rex twice should fail
         realm.beginTransaction();
         try {
-            rex.removeFromRealm();
+            rex.deleteFromRealm();
             realm.close();
             fail();
         } catch (IllegalStateException ignored) {}
@@ -189,7 +188,7 @@ public class RealmObjectTests {
     }
 
     @Test
-    public void removeFromRealm_twiceThrows() {
+    public void deleteFromRealm_twiceThrows() {
         realm.beginTransaction();
         Dog dog = realm.createObject(Dog.class);
         dog.setAge(42);
@@ -197,11 +196,11 @@ public class RealmObjectTests {
 
         realm.beginTransaction();
         assertTrue(dog.isValid());
-        dog.removeFromRealm();
+        dog.deleteFromRealm();
         assertFalse(dog.isValid());
 
         try {
-            dog.removeFromRealm();
+            dog.deleteFromRealm();
             fail();
         } catch (IllegalStateException ignored) {
         }
@@ -209,9 +208,9 @@ public class RealmObjectTests {
 
     // query for an object, remove it and see it has been removed from realm
     @Test
-    public void removeFromRealm_removedFromResults() {
+    public void deleteFromRealm_removedFromResults() {
         realm.beginTransaction();
-        realm.clear(Dog.class);
+        realm.delete(Dog.class);
         Dog dogToAdd = realm.createObject(Dog.class);
         dogToAdd.setName("Rex");
         realm.commitTransaction();
@@ -221,7 +220,7 @@ public class RealmObjectTests {
         Dog dogToRemove = realm.where(Dog.class).findFirst();
         assertNotNull(dogToRemove);
         realm.beginTransaction();
-        dogToRemove.removeFromRealm();
+        dogToRemove.deleteFromRealm();
         realm.commitTransaction();
 
         assertEquals(0, realm.allObjects(Dog.class).size());
@@ -243,7 +242,7 @@ public class RealmObjectTests {
     private void removeOneByOne(boolean atFirst) {
         Set<Long> ages = new HashSet<Long>();
         realm.beginTransaction();
-        realm.clear(Dog.class);
+        realm.delete(Dog.class);
         for (int i = 0; i < TEST_SIZE; i++) {
             Dog dog = realm.createObject(Dog.class);
             dog.setAge(i);
@@ -263,7 +262,7 @@ public class RealmObjectTests {
                 dogToRemove = dogs.last();
             }
             ages.remove(dogToRemove.getAge());
-            dogToRemove.removeFromRealm();
+            dogToRemove.deleteFromRealm();
 
             // object is no longer valid
             try {
@@ -284,7 +283,7 @@ public class RealmObjectTests {
     }
 
     @Test
-    public void removeFromRealm_atPosition() {
+    public void deleteFromRealm_atPosition() {
         removeOneByOne(REMOVE_FIRST);
         removeOneByOne(REMOVE_LAST);
     }
@@ -292,7 +291,7 @@ public class RealmObjectTests {
     private enum Method {
         METHOD_GETTER,
         METHOD_SETTER,
-        METHOD_REMOVE_FROM_REALM
+        METHOD_DELETE_FROM_REALM
     }
 
     private boolean runMethodOnWrongThread(final Method method) throws ExecutionException, InterruptedException {
@@ -309,8 +308,8 @@ public class RealmObjectTests {
                         case METHOD_SETTER:
                             allTypes.setColumnFloat(1.0f);
                             break;
-                        case METHOD_REMOVE_FROM_REALM:
-                            allTypes.removeFromRealm();
+                        case METHOD_DELETE_FROM_REALM:
+                            allTypes.deleteFromRealm();
                             break;
                     }
                     return false;
@@ -408,7 +407,7 @@ public class RealmObjectTests {
         realm.beginTransaction();
         CyclicType foo = createCyclicData();
         realm.commitTransaction();
-        String expected = "CyclicType = [{name:Foo},{object:CyclicType},{otherObject:null},{objects:RealmList<CyclicType>[0]}]";
+        String expected = "CyclicType = [{id:0},{name:Foo},{date:null},{object:CyclicType},{otherObject:null},{objects:RealmList<CyclicType>[0]}]";
         assertEquals(expected, foo.toString());
     }
 
@@ -503,7 +502,7 @@ public class RealmObjectTests {
 
         // test valid dates but with precision lost
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         for (long value : testDatesLoosePrecision) {
             AllTypes allTypes = realm.createObject(AllTypes.class);
             allTypes.setColumnDate(new Date(value));
@@ -585,7 +584,7 @@ public class RealmObjectTests {
             CyclicType target = realm.createObject(CyclicType.class);
 
             CyclicType removed = realm.createObject(CyclicType.class);
-            removed.removeFromRealm();
+            removed.deleteFromRealm();
 
             try {
                 target.setObject(removed);
@@ -725,7 +724,7 @@ public class RealmObjectTests {
             CyclicType target = realm.createObject(CyclicType.class);
 
             CyclicType removed = realm.createObject(CyclicType.class);
-            removed.removeFromRealm();
+            removed.deleteFromRealm();
 
             RealmList<CyclicType> list = new RealmList<>();
             list.add(realm.createObject(CyclicType.class));
@@ -889,7 +888,7 @@ public class RealmObjectTests {
         realm.beginTransaction();
         AllTypes allTypes = realm.createObject(AllTypes.class);
         assertTrue(allTypes.isValid());
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         realm.commitTransaction();
         assertFalse(allTypes.isValid());
     }
@@ -1130,7 +1129,7 @@ public class RealmObjectTests {
             public void run() {
                 Realm realm = Realm.getInstance(realmConfig);
                 realm.beginTransaction();
-                realm.clear(AllTypes.class);
+                realm.delete(AllTypes.class);
                 realm.commitTransaction();
                 realm.close();
                 objectDeletedInBackground.countDown();
@@ -1155,7 +1154,7 @@ public class RealmObjectTests {
         assertTrue(dog.isValid());
 
         realm.beginTransaction();
-        dog.removeFromRealm();
+        dog.deleteFromRealm();
         realm.commitTransaction();
 
         assertFalse(dog.isValid());
@@ -1358,5 +1357,136 @@ public class RealmObjectTests {
         assertEquals("listeners_updated", managed.getListeners());
         assertEquals("pendingQuery_updated", managed.getPendingQuery());
         assertEquals("currentTableVersion_updated", managed.getCurrentTableVersion());
+    }
+
+    // Setting a not-nullable field to null is an error
+    // TODO Move this to RealmObjectTests?
+    @Test
+    public void setter_nullValueInRequiredField() {
+        TestHelper.populateTestRealmForNullTests(realm);
+        RealmResults<NullTypes> list = realm.allObjects(NullTypes.class);
+
+        // 1 String
+        try {
+            realm.beginTransaction();
+            list.first().setFieldStringNotNull(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+
+        // 2 Bytes
+        try {
+            realm.beginTransaction();
+            list.first().setFieldBytesNotNull(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+
+        // 3 Boolean
+        try {
+            realm.beginTransaction();
+            list.first().setFieldBooleanNotNull(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+
+        // 4 Byte
+        try {
+            realm.beginTransaction();
+            list.first().setFieldBytesNotNull(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+
+        // 5 Short 6 Integer 7 Long are skipped for this case, same with Bytes
+
+        // 8 Float
+        try {
+            realm.beginTransaction();
+            list.first().setFieldFloatNotNull(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+
+        // 9 Double
+        try {
+            realm.beginTransaction();
+            list.first().setFieldDoubleNotNull(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+
+        // 10 Date
+        try {
+            realm.beginTransaction();
+            list.first().setFieldDateNotNull(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+
+    // Setting a nullable field to null is not an error
+    // TODO Move this to RealmObjectsTest?
+    @Test
+    public void setter_nullValueInNullableField() {
+        TestHelper.populateTestRealmForNullTests(realm);
+        RealmResults<NullTypes> list = realm.allObjects(NullTypes.class);
+
+        // 1 String
+        realm.beginTransaction();
+        list.first().setFieldStringNull(null);
+        realm.commitTransaction();
+        assertNull(realm.allObjects(NullTypes.class).first().getFieldStringNull());
+
+        // 2 Bytes
+        realm.beginTransaction();
+        list.first().setFieldBytesNull(null);
+        realm.commitTransaction();
+        assertNull(realm.allObjects(NullTypes.class).first().getFieldBytesNull());
+
+        // 3 Boolean
+        realm.beginTransaction();
+        list.first().setFieldBooleanNull(null);
+        realm.commitTransaction();
+        assertNull(realm.allObjects(NullTypes.class).first().getFieldBooleanNull());
+
+        // 4 Byte
+        // 5 Short 6 Integer 7 Long are skipped
+        realm.beginTransaction();
+        list.first().setFieldByteNull(null);
+        realm.commitTransaction();
+        assertNull(realm.allObjects(NullTypes.class).first().getFieldByteNull());
+
+        // 8 Float
+        realm.beginTransaction();
+        list.first().setFieldFloatNull(null);
+        realm.commitTransaction();
+        assertNull(realm.allObjects(NullTypes.class).first().getFieldFloatNull());
+
+        // 9 Double
+        realm.beginTransaction();
+        list.first().setFieldDoubleNull(null);
+        realm.commitTransaction();
+        assertNull(realm.allObjects(NullTypes.class).first().getFieldDoubleNull());
+
+        // 10 Date
+        realm.beginTransaction();
+        list.first().setFieldDateNull(null);
+        realm.commitTransaction();
+        assertNull(realm.allObjects(NullTypes.class).first().getFieldDateNull());
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -86,8 +86,7 @@ public class RealmQueryTests {
 
     private void populateTestRealm(Realm testRealm, int objects) {
         testRealm.beginTransaction();
-        testRealm.allObjects(AllTypes.class).clear();
-        testRealm.allObjects(NonLatinFieldNames.class).clear();
+        testRealm.deleteAll();
         for (int i = 0; i < objects; ++i) {
             AllTypes allTypes = testRealm.createObject(AllTypes.class);
             allTypes.setColumnBoolean((i % 3) == 0);
@@ -460,7 +459,7 @@ public class RealmQueryTests {
         populateTestRealm();
 
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         AllTypes at1 = realm.createObject(AllTypes.class);
         at1.setColumnString("Αλφα");
         AllTypes at2 = realm.createObject(AllTypes.class);
@@ -620,11 +619,12 @@ public class RealmQueryTests {
     public void georgian() {
         String words[] = {"მონაცემთა ბაზა", "მიწისქვეშა გადასასვლელი", "რუსთაველის გამზირი",
                 "მთავარი ქუჩა", "სადგურის მოედანი", "ველოცირაპტორების ჯოგი"};
+
         String sorted[] = {"ველოცირაპტორების ჯოგი", "მთავარი ქუჩა", "მიწისქვეშა გადასასვლელი",
                 "მონაცემთა ბაზა", "რუსთაველის გამზირი", "სადგურის მოედანი"};
 
         realm.beginTransaction();
-        realm.clear(StringOnly.class);
+        realm.delete(StringOnly.class);
         for (String word : words) {
             StringOnly stringOnly = realm.createObject(StringOnly.class);
             stringOnly.setChars(word);
@@ -635,7 +635,7 @@ public class RealmQueryTests {
         assertEquals(1, stringOnlies1.size());
 
         RealmResults<StringOnly> stringOnlies2 = realm.allObjects(StringOnly.class);
-        stringOnlies2.sort("chars");
+        stringOnlies2 = stringOnlies2.sort("chars");
         for (int i = 0; i < stringOnlies2.size(); i++) {
             assertEquals(sorted[i], stringOnlies2.get(i).getChars());
         }
@@ -1218,6 +1218,12 @@ public class RealmQueryTests {
         assertEquals(11d, query.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
     }
 
+    @Test
+    public void count() {
+        populateTestRealm(realm, TEST_DATA_SIZE);
+        assertEquals(TEST_DATA_SIZE, realm.where(AllTypes.class).count());
+    }
+
     // Test isNull on link's nullable field.
     @Test
     public void isNull_linkField() {
@@ -1512,7 +1518,7 @@ public class RealmQueryTests {
         final CountDownLatch latch = new CountDownLatch(nThreads);
 
         realm.beginTransaction();
-        realm.clear(StringOnly.class);
+        realm.delete(StringOnly.class);
         for (int i = 0; i < nObjects; i++) {
             StringOnly stringOnly = realm.createObject(StringOnly.class);
             stringOnly.setChars(String.format("string %d", i));
@@ -1613,7 +1619,7 @@ public class RealmQueryTests {
         assertTrue(query.isValid());
 
         realm.beginTransaction();
-        obj.removeFromRealm();
+        obj.deleteFromRealm();
         realm.commitTransaction();
 
         // invalid if parent has been removed

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsIteratorTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsIteratorTests.java
@@ -149,7 +149,7 @@ public class RealmResultsIteratorTests extends AndroidTestCase {
         testRealm.beginTransaction();
         try {
             for (AllTypes obj : result) {
-                obj.removeFromRealm();
+                obj.deleteFromRealm();
             }
         } catch (ConcurrentModificationException ignored) {
             return;
@@ -255,7 +255,7 @@ public class RealmResultsIteratorTests extends AndroidTestCase {
         final RealmConfiguration realmConfig = TestHelper.createConfiguration(getContext(), "test");
         Realm realm = Realm.getInstance(realmConfig);
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         AllTypes o1 = realm.createObject(AllTypes.class);
         o1.setColumnLong(1);
         AllTypes o2 = realm.createObject(AllTypes.class);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -16,6 +16,7 @@
 
 package io.realm;
 
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
@@ -26,23 +27,18 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AnnotationIndexTypes;
-import io.realm.entities.Cat;
+import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
-import io.realm.entities.NullTypes;
 import io.realm.entities.Owner;
 import io.realm.internal.Table;
 import io.realm.rule.RunInLooperThread;
@@ -51,17 +47,14 @@ import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-public class RealmResultsTests {
+public class RealmResultsTests extends CollectionTests {
 
     private final static int TEST_DATA_SIZE = 2516;
-    private final static int TEST_DATA_FIRST_HALF = 2 * (TEST_DATA_SIZE / 4) - 1;
-    private final static int TEST_DATA_LAST_HALF = 2 * (TEST_DATA_SIZE / 4) + 1;
     private final static long YEAR_MILLIS = TimeUnit.DAYS.toMillis(365);
     private final static long DECADE_MILLIS = 10 * TimeUnit.DAYS.toMillis(365);
 
@@ -73,12 +66,14 @@ public class RealmResultsTests {
     public final RunInLooperThread looperThread = new RunInLooperThread();
 
     private Realm realm;
+    private RealmResults<AllTypes> collection;
 
     @Before
     public void setUp() {
         RealmConfiguration realmConfig = configFactory.createConfiguration();
         realm = Realm.getInstance(realmConfig);
         populateTestRealm();
+        collection = realm.allObjects(AllTypes.class);
     }
 
     @After
@@ -90,8 +85,7 @@ public class RealmResultsTests {
 
     private void populateTestRealm(int objects) {
         realm.beginTransaction();
-        realm.allObjects(AllTypes.class).clear();
-        realm.allObjects(NonLatinFieldNames.class).clear();
+        realm.deleteAll();
 
         for (int i = 0; i < objects; ++i) {
             AllTypes allTypes = realm.createObject(AllTypes.class);
@@ -117,773 +111,6 @@ public class RealmResultsTests {
         populateTestRealm(TEST_DATA_SIZE);
     }
 
-    private void populatePartialNullRowsForNumericTesting() {
-        NullTypes nullTypes1 = new NullTypes();
-        nullTypes1.setId(1);
-        nullTypes1.setFieldIntegerNull(1);
-        nullTypes1.setFieldFloatNull(2F);
-        nullTypes1.setFieldDoubleNull(3D);
-        nullTypes1.setFieldBooleanNull(true);
-        nullTypes1.setFieldStringNull("4");
-        nullTypes1.setFieldDateNull(new Date(12345));
-
-        NullTypes nullTypes2 = new NullTypes();
-        nullTypes2.setId(2);
-
-        NullTypes nullTypes3 = new NullTypes();
-        nullTypes3.setId(3);
-        nullTypes3.setFieldIntegerNull(0);
-        nullTypes3.setFieldFloatNull(0F);
-        nullTypes3.setFieldDoubleNull(0D);
-        nullTypes3.setFieldBooleanNull(false);
-        nullTypes3.setFieldStringNull("0");
-        nullTypes3.setFieldDateNull(new Date(0));
-
-        realm.beginTransaction();
-        realm.copyToRealm(nullTypes1);
-        realm.copyToRealm(nullTypes2);
-        realm.copyToRealm(nullTypes3);
-        realm.commitTransaction();
-    }
-
-    private enum Method {
-        METHOD_MIN,
-        METHOD_MAX,
-        METHOD_SUM,
-        METHOD_AVG,
-        METHOD_SORT,
-        METHOD_WHERE,
-        METHOD_REMOVE,
-        METHOD_REMOVE_LAST,
-        METHOD_CLEAR
-    }
-
-    @Test
-    public void methodsThrowOnWrongThread() throws ExecutionException, InterruptedException {
-        for (Method method : Method.values()) {
-            assertTrue(runMethodOnWrongThread(method));
-        }
-    }
-
-    private boolean runMethodOnWrongThread(final Method method) throws ExecutionException, InterruptedException {
-        final RealmResults<AllTypes> allTypeses = realm.where(AllTypes.class).findAll();
-        realm.beginTransaction();
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                try {
-                    switch (method) {
-                        case METHOD_MIN:
-                            allTypeses.min(AllTypes.FIELD_FLOAT);
-                            break;
-                        case METHOD_MAX:
-                            allTypeses.max(AllTypes.FIELD_FLOAT);
-                            break;
-                        case METHOD_SUM:
-                            allTypeses.sum(AllTypes.FIELD_FLOAT);
-                            break;
-                        case METHOD_AVG:
-                            allTypeses.average(AllTypes.FIELD_FLOAT);
-                            break;
-                        case METHOD_SORT:
-                            allTypeses.sort(AllTypes.FIELD_FLOAT);
-                            break;
-                        case METHOD_WHERE:
-                            allTypeses.where();
-                            break;
-                        case METHOD_REMOVE:
-                            allTypeses.remove(0);
-                            break;
-                        case METHOD_REMOVE_LAST:
-                            allTypeses.removeLast();
-                            break;
-                        case METHOD_CLEAR:
-                            allTypeses.clear();
-                            break;
-                    }
-                    return false;
-                } catch (IllegalStateException ignored) {
-                    return true;
-                }
-            }
-        });
-        Boolean result = future.get();
-        realm.cancelTransaction();
-        return result;
-    }
-
-    @Test
-    public void clear() {
-        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
-        assertEquals(TEST_DATA_SIZE, results.size());
-
-        realm.beginTransaction();
-        results.clear();
-        realm.commitTransaction();
-
-        assertEquals(0, results.size());
-    }
-
-    @Test
-    public void removeLast_emptyList() {
-        RealmResults<AllTypes> resultsList = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_STRING, "Not there").findAll();
-        assertEquals(0, resultsList.size());
-        realm.beginTransaction();
-        resultsList.removeLast();
-        assertEquals(0, resultsList.size());
-    }
-
-    @Test
-    public void get() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-
-        AllTypes allTypes = resultList.get(0);
-        assertTrue(allTypes.getColumnString().startsWith("test data"));
-    }
-
-    @Test
-    public void first() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-
-        AllTypes allTypes = resultList.first();
-        assertTrue(allTypes.getColumnString().startsWith("test data 0"));
-    }
-
-    // first() and last() will throw an exception when no element exist
-    @Test
-    public void firstAndLast_throwsIfEmpty() {
-        realm.beginTransaction();
-        realm.clear(AllTypes.class);
-        realm.commitTransaction();
-
-        RealmResults<AllTypes> allTypes = realm.allObjects(AllTypes.class);
-        assertEquals(0, allTypes.size());
-        try {
-            allTypes.first();
-            fail();
-        } catch (ArrayIndexOutOfBoundsException ignored) {
-        }
-
-        try {
-            allTypes.last();
-            fail();
-        } catch (ArrayIndexOutOfBoundsException ignored) {
-        }
-    }
-
-    @Test
-    public void last() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-
-        AllTypes allTypes = resultList.last();
-        assertEquals((TEST_DATA_SIZE - 1), allTypes.getColumnLong());
-    }
-
-    @Test
-    public void min() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-
-        Number minimum = resultList.min(AllTypes.FIELD_LONG);
-        assertEquals(0, minimum.intValue());
-    }
-
-    // Test min on empty columns
-    @Test
-    public void min_emptyNonNullFields() {
-        RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
-        assertNull(results.min(NullTypes.FIELD_INTEGER_NOT_NULL));
-        assertNull(results.min(NullTypes.FIELD_FLOAT_NOT_NULL));
-        assertNull(results.min(NullTypes.FIELD_DOUBLE_NOT_NULL));
-        assertNull(results.minDate(NullTypes.FIELD_DATE_NOT_NULL));
-    }
-
-    // Test min on nullable rows with all null values
-    @Test
-    public void min_emptyNullFields() {
-        TestHelper.populateAllNullRowsForNumericTesting(realm);
-
-        RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
-        assertNull(results.max(NullTypes.FIELD_INTEGER_NULL));
-        assertNull(results.max(NullTypes.FIELD_FLOAT_NULL));
-        assertNull(results.max(NullTypes.FIELD_DOUBLE_NULL));
-        assertNull(results.maxDate(NullTypes.FIELD_DATE_NULL));
-    }
-
-    // Test min on nullable rows with partial null values
-    @Test
-    public void min_partialNullRows() {
-        populatePartialNullRowsForNumericTesting();
-
-        RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
-        assertEquals(0, results.min(NullTypes.FIELD_INTEGER_NULL).intValue());
-        assertEquals(0f, results.min(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
-        assertEquals(0d, results.min(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
-    }
-
-    @Test
-    public void max() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-
-        Number maximum = resultList.max(AllTypes.FIELD_LONG);
-        assertEquals(TEST_DATA_SIZE - 1, maximum.intValue());
-    }
-
-    // Test max on empty columns
-    @Test
-    public void max_emptyNonNullFields() {
-        RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
-        assertNull(results.max(NullTypes.FIELD_INTEGER_NOT_NULL));
-        assertNull(results.max(NullTypes.FIELD_FLOAT_NOT_NULL));
-        assertNull(results.max(NullTypes.FIELD_DOUBLE_NOT_NULL));
-        assertNull(results.maxDate(NullTypes.FIELD_DATE_NOT_NULL));
-    }
-
-    // Test max on nullable rows with all null values
-    @Test
-    public void max_emptyNullFields() {
-        TestHelper.populateAllNullRowsForNumericTesting(realm);
-
-        RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
-        assertNull(results.max(NullTypes.FIELD_INTEGER_NULL));
-        assertNull(results.max(NullTypes.FIELD_FLOAT_NULL));
-        assertNull(results.max(NullTypes.FIELD_DOUBLE_NULL));
-        assertNull(results.maxDate(NullTypes.FIELD_DATE_NULL));
-    }
-
-    // Test max on nullable rows with partial null values
-    @Test
-    public void max_partialNullRows() {
-        populatePartialNullRowsForNumericTesting();
-
-        RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
-        assertEquals(1, results.max(NullTypes.FIELD_INTEGER_NULL).intValue());
-        assertEquals(2f, results.max(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
-        assertEquals(3d, results.max(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
-    }
-
-    @Test
-    public void sum() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-
-        Number sum = resultList.sum(AllTypes.FIELD_LONG);
-        // Sum of numbers 0 to M-1: (M-1)*M/2
-        assertEquals((TEST_DATA_SIZE - 1) * TEST_DATA_SIZE / 2, sum.intValue());
-    }
-
-    // Test sum on nullable rows with all null values
-    @Test
-    public void sum_nullRows() {
-        TestHelper.populateAllNullRowsForNumericTesting(realm);
-
-        RealmResults<NullTypes> resultList = realm.where(NullTypes.class).findAll();
-        assertEquals(0, resultList.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
-        assertEquals(0f, resultList.sum(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
-        assertEquals(0d, resultList.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
-    }
-
-    // Test sum on nullable rows with partial null values
-    @Test
-    public void sum_partialNullRows() {
-        populatePartialNullRowsForNumericTesting();
-        RealmResults<NullTypes> resultList = realm.where(NullTypes.class).findAll();
-
-        assertEquals(1, resultList.sum(NullTypes.FIELD_INTEGER_NULL).intValue());
-        assertEquals(2f, resultList.sum(NullTypes.FIELD_FLOAT_NULL).floatValue(), 0f);
-        assertEquals(3d, resultList.sum(NullTypes.FIELD_DOUBLE_NULL).doubleValue(), 0d);
-    }
-
-    @Test
-    public void sum_nonLatinColumnNames() {
-        RealmResults<NonLatinFieldNames> resultList = realm.where(NonLatinFieldNames.class).findAll();
-
-        Number sum = resultList.sum(NonLatinFieldNames.FIELD_LONG_KOREAN_CHAR);
-        // Sum of numbers 0 to M-1: (M-1)*M/2
-        assertEquals((TEST_DATA_SIZE - 1) * TEST_DATA_SIZE / 2, sum.intValue());
-
-        sum = resultList.sum(NonLatinFieldNames.FIELD_LONG_GREEK_CHAR);
-        // Sum of numbers 0 to M-1: (M-1)*M/2
-        assertEquals((TEST_DATA_SIZE - 1) * TEST_DATA_SIZE / 2, sum.intValue());
-    }
-
-    @Test
-    public void avg() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        double N = (double) TEST_DATA_SIZE;
-
-        // Sum of numbers 1 to M: M*(M+1)/2
-        // See setUp() for values of fields
-        // N = TEST_DATA_SIZE
-
-        // Type: double; a = 3.1415
-        // a, a+1, ..., a+i, ..., a+N-1
-        // sum = 3.1415*N + N*(N-1)/2
-        // average = sum/N = 3.1415+(N-1)/2
-        double average = 3.1415 + (N - 1.0) * 0.5;
-        assertEquals(average, resultList.average(AllTypes.FIELD_DOUBLE), 0.0001);
-
-        // Type: long
-        // 0, 1, ..., N-1
-        // sum = N*(N-1)/2
-        // average = sum/N = (N-1)/2
-        assertEquals(0.5 * (N - 1), resultList.average(AllTypes.FIELD_LONG), 0.0001);
-
-        // Type: float; b = 1.234567
-        // b, b+1, ..., b+i, ..., b+N-1
-        // sum = b*N + N*(N-1)/2
-        // average = sum/N = b + (N-1)/2
-        assertEquals(1.234567 + 0.5 * (N - 1.0), resultList.average(AllTypes.FIELD_FLOAT), 0.0001);
-    }
-
-    // Test average on empty columns
-    @Test
-    public void avg_emptyNonNullFields() {
-        RealmResults<NullTypes> resultList = realm.where(NullTypes.class).findAll();
-
-        assertEquals(0d, resultList.average(NullTypes.FIELD_INTEGER_NOT_NULL), 0d);
-        assertEquals(0d, resultList.average(NullTypes.FIELD_FLOAT_NOT_NULL), 0d);
-        assertEquals(0d, resultList.average(NullTypes.FIELD_DOUBLE_NOT_NULL), 0d);
-    }
-
-    // Test average on nullable rows with all null values
-    @Test
-    public void avg_emptyNullFields() {
-        TestHelper.populateAllNullRowsForNumericTesting(realm);
-
-        RealmResults<NullTypes> resultList = realm.where(NullTypes.class).findAll();
-        assertEquals(0d, resultList.average(NullTypes.FIELD_INTEGER_NULL), 0d);
-        assertEquals(0d, resultList.average(NullTypes.FIELD_FLOAT_NULL), 0d);
-        assertEquals(0d, resultList.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
-    }
-
-    // Test average on nullable rows with partial null values
-    @Test
-    public void avg_partialNullRows() {
-        populatePartialNullRowsForNumericTesting();
-        RealmResults<NullTypes> resultList = realm.where(NullTypes.class).findAll();
-
-        assertEquals(0.5, resultList.average(NullTypes.FIELD_INTEGER_NULL), 0d);
-        assertEquals(1.0, resultList.average(NullTypes.FIELD_FLOAT_NULL), 0d);
-        assertEquals(1.5, resultList.average(NullTypes.FIELD_DOUBLE_NULL), 0d);
-    }
-
-    @Test
-    public void remove() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        realm.beginTransaction();
-        resultList.remove(0);
-        realm.commitTransaction();
-
-        assertEquals(TEST_DATA_SIZE - 1, resultList.size());
-
-        AllTypes allTypes = resultList.get(0);
-        assertEquals(1, allTypes.getColumnLong());
-    }
-
-    @Test
-    public void removeLast() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        realm.beginTransaction();
-        resultList.removeLast();
-        realm.commitTransaction();
-
-        assertEquals("ResultList.removeLast did not remove record", TEST_DATA_SIZE - 1, resultList.size());
-
-        AllTypes allTypes = resultList.get(resultList.size() - 1);
-        assertEquals("ResultList.removeLast unexpected last record", TEST_DATA_SIZE - 2, allTypes.getColumnLong());
-
-        RealmResults<AllTypes> resultListCheck = realm.where(AllTypes.class).findAll();
-        assertEquals("ResultList.removeLast not committed", TEST_DATA_SIZE - 1, resultListCheck.size());
-    }
-
-    @Test
-    public void sort_long() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = realm.allObjects(AllTypes.class);
-        sortedList.sort(AllTypes.FIELD_LONG, Sort.DESCENDING);
-        assertEquals("Should have same size", resultList.size(), sortedList.size());
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals("First excepted to be last", resultList.first().getColumnLong(), sortedList.last().getColumnLong());
-
-        sortedList.sort(AllTypes.FIELD_LONG, Sort.ASCENDING);
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals("First excepted to be first", resultList.first().getColumnLong(), sortedList.first().getColumnLong());
-        assertEquals("Last excepted to be last", resultList.last().getColumnLong(), sortedList.last().getColumnLong());
-
-        sortedList.sort(AllTypes.FIELD_LONG, Sort.DESCENDING);
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-    }
-
-    @Test
-    public void sort_date() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.where().findAll();
-        sortedList.sort(AllTypes.FIELD_DATE, Sort.DESCENDING);
-        assertEquals(resultList.size(), sortedList.size());
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals(resultList.first().getColumnDate(), sortedList.last().getColumnDate());
-
-        RealmResults<AllTypes> reverseList = sortedList.where().findAll();
-        reverseList.sort(AllTypes.FIELD_DATE, Sort.ASCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseList.size());
-        assertEquals(resultList.first().getColumnDate(), reverseList.first().getColumnDate());
-        assertEquals(resultList.last().getColumnDate(), reverseList.last().getColumnDate());
-
-        RealmResults<AllTypes> reserveSortedList = reverseList.where().findAll();
-        reserveSortedList.sort(AllTypes.FIELD_DATE, Sort.DESCENDING);
-        assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
-    }
-
-    @Test
-    public void sort_boolean() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.where().findAll();
-        sortedList.sort(AllTypes.FIELD_BOOLEAN, Sort.DESCENDING);
-        assertEquals(resultList.size(), sortedList.size());
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals(false, sortedList.last().isColumnBoolean());
-        assertEquals(true, sortedList.first().isColumnBoolean());
-        assertEquals(true, sortedList.get(TEST_DATA_FIRST_HALF).isColumnBoolean());
-        assertEquals(false, sortedList.get(TEST_DATA_LAST_HALF).isColumnBoolean());
-
-        RealmResults<AllTypes> reverseList = sortedList.where().findAll();
-        reverseList.sort(AllTypes.FIELD_BOOLEAN, Sort.ASCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseList.size());
-        assertEquals(true, reverseList.last().isColumnBoolean());
-        assertEquals(false, reverseList.first().isColumnBoolean());
-        assertEquals(false, reverseList.get(TEST_DATA_FIRST_HALF).isColumnBoolean());
-        assertEquals(true, reverseList.get(TEST_DATA_LAST_HALF).isColumnBoolean());
-
-        RealmResults<AllTypes> reserveSortedList = reverseList.where().findAll();
-        reserveSortedList.sort(AllTypes.FIELD_BOOLEAN, Sort.DESCENDING);
-        assertEquals(TEST_DATA_SIZE, reserveSortedList.size());
-        assertEquals(reserveSortedList.first(), sortedList.first());
-    }
-
-    @Test
-    public void sort_string() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.where().findAll();
-        sortedList.sort(AllTypes.FIELD_STRING, Sort.DESCENDING);
-
-        assertEquals(resultList.size(), sortedList.size());
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals(resultList.first().getColumnString(), sortedList.last().getColumnString());
-
-        RealmResults<AllTypes> reverseList = sortedList.where().findAll();
-        reverseList.sort(AllTypes.FIELD_STRING, Sort.ASCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseList.size());
-        assertEquals(resultList.first().getColumnString(), reverseList.first().getColumnString());
-
-        int numberOfDigits = 1 + ((int) Math.log10(TEST_DATA_SIZE));
-        int largestNumber = 1;
-        for (int i = 1; i < numberOfDigits; i++)
-            largestNumber *= 10;  // 10*10* ... *10
-        largestNumber = largestNumber - 1;
-        assertEquals(resultList.get(largestNumber).getColumnString(), reverseList.last().getColumnString());
-        RealmResults<AllTypes> reverseSortedList = reverseList.where().findAll();
-        reverseList.sort(AllTypes.FIELD_STRING, Sort.DESCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseSortedList.size());
-    }
-
-    @Test
-    public void sort_double() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.where().findAll();
-        sortedList.sort(AllTypes.FIELD_DOUBLE, Sort.DESCENDING);
-        assertEquals(resultList.size(), sortedList.size());
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals(resultList.first().getColumnDouble(), sortedList.last().getColumnDouble(), 0D);
-
-        RealmResults<AllTypes> reverseList = sortedList.where().findAll();
-        reverseList.sort(AllTypes.FIELD_DOUBLE, Sort.ASCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseList.size());
-        assertEquals(resultList.first().getColumnDouble(), reverseList.first().getColumnDouble(), 0D);
-        assertEquals(resultList.last().getColumnDouble(), reverseList.last().getColumnDouble(), 0D);
-
-        RealmResults<AllTypes> reverseSortedList = reverseList.where().findAll();
-        reverseSortedList.sort(AllTypes.FIELD_DOUBLE, Sort.DESCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseSortedList.size());
-    }
-
-    @Test
-    public void sort_float() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        RealmResults<AllTypes> sortedList = resultList.where().findAll();
-        sortedList.sort(AllTypes.FIELD_FLOAT, Sort.DESCENDING);
-        assertEquals(resultList.size(), sortedList.size());
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals(resultList.first().getColumnFloat(), sortedList.last().getColumnFloat(), 0D);
-
-        RealmResults<AllTypes> reverseList = sortedList.where().findAll();
-        reverseList.sort(AllTypes.FIELD_FLOAT, Sort.ASCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseList.size());
-        assertEquals(resultList.first().getColumnFloat(), reverseList.first().getColumnFloat(), 0D);
-        assertEquals(resultList.last().getColumnFloat(), reverseList.last().getColumnFloat(), 0D);
-
-        RealmResults<AllTypes> reverseSortedList = reverseList.where().findAll();
-        reverseSortedList.sort(AllTypes.FIELD_FLOAT, Sort.DESCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseSortedList.size());
-    }
-
-    private void doTestSortOnColumnWithPartialNullValues(String fieldName) {
-        RealmResults<NullTypes> resultList = realm.where(NullTypes.class).findAll();
-        // Ascending
-        RealmResults<NullTypes> sortedList = realm.allObjects(NullTypes.class);
-        sortedList.sort(fieldName, Sort.ASCENDING);
-        assertEquals("Should have same size", resultList.size(), sortedList.size());
-        // Null should always be the first one in the ascending sorted list
-        assertEquals(2, sortedList.first().getId());
-        assertEquals(1, sortedList.last().getId());
-
-        // Descending
-        sortedList = realm.allObjects(NullTypes.class);
-        sortedList.sort(fieldName, Sort.DESCENDING);
-        assertEquals("Should have same size", resultList.size(), sortedList.size());
-        assertEquals(1, sortedList.first().getId());
-        // Null should always be the last one in the descending sorted list
-        assertEquals(2, sortedList.last().getId());
-    }
-
-    // Test sort on nullable fields with null values partially
-    @Test
-    public void sort_rowsWithPartialNullValues() {
-        populatePartialNullRowsForNumericTesting();
-
-        // 1 String
-        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_STRING_NULL);
-
-        // 3 Boolean
-        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_BOOLEAN_NULL);
-
-        // 6 Integer
-        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_INTEGER_NULL);
-
-        // 7 Float
-        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_FLOAT_NULL);
-
-        // 8 Double
-        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_DOUBLE_NULL);
-
-        // 10 Date
-        doTestSortOnColumnWithPartialNullValues(NullTypes.FIELD_DATE_NULL);
-    }
-
-    @Test
-    public void sort_nonExistingColumn() {
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        thrown.expect(IllegalArgumentException.class);
-        resultList.sort("Non-existing");
-    }
-
-    @Test
-    public void sort_danishCharacters() {
-        realm.beginTransaction();
-        realm.clear(AllTypes.class);
-        AllTypes at1 = realm.createObject(AllTypes.class);
-        at1.setColumnString("Æble");
-        AllTypes at2 = realm.createObject(AllTypes.class);
-        at2.setColumnString("Øl");
-        AllTypes at3 = realm.createObject(AllTypes.class);
-        at3.setColumnString("Århus");
-        realm.commitTransaction();
-
-        RealmResults<AllTypes> result = realm.allObjects(AllTypes.class);
-        RealmResults<AllTypes> sortedResult = result.where().findAll();
-        sortedResult.sort(AllTypes.FIELD_STRING);
-
-        assertEquals(3, sortedResult.size());
-        assertEquals("Æble", sortedResult.first().getColumnString());
-        assertEquals("Æble", sortedResult.get(0).getColumnString());
-        assertEquals("Øl", sortedResult.get(1).getColumnString());
-        assertEquals("Århus", sortedResult.get(2).getColumnString());
-
-        RealmResults<AllTypes> reverseResult = result.where().findAll();
-        reverseResult.sort(AllTypes.FIELD_STRING, Sort.DESCENDING);
-        assertEquals(3, reverseResult.size());
-        assertEquals("Æble", reverseResult.last().getColumnString());
-        assertEquals("Århus", reverseResult.get(0).getColumnString());
-        assertEquals("Øl", reverseResult.get(1).getColumnString());
-        assertEquals("Æble", reverseResult.get(2).getColumnString());
-    }
-
-    @Test
-    public void sort_russianCharacters() {
-        realm.beginTransaction();
-        realm.clear(AllTypes.class);
-        AllTypes at1 = realm.createObject(AllTypes.class);
-        at1.setColumnString("Санкт-Петербург");
-        AllTypes at2 = realm.createObject(AllTypes.class);
-        at2.setColumnString("Москва");
-        AllTypes at3 = realm.createObject(AllTypes.class);
-        at3.setColumnString("Новороссийск");
-        realm.commitTransaction();
-
-        RealmResults<AllTypes> result = realm.allObjects(AllTypes.class);
-        RealmResults<AllTypes> sortedResult = result.where().findAll();
-        sortedResult.sort(AllTypes.FIELD_STRING);
-
-        assertEquals(3, sortedResult.size());
-        assertEquals("Москва", sortedResult.first().getColumnString());
-        assertEquals("Москва", sortedResult.get(0).getColumnString());
-        assertEquals("Новороссийск", sortedResult.get(1).getColumnString());
-        assertEquals("Санкт-Петербург", sortedResult.get(2).getColumnString());
-
-        RealmResults<AllTypes> reverseResult = result.where().findAll();
-        reverseResult.sort(AllTypes.FIELD_STRING, Sort.DESCENDING);
-        assertEquals(3, reverseResult.size());
-        assertEquals("Москва", reverseResult.last().getColumnString());
-        assertEquals("Санкт-Петербург", reverseResult.get(0).getColumnString());
-        assertEquals("Новороссийск", reverseResult.get(1).getColumnString());
-        assertEquals("Москва", reverseResult.get(2).getColumnString());
-    }
-
-    @Test
-    public void sort_greekCharacters() {
-        realm.beginTransaction();
-        realm.clear(AllTypes.class);
-        AllTypes at1 = realm.createObject(AllTypes.class);
-        at1.setColumnString("αύριο");
-        AllTypes at2 = realm.createObject(AllTypes.class);
-        at2.setColumnString("ημέρες");
-        AllTypes at3 = realm.createObject(AllTypes.class);
-        at3.setColumnString("δοκιμές");
-        realm.commitTransaction();
-
-        RealmResults<AllTypes> result = realm.allObjects(AllTypes.class);
-        RealmResults<AllTypes> sortedResult = result.where().findAll();
-        sortedResult.sort(AllTypes.FIELD_STRING);
-
-        assertEquals(3, sortedResult.size());
-        assertEquals("αύριο", sortedResult.first().getColumnString());
-        assertEquals("αύριο", sortedResult.get(0).getColumnString());
-        assertEquals("δοκιμές", sortedResult.get(1).getColumnString());
-        assertEquals("ημέρες", sortedResult.get(2).getColumnString());
-
-        RealmResults<AllTypes> reverseResult = result.where().findAll();
-        reverseResult.sort(AllTypes.FIELD_STRING, Sort.DESCENDING);
-        assertEquals(3, reverseResult.size());
-        assertEquals("αύριο", reverseResult.last().getColumnString());
-        assertEquals("ημέρες", reverseResult.get(0).getColumnString());
-        assertEquals("δοκιμές", reverseResult.get(1).getColumnString());
-        assertEquals("αύριο", reverseResult.get(2).getColumnString());
-    }
-
-    //No sorting order defined. There are Korean, Arabic and Chinese characters.
-    @Test
-    public void sort_manyDifferentCharacters() {
-        realm.beginTransaction();
-        realm.clear(AllTypes.class);
-        AllTypes at1 = realm.createObject(AllTypes.class);
-        at1.setColumnString("단위");
-        AllTypes at2 = realm.createObject(AllTypes.class);
-        at2.setColumnString("테스트");
-        AllTypes at3 = realm.createObject(AllTypes.class);
-        at3.setColumnString("وحدة");
-        AllTypes at4 = realm.createObject(AllTypes.class);
-        at4.setColumnString("اختبار");
-        AllTypes at5 = realm.createObject(AllTypes.class);
-        at5.setColumnString("单位");
-        AllTypes at6 = realm.createObject(AllTypes.class);
-        at6.setColumnString("试验");
-        AllTypes at7 = realm.createObject(AllTypes.class);
-        at7.setColumnString("單位");
-        AllTypes at8 = realm.createObject(AllTypes.class);
-        at8.setColumnString("測試");
-        realm.commitTransaction();
-
-        RealmResults<AllTypes> result = realm.allObjects(AllTypes.class);
-        RealmResults<AllTypes> sortedResult = result.where().findAll();
-        sortedResult.sort(AllTypes.FIELD_STRING);
-
-        assertEquals(8, sortedResult.size());
-
-        @SuppressWarnings("UnnecessaryLocalVariable")
-        RealmResults<AllTypes> reverseResult = result;
-        reverseResult.sort(AllTypes.FIELD_STRING, Sort.DESCENDING);
-        assertEquals(8, reverseResult.size());
-    }
-
-    @Test
-    public void sort_twoLanguages() {
-        realm.beginTransaction();
-        realm.clear(AllTypes.class);
-        AllTypes allTypes1 = realm.createObject(AllTypes.class);
-        allTypes1.setColumnString("test");
-        AllTypes allTypes2 = realm.createObject(AllTypes.class);
-        allTypes2.setColumnString("αύριο");
-        AllTypes allTypes3 = realm.createObject(AllTypes.class);
-        allTypes3.setColumnString("work");
-        realm.commitTransaction();
-
-        try {
-            RealmResults<AllTypes> result = realm.allObjects(AllTypes.class);
-            result.sort(AllTypes.FIELD_STRING);
-        } catch (IllegalArgumentException e) {
-            fail("Failed to sort with two kinds of alphabets");
-        }
-    }
-
-    @Test
-    public void sort_usingChildObject() {
-        realm.beginTransaction();
-        Owner owner = realm.createObject(Owner.class);
-        owner.setName("owner");
-        Cat cat = realm.createObject(Cat.class);
-        cat.setName("cat");
-        owner.setCat(cat);
-        realm.commitTransaction();
-
-        RealmQuery<Owner> query = realm.where(Owner.class);
-        RealmResults<Owner> owners = query.findAll();
-
-        try {
-            owners.sort("cat.name");
-            fail("Sorting by child object properties should result in a IllegalArgumentException");
-        } catch (IllegalArgumentException ignore) {
-        }
-    }
-
-    @Test
-    public void sort_nullArguments() {
-        RealmResults<AllTypes> result = realm.allObjects(AllTypes.class);
-        try {
-            result.sort(null);
-            fail("Sorting with a null field name should throw an IllegalArgumentException");
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            result.sort((String) null, null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-    }
-
-    @Test
-    public void sort_emptyResults() {
-        realm.beginTransaction();
-        realm.clear(AllTypes.class);
-        realm.commitTransaction();
-        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
-        assertEquals(0, results.size());
-        results.sort(AllTypes.FIELD_STRING);
-        assertEquals(0, results.size());
-    }
-
-    @Test
-    public void sort_singleField() {
-        RealmResults<AllTypes> sortedList = realm.allObjects(AllTypes.class);
-        sortedList.sort(new String[]{AllTypes.FIELD_LONG}, new Sort[]{Sort.DESCENDING});
-        assertEquals(TEST_DATA_SIZE, sortedList.size());
-        assertEquals(TEST_DATA_SIZE - 1, sortedList.first().getColumnLong());
-        assertEquals(0, sortedList.last().getColumnLong());
-    }
-
-    @Test
-    public void count() {
-        assertEquals(TEST_DATA_SIZE, realm.where(AllTypes.class).count());
-    }
-
     @Test
     public void findFirst() {
         AllTypes result = realm.where(AllTypes.class).findFirst();
@@ -892,117 +119,6 @@ public class RealmResultsTests {
 
         AllTypes none = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_STRING, "smurf").findFirst();
         assertNull(none);
-    }
-
-    @Test
-    public void where_equalTo_manyConditions() {
-        RealmQuery<AllTypes> query = realm.where(AllTypes.class);
-        query.equalTo(AllTypes.FIELD_LONG, 0);
-        for (int i = 1; i < TEST_DATA_SIZE; i++) {
-            query.or().equalTo(AllTypes.FIELD_LONG, i);
-        }
-        RealmResults<AllTypes> allTypesRealmResults = query.findAll();
-        assertEquals(TEST_DATA_SIZE, allTypesRealmResults.size());
-    }
-
-    @Test
-    public void where() {
-        RealmQuery<AllTypes> query = realm.where(AllTypes.class).findAll().where();
-        assertNotNull(query);
-    }
-
-    @Test
-    public void where_contains() {
-        RealmQuery<AllTypes> query = realm.where(AllTypes.class).findAll().where();
-        AllTypes item = query.findFirst();
-        assertTrue("Item should exist in results.", query.findAll().contains(item));
-    }
-
-    @Test
-    public void where_contains_null() {
-        RealmQuery<AllTypes> query = realm.where(AllTypes.class).findAll().where();
-        assertFalse("Should not contain a null item.", query.findAll().contains(null));
-    }
-
-    @Test
-    public void where_shouldNotContainRemovedItem() {
-        RealmQuery<AllTypes> query = realm.where(AllTypes.class).findAll().where();
-        AllTypes item = realm.where(AllTypes.class).findFirst();
-        realm.beginTransaction();
-        item.removeFromRealm();
-        realm.commitTransaction();
-        assertFalse("Should not contain a removed item.", query.findAll().contains(item));
-    }
-
-    /**
-     * Test to see if a particular item that does exist in the same Realm does not
-     * exist in the result set of another query.
-     */
-    @Test
-    public void where_lessThanGreaterThan() {
-        RealmResults<AllTypes> items = realm.where(AllTypes.class).lessThan(AllTypes.FIELD_LONG, 1000).findAll();
-        AllTypes anotherType = realm.where(AllTypes.class).greaterThan(AllTypes.FIELD_LONG, 1000).findFirst();
-        assertFalse("Should not be able to find item in another result list.", items.contains(anotherType));
-    }
-
-    // Tests that `contains()` correctly doesn't find RealmObjects that belongs to another Realm file.
-    @Test
-    public void contains_realmObjectFromOtherRealm() {
-        RealmConfiguration realmConfig = configFactory.createConfiguration("contains_test.realm");
-        Realm realmTwo = Realm.getInstance(realmConfig);
-        try {
-
-            realmTwo.beginTransaction();
-            realmTwo.allObjects(AllTypes.class).clear();
-            realmTwo.allObjects(NonLatinFieldNames.class).clear();
-
-            for (int i = 0; i < TEST_DATA_SIZE; ++i) {
-                AllTypes allTypes = realmTwo.createObject(AllTypes.class);
-                allTypes.setColumnBoolean((i % 2) == 0);
-                allTypes.setColumnBinary(new byte[]{1, 2, 3});
-                allTypes.setColumnDate(new Date(YEAR_MILLIS * (i - TEST_DATA_SIZE / 2)));
-                allTypes.setColumnDouble(3.1415 + i);
-                allTypes.setColumnFloat(1.234567f + i);
-                allTypes.setColumnString("test data " + i);
-                allTypes.setColumnLong(i);
-                Dog d = realmTwo.createObject(Dog.class);
-                d.setName("Foo " + i);
-                allTypes.setColumnRealmObject(d);
-                allTypes.getColumnRealmList().add(d);
-                NonLatinFieldNames nonLatinFieldNames = realmTwo.createObject(NonLatinFieldNames.class);
-                nonLatinFieldNames.set델타(i);
-                nonLatinFieldNames.setΔέλτα(i);
-            }
-            realmTwo.commitTransaction();
-
-            final AllTypes item = realmTwo.where(AllTypes.class).findFirst();
-
-            assertFalse("Should not be able to find one object in another Realm via RealmResults#contains",
-                    realm.where(AllTypes.class).findAll().contains(item));
-
-        } finally {
-            if (realmTwo != null && !realmTwo.isClosed()) {
-                realmTwo.close();
-            }
-        }
-    }
-
-    @Test
-    public void where_findAll_size() {
-        RealmResults<AllTypes> allTypes = realm.where(AllTypes.class).findAll();
-        assertEquals(TEST_DATA_SIZE, allTypes.size());
-
-        // querying a RealmResults should find objects that fulfill the condition
-        RealmResults<AllTypes> onedigits = allTypes.where().lessThan(AllTypes.FIELD_LONG, 10).findAll();
-        assertEquals(Math.min(10, TEST_DATA_SIZE), onedigits.size());
-
-        // if no objects fulfill conditions, the result has zero objects
-        RealmResults<AllTypes> none = allTypes.where().greaterThan(AllTypes.FIELD_LONG, TEST_DATA_SIZE).findAll();
-        assertEquals(0, none.size());
-
-        // querying a result with zero objects must give zero objects
-        RealmResults<AllTypes> stillNone = none.where().greaterThan(AllTypes.FIELD_LONG, TEST_DATA_SIZE).findAll();
-        assertEquals(0, stillNone.size());
     }
 
     @Test
@@ -1019,56 +135,6 @@ public class RealmResultsTests {
     }
 
     @Test
-    public void where_findAllSorted() {
-        RealmResults<AllTypes> allTypes = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG, Sort.ASCENDING);
-        assertEquals(TEST_DATA_SIZE, allTypes.size());
-        assertEquals(0, allTypes.first().getColumnLong());
-        assertEquals(TEST_DATA_SIZE - 1, allTypes.last().getColumnLong());
-
-        RealmResults<AllTypes> reverseList = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG, Sort.DESCENDING);
-        assertEquals(TEST_DATA_SIZE, reverseList.size());
-        assertEquals(0, reverseList.last().getColumnLong());
-        assertEquals(TEST_DATA_SIZE - 1, reverseList.first().getColumnLong());
-
-        try {
-            realm.where(AllTypes.class).findAllSorted("invalid",
-                    Sort.DESCENDING);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-    }
-
-    @Test
-    public void where_queryDateField() {
-        RealmQuery<AllTypes> query = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_DATE, new Date(YEAR_MILLIS * 5));
-        RealmResults<AllTypes> all = query.findAll();
-        assertEquals(1, query.count());
-        assertEquals(1, all.size());
-
-        // before 1901
-        query = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_DATE, new Date(YEAR_MILLIS * -100));
-        all = query.findAll();
-        assertEquals(1, query.count());
-        assertEquals(1, all.size());
-
-        // after 2038
-        query = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_DATE, new Date(YEAR_MILLIS * 100));
-        all = query.findAll();
-        assertEquals(1, query.count());
-        assertEquals(1, all.size());
-    }
-
-    @Test
-    public void indexOf() {
-        try {
-            RealmResults<AllTypes> all = realm.allObjects(AllTypes.class);
-            all.indexOf(all.first());
-            fail();
-        } catch (NoSuchMethodError ignored) {
-        }
-    }
-
-    @Test
     public void subList() {
         RealmResults<AllTypes> list = realm.allObjects(AllTypes.class);
         list.sort("columnLong");
@@ -1076,196 +142,53 @@ public class RealmResultsTests {
         assertEquals(TEST_DATA_SIZE - 1, sublist.get(sublist.size() - 1).getColumnLong());
     }
 
-    // Setting a not-nullable field to null is an error
-    // TODO Move this to RealmObjectTests?
-    @Test
-    public void setter_nullValueInRequiredField() {
-        TestHelper.populateTestRealmForNullTests(realm);
-        RealmResults<NullTypes> list = realm.allObjects(NullTypes.class);
-
-        // 1 String
-        try {
-            realm.beginTransaction();
-            list.first().setFieldStringNotNull(null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            realm.cancelTransaction();
-        }
-
-        // 2 Bytes
-        try {
-            realm.beginTransaction();
-            list.first().setFieldBytesNotNull(null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            realm.cancelTransaction();
-        }
-
-        // 3 Boolean
-        try {
-            realm.beginTransaction();
-            list.first().setFieldBooleanNotNull(null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            realm.cancelTransaction();
-        }
-
-        // 4 Byte
-        try {
-            realm.beginTransaction();
-            list.first().setFieldBytesNotNull(null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            realm.cancelTransaction();
-        }
-
-        // 5 Short 6 Integer 7 Long are skipped for this case, same with Bytes
-
-        // 8 Float
-        try {
-            realm.beginTransaction();
-            list.first().setFieldFloatNotNull(null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            realm.cancelTransaction();
-        }
-
-        // 9 Double
-        try {
-            realm.beginTransaction();
-            list.first().setFieldDoubleNotNull(null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            realm.cancelTransaction();
-        }
-
-        // 10 Date
-        try {
-            realm.beginTransaction();
-            list.first().setFieldDateNotNull(null);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            realm.cancelTransaction();
-        }
-    }
-
-    // Setting a nullable field to null is not an error
-    // TODO Move this to RealmObjectsTest?
-    @Test
-    public void setter_nullValueInNullableField() {
-        TestHelper.populateTestRealmForNullTests(realm);
-        RealmResults<NullTypes> list = realm.allObjects(NullTypes.class);
-
-        // 1 String
-        realm.beginTransaction();
-        list.first().setFieldStringNull(null);
-        realm.commitTransaction();
-        assertNull(realm.allObjects(NullTypes.class).first().getFieldStringNull());
-
-        // 2 Bytes
-        realm.beginTransaction();
-        list.first().setFieldBytesNull(null);
-        realm.commitTransaction();
-        assertNull(realm.allObjects(NullTypes.class).first().getFieldBytesNull());
-
-        // 3 Boolean
-        realm.beginTransaction();
-        list.first().setFieldBooleanNull(null);
-        realm.commitTransaction();
-        assertNull(realm.allObjects(NullTypes.class).first().getFieldBooleanNull());
-
-        // 4 Byte
-        // 5 Short 6 Integer 7 Long are skipped
-        realm.beginTransaction();
-        list.first().setFieldByteNull(null);
-        realm.commitTransaction();
-        assertNull(realm.allObjects(NullTypes.class).first().getFieldByteNull());
-
-        // 8 Float
-        realm.beginTransaction();
-        list.first().setFieldFloatNull(null);
-        realm.commitTransaction();
-        assertNull(realm.allObjects(NullTypes.class).first().getFieldFloatNull());
-
-        // 9 Double
-        realm.beginTransaction();
-        list.first().setFieldDoubleNull(null);
-        realm.commitTransaction();
-        assertNull(realm.allObjects(NullTypes.class).first().getFieldDoubleNull());
-
-        // 10 Date
-        realm.beginTransaction();
-        list.first().setFieldDateNull(null);
-        realm.commitTransaction();
-        assertNull(realm.allObjects(NullTypes.class).first().getFieldDateNull());
-    }
-
+    @SuppressWarnings("deprecation")
     @Test
     public void unsupportedMethods() {
-        RealmResults<AllTypes> result = realm.where(AllTypes.class).findAll();
+        for (CollectionMutatorMethod method : CollectionMutatorMethod.values()) {
+            try {
+                switch (method) {
+                    case ADD_OBJECT: collection.add(new AllTypes());
+                    case ADD_ALL_OBJECTS: collection.addAll(Collections.singletonList(new AllTypes())); break;
+                    case CLEAR: collection.clear(); break;
+                    case REMOVE_OBJECT: collection.remove(new AllTypes());
+                    case REMOVE_ALL: collection.removeAll(Collections.singletonList(new AllTypes())); break;
+                    case RETAIN_ALL: collection.retainAll(Collections.singletonList(new AllTypes())); break;
 
-        try { //noinspection deprecation
-            result.add(null);
-            fail();
-        } catch (UnsupportedOperationException ignored) {
+                    // Supported methods
+                    case DELETE_ALL:
+                        continue;
+                }
+                fail("Unknown method or failed to throw:" + method);
+            } catch (UnsupportedOperationException ignored) {
+            }
         }
-        try {
-            result.set(0, null);
-            fail();
-        } catch (UnsupportedOperationException ignored) {
+
+        for (OrderedCollectionMutatorMethod method : OrderedCollectionMutatorMethod.values()) {
+            try {
+                switch (method) {
+                    case ADD_INDEX: collection.add(0, new AllTypes()); break;
+                    case ADD_ALL_INDEX: collection.addAll(0, Collections.singletonList(new AllTypes())); break;
+                    case SET: collection.set(0, new AllTypes()); break;
+                    case REMOVE_INDEX: collection.remove(0); break;
+
+                    // Supported methods
+                    case DELETE_INDEX:
+                    case DELETE_FIRST:
+                    case DELETE_LAST:
+                        continue;
+                }
+                fail("Unknown method or failed to throw:" + method);
+            } catch (UnsupportedOperationException ignored) {
+            }
         }
-    }
-
-
-    // Test that all methods that require a transaction (ie. any function that mutates Realm data)
-    @Test
-    public void mutableMethodsOutsideTransactions() {
-        RealmResults<AllTypes> result = realm.where(AllTypes.class).findAll();
-
-        try {
-            result.clear();
-            fail();
-        } catch (IllegalStateException ignored) {
-        }
-        try {
-            result.remove(0);
-            fail();
-        } catch (IllegalStateException ignored) {
-        }
-        try {
-            result.removeLast();
-            fail();
-        } catch (IllegalStateException ignored) {
-        }
-    }
-
-    // TODO: More extended tests of querying all types must be done.
-
-    @Test
-    public void isValid() {
-        final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
-
-        assertTrue(results.isValid());
-        populateTestRealm(1);
-        // still valid if result changed
-        assertTrue(results.isValid());
-
-        realm.close();
-        assertFalse(results.isValid());
     }
 
     // Triggered an ARM bug
     @Test
     public void verifyArmComparisons() {
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         long id = -1;
         for (int i = 0; i < 10; i++) {
             AllTypes allTypes = realm.createObject(AllTypes.class);
@@ -1343,7 +266,6 @@ public class RealmResultsTests {
         // all three results are the same object
         assertTrue(allResults == distinctDates);
         assertTrue(allResults == distinctBooleans);
-        assertTrue(distinctDates == distinctBooleans);
     }
 
     @Test
@@ -1441,16 +363,9 @@ public class RealmResultsTests {
     }
 
     // distinctAsync
-    private Realm openRealmInstance(String name) {
-        RealmConfiguration config = configFactory.createConfiguration(name);
-        Realm.deleteRealm(config);
-        return Realm.getInstance(config);
-    }
-
     private void populateTestRealm(Realm testRealm, int objects) {
         testRealm.beginTransaction();
-        testRealm.allObjects(AllTypes.class).clear();
-        testRealm.allObjects(NonLatinFieldNames.class).clear();
+        testRealm.deleteAll();
         for (int i = 0; i < objects; ++i) {
             AllTypes allTypes = testRealm.createObject(AllTypes.class);
             allTypes.setColumnBoolean((i % 3) == 0);
@@ -1695,12 +610,12 @@ public class RealmResultsTests {
         }
         // a null string field in the middle
         try {
-            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, (String)null, AnnotationIndexTypes.FIELD_INDEX_INT);
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, null, AnnotationIndexTypes.FIELD_INDEX_INT);
         } catch (IllegalArgumentException ignored) {
         }
         // a null string field at the end
         try {
-            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, (String)null);
+            results.distinct(AnnotationIndexTypes.FIELD_INDEX_BOOL, AnnotationIndexTypes.FIELD_INDEX_INT, null);
         } catch (IllegalArgumentException ignored) {
         }
         // (String)null makes varargs a null array.
@@ -1710,17 +625,17 @@ public class RealmResultsTests {
         }
         // Two (String)null for first and varargs fields
         try {
-            results.distinct((String)null, (String)null);
+            results.distinct(null, (String) null);
         } catch (IllegalArgumentException ignored) {
         }
         // "" & (String)null combination
         try {
-            results.distinct("", (String)null);
+            results.distinct("", (String) null);
         } catch (IllegalArgumentException ignored) {
         }
         // "" & (String)null combination
         try {
-            results.distinct((String)null, "");
+            results.distinct(null, "");
         } catch (IllegalArgumentException ignored) {
         }
         // Two empty fields tests
@@ -1828,10 +743,9 @@ public class RealmResultsTests {
 
 
         RealmResults<Dog> dogs = owner.getDogs().where().equalTo(Dog.FIELD_NAME, "name_0").findAll();
-        //dogs = dogs.where().findFirst().getOwner().getDogs().where().equalTo(Dog.FIELD_NAME, "name_0").findAll();
 
         realm.beginTransaction();
-        owner.removeFromRealm();
+        owner.deleteFromRealm();
         realm.commitTransaction();
         return dogs;
     }
@@ -1851,7 +765,7 @@ public class RealmResultsTests {
     public void first_resultsBuiltOnDeletedLinkView() {
         try {
             populateRealmResultsOnDeletedLinkView().first();
-        } catch (ArrayIndexOutOfBoundsException ignored) {
+        } catch (IndexOutOfBoundsException ignored) {
         }
     }
 
@@ -1859,7 +773,7 @@ public class RealmResultsTests {
     public void last_resultsBuiltOnDeletedLinkView() {
         try {
             populateRealmResultsOnDeletedLinkView().last();
-        } catch (ArrayIndexOutOfBoundsException ignored) {
+        } catch (IndexOutOfBoundsException ignored) {
         }
     }
 
@@ -1880,42 +794,186 @@ public class RealmResultsTests {
     }
 
     @Test
-    public void clear_resultsBuiltOnDeletedLinkView() {
-        RealmResults<Dog> dogs = populateRealmResultsOnDeletedLinkView();
-        realm.beginTransaction();
-        dogs.clear();
-        assertEquals(0, dogs.size());
-        realm.commitTransaction();
-    }
-
-    @Test
-    public void max_resultsBuiltOnDeletedLinkView() {
-        RealmResults<Dog> dogs = populateRealmResultsOnDeletedLinkView();
-        assertNull(dogs.max(Dog.FIELD_AGE));
-        assertNull(dogs.max(Dog.FIELD_HEIGHT));
-        assertNull(dogs.max(Dog.FIELD_WEIGHT));
-    }
-
-    @Test
-    public void max_dateResultsBuiltOnDeletedLinkView() {
-        assertEquals(null, populateRealmResultsOnDeletedLinkView().maxDate(Dog.FIELD_BIRTHDAY));
+    public void where_resultsBuiltOnDeletedLinkView() {
+        OrderedRealmCollection<CyclicType> results = populateCollectionOnDeletedLinkView(realm, ManagedCollection.REALMRESULTS);
+        assertEquals(0, results.where().findAll().size());
     }
 
     @Test
     public void min_resultsBuiltOnDeletedLinkView() {
-        RealmResults<Dog> dogs = populateRealmResultsOnDeletedLinkView();
-        assertNull(dogs.min(Dog.FIELD_AGE));
-        assertNull(dogs.min(Dog.FIELD_HEIGHT));
-        assertNull(dogs.min(Dog.FIELD_WEIGHT));
+        OrderedRealmCollection<CyclicType> results = populateCollectionOnDeletedLinkView(realm, ManagedCollection.REALMRESULTS);
+        assertNull(results.min(CyclicType.FIELD_ID));
     }
 
     @Test
-    public void minDateResultsBuiltOnDeletedLinkView() {
-        assertEquals(null, populateRealmResultsOnDeletedLinkView().minDate(Dog.FIELD_BIRTHDAY));
+    public void min_dateResultsBuiltOnDeletedLinkView() {
+        OrderedRealmCollection<CyclicType> results = populateCollectionOnDeletedLinkView(realm, ManagedCollection.REALMRESULTS);
+        assertEquals(null, results.minDate(CyclicType.FIELD_DATE));
     }
 
     @Test
-    public void whereResultsBuiltOnDeletedLinkView() {
-        assertEquals(0, populateRealmResultsOnDeletedLinkView().where().findAll().size());
+    public void max_dateResultsBuiltOnDeletedLinkView() {
+        OrderedRealmCollection<CyclicType> results = populateCollectionOnDeletedLinkView(realm, ManagedCollection.REALMRESULTS);
+        assertEquals(null, results.maxDate(CyclicType.FIELD_DATE));
+    }
+
+    @Test
+    public void max_resultsBuiltOnDeletedLinkView() {
+        OrderedRealmCollection<CyclicType> results = populateCollectionOnDeletedLinkView(realm, ManagedCollection.REALMRESULTS);
+        assertNull(results.max(CyclicType.FIELD_ID));
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void addChangeListener() {
+        Realm realm = looperThread.realm;
+        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+
+        collection.addChangeListener(new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void addChangeListener_twice() {
+        final AtomicInteger listenersTriggered = new AtomicInteger(0);
+        final Realm realm = looperThread.realm;
+        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+
+        RealmChangeListener listener = new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                listenersTriggered.incrementAndGet();
+            }
+        };
+
+        realm.addChangeListener(new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                listenersTriggered.incrementAndGet();
+                looperThread.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (listenersTriggered.get() == 1) {
+                            looperThread.testComplete();
+                        } else {
+                            fail("Only global listener should be triggered");
+                        }
+                    }
+                });
+            }
+        });
+
+        // Adding it twice will be ignored, so removing it will not cause the listener to be triggered.
+        collection.addChangeListener(listener);
+        collection.addChangeListener(listener);
+        collection.removeChangeListener(listener);
+
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+    }
+
+    @Test
+    @UiThreadTest
+    public void addChangeListener_null() {
+        try {
+            collection.addChangeListener(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void removeChangeListener() {
+        final AtomicInteger listenersTriggered = new AtomicInteger(0);
+        final Realm realm = looperThread.realm;
+        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+
+        RealmChangeListener listener = new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                listenersTriggered.incrementAndGet();
+            }
+        };
+
+        collection.addChangeListener(listener);
+        collection.removeChangeListener(listener);
+
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+
+        // The above commit should have put a REALM_CHANGED event on the Looper queue before this runnable.
+        looperThread.postRunnable(new Runnable() {
+            @Override
+            public void run() {
+                if (listenersTriggered.get() == 0) {
+                    looperThread.testComplete();
+                } else {
+                    fail("Listener wasn't removed");
+                }
+            }
+        });
+    }
+
+    @Test
+    @UiThreadTest
+    public void removeChangeListener_null() {
+        try {
+            collection.removeChangeListener(null);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void removeAllChangeListeners() {
+        final AtomicInteger listenersTriggered = new AtomicInteger(0);
+        final Realm realm = looperThread.realm;
+        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+
+        RealmChangeListener listenerA = new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                listenersTriggered.incrementAndGet();
+            }
+        };
+        RealmChangeListener listenerB = new RealmChangeListener() {
+            @Override
+            public void onChange() {
+                listenersTriggered.incrementAndGet();
+            }
+        };
+
+        collection.addChangeListener(listenerA);
+        collection.addChangeListener(listenerB);
+        collection.removeChangeListeners();
+
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+
+        // The above commit should have put a REALM_CHANGED event on the Looper queue before this runnable.
+        looperThread.postRunnable(new Runnable() {
+            @Override
+            public void run() {
+                if (listenersTriggered.get() == 0) {
+                    looperThread.testComplete();
+                } else {
+                    fail("Listeners wasn't removed");
+                }
+            }
+        });
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -136,8 +136,7 @@ public class RealmTests {
 
     private void populateTestRealm(Realm realm, int objects) {
         realm.beginTransaction();
-        realm.allObjects(AllTypes.class).clear();
-        realm.allObjects(NonLatinFieldNames.class).clear();
+        realm.deleteAll();
         for (int i = 0; i < objects; ++i) {
             AllTypes allTypes = realm.createObject(AllTypes.class);
             allTypes.setColumnBoolean((i % 3) == 0);
@@ -145,6 +144,7 @@ public class RealmTests {
             allTypes.setColumnDate(new Date());
             allTypes.setColumnDouble(3.1415);
             allTypes.setColumnFloat(1.234567f + i);
+
             allTypes.setColumnString("test data " + i);
             allTypes.setColumnLong(i);
             NonLatinFieldNames nonLatinFieldNames = realm.createObject(NonLatinFieldNames.class);
@@ -646,8 +646,8 @@ public class RealmTests {
         METHOD_BEGIN,
         METHOD_COMMIT,
         METHOD_CANCEL,
-        METHOD_CLEAR,
-        METHOD_CLEAR_ALL,
+        METHOD_DELETE_TYPE,
+        METHOD_DELETE_ALL,
         METHOD_DISTINCT,
         METHOD_CREATE_OBJECT,
         METHOD_COPY_TO_REALM,
@@ -679,10 +679,10 @@ public class RealmTests {
                         case METHOD_CANCEL:
                             realm.cancelTransaction();
                             break;
-                        case METHOD_CLEAR:
-                            realm.clear(AllTypes.class);
+                        case METHOD_DELETE_TYPE:
+                            realm.delete(AllTypes.class);
                             break;
-                        case METHOD_CLEAR_ALL:
+                        case METHOD_DELETE_ALL:
                             realm.deleteAll();
                             break;
                         case METHOD_DISTINCT:
@@ -848,14 +848,13 @@ public class RealmTests {
     }
 
     @Test
-    public void clear_type() {
-        // ** clear non existing table should succeed
-
+    public void delete_type() {
+        // ** delete non existing table should succeed
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         realm.commitTransaction();
 
-        // ** clear existing class, but leave other classes classes
+        // ** delete existing class, but leave other classes classes
 
         // Add two classes
         populateTestRealm();
@@ -865,7 +864,7 @@ public class RealmTests {
         realm.commitTransaction();
         // Clear
         realm.beginTransaction();
-        realm.clear(Dog.class);
+        realm.delete(Dog.class);
         realm.commitTransaction();
         // Check one class is cleared but other class is still there
         RealmResults<AllTypes> resultListTypes = realm.where(AllTypes.class).findAll();
@@ -873,9 +872,9 @@ public class RealmTests {
         RealmResults<Dog> resultListDogs = realm.where(Dog.class).findAll();
         assertEquals(0, resultListDogs.size());
 
-        // ** clear() must throw outside a transaction
+        // ** delete() must throw outside a transaction
         try {
-            realm.clear(AllTypes.class);
+            realm.delete(AllTypes.class);
             fail("Expected exception");
         } catch (IllegalStateException ignored) {
         }
@@ -916,7 +915,7 @@ public class RealmTests {
     @Test
     public void utf8Tests() {
         realm.beginTransaction();
-        realm.clear(AllTypes.class);
+        realm.delete(AllTypes.class);
         realm.commitTransaction();
 
         String file = "assets/unicode_codepoints.csv";
@@ -997,7 +996,7 @@ public class RealmTests {
             realm.allObjects(StringOnly.class).get(0).getChars();
 
             realm.beginTransaction();
-            realm.clear(StringOnly.class);
+            realm.delete(StringOnly.class);
             realm.commitTransaction();
         }
     }
@@ -1967,8 +1966,8 @@ public class RealmTests {
         try { realm.copyToRealmOrUpdate(t);         fail(); } catch (IllegalStateException expected) {}
         try { realm.copyToRealmOrUpdate(ts);        fail(); } catch (IllegalStateException expected) {}
         try { realm.remove(AllTypes.class, 0);      fail(); } catch (IllegalStateException expected) {}
-        try { realm.clear(AllTypes.class);          fail(); } catch (IllegalStateException expected) {}
-        try { realm.deleteAll();                        fail(); } catch (IllegalStateException expected) {}
+        try { realm.delete(AllTypes.class);         fail(); } catch (IllegalStateException expected) {}
+        try { realm.deleteAll();                    fail(); } catch (IllegalStateException expected) {}
 
         try { realm.createObjectFromJson(AllTypesPrimaryKey.class, jsonObj);                fail(); } catch (RealmException expected) {}
         try { realm.createObjectFromJson(AllTypesPrimaryKey.class, jsonObjStr);             fail(); } catch (RealmException expected) {}
@@ -2640,7 +2639,7 @@ public class RealmTests {
     public void copyFromRealm_invalidObjectThrows() {
         realm.beginTransaction();
         AllTypes obj = realm.createObject(AllTypes.class);
-        obj.removeFromRealm();
+        obj.deleteFromRealm();
         realm.commitTransaction();
 
         try {
@@ -2783,7 +2782,7 @@ public class RealmTests {
         realm.beginTransaction();
         AllTypes object = realm.createObject(AllTypes.class);
         List<AllTypes> list = new RealmList<AllTypes>(object);
-        object.removeFromRealm();
+        object.deleteFromRealm();
         realm.commitTransaction();
 
         thrown.expect(IllegalArgumentException.class);
@@ -3069,7 +3068,7 @@ public class RealmTests {
     }
 
     @Test
-    public void clear_all() {
+    public void deleteAll() {
         realm.beginTransaction();
         realm.createObject(AllTypes.class);
         realm.createObject(Owner.class).setCat(realm.createObject(Cat.class));

--- a/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
@@ -198,6 +198,23 @@ public class RxJavaTests {
     }
 
     @Test
+    @UiThreadTest
+    public void dynamicRealmResults_emittedOnSubscribe() {
+        final DynamicRealm dynamicRealm = DynamicRealm.createInstance(realm.getConfiguration());
+        final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
+        final RealmResults<DynamicRealmObject> results = dynamicRealm.allObjects(AllTypes.CLASS_NAME);
+        results.asObservable().subscribe(new Action1<RealmResults<DynamicRealmObject>>() {
+            @Override
+            public void call(RealmResults<DynamicRealmObject> rxResults) {
+                assertTrue(rxResults == results);
+                subscribedNotified.set(true);
+            }
+        });
+        assertTrue(subscribedNotified.get());
+        dynamicRealm.close();
+    }
+
+    @Test
     @RunTestInLooperThread
     public void realmResults_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
@@ -218,6 +235,30 @@ public class RxJavaTests {
         realm.beginTransaction();
         realm.createObject(AllTypes.class);
         realm.commitTransaction();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void dynamicRealmResults_emittedOnUpdate() {
+        final AtomicInteger subscriberCalled = new AtomicInteger(0);
+        final DynamicRealm dynamicRealm = DynamicRealm.createInstance(looperThread.realmConfiguration);
+        dynamicRealm.beginTransaction();
+        RealmResults<DynamicRealmObject> results = dynamicRealm.allObjects(AllTypes.CLASS_NAME);
+        dynamicRealm.commitTransaction();
+
+        results.asObservable().subscribe(new Action1<RealmResults<DynamicRealmObject>>() {
+            @Override
+            public void call(RealmResults<DynamicRealmObject> allTypes) {
+                if (subscriberCalled.incrementAndGet() == 2) {
+                    dynamicRealm.close();
+                    looperThread.testComplete();
+                }
+            }
+        });
+
+        dynamicRealm.beginTransaction();
+        dynamicRealm.createObject(AllTypes.CLASS_NAME);
+        dynamicRealm.commitTransaction();
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/SortTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/SortTest.java
@@ -45,7 +45,7 @@ public class SortTest extends AndroidTestCase {
         testRealm = Realm.getInstance(config);
 
         testRealm.beginTransaction();
-        testRealm.clear(AllTypes.class);
+        testRealm.delete(AllTypes.class);
         AllTypes object1 = testRealm.createObject(AllTypes.class);
         object1.setColumnLong(5);
         object1.setColumnString("Adam");
@@ -211,20 +211,16 @@ public class SortTest extends AndroidTestCase {
     }
 
     public void testSortRealmResultsTwoFields() {
-        RealmResults<AllTypes> results1 = testRealm.allObjects(AllTypes.class);
-        results1.sort(ORDER_STRING_INT, ORDER_ASC_ASC);
+        RealmResults<AllTypes> results1 = testRealm.allObjects(AllTypes.class).sort(ORDER_STRING_INT, ORDER_ASC_ASC);
         checkSortTwoFieldsStringAscendingIntAscending(results1);
 
-        RealmResults<AllTypes> results2 = testRealm.allObjects(AllTypes.class);
-        results2.sort(ORDER_INT_STRING, ORDER_ASC_ASC);
+        RealmResults<AllTypes> results2 = testRealm.allObjects(AllTypes.class).sort(ORDER_INT_STRING, ORDER_ASC_ASC);
         checkSortTwoFieldsIntString(results2);
 
-        RealmResults<AllTypes> results3 = testRealm.allObjects(AllTypes.class);
-        results3.sort(ORDER_STRING_INT, ORDER_ASC_DES);
+        RealmResults<AllTypes> results3 = testRealm.allObjects(AllTypes.class).sort(ORDER_STRING_INT, ORDER_ASC_DES);
         checkSortTwoFieldsStringAscendingIntDescending(results3);
 
-        RealmResults<AllTypes> results4 = testRealm.allObjects(AllTypes.class);
-        results4.sort(ORDER_INT_STRING, ORDER_ASC_DES);
+        RealmResults<AllTypes> results4 = testRealm.allObjects(AllTypes.class).sort(ORDER_INT_STRING, ORDER_ASC_DES);
         checkSortTwoFieldsIntAscendingStringDescending(results4);
    }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -499,6 +499,10 @@ public class TestHelper {
     }
 
     public static void populatePartialNullRowsForNumericTesting (Realm realm) {
+        // Id values are [1, 2, 3]
+        // IntegerNull values are [3, null, 4]
+        // FloatNull values are [4F, null, 5F]
+        // DoubleNull values are [5D, null, 6F]
         NullTypes nullTypes1 = new NullTypes();
         nullTypes1.setId(1);
         nullTypes1.setFieldIntegerNull(3);
@@ -627,7 +631,7 @@ public class TestHelper {
 
     public static void populateForMultiSort(DynamicRealm realm) {
         realm.beginTransaction();
-        realm.clear(AllTypes.CLASS_NAME);
+        realm.delete(AllTypes.CLASS_NAME);
         DynamicRealmObject object1 = realm.createObject(AllTypes.CLASS_NAME);
         object1.setLong(AllTypes.FIELD_LONG, 5);
         object1.setString(AllTypes.FIELD_STRING, "Adam");

--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
@@ -1786,7 +1786,7 @@ public class TypeBasedNotificationsTests {
 
         // Trigger the listener at the first time.
         realm.beginTransaction();
-        allTypes.removeFromRealm();
+        allTypes.deleteFromRealm();
         realm.commitTransaction();
 
         // Try to trigger the listener second time.

--- a/realm/realm-library/src/androidTest/java/io/realm/UnManagedOrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/UnManagedOrderedRealmCollectionTests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.realm.entities.AllJavaTypes;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for all methods part of the the {@link OrderedRealmCollection} interface, that have a different behavior
+ * than managed RealmCollection classes.
+ *
+ * Methods tested in this class:
+ *
+ * # OrderedRealmCollection
+ *
+ * - E first()
+ * - E last()
+ * - void sort(String field)
+ * - void sort(String field, Sort sortOrder)
+ * - void sort(String field1, Sort sortOrder1, String field2, Sort sortOrder2)
+ * - void sort(String[] fields, Sort[] sortOrders)
+ * - void deleteFromRealm(int location)
+ * - void deleteFirstFromRealm()
+ * - void deleteLastFromRealm();
+ *
+ * # List
+ *
+ *  - void add(int location, E object);
+ *  - boolean addAll(int location, Collection<? extends E> collection);
+ *  - E get(int location);
+ *  - int indexOf(Object object);
+ *  - int lastIndexOf(Object object);
+ *  - ListIterator<E> listIterator();
+ *  - ListIterator<E> listIterator(int location);
+ *  - E remove(int location);
+ *  - E set(int location, E object);
+ *  - List<E> subList(int start, int end);
+ *
+ * # RealmCollection
+ *
+ * - RealmQuery<E> where();
+ * - Number min(String fieldName);
+ * - Number max(String fieldName);
+ * - Number sum(String fieldName);
+ * - double average(String fieldName);
+ * - Date maxDate(String fieldName);
+ * - Date minDate(String fieldName);
+ * - void deleteAllFromRealm();
+ * + boolean isLoaded();
+ * + boolean load();
+ * + boolean isValid();
+ * + BaseRealm getRealm();
+ *
+ * # Collection
+ *
+ * - public boolean add(E object);
+ * - public boolean addAll(Collection<? extends E> collection);
+ * - public void deleteAll();
+ * - public boolean contains(Object object);
+ * - public boolean containsAll(Collection<?> collection);
+ * - public boolean equals(Object object);
+ * - public int hashCode();
+ * - public boolean isEmpty();
+ * - public Iterator<E> iterator();
+ * - public boolean remove(Object object);
+ * - public boolean removeAll(Collection<?> collection);
+ * - public boolean retainAll(Collection<?> collection);
+ * - public int size();
+ * - public Object[] toArray();
+ * - public <T> T[] toArray(T[] array);
+ **
+ * See {@link ManagedOrderedRealmCollectionTests} for similar tests for the managed behavior.
+ */
+@RunWith(Parameterized.class)
+public class UnManagedOrderedRealmCollectionTests extends CollectionTests {
+
+    private static final int TEST_SIZE = 10;
+
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+
+    private final UnManagedCollection collectionClass;
+    private Realm realm;
+    private OrderedRealmCollection<AllJavaTypes> collection;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<UnManagedCollection> data() {
+        return Arrays.asList(UnManagedCollection.values());
+    }
+
+    public UnManagedOrderedRealmCollectionTests(UnManagedCollection collectionType) {
+        this.collectionClass = collectionType;
+    }
+
+    @Before
+    public void setup() {
+        realm = Realm.getInstance(configFactory.createConfiguration());
+        collection = createCollection(collectionClass);
+    }
+
+    private OrderedRealmCollection<AllJavaTypes> createCollection(UnManagedCollection collectionClass) {
+        switch (collectionClass) {
+            case UNMANAGED_REALMLIST:
+                return populateInMemoryList(TEST_SIZE);
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        realm.close();
+    }
+
+    @Test
+    public void unsupportedMethods_unManagedCollections() {
+        // RealmCollection methods
+        for (OrderedRealmCollectionMethod method : OrderedRealmCollectionMethod.values()) {
+            try {
+                switch (method) {
+                    case DELETE_INDEX: collection.deleteFromRealm(0); break;
+                    case DELETE_FIRST: collection.deleteFirstFromRealm(); break;
+                    case DELETE_LAST: collection.deleteLastFromRealm(); break;
+                    case SORT: collection.sort(AllJavaTypes.FIELD_STRING); break;
+                    case SORT_FIELD: collection.sort(AllJavaTypes.FIELD_STRING, Sort.ASCENDING); break;
+                    case SORT_2FIELDS: collection.sort(AllJavaTypes.FIELD_STRING, Sort.ASCENDING, AllJavaTypes.FIELD_LONG, Sort.DESCENDING); break;
+                    case SORT_MULTI: collection.sort(new String[] { AllJavaTypes.FIELD_STRING, AllJavaTypes.FIELD_LONG }, new Sort[] { Sort.ASCENDING, Sort.DESCENDING }); break;
+                }
+                fail(method + " should have thrown an exception.");
+            } catch (UnsupportedOperationException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void isLoaded() {
+        assertTrue(collection.isLoaded());
+    }
+
+    @Test
+    public void load() {
+        assertTrue(collection.load());
+    }
+
+    @Test
+    public void isValid() {
+        assertFalse(collection.isValid());
+    }
+
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/UnManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/UnManagedRealmCollectionTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import io.realm.entities.AllJavaTypes;
+import io.realm.entities.Dog;
+import io.realm.entities.Owner;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for all methods part of the the {@link RealmCollection} interface, that have a different behavior
+ * than managed RealmCollection classes.
+ *
+ * See {@link ManagedRealmCollectionTests} for similar tests for the managed behavior.
+ */
+@RunWith(Parameterized.class)
+public class UnManagedRealmCollectionTests extends CollectionTests {
+
+    private static final int TEST_SIZE = 10;
+
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+
+    private final UnManagedCollection collectionClass;
+    private Realm realm;
+    private RealmCollection<AllJavaTypes> collection;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<UnManagedCollection> data() {
+        return Arrays.asList(UnManagedCollection.values());
+    }
+
+    public UnManagedRealmCollectionTests(UnManagedCollection collectionType) {
+        this.collectionClass = collectionType;
+    }
+
+    @Before
+    public void setup() {
+        realm = Realm.getInstance(configFactory.createConfiguration());
+        collection = createCollection(collectionClass);
+    }
+
+    private RealmCollection<AllJavaTypes> createCollection(UnManagedCollection collectionClass) {
+        switch (collectionClass) {
+            case UNMANAGED_REALMLIST:
+                return populateInMemoryList(TEST_SIZE);
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        realm.close();
+    }
+
+    @Test
+    public void unsupportedMethods_unManagedCollections() {
+        // RealmCollection methods
+        for (RealmCollectionMethod method : RealmCollectionMethod.values()) {
+            try {
+                switch (method) {
+                    // Unsupported methods
+                    case WHERE: collection.where(); break;
+                    case MIN: collection.min(AllJavaTypes.FIELD_LONG); break;
+                    case MAX: collection.max(AllJavaTypes.FIELD_LONG); break;
+                    case SUM: collection.sum(AllJavaTypes.FIELD_LONG); break;
+                    case AVERAGE: collection.average(AllJavaTypes.FIELD_LONG); break;
+                    case MIN_DATE: collection.minDate(AllJavaTypes.FIELD_DATE); break;
+                    case MAX_DATE: collection.maxDate(AllJavaTypes.FIELD_DATE); break;
+                    case DELETE_ALL_FROM_REALM: collection.deleteAllFromRealm(); break;
+
+                    // Supported methods
+                    case IS_VALID: assertFalse(collection.isValid()); continue;
+                }
+                fail(method + " should have thrown an exception.");
+            } catch (UnsupportedOperationException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void isLoaded() {
+        assertTrue(collection.isLoaded());
+    }
+
+    @Test
+    public void load() {
+        assertTrue(collection.load());
+    }
+
+    @Test
+    public void isValid() {
+        assertFalse(collection.isValid());
+    }
+
+    @Test
+    public void contains() {
+        AllJavaTypes obj = collection.iterator().next();
+        assertTrue(collection.contains(obj));
+    }
+
+    @Test
+    public void equals_sameRealmObjectsDifferentCollection() {
+        List<AllJavaTypes> list = new ArrayList<AllJavaTypes>();
+        list.addAll(collection);
+        assertTrue(collection.equals(list));
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
@@ -58,6 +58,14 @@ public class AllJavaTypes extends RealmObject{
     private AllJavaTypes fieldObject;
     private RealmList<AllJavaTypes> fieldList;
 
+    public AllJavaTypes() {
+
+    }
+
+    public AllJavaTypes(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
     public String getFieldIgnored() {
         return fieldIgnored;
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/CyclicType.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/CyclicType.java
@@ -16,12 +16,20 @@
 
 package io.realm.entities;
 
+import java.util.Date;
+
 import io.realm.RealmList;
 import io.realm.RealmObject;
 
 public class CyclicType extends RealmObject {
 
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_DATE = "date";
+
+    private long id;
     private String name;
+    private Date date;
     private CyclicType object;
     private CyclicType otherObject;
     private RealmList<CyclicType> objects;
@@ -31,6 +39,15 @@ public class CyclicType extends RealmObject {
 
     public CyclicType(String name) {
         this.name = name;
+    }
+
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 
     public String getName() {
@@ -63,5 +80,13 @@ public class CyclicType extends RealmObject {
 
     public void setOtherObject(CyclicType otherObject) {
         this.otherObject = otherObject;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/NonLatinFieldNames.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/NonLatinFieldNames.java
@@ -16,6 +16,7 @@
 
 package io.realm.entities;
 
+import io.realm.RealmList;
 import io.realm.RealmObject;
 
 public class NonLatinFieldNames extends RealmObject{
@@ -24,12 +25,15 @@ public class NonLatinFieldNames extends RealmObject{
     public final static String FIELD_LONG_GREEK_CHAR = "Δέλτα";
     public final static String FIELD_FLOAT_KOREAN_CHAR = "베타";
     public final static String FIELD_FLOAT_GREEK_CHAR = "βήτα";
+    public final static String FIELD_CHILDREN = "children";
 
     private long 델타;
     private long Δέλτα;
 
     private float 베타;
     private float βήτα;
+
+    private RealmList<NonLatinFieldNames> children;
 
     public float get베타() { return 베타; }
 
@@ -46,4 +50,12 @@ public class NonLatinFieldNames extends RealmObject{
     public long getΔέλτα() { return Δέλτα; }
 
     public void setΔέλτα(long δέλτα) { this.Δέλτα = δέλτα; }
+
+    public RealmList<NonLatinFieldNames> getChildren() {
+        return children;
+    }
+
+    public void setChildren(RealmList<NonLatinFieldNames> children) {
+        this.children = children;
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/RealmAdapter.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/RealmAdapter.java
@@ -23,6 +23,7 @@ import android.widget.ListAdapter;
 import android.widget.TextView;
 
 import io.realm.RealmBaseAdapter;
+import io.realm.OrderedRealmCollection;
 import io.realm.RealmResults;
 
 public class RealmAdapter extends RealmBaseAdapter<AllTypes> implements ListAdapter {
@@ -47,12 +48,12 @@ public class RealmAdapter extends RealmBaseAdapter<AllTypes> implements ListAdap
             viewHolder = (ViewHolder) convertView.getTag();
         }
 
-        AllTypes item = realmResults.get(position);
+        AllTypes item = adapterData.get(position);
         viewHolder.textView.setText(item.getColumnString());
         return convertView;
     }
 
-    public RealmResults<AllTypes> getRealmResults() {
-        return realmResults;
+    public OrderedRealmCollection<AllTypes> getRealmResults() {
+        return adapterData;
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -553,9 +553,9 @@ abstract class BaseRealm implements Closeable {
     }
 
     /**
-     * Removes all objects from this Realm.
+     * Deletes all objects from this Realm.
      *
-     * @throws IllegalStateException if the corresponding Realm is closed or on an incorrect thread.
+     * @throws IllegalStateException if the corresponding Realm is closed or called from an incorrect thread.
      */
     public void deleteAll() {
         checkIfValid();

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -120,9 +120,21 @@ public final class DynamicRealm extends BaseRealm {
     /**
      * Removes all objects of the specified class.
      *
+     * DEPRECATED: Use {@link #delete(String)} instead.
+     *
      * @param className the class for which all objects should be removed.
      */
+    @Deprecated
     public void clear(String className) {
+        delete(className);
+    }
+
+    /**
+     * Deletes all objects of the specified class from the Realm.
+     *
+     * @param className the class for which all objects should be removed.
+     */
+    public void delete(String className) {
         checkIfValid();
         schema.getTable(className).clear();
     }

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -170,6 +170,24 @@ public class HandlerController implements Handler.Callback {
         }
     }
 
+    void removeWeakChangeListener(RealmChangeListener listener) {
+        List<WeakReference<RealmChangeListener>> toRemoveList = null;
+        for (int i = 0; i < weakChangeListeners.size(); i++) {
+            WeakReference<RealmChangeListener> weakRef = weakChangeListeners.get(i);
+            RealmChangeListener weakListener = weakRef.get();
+
+            // Collect all listeners that are GC'ed or we need to remove
+            if (weakListener == null || weakListener == listener) {
+                if (toRemoveList == null) {
+                    toRemoveList = new ArrayList<WeakReference<RealmChangeListener>>(weakChangeListeners.size());
+                }
+                toRemoveList.add(weakRef);
+            }
+        }
+
+        weakChangeListeners.removeAll(toRemoveList);
+    }
+
     void removeChangeListener(RealmChangeListener listener) {
         changeListeners.remove(listener);
     }

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollection.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import java.util.List;
+
+/**
+ * An {@code OrderedRealmCollection} is a collection which maintains an ordering for its elements. Every
+ * element in the {@code OrderedRealmCollection} has an index. Each element can thus be accessed by its
+ * index, with the first index being zero. Normally, {@code OrderedRealmCollection}s allow duplicate
+ * elements, as compared to Sets, where elements have to be unique.
+ */
+public interface OrderedRealmCollection<E extends RealmObject> extends List<E>, RealmCollection<E> {
+
+    /**
+     * Gets the first object from the collection.
+     *
+     * @return the first object.
+     * @throws IndexOutOfBoundsException if the collection is empty.
+     */
+    E first();
+
+    /**
+     * Gets the last object from the collection.
+     *
+     * @return the last object.
+     * @throws IndexOutOfBoundsException if the collection is empty.
+     */
+    E last();
+
+    /**
+     * Sorts a collection based on the provided field in ascending order.
+     *
+     * @param fieldName the field name to sort by. Only fields of type boolean, short, int, long, float, double, Date,
+     *                  and String are supported.
+     * @return a sorted view of the collection.
+     * @throws java.lang.IllegalArgumentException if field name does not exist or it has an invalid type.
+     * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
+     *                                         an un-managed collection.
+     */
+    RealmResults<E> sort(String fieldName);
+
+    /**
+     * Sorts a collection based on the provided field and sort order.
+     *
+     * @param fieldName the field name to sort by. Only fields of type boolean, short, int, long, float, double, Date,
+     *                  and String are supported.
+     * @param sortOrder the direction to sort by.
+     * @return a sorted view of the collection.
+     * @throws java.lang.IllegalArgumentException if field name does not exist or has an invalid type.
+     * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
+     *                                         an un-managed collection.
+     */
+    RealmResults<E> sort(String fieldName, Sort sortOrder);
+
+    /**
+     * Sorts a collection based on the provided fields and sort orders.
+     *
+     * @param fieldName1 first field name. Only fields of type boolean, short, int, long, float,
+     *                   double, Date, and String are supported.
+     * @param sortOrder1 sort order for first field.
+     * @param fieldName2 second field name. Only fields of type boolean, short, int, long, float,
+     *                   double, Date, and String are supported.
+     * @param sortOrder2 sort order for second field.
+     * @return a sorted view of the collection.
+     * @throws java.lang.IllegalArgumentException if a field name does not exist or has an invalid type.
+     * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
+     *                                         an un-managed collection.
+     */
+    RealmResults<E> sort(String fieldName1, Sort sortOrder1, String fieldName2, Sort sortOrder2);
+
+    /**
+     * Sorts a collection based on the provided fields and sort orders.
+     *
+     * @param fieldNames an array of field names to sort by. Only fields of type boolean, short, int, long, float,
+     *                   double, Date, and String are supported.
+     * @param sortOrders the directions to sort by.
+     * @return a sorted view of the collection.
+     * @throws java.lang.IllegalArgumentException if a field name does not exist or has an invalid type.
+     * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
+     *                                         an un-managed collection.
+     */
+    RealmResults<E> sort(String[] fieldNames, Sort[] sortOrders);
+
+    /**
+     * Deletes the object at the given index from the Realm. This also removes it from the collection.
+     *
+     * @param location the array index identifying the object to be removed.
+     * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}.
+     * @throws java.lang.IllegalStateException if the Realm is closed or the method is called from the wrong thread.
+     * @throws UnsupportedOperationException if the collection is un-managed.
+     */
+    void deleteFromRealm(int location);
+
+    /**
+     * Deletes the first object from the Realm. This also removes it from this collection.
+     *
+     * @return {@code true} if an object was deleted, {@code false} otherwise.
+     * @throws java.lang.IllegalStateException if the Realm is closed or the method is called on the wrong thread.
+     * @throws UnsupportedOperationException if the collection is un-managed.
+     */
+    boolean deleteFirstFromRealm();
+
+    /**
+     * Deletes the last object from the Realm. This also removes it from this collection.
+     *
+     * @return {@code true} if an object was deleted, {@code false} otherwise.
+     * @throws java.lang.IllegalStateException if the Realm is closed or the method is called from the wrong thread.
+     * @throws UnsupportedOperationException if the collection is un-managed.
+     */
+    boolean deleteLastFromRealm();
+}

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1383,13 +1383,27 @@ public final class Realm extends BaseRealm {
     /**
      * Removes all objects of the specified class.
      *
+     * DEPRECATED: Use {@link #delete(Class)} instead.
+     *
      * @param clazz the class which objects should be removed.
      * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      */
+    @Deprecated
     public void clear(Class<? extends RealmObject> clazz) {
+        delete(clazz);
+    }
+
+    /**
+     * Deletes all objects of the specified class from the Realm.
+     *
+     * @param clazz the class which objects should be removed.
+     * @throws IllegalStateException if the corresponding Realm is closed or called from an incorrect thread.
+     */
+    public void delete(Class<? extends RealmObject> clazz) {
         checkIfValid();
         getTable(clazz).clear();
     }
+
 
     @SuppressWarnings("unchecked")
     private <E extends RealmObject> E copyOrUpdate(E object, boolean update) {

--- a/realm/realm-library/src/main/java/io/realm/RealmCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCollection.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+
+/**
+ * {@code RealmCollection} is the root of the collection hierarchy that Realm supports. It defines operations on data
+ * collections and the behavior that they will have in all implementations of {@code RealmCollection}s.
+ *
+ * Realm collections are "live" views to the underlying data. This means that they automatically will be kept up to
+ * date. As a consequence, using methods like {@link Collections#unmodifiableCollection(Collection)} will not prevent
+ * a collection from being modified.
+ *
+ * @param <E> type of {@link RealmObject} stored in the collection.
+ */
+public interface RealmCollection<E extends RealmObject> extends Collection<E> {
+
+    /**
+     * Returns a {@link RealmQuery}, which can be used to query for specific objects from this collection.
+     *
+     * @return a RealmQuery object.
+     * @throws IllegalStateException if the Realm instance has been closed or queries are not otherwise available.
+     * @see io.realm.RealmQuery
+     */
+    RealmQuery<E> where();
+
+    /**
+     * Finds the minimum value of a field.
+     *
+     * @param fieldName the field to look for a minimum on. Only number fields are supported.
+     * @return if no objects exist or they all have {@code null} as the value for the given field, {@code null} will be
+     * returned. Otherwise the minimum value is returned. When determining the minimum value, objects with {@code null}
+     * values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    Number min(String fieldName);
+
+    /**
+     * Finds the maximum value of a field.
+     *
+     * @param fieldName the field to look for a maximum on. Only number fields are supported.
+     * @return if no objects exist or they all have {@code null} as the value for the given field, {@code null} will be
+     * returned. Otherwise the maximum value is returned. When determining the maximum value, objects with {@code null}
+     * values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    Number max(String fieldName);
+
+    /**
+     * Calculates the sum of a given field.
+     *
+     * @param fieldName the field to sum. Only number fields are supported.
+     * @return the sum. If no objects exist or they all have {@code null} as the value for the given field, {@code 0}
+     * will be returned. When computing the sum, objects with {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    Number sum(String fieldName);
+
+    /**
+     * Returns the average of a given field.
+     *
+     * @param fieldName the field to calculate average on. Only number fields are supported.
+     * @return the average for the given field amongst objects in query results. This will be of type double for all
+     * types of number fields. If no objects exist or they all have {@code null} as the value for the given field,
+     * {@code 0} will be returned. When computing the average, objects with {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    double average(String fieldName);
+
+    /**
+     * Finds the maximum date.
+     *
+     * @param fieldName the field to look for the maximum date. If fieldName is not of Date type, an exception is
+     *                  thrown.
+     * @return if no objects exist or they all have {@code null} as the value for the given date field, {@code null}
+     * will be returned. Otherwise the maximum date is returned. When determining the maximum date, objects with
+     * {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if fieldName is not a Date field.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    Date maxDate(String fieldName);
+
+    /**
+     * Finds the minimum date.
+     *
+     * @param fieldName the field to look for the minimum date. If fieldName is not of Date type, an exception is
+     *                  thrown.
+     * @return if no objects exist or they all have {@code null} as the value for the given date field, {@code null}
+     * will be returned. Otherwise the minimum date is returned. When determining the minimum date, objects with
+     * {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if fieldName is not a Date field.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    Date minDate(String fieldName);
+
+    /**
+     * This deletes all objects in the collection from the underlying Realm as well as from the collection.
+     *
+     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
+     * @return {@code true} if objects was deleted, {@code false} otherwise.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    boolean deleteAllFromRealm();
+
+    /**
+     * Checks if a collection has finished loading its data yet.
+     *
+     * @return {@code true} if data has been loaded and is available, {@code false} if data is still being loaded.
+     */
+    boolean isLoaded();
+
+    /**
+     * Blocks the collection until all data are available.
+     *
+     * @return {@code true} if the data could be successfully loaded, {@code false} otherwise.
+     */
+    boolean load();
+
+    /**
+     * Checks if the collection is still valid to use e.g. the {@link io.realm.Realm} instance hasn't
+     * been closed.
+     *
+     * @return {@code true} if still valid to use, {@code false} otherwise.
+     */
+    boolean isValid();
+
+    /**
+     * Tests whether this {@code Collection} contains the specified object. Returns
+     * {@code true} if and only if at least one element {@code elem} in this
+     * {@code Collection} meets following requirement:
+     * {@code (object==null ? elem==null : object.equals(elem))}.
+     *
+     * @param object the object to search for.
+     * @return {@code true} if object is an element of this {@code Collection}, {@code false} otherwise.
+     * @throws NullPointerException if the object to look for is {@code null} and this {@code Collection} doesn't
+     *                              support {@code null} elements.
+     */
+    boolean contains(Object object);
+}

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -79,6 +79,8 @@ public abstract class RealmObject {
     private long currentTableVersion = -1;
 
     /**
+     * DEPRECATED: Use {@link #deleteFromRealm()} instead.
+     *
      * Removes the object from the Realm it is currently associated to.
      * <p>
      * After this method is called the object will be invalid and any operation (read or write) performed on it will
@@ -86,7 +88,21 @@ public abstract class RealmObject {
      *
      * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      */
+    @Deprecated
     public void removeFromRealm() {
+        deleteFromRealm();
+    }
+
+    /**
+     * Deletes the object from the Realm it is currently associated to.
+     * <p>
+     * After this method is called the object will be invalid and any operation (read or write) performed on it will
+     * fail with an IllegalStateException.
+     *
+     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
+     * @see #isValid()
+     */
+    public void deleteFromRealm() {
         if (row == null) {
             throw new IllegalStateException("Object malformed: missing object in Realm. Make sure to instantiate RealmObjects with Realm.createObject()");
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -607,13 +607,27 @@ public final class RealmObjectSchema {
 
     /**
      * Returns the column index in the underlying table for the given field name.
-     * INVARIANT: fieldName should be present.
      *
      * @param fieldName field name to find index for.
-     * @return column index
+     * @return column index or null if it doesn't exists.
      */
     Long getFieldIndex(String fieldName) {
         return columnIndices.get(fieldName);
+    }
+
+    /**
+     * Returns the column index in the underlying table for the given field name.
+     *
+     * @param fieldName field name to find index for.
+     * @return column index.
+     * @throws IllegalArgumentException if the field does not exists.
+     */
+    long getAndCheckFieldIndex(String fieldName) {
+        Long index = columnIndices.get(fieldName);
+        if (index == null) {
+            throw new IllegalArgumentException("Field does not exist: " + fieldName);
+        }
+        return index;
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1287,7 +1287,7 @@ public class RealmQuery<E extends RealmObject> {
      * @throws java.lang.IllegalArgumentException if the field is not a number type.
      */
     public Number sum(String fieldName) {
-        long columnIndex = schema.getFieldIndex(fieldName);
+        long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
                 return query.sumInt(columnIndex);
@@ -1312,7 +1312,7 @@ public class RealmQuery<E extends RealmObject> {
      * @throws java.lang.IllegalArgumentException if the field is not a number type.
      */
     public double average(String fieldName) {
-        long columnIndex = schema.getFieldIndex(fieldName);
+        long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
                 return query.averageInt(columnIndex);
@@ -1338,7 +1338,7 @@ public class RealmQuery<E extends RealmObject> {
      */
     public Number min(String fieldName) {
         realm.checkIfValid();
-        long columnIndex = table.getColumnIndex(fieldName);
+        long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
                 return this.query.minimumInt(columnIndex);
@@ -1361,7 +1361,7 @@ public class RealmQuery<E extends RealmObject> {
      * @throws java.lang.UnsupportedOperationException if the query is not valid ("syntax error").
      */
     public Date minimumDate(String fieldName) {
-        long columnIndex = schema.getFieldIndex(fieldName);
+        long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         return this.query.minimumDate(columnIndex);
     }
 
@@ -1378,7 +1378,7 @@ public class RealmQuery<E extends RealmObject> {
      */
     public Number max(String fieldName) {
         realm.checkIfValid();
-        long columnIndex = table.getColumnIndex(fieldName);
+        long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
                 return this.query.maximumInt(columnIndex);
@@ -1401,7 +1401,7 @@ public class RealmQuery<E extends RealmObject> {
      * @throws java.lang.UnsupportedOperationException if the query is not valid ("syntax error").
      */
     public Date maximumDate(String fieldName) {
-        long columnIndex = schema.getFieldIndex(fieldName);
+        long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         return this.query.maximumDate(columnIndex);
     }
 
@@ -2052,6 +2052,9 @@ public class RealmQuery<E extends RealmObject> {
     // Get the column index for sorting related functions. A proper exception will be thrown if the field doesn't exist
     // or it belongs to the child object.
     private long getColumnIndexForSort(String fieldName) {
+        if (fieldName == null || fieldName.isEmpty()) {
+            throw new IllegalArgumentException("Non-empty fieldname required.");
+        }
         if (fieldName.contains(".")) {
             throw new IllegalArgumentException("Sorting using child object fields is not supported: " + fieldName);
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
@@ -16,8 +16,9 @@
 
 package io.realm.internal;
 
-import io.realm.RealmFieldType;
 import java.lang.ref.ReferenceQueue;
+
+import io.realm.RealmFieldType;
 
 /**
  * The LinkView class represents a core {@link RealmFieldType#LIST}.
@@ -153,6 +154,14 @@ public class LinkView extends NativeObject {
         nativeRemoveAllTargetRows(nativePointer);
     }
 
+    /**
+     * Removes target row from both the Realm and the LinkView.
+     */
+    public void removeTargetRow(int index) {
+        checkImmutable();
+        nativeRemoveTargetRow(nativePointer, index);
+    }
+
     public Table getTargetTable() {
         // Execute the disposal of abandoned realm objects each time a new realm object is created
         context.executeDelayedDisposal();
@@ -168,7 +177,7 @@ public class LinkView extends NativeObject {
 
     private void checkImmutable() {
         if (parent.isImmutable()) {
-            throw new IllegalStateException("Changing Realm data can only be done from inside a transaction.");
+            throw new IllegalStateException("Changing Realm data can only be done from inside a write transaction.");
         }
     }
 
@@ -186,6 +195,7 @@ public class LinkView extends NativeObject {
     protected native long nativeWhere(long nativeLinkViewPtr);
     private native boolean nativeIsAttached(long nativeLinkViewPtr);
     private native long nativeFind(long nativeLinkViewPtr, long targetRowIndex);
+    private native void nativeRemoveTargetRow(long nativeLinkViewPtr, long rowIndex);
     private native void nativeRemoveAllTargetRows(long nativeLinkViewPtr);
     private native long nativeGetTargetTable(long nativeLinkViewPtr);
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -339,6 +339,12 @@ public class Table implements TableOrView, TableSchema, Closeable {
     }
 
     @Override
+    public void removeFirst() {
+        checkImmutable();
+        remove(0);
+    }
+
+    @Override
     public void removeLast() {
         checkImmutable();
         nativeRemoveLast(nativePtr);

--- a/realm/realm-library/src/main/java/io/realm/internal/TableOrView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableOrView.java
@@ -353,6 +353,8 @@ public interface TableOrView {
 
     long count(long columnIndex, String value);
 
+    void removeFirst();
+
     enum PivotType {
         COUNT(0),
         SUM(1),

--- a/realm/realm-library/src/main/java/io/realm/internal/TableView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableView.java
@@ -454,6 +454,14 @@ public class TableView implements TableOrView, Closeable {
     }
 
     @Override
+    public void removeFirst() {
+        if (parent.isImmutable()) throwImmutable();
+        if (!isEmpty()) {
+            nativeRemoveRow(nativePtr, 0);
+        }
+    }
+
+    @Override
     public void removeLast() {
         if (parent.isImmutable()) throwImmutable();
         if (!isEmpty()) {
@@ -765,7 +773,7 @@ public class TableView implements TableOrView, Closeable {
 
 
     private void throwImmutable() {
-        throw new IllegalStateException("Mutable method call during read transaction.");
+        throw new IllegalStateException("Realm data can only be changed inside a write transaction.");
     }
 
     protected long nativePtr;


### PR DESCRIPTION
Fixes #1363 

# TODO

- [x] Split existing unit tests so they work as parameterised tests.
- [x] Implement new methods in RealmList.
- [x] Implement new methods in RealmResults.
- [x] Determine exactly what should happen with `remove`/`clear` for RealmResults. Core doesn't currently support mutating a TableView. RealmResults will have immutable behaviour until https://github.com/realm/realm-core/issues/1530 is fixed.
- [x] Ensure that everybody is onboard with the naming of interfaces.
- [ ] Should we shorten `delete*FromRealm` to just `delete*` ?
- [x] `Realm.clear()` -> `Realm.delete/deleteAll`
- [x] `RealmObject.removeFromRealm()` -> `RealmObject.deleteFromRealm()`
- [x] Change BaseRealmAdapter to work with `RealmOrderedCollection`.

**Behavior changes**
- `first()`/`last()` now returns null instead of throwing an Exception if the collection is empty (RealmList did that / RealmResults threw an exception before).
- `remove`/`removeAll`/`retainAll`/`clear` now all throws an UnsupportedException for RealmResults. All methods have been replaced by `delete*` instead.
- `indexOf` no longer throws UnsupportedOperation on RealmResults.
- `sort()` have been added to RealmList and both now returns a sorted copy instead of sorting in-place.
- BaseRealm is now public. Should it be renamed to something else? `AbstractRealm`, `BaseRealm`?

**Test coverage**
Coverage (Instructions / Branches)
RealmList: 
new: 96% / 88%
old: 89% / 78%
RealmResults: 
new: 92% / 88%
old: 77% / 76%

------
# Discussion / Details
The primary driver for this is the following design goal

1) Expose interfaces to UI components so they don't have to know the specific implementation.
   This is currently a problem in `BaseRealmAdapter` that only accepts `RealmResults` but not 
   `RealmList`.

2) Support future collection types.

3) Mirror RealmCollectionType in Swift: https://realm.io/docs/swift/latest/api/Protocols/RealmCollectionType.html 


## The current situation

Right now Realm exposes two collections: `RealmList` and `RealmResults`. Both extend from 
`AbstractList` but have different public interface behavior. Most noticeably around 
`List.remove()` which in `RealmList` only removes objects from the list, while in `RealmResult` 
it also removes the object from the underlying Realm.

This proposal also fixes these inconsistencies.

## What collections do we need? 

```
// Current collections
RealmList
RealmResults

// Future collections
RealmSet
RealmMap

// Even further in the future
TreeRealmMap
CustomRealmList
...
```

## The proposal

The driving design principle was to mirror the structure in the Java Collection API to increase 
flexibility in regards to the number of collection types we implement later.


```
// New interfaces

public interface RealmCollection<E extends RealmObject> extends Collection {
    // Query methods
    RealmQuery<E> where();
    Number min(String field);
    Number max(String field);
    Number sum(String field);
    Number average(String field);
    Date maxDate(String field);
    Date minDate(String field);

    // Removal from the underlying realm. `clear` will not
    // do that anymore, only remove objects from the Collection.
    boolean deleteAllFromRealm();

    // Async methods ()
    boolean isLoaded();
    boolean load();
    
    boolean isValid();
}

public interface OrderedRealmCollection<E extends RealmObject> extends List, RealmCollection {

    // Removal from the underlying realm. `remove(location)` will not
    // do that anymore, only remove objects from the Collection.
    // delete* methods returns a boolean where possible to mimic `remove` behaviour.
    void deleteFromRealm(int location);
    boolean deleteFirstFromRealm();
    boolean deleteLastFromRealm();

    E first();
    E last();

    // These have been changed from sort-in-place to return a sorted copy. Only way to support      RealmList.sort() which isn't ready in core yet, but behaviour is also more flexible.
    RealmResults<E> sort(String field);
    RealmResults<E> sort(String field, Sort sortOrder);
    RealmResults<E> sort(String field1, Sort sortOrder1, String field2, Sort sortOrder2);
    RealmResults<E> sort(String[] fields, Sort[] sortOrders);
}

public interface RealmUnorderedCollection extends Set, RealmCollection {
    // Not used right now, so don't implement right away.
}
```

Methods like `clear` and `remove` have origins the Collection API which is also why we have have method names like `RealmObject.removeFromRealm()` and `Realm.clear()` as we wanted to make that conncection stronger. However if we need to reserve the use of these methods to only operate on the collection, we should also strongly consider  renaming these methods to make them more apart from normal Collection methods. Swift uses `delete`/`deleteAll` and I propose we change to that terminology as well.

* `Realm.clear()` -> `Realm.deleteAll()`
* `Realm.clear(Class)` -> `Realm.delete(Class)`
* `RealmObject.removeFromRealm()` -> `RealmObject.deleteFromRealm()`
* `RealmList.removeAllFromRealm()` -> `RealmList.deleteAllFromRealm()`

## Consequences

- All collections now only modify the collection with the Collection API methods, i.e. data is not 
  removed from the underlying Realm using these methods. This is not a guarentee that objects that
  the object is excluded always. In the case of RealmResults, it might appear again after a refresh
  but since this proposal build on top of Delayed Notifactions, it will be gone until a ChangeListener
  is triggered. This makes it possible to manipulate RealmResults much more freely than today, where
  RealmResults are "live" at all times.

- Since we are departing from using the Collection API to cover actual deletes from Realm this is
  also a good change to unify the naming. This is a depature from previous decissions where we
  wanted to stay as close as possible to the Collection API (which are now giving us a lot of 
  headache).

- This proposal means that all collections will work like RealmList does today. It will introduce
  a breaking change for RealmResults that need to move from `results.remove(index)` to 
  `results.deleteFromRealm(index)`.

- Going forward this proposal means that all Collections no have the same semantics for the methods
  implemented as well as enable the support of more advanced collection types later. 


### Observations and reasoning

* List / Set / Map already used by the Java framework API

* We cannot differentiate between Mutable and Immutable lists. We have to throw in RealmResults for 
  mutator methods  :(

* CollectionType in Swift is not the same as Collection in Java. 

* Our current collections are very list-centric or "ordered".

* Take-aways from the guys designing the offical Collection interface: 
  http://docs.oracle.com/javase/1.5.0/docs/guide/collections/designfaq.html#1

* Java Collection API overview: http://ordinarygeek.me/wp-content/uploads/2009/12/collections-2.png

* Even though the most accurate name for a shared class between `RealmResults` and `RealmList` would 
  be something like `AbstractRealmList` it would be a quite "ugly" name as input argument to a method.
  RealmList would be much more accurate (and fit the List interface), but is unfortunately already
  taken. This proposal suggests "OrderedRealmCollection" and "UnorderedRealmCollection".

* RealmList does not support ChangeListeners, so change listeners will either be added later or split into their own interfaces. Once we have fine-grained notifications they will most likely influence the design of that.


### Alternative names considered

* RealmOrderedCollection:
    - OrderedRealmCollection
    - RealmEnumerable
    - RealmAbstractList
    - AbstractRealmList
    - RealmCollectionType
    - RealmList -> RealmArrayList. Raise RealmList to interface status.

## Feedback requested

* Is the proposal in general acceptable?
* Naming: Do you like OrderedRealmCollection?
* Naming: What do you think about renaming from `remove*` to `delete*`?
* Should `remove`/`clear` be allowed for RealmResults or should it just throw?
* Should we move all `delete*` methods to Realm instead of having them on `RealmObject`, `RealmResults` and `RealmList`?

----
EDIT
Regarding sort methods. If we want to support sort on all `RealmOrderedCollection`s we need to use `RealmResults<Foo> sort(field, sort)` as a RealmList cannot be sorted in-place and needs to be converted to a RealmResults in order to so.