### PR TITLE
Only load RealmObservableFactory when RxJava exist

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -43,6 +43,8 @@ import io.realm.exceptions.RealmMigrationNeededException;
 import io.realm.internal.modules.CompositeMediator;
 import io.realm.internal.modules.FilterableMediator;
 import io.realm.rule.TestRealmConfigurationFactory;
+import io.realm.rx.RxObservableFactory;
+import rx.Observable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -576,5 +578,70 @@ public class RealmConfigurationTests {
             fail();
         } catch (UnsupportedOperationException ignored) {
         }
+    }
+
+    @Test
+    public void rxFactory() {
+        final RxObservableFactory dummyFactory = new RxObservableFactory() {
+            @Override
+            public Observable<Realm> from(Realm realm) {
+                return null;
+            }
+
+            @Override
+            public Observable<DynamicRealm> from(DynamicRealm realm) {
+                return null;
+            }
+
+            @Override
+            public <E extends RealmObject> Observable<RealmResults<E>> from(Realm realm, RealmResults<E> results) {
+                return null;
+            }
+
+            @Override
+            public Observable<RealmResults<DynamicRealmObject>> from(DynamicRealm realm, RealmResults<DynamicRealmObject> results) {
+                return null;
+            }
+
+            @Override
+            public <E extends RealmObject> Observable<RealmList<E>> from(Realm realm, RealmList<E> list) {
+                return null;
+            }
+
+            @Override
+            public Observable<RealmList<DynamicRealmObject>> from(DynamicRealm realm, RealmList<DynamicRealmObject> list) {
+                return null;
+            }
+
+            @Override
+            public <E extends RealmObject> Observable<E> from(Realm realm, E object) {
+                return null;
+            }
+
+            @Override
+            public Observable<DynamicRealmObject> from(DynamicRealm realm, DynamicRealmObject object) {
+                return null;
+            }
+
+            @Override
+            public <E extends RealmObject> Observable<RealmQuery<E>> from(Realm realm, RealmQuery<E> query) {
+                return null;
+            }
+
+            @Override
+            public Observable<RealmQuery<DynamicRealmObject>> from(DynamicRealm realm, RealmQuery<DynamicRealmObject> query) {
+                return null;
+            }
+        };
+
+        RealmConfiguration configuration1 = configFactory.createConfigurationBuilder()
+                .rxFactory(dummyFactory)
+                .build();
+        assertTrue(configuration1.getRxFactory() == dummyFactory);
+
+        RealmConfiguration configuration2 = configFactory.createConfigurationBuilder()
+                .build();
+        assertNotNull(configuration2.getRxFactory());
+        assertFalse(configuration2.getRxFactory() == dummyFactory);
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -275,7 +275,8 @@ public abstract class RealmObject {
      *
      * @param <E> RealmObject class that is being observed. Must be this class or its super types.
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
-     * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
+     * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath or the
+     * corresponding Realm instance doesn't support RxJava.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>
      */
     public <E extends RealmObject> Observable<E> asObservable() {
@@ -287,10 +288,12 @@ public abstract class RealmObject {
             DynamicRealm dynamicRealm = (DynamicRealm) realm;
             DynamicRealmObject dynamicObject = (DynamicRealmObject) this;
             @SuppressWarnings("unchecked")
-            Observable<E> observable = (Observable<E>) realm.configuration.getRxFactory().from(dynamicRealm, dynamicObject);
+            Observable<E> observable = (Observable<E>) realm.configuration.getRxFactory().from(dynamicRealm,
+                    dynamicObject);
             return observable;
         } else {
-            throw new UnsupportedOperationException(realm.getClass() + " not supported");
+            throw new UnsupportedOperationException(realm.getClass() + " does not support RxJava." +
+                    " See https://realm.io/docs/java/latest/#rxjava for more details.");
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -933,7 +933,8 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
      * </pre>
      *
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
-     * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
+     * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath or the
+     * corresponding Realm instance doesn't support RxJava.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>
      */
     @SuppressWarnings("unchecked")
@@ -947,7 +948,7 @@ public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
             Observable results = realm.configuration.getRxFactory().from(dynamicRealm, dynamicResults);
             return results;
         } else {
-            throw new UnsupportedOperationException(realm.getClass() + " not supported");
+            throw new UnsupportedOperationException(realm.getClass() + " does not support RxJava.");
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
@@ -40,20 +40,8 @@ import rx.subscriptions.Subscriptions;
  */
 public class RealmObservableFactory implements RxObservableFactory {
 
-    private boolean rxJavaAvailable;
-
-    public RealmObservableFactory() {
-        try {
-            Class.forName("rx.Observable");
-            rxJavaAvailable = true;
-        } catch (ClassNotFoundException ignore) {
-            rxJavaAvailable = false;
-        }
-    }
-
     @Override
     public Observable<Realm> from(final Realm realm) {
-        checkRxJavaAvailable();
         return Observable.create(new Observable.OnSubscribe<Realm>() {
             @Override
             public void call(final Subscriber<? super Realm> subscriber) {
@@ -79,7 +67,6 @@ public class RealmObservableFactory implements RxObservableFactory {
 
     @Override
     public Observable<DynamicRealm> from(final DynamicRealm realm) {
-        checkRxJavaAvailable();
         return Observable.create(new Observable.OnSubscribe<DynamicRealm>() {
             @Override
             public void call(final Subscriber<? super DynamicRealm> subscriber) {
@@ -108,17 +95,17 @@ public class RealmObservableFactory implements RxObservableFactory {
 
     @Override
     public <E extends RealmObject> Observable<RealmResults<E>> from(Realm realm, RealmResults<E> results) {
-        checkRxJavaAvailable();
         return getRealmResultsObservable(results);
     }
 
     @Override
-    public Observable<RealmResults<DynamicRealmObject>> from(DynamicRealm realm, RealmResults<DynamicRealmObject> results) {
-        checkRxJavaAvailable();
+    public Observable<RealmResults<DynamicRealmObject>> from(DynamicRealm realm,
+                                                             RealmResults<DynamicRealmObject> results) {
         return getRealmResultsObservable(results);
     }
 
-    private <E extends RealmObject> Observable<RealmResults<E>> getRealmResultsObservable(final RealmResults<E> results) {
+    private <E extends RealmObject> Observable<RealmResults<E>> getRealmResultsObservable(
+            final RealmResults<E> results) {
         return Observable.create(new Observable.OnSubscribe<RealmResults<E>>() {
             @Override
             public void call(final Subscriber<? super RealmResults<E>> subscriber) {
@@ -147,13 +134,11 @@ public class RealmObservableFactory implements RxObservableFactory {
 
     @Override
     public <E extends RealmObject> Observable<RealmList<E>> from(Realm realm, RealmList<E> list) {
-        checkRxJavaAvailable();
         return getRealmListObservable();
     }
 
     @Override
     public Observable<RealmList<DynamicRealmObject>> from(DynamicRealm realm, RealmList<DynamicRealmObject> list) {
-        checkRxJavaAvailable();
         return getRealmListObservable();
     }
 
@@ -163,13 +148,11 @@ public class RealmObservableFactory implements RxObservableFactory {
 
     @Override
     public <E extends RealmObject> Observable<E> from(Realm realm, final E object) {
-        checkRxJavaAvailable();
         return getObjectObservable(object);
     }
 
     @Override
     public Observable<DynamicRealmObject> from(DynamicRealm realm, DynamicRealmObject object) {
-        checkRxJavaAvailable();
         return getObjectObservable(object);
     }
 
@@ -206,15 +189,9 @@ public class RealmObservableFactory implements RxObservableFactory {
     }
 
     @Override
-    public Observable<RealmQuery<DynamicRealmObject>> from(final DynamicRealm realm, final RealmQuery<DynamicRealmObject> query) {
+    public Observable<RealmQuery<DynamicRealmObject>> from(final DynamicRealm realm,
+                                                           final RealmQuery<DynamicRealmObject> query) {
         throw new RuntimeException("RealmQuery not supported yet.");
-    }
-
-    private void checkRxJavaAvailable() {
-        if (!rxJavaAvailable) {
-            throw new IllegalStateException("RxJava seems to be missing from the classpath. " +
-                    "Remember to add it as a compile dependency. See https://realm.io/docs/java/latest/#rxjava for more details.");
-        }
     }
 
     @Override


### PR DESCRIPTION
Close #1990.

* Check RxJava existence only once.
* Don't load RealmObservableFactory if RxJava doesn't exist.
* Correct exceptions in the java doc.

NOTE: When reflection called on the RealmObject/RealmResults, crash will
still happen because of Observable doesn't exist in the class path. In
such a case, a dummy rx.Observable is still needed as a workaround.