### PR TITLE
Realm Observables now holds a Realm instance reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * BREAKING CHANGE: All thread local change listeners are now delayed until the next Looper event instead of being triggered when committing.
 * BREAKING CHANGE: Removed RealmConfiguration.getSchemaMediator() from public API which was deprecated in 0.86.0. Please use RealmConfiguration.getRealmObjectClasses() to obtain the set of model classes (#1797).
 * BREAKING CHANGE: Realm.migrateRealm() throws a FileNotFoundException if the Realm file doesn't exist.
+* BREAKING CHANGE: It is now required to unsubscribe from all Realm RxJava observables in order to fully close the Realm (#2357).
 * Added support for custom methods, custom logic in accessors, custom accessor names, interface implementation and public fields in Realm objects. (#909)
 * Added support to project Lombok. (#502)
 * Deprecated methods: Realm.getInstance(Context). Use Realm.getInstance(RealmConfiguration) or Realm.getDefaultInstance() instead.

--- a/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
@@ -37,6 +37,7 @@ import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;
 import rx.Observable;
 import rx.Subscription;
+import rx.functions.Action0;
 import rx.functions.Action1;
 
 import static org.junit.Assert.assertEquals;
@@ -49,20 +50,29 @@ public class RxJavaTests {
     @Rule
     public final UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
     @Rule
-    public final RunInLooperThread looperThread = new RunInLooperThread();
+    public final RunInLooperThread looperThread = new RunInLooperThread() {
+        @Override
+        public void looperTearDown() {
+            if (subscription != null && !subscription.isUnsubscribed()) {
+                subscription.unsubscribe();
+            }
+        }
+    };
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
 
     private Realm realm;
+    private Subscription subscription;
 
     @Before
     public void setUp() throws Exception {
-        RealmConfiguration realmConfig = configFactory.createConfiguration();
-        realm = Realm.getInstance(realmConfig);
+        // For non-LooperThread tests
+        realm = Realm.getInstance(configFactory.createConfiguration());
     }
 
     @After
     public void tearDown() throws Exception {
+        // For non-LooperThread tests
         if (realm != null) {
             realm.close();
         }
@@ -76,7 +86,7 @@ public class RxJavaTests {
         realm.commitTransaction();
 
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
-        obj.<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
+        subscription = obj.<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
             @Override
             public void call(AllTypes rxObject) {
                 assertTrue(rxObject == obj);
@@ -84,6 +94,7 @@ public class RxJavaTests {
             }
         });
         assertTrue(subscribedNotified.get());
+        subscription.unsubscribe();
     }
 
     @Test
@@ -95,7 +106,7 @@ public class RxJavaTests {
         final AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();
 
-        obj.<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
+        subscription = obj.<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
             @Override
             public void call(AllTypes rxObject) {
                 if (subscriberCalled.incrementAndGet() == 2) {
@@ -117,7 +128,7 @@ public class RxJavaTests {
         realm.commitTransaction();
 
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
-        realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 42).findFirst().<AllTypes>asObservable()
+        subscription = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 42).findFirst().<AllTypes>asObservable()
                 .subscribe(new Action1<AllTypes>() {
                     @Override
                     public void call(AllTypes rxObject) {
@@ -125,6 +136,7 @@ public class RxJavaTests {
                     }
                 });
         assertTrue(subscribedNotified.get());
+        subscription.unsubscribe();
     }
 
     @Test
@@ -136,7 +148,7 @@ public class RxJavaTests {
 
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
         final AllTypes asyncObj = realm.where(AllTypes.class).findFirstAsync();
-        asyncObj.<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
+        subscription = asyncObj.<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
             @Override
             public void call(AllTypes rxObject) {
                 assertTrue(rxObject == asyncObj);
@@ -144,27 +156,29 @@ public class RxJavaTests {
             }
         });
         assertTrue(subscribedNotified.get());
+        subscription.unsubscribe();
     }
 
     @Test
-    @UiThreadTest
+    @RunTestInLooperThread
     public void findFirstAsync_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
+        Realm realm = looperThread.realm;
         realm.beginTransaction();
         AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();
-        realm.where(AllTypes.class).findFirstAsync().<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
+        subscription = realm.where(AllTypes.class).findFirstAsync().<AllTypes>asObservable().subscribe(new Action1<AllTypes>() {
             @Override
             public void call(AllTypes rxObject) {
-                subscriberCalled.incrementAndGet();
+                if (subscriberCalled.incrementAndGet() == 2) {
+                    looperThread.testComplete();
+                }
             }
         });
 
         realm.beginTransaction();
         obj.setColumnLong(1);
         realm.commitTransaction();
-
-        assertEquals(1, subscriberCalled.get());
     }
 
     @Test
@@ -172,7 +186,7 @@ public class RxJavaTests {
     public void realmResults_emittedOnSubscribe() {
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
         final RealmResults<AllTypes> results = realm.allObjects(AllTypes.class);
-        results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
+        subscription = results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
             @Override
             public void call(RealmResults<AllTypes> rxResults) {
                 assertTrue(rxResults == results);
@@ -180,6 +194,7 @@ public class RxJavaTests {
             }
         });
         assertTrue(subscribedNotified.get());
+        subscription.unsubscribe();
     }
 
     @Test
@@ -191,7 +206,7 @@ public class RxJavaTests {
         RealmResults<AllTypes> results = realm.allObjects(AllTypes.class);
         realm.commitTransaction();
 
-        results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
+        subscription = results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
             @Override
             public void call(RealmResults<AllTypes> allTypes) {
                 if (subscriberCalled.incrementAndGet() == 2) {
@@ -210,7 +225,7 @@ public class RxJavaTests {
     public void findAllAsync_emittedOnSubscribe() {
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
         final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
-        results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
+        subscription = results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
             @Override
             public void call(RealmResults<AllTypes> rxResults) {
                 assertTrue(rxResults == results);
@@ -218,31 +233,33 @@ public class RxJavaTests {
             }
         });
         assertTrue(subscribedNotified.get());
+        subscription.unsubscribe();
     }
 
     @Test
-    @UiThreadTest
+    @RunTestInLooperThread
     public void findAllAsync_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        realm.where(AllTypes.class).findAllAsync().asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
+        Realm realm = looperThread.realm;
+        subscription = realm.where(AllTypes.class).findAllAsync().asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
             @Override
             public void call(RealmResults<AllTypes> rxResults) {
-                subscriberCalled.incrementAndGet();
+                if (subscriberCalled.incrementAndGet() == 2) {
+                    looperThread.testComplete();
+                }
             }
         });
 
         realm.beginTransaction();
         realm.createObject(AllTypes.class);
         realm.commitTransaction();
-
-        assertEquals(1, subscriberCalled.get());
     }
 
     @Test
     @UiThreadTest
     public void realm_emittedOnSubscribe() {
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
-        realm.asObservable().subscribe(new Action1<Realm>() {
+        subscription = realm.asObservable().subscribe(new Action1<Realm>() {
             @Override
             public void call(Realm rxRealm) {
                 assertTrue(rxRealm == realm);
@@ -250,6 +267,7 @@ public class RxJavaTests {
             }
         });
         assertTrue(subscribedNotified.get());
+        subscription.unsubscribe();
     }
 
     @Test
@@ -257,7 +275,7 @@ public class RxJavaTests {
     public void realm_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
         Realm realm = looperThread.realm;
-        realm.asObservable().subscribe(new Action1<Realm>() {
+        subscription = realm.asObservable().subscribe(new Action1<Realm>() {
             @Override
             public void call(Realm rxRealm) {
                 if (subscriberCalled.incrementAndGet() == 2) {
@@ -274,25 +292,32 @@ public class RxJavaTests {
     @Test
     @UiThreadTest
     public void dynamicRealm_emittedOnSubscribe() {
-        final DynamicRealm dynamicRealm = DynamicRealm.createInstance(realm.getConfiguration());
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
-        dynamicRealm.asObservable().subscribe(new Action1<DynamicRealm>() {
+        subscription = dynamicRealm.asObservable().subscribe(new Action1<DynamicRealm>() {
             @Override
             public void call(DynamicRealm rxRealm) {
                 assertTrue(rxRealm == dynamicRealm);
                 subscribedNotified.set(true);
             }
+        }, new Action1<Throwable>() {
+            @Override
+            public void call(Throwable throwable) {
+                throwable.printStackTrace();
+            }
         });
+
         assertTrue(subscribedNotified.get());
         dynamicRealm.close();
+        subscription.unsubscribe();
     }
 
     @Test
     @RunTestInLooperThread
     public void dynamicRealm_emittedOnUpdate() {
-        final DynamicRealm dynamicRealm = DynamicRealm.createInstance(realm.getConfiguration());
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.realmConfiguration);
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        dynamicRealm.asObservable().subscribe(new Action1<DynamicRealm>() {
+        subscription = dynamicRealm.asObservable().subscribe(new Action1<DynamicRealm>() {
             @Override
             public void call(DynamicRealm rxRealm) {
                 if (subscriberCalled.incrementAndGet() == 2) {
@@ -309,9 +334,9 @@ public class RxJavaTests {
 
     @Test
     @UiThreadTest
-    public void unsubscribe() {
+    public void unsubscribe_sameThread() {
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
-        Subscription subscription = realm.asObservable().subscribe(new Action1<Realm>() {
+        subscription = realm.asObservable().subscribe(new Action1<Realm>() {
             @Override
             public void call(Realm rxRealm) {
                 assertTrue(rxRealm == realm);
@@ -325,7 +350,7 @@ public class RxJavaTests {
 
     @Test
     @UiThreadTest
-    public void unsubscribe_fromOtherThreadThrows() {
+    public void unsubscribe_fromOtherThread() {
         final CountDownLatch unsubscribeCompleted = new CountDownLatch(1);
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
         final Subscription subscription = realm.asObservable().subscribe(new Action1<Realm>() {
@@ -335,6 +360,7 @@ public class RxJavaTests {
                 subscribedNotified.set(true);
             }
         });
+        assertTrue(subscribedNotified.get());
         assertEquals(1, realm.handlerController.changeListeners.size());
         new Thread(new Runnable() {
             @Override
@@ -350,6 +376,9 @@ public class RxJavaTests {
         }).start();
         TestHelper.awaitOrFail(unsubscribeCompleted);
         assertEquals(1, realm.handlerController.changeListeners.size());
+        // We cannot call subscription.unsubscribe() again, so manually close the extra Realm instance opened by
+        // the Observable.
+        realm.close();
     }
 
     @Test
@@ -371,4 +400,144 @@ public class RxJavaTests {
             }
         });
     }
+
+    @Test
+    @UiThreadTest
+    public void realm_closeInDoOnUnsubscribe() {
+        Observable<Realm> observable = realm.asObservable()
+                .doOnUnsubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        realm.close();
+                    }
+                });
+
+        subscription = observable.subscribe(new Action1<Realm>() {
+            @Override
+            public void call(Realm rxRealm) {
+            }
+        });
+
+        subscription.unsubscribe();
+        assertTrue(realm.isClosed());
+    }
+
+    @Test
+    @UiThreadTest
+    public void dynamicRealm_closeInDoOnUnsubscribe() {
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
+
+        Observable<DynamicRealm> observable = dynamicRealm.asObservable()
+                .doOnUnsubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        dynamicRealm.close();
+                    }
+                });
+
+        subscription = observable.subscribe(new Action1<DynamicRealm>() {
+            @Override
+            public void call(DynamicRealm rxRealm) {
+            }
+        });
+
+        subscription.unsubscribe();
+        assertTrue(dynamicRealm.isClosed());
+    }
+
+    @Test
+    @UiThreadTest
+    public void realmResults_closeInDoOnUnsubscribe() {
+        Observable<RealmResults<AllTypes>> observable = realm.allObjects(AllTypes.class).asObservable()
+                .doOnUnsubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        realm.close();
+                    }
+                });
+
+        subscription = observable.subscribe(new Action1<RealmResults<AllTypes>>() {
+            @Override
+            public void call(RealmResults<AllTypes> allTypes) {
+            }
+        });
+
+        subscription.unsubscribe();
+        assertTrue(realm.isClosed());
+    }
+
+    @Test
+    @UiThreadTest
+    public void dynamicRealmResults_closeInDoOnUnsubscribe() {
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
+
+        Observable<RealmResults<DynamicRealmObject>> observable = dynamicRealm.allObjects(AllTypes.CLASS_NAME).asObservable()
+                .doOnUnsubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        dynamicRealm.close();
+                    }
+                });
+
+        subscription = observable.subscribe(new Action1<RealmResults<DynamicRealmObject>>() {
+            @Override
+            public void call(RealmResults<DynamicRealmObject> allTypes) {
+            }
+        });
+
+        subscription.unsubscribe();
+        assertTrue(dynamicRealm.isClosed());
+    }
+
+    @Test
+    @UiThreadTest
+    public void realmObject_closeInDoOnUnsubscribe() {
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+
+        Observable<AllTypes> observable = realm.allObjects(AllTypes.class).first().<AllTypes>asObservable()
+                .doOnUnsubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        realm.close();
+                    }
+                });
+
+        subscription = observable.subscribe(new Action1<AllTypes>() {
+            @Override
+            public void call(AllTypes allTypes) {
+            }
+        });
+
+        subscription.unsubscribe();
+        assertTrue(realm.isClosed());
+    }
+
+    @Test
+    @UiThreadTest
+    public void dynamicRealmObject_closeInDoOnUnsubscribe() {
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
+
+        Observable<DynamicRealmObject> observable = dynamicRealm.allObjects(AllTypes.CLASS_NAME).first().<DynamicRealmObject>asObservable()
+                .doOnUnsubscribe(new Action0() {
+                    @Override
+                    public void call() {
+                        dynamicRealm.close();
+                    }
+                });
+
+        subscription = observable.subscribe(new Action1<DynamicRealmObject>() {
+            @Override
+            public void call(DynamicRealmObject obj) {
+            }
+        });
+
+        subscription.unsubscribe();
+        assertTrue(dynamicRealm.isClosed());
+    }
+
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -103,6 +103,14 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
                                 threadAssertionError[0] = e;
                                 unitTestFailed = true;
                             } finally {
+                                try {
+                                    looperTearDown();
+                                } catch (Throwable t) {
+                                    if (threadAssertionError[0] == null) {
+                                        threadAssertionError[0] = t;
+                                    }
+                                    unitTestFailed = true;
+                                }
                                 if (signalTestCompleted.getCount() > 0) {
                                     signalTestCompleted.countDown();
                                 }
@@ -180,5 +188,12 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
      */
     public void postRunnable(Runnable runnable) {
         backgroundHandler.post(runnable);
+    }
+
+    /**
+     * Tear down logic which is guaranteed to run after the looper test has either completed or failed.
+     * This will run on the same thread as the looper test.
+     */
+    public void looperTearDown() {
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
@@ -20,6 +20,7 @@ import io.realm.DynamicRealm;
 import io.realm.DynamicRealmObject;
 import io.realm.Realm;
 import io.realm.RealmChangeListener;
+import io.realm.RealmConfiguration;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.RealmQuery;
@@ -41,74 +42,77 @@ import rx.subscriptions.Subscriptions;
 public class RealmObservableFactory implements RxObservableFactory {
 
     @Override
-    public Observable<Realm> from(final Realm realm) {
+    public Observable<Realm> from(Realm realm) {
+        final RealmConfiguration realmConfig = realm.getConfiguration();
         return Observable.create(new Observable.OnSubscribe<Realm>() {
             @Override
             public void call(final Subscriber<? super Realm> subscriber) {
+                // Get instance to make sure that the Realm is open for as long as the
+                // Observable is subscribed to it.
+                final Realm observableRealm = Realm.getInstance(realmConfig);
                 final RealmChangeListener listener = new RealmChangeListener() {
                     @Override
                     public void onChange() {
                         if (!subscriber.isUnsubscribed()) {
-                            subscriber.onNext(realm);
+                            subscriber.onNext(observableRealm);
                         }
                     }
                 };
-                realm.addChangeListener(listener);
+                observableRealm.addChangeListener(listener);
                 subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
-                        realm.removeChangeListener(listener);
+                        observableRealm.removeChangeListener(listener);
+                        observableRealm.close();
                     }
                 }));
-                subscriber.onNext(realm);
+                subscriber.onNext(observableRealm);
             }
         });
     }
 
     @Override
-    public Observable<DynamicRealm> from(final DynamicRealm realm) {
+    public Observable<DynamicRealm> from(DynamicRealm realm) {
+        final RealmConfiguration realmConfig = realm.getConfiguration();
         return Observable.create(new Observable.OnSubscribe<DynamicRealm>() {
             @Override
             public void call(final Subscriber<? super DynamicRealm> subscriber) {
+                // Get instance to make sure that the Realm is open for as long as the
+                // Observable is subscribed to it.
+                final DynamicRealm observableRealm = DynamicRealm.getInstance(realmConfig);
                 final RealmChangeListener listener = new RealmChangeListener() {
                     @Override
                     public void onChange() {
                         if (!subscriber.isUnsubscribed()) {
-                            subscriber.onNext(realm);
+                            subscriber.onNext(observableRealm);
                         }
                     }
                 };
-                realm.addChangeListener(listener);
+                observableRealm.addChangeListener(listener);
                 subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
-                        realm.removeChangeListener(listener);
+                        observableRealm.removeChangeListener(listener);
+                        observableRealm.close();
                     }
                 }));
 
-                // Immediately call onNext with the current value, as due to Realms auto-update, it will be the latest
+                    // Immediately call onNext with the current value, as due to Realm's auto-update, it will be the latest
                 // value.
-                subscriber.onNext(realm);
+                subscriber.onNext(observableRealm);
             }
         });
     }
 
     @Override
-    public <E extends RealmObject> Observable<RealmResults<E>> from(Realm realm, RealmResults<E> results) {
-        return getRealmResultsObservable(results);
-    }
-
-    @Override
-    public Observable<RealmResults<DynamicRealmObject>> from(DynamicRealm realm,
-                                                             RealmResults<DynamicRealmObject> results) {
-        return getRealmResultsObservable(results);
-    }
-
-    private <E extends RealmObject> Observable<RealmResults<E>> getRealmResultsObservable(
-            final RealmResults<E> results) {
+    public <E extends RealmObject> Observable<RealmResults<E>> from(final Realm realm, final RealmResults<E> results) {
+        final RealmConfiguration realmConfig = realm.getConfiguration();
         return Observable.create(new Observable.OnSubscribe<RealmResults<E>>() {
             @Override
             public void call(final Subscriber<? super RealmResults<E>> subscriber) {
+                // Get instance to make sure that the Realm is open for as long as the
+                // Observable is subscribed to it.
+                final Realm observableRealm = Realm.getInstance(realmConfig);
                 final RealmChangeListener listener = new RealmChangeListener() {
                     @Override
                     public void onChange() {
@@ -122,10 +126,44 @@ public class RealmObservableFactory implements RxObservableFactory {
                     @Override
                     public void call() {
                         results.removeChangeListener(listener);
+                        observableRealm.close();
                     }
                 }));
 
-                // Immediately call onNext with the current value, as due to Realms auto-update, it will be the latest
+                // Immediately call onNext with the current value, as due to Realm's auto-update, it will be the latest
+                // value.
+                subscriber.onNext(results);
+            }
+        });
+    }
+
+    @Override
+    public Observable<RealmResults<DynamicRealmObject>> from(DynamicRealm realm, final RealmResults<DynamicRealmObject> results) {
+        final RealmConfiguration realmConfig = realm.getConfiguration();
+        return Observable.create(new Observable.OnSubscribe<RealmResults<DynamicRealmObject>>() {
+            @Override
+            public void call(final Subscriber<? super RealmResults<DynamicRealmObject>> subscriber) {
+                // Get instance to make sure that the Realm is open for as long as the
+                // Observable is subscribed to it.
+                final DynamicRealm observableRealm = DynamicRealm.getInstance(realmConfig);
+                final RealmChangeListener listener = new RealmChangeListener() {
+                    @Override
+                    public void onChange() {
+                        if (!subscriber.isUnsubscribed()) {
+                            subscriber.onNext(results);
+                        }
+                    }
+                };
+                results.addChangeListener(listener);
+                subscriber.add(Subscriptions.create(new Action0() {
+                    @Override
+                    public void call() {
+                        results.removeChangeListener(listener);
+                        observableRealm.close();
+                    }
+                }));
+
+                // Immediately call onNext with the current value, as due to Realm's auto-update, it will be the latest
                 // value.
                 subscriber.onNext(results);
             }
@@ -147,19 +185,14 @@ public class RealmObservableFactory implements RxObservableFactory {
     }
 
     @Override
-    public <E extends RealmObject> Observable<E> from(Realm realm, final E object) {
-        return getObjectObservable(object);
-    }
-
-    @Override
-    public Observable<DynamicRealmObject> from(DynamicRealm realm, DynamicRealmObject object) {
-        return getObjectObservable(object);
-    }
-
-    private <E extends RealmObject> Observable<E> getObjectObservable(final E object) {
+    public <E extends RealmObject> Observable<E> from(final Realm realm, final E object) {
+        final RealmConfiguration realmConfig = realm.getConfiguration();
         return Observable.create(new Observable.OnSubscribe<E>() {
             @Override
             public void call(final Subscriber<? super E> subscriber) {
+                // Get instance to make sure that the Realm is open for as long as the
+                // Observable is subscribed to it.
+                final Realm observableRealm = Realm.getInstance(realmConfig);
                 final RealmChangeListener listener = new RealmChangeListener() {
                     @Override
                     public void onChange() {
@@ -173,10 +206,11 @@ public class RealmObservableFactory implements RxObservableFactory {
                     @Override
                     public void call() {
                         object.removeChangeListener(listener);
+                        observableRealm.close();
                     }
                 }));
 
-                // Immediately call onNext with the current value, as due to Realms auto-update, it will be the latest
+                // Immediately call onNext with the current value, as due to Realm's auto-update, it will be the latest
                 // value.
                 subscriber.onNext(object);
             }
@@ -184,13 +218,45 @@ public class RealmObservableFactory implements RxObservableFactory {
     }
 
     @Override
-    public <E extends RealmObject> Observable<RealmQuery<E>> from(final Realm realm, final RealmQuery<E> query) {
+    public Observable<DynamicRealmObject> from(DynamicRealm realm, final DynamicRealmObject object) {
+        final RealmConfiguration realmConfig = realm.getConfiguration();
+        return Observable.create(new Observable.OnSubscribe<DynamicRealmObject>() {
+            @Override
+            public void call(final Subscriber<? super DynamicRealmObject> subscriber) {
+                // Get instance to make sure that the Realm is open for as long as the
+                // Observable is subscribed to it.
+                final DynamicRealm observableRealm = DynamicRealm.getInstance(realmConfig);
+                final RealmChangeListener listener = new RealmChangeListener() {
+                    @Override
+                    public void onChange() {
+                        if (!subscriber.isUnsubscribed()) {
+                            subscriber.onNext(object);
+                        }
+                    }
+                };
+                object.addChangeListener(listener);
+                subscriber.add(Subscriptions.create(new Action0() {
+                    @Override
+                    public void call() {
+                        object.removeChangeListener(listener);
+                        observableRealm.close();
+                    }
+                }));
+
+                // Immediately call onNext with the current value, as due to Realm's auto-update, it will be the latest
+                // value.
+                subscriber.onNext(object);
+            }
+        });
+    }
+
+    @Override
+    public <E extends RealmObject> Observable<RealmQuery<E>> from(Realm realm, RealmQuery<E> query) {
         throw new RuntimeException("RealmQuery not supported yet.");
     }
 
     @Override
-    public Observable<RealmQuery<DynamicRealmObject>> from(final DynamicRealm realm,
-                                                           final RealmQuery<DynamicRealmObject> query) {
+    public Observable<RealmQuery<DynamicRealmObject>> from(DynamicRealm realm, RealmQuery<DynamicRealmObject> query) {
         throw new RuntimeException("RealmQuery not supported yet.");
     }
 


### PR DESCRIPTION
Fixes #2357 

Due to how RxJava executes the chain of Observables, currently it isn't possible to use `doOnUnsubscribe()` to close Realm instances as the side-effect is triggered before the Observable is truly unsubscribed to (crashing our 'removeChangeListeners() method).

This PR changes the current implementation so each Observable also holds onto a Realm instance prevent the Realm from being fully closed until the Observable is unsubscribed to. This means we can now guarantee that the Realm is alive for as long as the Observable is subscribed to. The only downside is that you risk leaking Realm instances if you forget to unsubscribe, but that would be a memory leak in any case.

@realm/java 
/cc @lucamtudor