### PR TITLE
Useless line triggers bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Prevent throwing NullPointerException in RealmConfiguration.equals(RealmConfiguration) when RxJava is not in the classpath (#2416).
+* RealmTransformer fails because of missing annotation classes in user's project. (#2413)
 
 ## 0.88.0
 

--- a/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
@@ -112,7 +112,6 @@ class RealmTransformer extends Transform {
         def allManagedFields = []
         allModelClasses.each {
             allManagedFields.addAll(it.declaredFields.findAll {
-                it.getAnnotations()
                 it.getAnnotation(Ignore.class) == null && !Modifier.isStatic(it.getModifiers())
             })
         }


### PR DESCRIPTION
getAnnotations will return all Annotation classes, if the class doesn't
exist in the transformer project, exception will be thrown.

Fix #2413