### PR TITLE
Add a check whether transformer was applied or not.

### DIFF
--- a/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
@@ -117,4 +117,19 @@ class BytecodeModifier {
             }
         }
     }
+
+    /**
+     * Adds a method to indicate that Realm transformer has been applied.
+     *
+     * @param clazz The CtClass to modify.
+     */
+    public static void overrideTransformedMarker(CtClass clazz) {
+        logger.info "  Realm: Marking as transformed ${clazz.simpleName}"
+        try {
+            clazz.getDeclaredMethod("transformerApplied", new CtClass[0])
+        } catch (NotFoundException ignored) {
+            clazz.addMethod(CtNewMethod.make(Modifier.PUBLIC, CtClass.booleanType, "transformerApplied",
+                    new CtClass[0], new CtClass[0], "{return true;}", clazz))
+        }
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/MediatorTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/MediatorTest.java
@@ -82,4 +82,9 @@ public class MediatorTest extends AndroidTestCase {
         assertFalse(mediator.getModelClasses().contains(Dog.class));
         assertFalse(mediator.getModelClasses().contains(AllTypes.class));
     }
+
+    public void testDefaultMediatorWasTransformed() {
+        final DefaultRealmModuleMediator defaultMediator = new DefaultRealmModuleMediator();
+        assertTrue(defaultMediator.transformerApplied());
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -65,7 +65,13 @@ public class RealmConfiguration {
     static {
         DEFAULT_MODULE = Realm.getDefaultModule();
         if (DEFAULT_MODULE != null) {
-            DEFAULT_MODULE_MEDIATOR = getModuleMediator(DEFAULT_MODULE.getClass().getCanonicalName());
+            final RealmProxyMediator mediator = getModuleMediator(DEFAULT_MODULE.getClass().getCanonicalName());
+            if (!mediator.transformerApplied()) {
+                throw new ExceptionInInitializerError("RealmTransformer doesn't seem to be applied." +
+                        " Please update the project configuration to use the Realm Gradle plugin." +
+                        " See https://realm.io/news/android-installation-change/");
+            }
+            DEFAULT_MODULE_MEDIATOR = mediator;
         } else {
             DEFAULT_MODULE_MEDIATOR = null;
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -138,6 +138,17 @@ public abstract class RealmProxyMediator {
      */
     public abstract <E extends RealmObject> E createDetachedCopy(E realmObject, int maxDepth, Map<RealmObject, RealmObjectProxy.CacheData<RealmObject>> cache);
 
+    /**
+     * Returns whether Realm transformer has been applied or not. Subclasses of this class are
+     * created by the annotation processor and the Realm transformer will add an override of
+     * this method that always return {@code true} if the transform was successful.
+     *
+     * @return {@code true} if Realm transformer was applied, {@code false} otherwise.
+     */
+    public boolean transformerApplied() {
+        return false;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof RealmProxyMediator)) {

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -115,6 +115,16 @@ public class CompositeMediator extends RealmProxyMediator {
         return mediator.createDetachedCopy(realmObject, maxDepth, cache);
     }
 
+    @Override
+    public boolean transformerApplied() {
+        for (Map.Entry<Class<? extends RealmObject>, RealmProxyMediator> entry : mediators.entrySet()) {
+            if (!entry.getValue().transformerApplied()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     // Returns the mediator for a given model class (not RealmProxy) or throws exception
     private RealmProxyMediator getMediator(Class<? extends RealmObject> clazz) {
         RealmProxyMediator mediator = mediators.get(clazz);

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -131,6 +131,15 @@ public class FilterableMediator extends RealmProxyMediator {
         return originalMediator.createDetachedCopy(realmObject, maxDepth, cache);
     }
 
+    @Override
+    public boolean transformerApplied() {
+        //noinspection SimplifiableIfStatement
+        if (originalMediator == null) {
+            return true;
+        }
+        return originalMediator.transformerApplied();
+    }
+
     // Validate if a model class (not RealmProxy) is part of this Schema.
     private void checkSchemaHasClass(Class<? extends RealmObject> clazz) {
         if (!allowedClasses.contains(clazz)) {


### PR DESCRIPTION
This commit adds default implementation of `transformerApplied()` to `RealmProxyMediator` class which returns `false`.
And then Realm transformer adds overriding methods to its subclasses and those methods returns `true`.

If Realm transformer was applied, `RealmProxyMediator.transformerApplied()` returns `true` and
if not, `RealmProxyMediator.transformerApplied()` returns `false`.
That enable us to detect Realm transformer was applied or not at runtime.

review this please @realm/java @emanuelez 