### PR TITLE
RealmPrimaryKeyConstraintException in copyToRealmOrUpdate

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -1602,22 +1602,21 @@ public class RealmTests {
     @Test
     public void copyToRealmOrUpdate_asyncChildObjectDuplication() throws Throwable {
         // prepare an object with subsidiary items that would be duplicated in background.
-        // please noted that the primary key for the mother object will be different
-        {
-            realm.beginTransaction();
-            PrimaryKeyAsIntWithFieldList obj = new PrimaryKeyAsIntWithFieldList();
-            obj.setId(123);
-            RealmList<StringAndInt> list = new RealmList<StringAndInt>();
-            for (int i = 0; i < 100; i++) {
-                StringAndInt item = new StringAndInt();
-                item.setNumber(i);
-                item.setStr(Integer.toString(i));
-                list.add(item);
-            }
-            obj.setList(list);
-            realm.copyToRealm(obj);
-            realm.commitTransaction();
+        // please noted that the primary key for the mother object will be different.
+        realm.beginTransaction();
+        PrimaryKeyAsIntWithFieldList obj = new PrimaryKeyAsIntWithFieldList();
+        obj.setId(123);
+        RealmList<StringAndInt> list = new RealmList<StringAndInt>();
+        for (int i = 0; i < 100; i++) {
+            StringAndInt item = new StringAndInt();
+            item.setNumber(i);
+            item.setStr(Integer.toString(i));
+            list.add(item);
         }
+        obj.setList(list);
+        realm.copyToRealmOrUpdate(obj);
+        realm.commitTransaction();
+
         // async duplicated child object task
         final CountDownLatch signalCallbackFinished = new CountDownLatch(1);
         final CountDownLatch signalClosedRealm = new CountDownLatch(1);
@@ -1635,7 +1634,7 @@ public class RealmTests {
                     RealmConfiguration config = configFactory.createConfiguration("asyncRealm");
                     Realm.deleteRealm(config);
                     asyncRealm = Realm.getInstance(config);
-                    
+
                     // child objects with exactly the same content will be created
                     asyncRealm.beginTransaction();
                     PrimaryKeyAsIntWithFieldList obj = new PrimaryKeyAsIntWithFieldList();

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsIntWithFieldList.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsIntWithFieldList.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class PrimaryKeyAsIntWithFieldList extends RealmObject {
+
+    @PrimaryKey
+    private int id;
+    private RealmList<StringAndInt> list;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public RealmList<StringAndInt> getList() {
+        return this.list;
+    }
+
+    public void setList(RealmList<StringAndInt> list) {
+        this.list = list;
+    }
+}


### PR DESCRIPTION
To check duplicated primarykey exception in `copyToRealmOrUpdate` or `createOrUpdateObjectFromJson` Fix for issue #2324 