### PR TITLE
More checkings when modify RealmList

### DIFF
--- a/realm/realm-jni/src/io_realm_internal_LinkView.cpp
+++ b/realm/realm-jni/src/io_realm_internal_LinkView.cpp
@@ -193,11 +193,24 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeFind
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveAllTargetRows
-  (JNIEnv *env, jobject, jlong nativeLinkViewPtr) {
+  (JNIEnv *env, jobject, jlong nativeLinkViewPtr)
+{
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
         LinkView *lv = LV(nativeLinkViewPtr);
         lv->remove_all_target_rows();
     } CATCH_STD()
- }
+}
+
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetTable
+  (JNIEnv*, jobject, jlong nativeLinkViewPtr)
+{
+    TR_ENTER_PTR(nativeLinkViewPtr)
+
+    LinkView* lv = LV(nativeLinkViewPtr);
+    Table* pTable = &(lv->get_target_table());
+    LangBindHelper::bind_table_ptr(pTable);
+
+    return reinterpret_cast<jlong>(pTable);
+}
 

--- a/realm/realm-jni/src/io_realm_internal_LinkView.h
+++ b/realm/realm-jni/src/io_realm_internal_LinkView.h
@@ -127,6 +127,14 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeFind
 JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveAllTargetRows
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     io_realm_internal_LinkView
+ * Method:    nativeGetTargetTable
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetTable
+  (JNIEnv *, jobject, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -27,12 +27,14 @@ import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import io.realm.entities.AllTypes;
+import io.realm.entities.Cat;
 import io.realm.entities.CyclicType;
 import io.realm.entities.CyclicTypePrimaryKey;
 import io.realm.entities.Dog;
@@ -103,6 +105,7 @@ public class RealmListTests {
     private void checkMethodsOnEmptyList(Realm realm, RealmList<Dog> list) {
         realm.beginTransaction();
         for (int i = 0; i < 4; i++) {
+            //noinspection TryWithIdenticalCatches
             try {
                 switch (i) {
                     case 0: list.get(0); break;
@@ -915,7 +918,7 @@ public class RealmListTests {
     }
 
     @Test
-    public void testRemoveAllFromRealm() {
+    public void removeAllFromRealm() {
         Owner owner = testRealm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         assertEquals(TEST_OBJECTS, dogs.size());
@@ -928,7 +931,7 @@ public class RealmListTests {
     }
 
     @Test
-    public void testRealmRemoveAllNotManagedList() {
+    public void removeAllFromRealm_notManagedList() {
         Owner owner = testRealm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         assertEquals(TEST_OBJECTS, dogs.size());
@@ -947,7 +950,7 @@ public class RealmListTests {
     }
 
     @Test
-    public void testRealmRemoveAllOutsideTransaction() {
+    public void removeAllFromRealm_outsideTransaction() {
         Owner owner = testRealm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         try {
@@ -959,7 +962,7 @@ public class RealmListTests {
     }
 
     @Test
-    public void testRemoveAllFromListStandaloneObjectShouldThrow() {
+    public void removeAllFromRealm_listWithStandaloneObjectShouldThrow() {
         final RealmList<Dog> list = new RealmList<Dog>();
 
         testRealm.beginTransaction();
@@ -986,7 +989,7 @@ public class RealmListTests {
     }
 
     @Test
-    public void testRemoveAllFromRealmEmptyList() {
+    public void removeAllFromRealm_emptyList() {
         RealmList<Dog> dogs = testRealm.where(Owner.class).findFirst().getDogs();
         assertEquals(TEST_OBJECTS, dogs.size());
 
@@ -1006,7 +1009,7 @@ public class RealmListTests {
     }
 
     @Test
-    public void testRemoveAllFromRealmInvalidListShouldThrow() {
+    public void removeAllFromRealm_invalidListShouldThrow() {
         RealmList<Dog> dogs = testRealm.where(Owner.class).findFirst().getDogs();
         assertEquals(TEST_OBJECTS, dogs.size());
         testRealm.close();
@@ -1018,5 +1021,167 @@ public class RealmListTests {
         } catch (IllegalStateException e) {
             assertEquals("This Realm instance has already been closed, making it unusable.", e.getMessage());
         }
+    }
+
+    @Test
+    public void add_set_objectFromOtherThread() {
+        final CountDownLatch finishedLatch = new CountDownLatch(1);
+        final Dog dog = testRealm.where(Dog.class).findFirst();
+        final String expectedMsg = "Cannot copy an object from another Realm instance.";
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(testRealm.getConfiguration());
+                realm.beginTransaction();
+                RealmList<Dog> list = realm.createObject(Owner.class).getDogs();
+                list.add(realm.createObject(Dog.class));
+                try {
+                    list.add(dog);
+                    fail();
+                } catch (IllegalArgumentException expected) {
+                    assertEquals(expectedMsg, expected.getMessage());
+                }
+
+                try {
+                    list.add(0, dog);
+                    fail();
+                } catch (IllegalArgumentException expected) {
+                    assertEquals(expectedMsg, expected.getMessage());
+                }
+
+                try {
+                    list.set(0, dog);
+                    fail();
+                } catch (IllegalArgumentException expected) {
+                    assertEquals(expectedMsg, expected.getMessage());
+                }
+
+                realm.cancelTransaction();
+                realm.close();
+                finishedLatch.countDown();
+            }
+        }).start();
+        TestHelper.awaitOrFail(finishedLatch);
+    }
+
+    @Test
+    public void add_set_dynamicObjectFromOtherThread() {
+        final CountDownLatch finishedLatch = new CountDownLatch(1);
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+        final DynamicRealmObject dynDog = dynamicRealm.where(Dog.CLASS_NAME).findFirst();
+        final String expectedMsg = "Cannot copy an object to a Realm instance created in another thread.";
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+                dynamicRealm.beginTransaction();
+                RealmList<DynamicRealmObject> list = dynamicRealm.createObject(Owner.CLASS_NAME)
+                        .getList(Owner.FIELD_DOGS);
+                list.add(dynamicRealm.createObject(Dog.CLASS_NAME));
+
+                try {
+                    list.add(dynDog);
+                    fail();
+                } catch (IllegalStateException expected) {
+                    assertEquals(expectedMsg, expected.getMessage());
+                }
+
+                try {
+                    list.add(0,dynDog);
+                    fail();
+                } catch (IllegalStateException expected) {
+                    assertEquals(expectedMsg, expected.getMessage());
+                }
+
+                try {
+                    list.set(0,dynDog);
+                    fail();
+                } catch (IllegalStateException expected) {
+                    assertEquals(expectedMsg, expected.getMessage());
+                }
+
+                dynamicRealm.cancelTransaction();
+                dynamicRealm.close();
+                finishedLatch.countDown();
+            }
+        }).start();
+        TestHelper.awaitOrFail(finishedLatch);
+        dynamicRealm.close();
+    }
+
+    @Test
+    public void add_set_withWrongDynamicObjectType() {
+        final String expectedMsg = "The object has a different type from list's. Type of the list is 'Dog'," +
+                        " type of object is 'Cat'.";
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+
+        dynamicRealm.beginTransaction();
+        RealmList<DynamicRealmObject> list = dynamicRealm.createObject(Owner.CLASS_NAME)
+                .getList(Owner.FIELD_DOGS);
+        DynamicRealmObject dynCat = dynamicRealm.createObject(Cat.CLASS_NAME);
+
+        try {
+            list.add(dynCat);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals(expectedMsg, expected.getMessage());
+
+        }
+
+        try {
+            list.add(0, dynCat);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals(expectedMsg, expected.getMessage());
+
+        }
+
+        try {
+            list.set(0, dynCat);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals(expectedMsg, expected.getMessage());
+
+        }
+
+        dynamicRealm.cancelTransaction();
+        dynamicRealm.close();
+    }
+
+    @Test
+    public void add_set_dynamicObjectCreatedFromTypedRealm() {
+        final String expectedMsg = "Cannot copy DynamicRealmObject between Realm instances.";
+        DynamicRealmObject dynDog = new DynamicRealmObject(testRealm.where(Dog.class).findFirst());
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(testRealm.getConfiguration());
+
+        dynamicRealm.beginTransaction();
+        RealmList<DynamicRealmObject> list = dynamicRealm.createObject(Owner.CLASS_NAME)
+                .getList(Owner.FIELD_DOGS);
+
+        try {
+            list.add(dynDog);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals(expectedMsg, expected.getMessage());
+        }
+
+        try {
+            list.add(0, dynDog);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals(expectedMsg, expected.getMessage());
+        }
+
+        try {
+            list.set(0, dynDog);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals(expectedMsg, expected.getMessage());
+        }
+
+        dynamicRealm.cancelTransaction();
+        dynamicRealm.close();
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2726,7 +2726,7 @@ public class RealmTests {
         DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
         dynamicRealm.beginTransaction();
         RealmList<DynamicRealmObject> dynamicList = dynamicRealm.createObject(AllTypes.CLASS_NAME).getList(AllTypes.FIELD_REALMLIST);
-        DynamicRealmObject dObj = dynamicRealm.createObject(AllTypes.CLASS_NAME);
+        DynamicRealmObject dObj = dynamicRealm.createObject(Dog.CLASS_NAME);
         dynamicList.add(dObj);
         dynamicRealm.commitTransaction();
         try {

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/Owner.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/Owner.java
@@ -22,6 +22,9 @@ import io.realm.RealmObject;
 public class Owner extends RealmObject {
 
     public static String CLASS_NAME = "Owner";
+    public static String FIELD_NAME = "name";
+    public static String FIELD_DOGS = "dogs";
+    public static String FIELD_CAT = "cat";
 
     private String name;
     private RealmList<Dog> dogs;

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -269,7 +269,7 @@ public final class DynamicRealmObject extends RealmObject {
     public RealmList<DynamicRealmObject> getList(String fieldName) {
         long columnIndex = row.getColumnIndex(fieldName);
         LinkView linkView = row.getLinkList(columnIndex);
-        String className = linkView.getTable().getLinkTarget(columnIndex).getName().substring(Table.TABLE_PREFIX.length());
+        String className = RealmSchema.getSchemaForTable(linkView.getTargetTable());
         return new RealmList<DynamicRealmObject>(className, linkView, realm);
     }
 
@@ -588,7 +588,7 @@ public final class DynamicRealmObject extends RealmObject {
         long columnIndex = row.getColumnIndex(fieldName);
         LinkView links = row.getLinkList(columnIndex);
         links.clear();
-        Table linkTargetTable = links.getTable().getLinkTarget(columnIndex);
+        Table linkTargetTable = links.getTargetTable();
         for (int i = 0; i < list.size(); i++) {
             RealmObject obj = list.get(i);
             if (obj.realm != realm) {
@@ -626,7 +626,7 @@ public final class DynamicRealmObject extends RealmObject {
      * @return this objects type.
      */
     public String getType() {
-        return row.getTable().getName().substring(Table.TABLE_PREFIX.length());
+        return RealmSchema.getSchemaForTable(row.getTable());
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -238,4 +238,8 @@ public final class RealmSchema {
     void setColumnIndices(ColumnIndices columnIndices) {
         this.columnIndices = columnIndices;
     }
+
+    static String getSchemaForTable(Table table) {
+        return table.getName().substring(Table.TABLE_PREFIX.length());
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -67,7 +67,7 @@ public class CheckedRow extends UncheckedRow {
      */
     public static CheckedRow get(Context context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativePointer, index);
-        CheckedRow row = new CheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent),
+        CheckedRow row = new CheckedRow(context, linkView.getTargetTable(),
                 nativeRowPointer);
         context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
                 Context.NATIVE_REFERENCES_VALUE);

--- a/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
@@ -153,6 +153,19 @@ public class LinkView extends NativeObject {
         nativeRemoveAllTargetRows(nativePointer);
     }
 
+    public Table getTargetTable() {
+        // Execute the disposal of abandoned realm objects each time a new realm object is created
+        context.executeDelayedDisposal();
+        long nativeTablePointer = nativeGetTargetTable(nativePointer);
+        try {
+            // Copy context reference from parent
+            return new Table(context, this.parent, nativeTablePointer);
+        } catch (RuntimeException e) {
+            Table.nativeClose(nativeTablePointer);
+            throw e;
+        }
+    }
+
     private void checkImmutable() {
         if (parent.isImmutable()) {
             throw new IllegalStateException("Changing Realm data can only be done from inside a transaction.");
@@ -174,4 +187,5 @@ public class LinkView extends NativeObject {
     private native boolean nativeIsAttached(long nativeLinkViewPtr);
     private native long nativeFind(long nativeLinkViewPtr, long targetRowIndex);
     private native void nativeRemoveAllTargetRows(long nativeLinkViewPtr);
+    private native long nativeGetTargetTable(long nativeLinkViewPtr);
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
@@ -96,7 +96,7 @@ public class UncheckedRow extends NativeObject implements Row {
      */
     public static UncheckedRow getByRowIndex(Context context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativePointer, index);
-        UncheckedRow row = new UncheckedRow(context, linkView.parent.getLinkTarget(linkView.columnIndexInParent),
+        UncheckedRow row = new UncheckedRow(context, linkView.getTargetTable(),
                 nativeRowPointer);
         context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
                 Context.NATIVE_REFERENCES_VALUE);


### PR DESCRIPTION
Fix #2381

* New method LinkView.getTargetTable().
* Proper checking to add DynamicRealmObject to RealmList.
* Disallow modifying with RealmObject belongs to another Realm instance.