### PR TITLE
Rename clear and removeAllFromRealm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Fixed bug when multiple calls of RealmResults.distinct() causes to return wrong results (#2198).
 * Fixed bug when calling DynamicRealmObject.setList() with RealmList<DynamicRealmObject> (#2368).
 * Added RealmQuery.isNotEmpty() (#2025). (Thank you @stk1m1)
-* Added Realm.clear() and RealmList.removeAllFromRealm() (#1560).
+* Added Realm.deleteAll() and RealmList.deleteAllFromRealm() (#1560).
 * Added RealmQuery.distinct() and RealmResults.distinct() (#1568).
 * Added RealmQuery.distinctAsync() and RealmResults.distinctAsync() (#2118).
 * Improved .so loading by using [ReLinker](https://github.com/KeepSafe/ReLinker).

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -973,7 +973,7 @@ public class DynamicRealmTests {
         assertEquals(1, realm.where("TestRemoveAll").count());
 
         realm.beginTransaction();
-        realm.clear();
+        realm.deleteAll();
         realm.commitTransaction();
 
         assertEquals(0, realm.where(AllTypes.CLASS_NAME).count());
@@ -990,7 +990,7 @@ public class DynamicRealmTests {
         assertEquals(2, list.size());
 
         realm.beginTransaction();
-        list.removeAllFromRealm();
+        list.deleteAllFromRealm();
         realm.commitTransaction();
 
         assertEquals(0, list.size());

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -921,7 +921,7 @@ public class RealmListTests {
         assertEquals(TEST_OBJECTS, dogs.size());
 
         testRealm.beginTransaction();
-        dogs.removeAllFromRealm();
+        dogs.deleteAllFromRealm();
         testRealm.commitTransaction();
         assertEquals(0, dogs.size());
         assertEquals(0, testRealm.where(Dog.class).count());
@@ -939,7 +939,7 @@ public class RealmListTests {
         }
 
         testRealm.beginTransaction();
-        notManagedDogs.removeAllFromRealm();
+        notManagedDogs.deleteAllFromRealm();
         testRealm.commitTransaction();
         assertEquals(0, dogs.size());
         assertEquals(0, notManagedDogs.size());
@@ -951,7 +951,7 @@ public class RealmListTests {
         Owner owner = testRealm.where(Owner.class).findFirst();
         RealmList<Dog> dogs = owner.getDogs();
         try {
-            dogs.removeAllFromRealm();
+            dogs.deleteAllFromRealm();
             fail("removeAllFromRealm should be called in a transaction.");
         } catch (IllegalStateException e) {
             assertEquals("Changing Realm data can only be done from inside a transaction.", e.getMessage());
@@ -972,7 +972,7 @@ public class RealmListTests {
 
         testRealm.beginTransaction();
         try {
-            list.removeAllFromRealm();
+            list.deleteAllFromRealm();
             fail("Cannot remove a list with a standalone object in it!");
         } catch (IllegalStateException e) {
             assertEquals("Object malformed: missing object in Realm. Make sure to instantiate RealmObjects with" +
@@ -991,14 +991,14 @@ public class RealmListTests {
         assertEquals(TEST_OBJECTS, dogs.size());
 
         testRealm.beginTransaction();
-        dogs.removeAllFromRealm();
+        dogs.deleteAllFromRealm();
         testRealm.commitTransaction();
         assertEquals(0, dogs.size());
         assertEquals(0, testRealm.where(Dog.class).count());
 
         // The dogs is empty now.
         testRealm.beginTransaction();
-        dogs.removeAllFromRealm();
+        dogs.deleteAllFromRealm();
         testRealm.commitTransaction();
         assertEquals(0, dogs.size());
         assertEquals(0, testRealm.where(Dog.class).count());
@@ -1013,7 +1013,7 @@ public class RealmListTests {
         testRealm = null;
 
         try {
-            dogs.removeAllFromRealm();
+            dogs.deleteAllFromRealm();
             fail("dogs is invalid and it should throw an exception");
         } catch (IllegalStateException e) {
             assertEquals("This Realm instance has already been closed, making it unusable.", e.getMessage());

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -663,7 +663,7 @@ public class RealmTests {
                             realm.clear(AllTypes.class);
                             break;
                         case METHOD_CLEAR_ALL:
-                            realm.clear();
+                            realm.deleteAll();
                             break;
                         case METHOD_DISTINCT:
                             realm.distinct(AllTypesPrimaryKey.class, "columnLong");
@@ -1856,7 +1856,7 @@ public class RealmTests {
         try { realm.copyToRealmOrUpdate(ts);        fail(); } catch (IllegalStateException expected) {}
         try { realm.remove(AllTypes.class, 0);      fail(); } catch (IllegalStateException expected) {}
         try { realm.clear(AllTypes.class);          fail(); } catch (IllegalStateException expected) {}
-        try { realm.clear();                        fail(); } catch (IllegalStateException expected) {}
+        try { realm.deleteAll();                        fail(); } catch (IllegalStateException expected) {}
 
         try { realm.createObjectFromJson(AllTypesPrimaryKey.class, jsonObj);                fail(); } catch (RealmException expected) {}
         try { realm.createObjectFromJson(AllTypesPrimaryKey.class, jsonObjStr);             fail(); } catch (RealmException expected) {}
@@ -2968,7 +2968,7 @@ public class RealmTests {
         assertEquals(1, realm.where(Cat.class).count());
 
         realm.beginTransaction();
-        realm.clear();
+        realm.deleteAll();
         realm.commitTransaction();
 
         assertEquals(0, realm.where(AllTypes.class).count());

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -557,7 +557,7 @@ abstract class BaseRealm implements Closeable {
      *
      * @throws IllegalStateException if the corresponding Realm is closed or on an incorrect thread.
      */
-    public void clear() {
+    public void deleteAll() {
         checkIfValid();
         for (RealmObjectSchema objectSchema : schema.getAll()) {
             schema.getTable(objectSchema.getClassName()).clear();

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -270,7 +270,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * @throws IllegalStateException if Realm instance has been closed or parent object has been removed.
      * @see List#isEmpty
      * @see List#size
-     * @see #removeAllFromRealm()
+     * @see #deleteAllFromRealm()
      */
     @Override
     public void clear() {
@@ -310,7 +310,7 @@ public class RealmList<E extends RealmObject> extends AbstractList<E> {
      * method is called in a wrong thread or any RealmObject in the list is not managed by Realm.
      * @see #clear()
      */
-    public void removeAllFromRealm() {
+    public void deleteAllFromRealm() {
         if (managedMode) {
             checkValidView();
             view.removeAllTargetRows();


### PR DESCRIPTION
0.88 will be released before the RealmCollection API is done with review. Since we are adding two new methods in 0.88 (`Realm.clear()` and `RealmList.removeAllFromRealm()` ) and these are not compatible with the refactoring done by the RealmCollection API. This PR changes these methods so they don't need to be deprecated right after they are released.

It means that API gets slightly confusing since we will have `Realm.clear(Class)` and `Realm.deleteAll()`, at least until the next release. I think that is acceptable.

@realm/java 
