### PR TITLE
removed runtime dependency from 'realm-transformer' to 'com.android.tools.build:transform-api:1.5.0'.

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -31,12 +31,23 @@ targetCompatibility = 1.6
 group = 'io.realm'
 version = file("${projectDir}/../version.txt").text.trim();
 
+configurations {
+    provided
+    compile.extendsFrom provided
+}
+
+sourceSets {
+    main {
+        compileClasspath += configurations.provided
+    }
+}
+
 dependencies {
     compile gradleApi()
     compile localGroovy()
     compile "io.realm:realm-transformer:${version}"
     compile 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-    compile 'com.android.tools.build:gradle:1.5.0'
+    provided 'com.android.tools.build:gradle:1.5.0'
 
     testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -35,6 +35,10 @@ class Realm implements Plugin<Project> {
             throw new GradleException("'com.android.application' or 'com.android.library' plugin required.")
         }
 
+        if (!isTransformAvailable()) {
+            throw new GradleException('Realm gradle plugin only supports android gradle plugin 1.5.0 or later.')
+        }
+
         def isKotlinProject = project.plugins.find {
             it.getClass().name == 'org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper'
         }
@@ -54,6 +58,15 @@ class Realm implements Plugin<Project> {
         } else {
             project.dependencies.add("apt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("apt", "io.realm:realm-annotations-processor:${Version.VERSION}")
+        }
+    }
+
+    private static boolean isTransformAvailable() {
+        try {
+            Class.forName('com.android.build.api.transform.Transform')
+            return true
+        } catch (Exception ignored) {
+            return false
         }
     }
 }

--- a/realm-transformer/build.gradle
+++ b/realm-transformer/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     compile gradleApi()
     compile "io.realm:realm-annotations:${version}"
     compile 'com.android.tools.build:gradle:1.5.0'
-    compile 'com.android.tools.build:transform-api:1.5.0'
     compile 'org.javassist:javassist:3.20.0-GA'
 
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {

--- a/realm-transformer/build.gradle
+++ b/realm-transformer/build.gradle
@@ -25,11 +25,22 @@ repositories {
     jcenter()
 }
 
+configurations {
+    provided
+    compile.extendsFrom provided
+}
+
+sourceSets {
+    main {
+        compileClasspath += configurations.provided
+    }
+}
+
 dependencies {
     compile localGroovy()
     compile gradleApi()
     compile "io.realm:realm-annotations:${version}"
-    compile 'com.android.tools.build:gradle:1.5.0'
+    provided 'com.android.tools.build:gradle:1.5.0'
     compile 'org.javassist:javassist:3.20.0-GA'
 
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {


### PR DESCRIPTION
We don't need to have runtime dependency to  `com.android.tools.build:transform-api` since android gradle plugin has that dependency.

Removing this explicit dependency from `realm-transformer` solves the compatibility issue against android gradle plugin 2.0.0-beta.

This fixes #2348

review this please @realm/java 