### PR TITLE
Moving examples over to execute transaction

### DIFF
--- a/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerHandler.java
+++ b/examples/adapterExample/src/main/java/io/realm/examples/realmadapters/WorkerHandler.java
@@ -45,14 +45,20 @@ public class WorkerHandler extends Handler {
 
         switch (action) {
             case ADD_TIMESTAMP:
-                realm.beginTransaction();
-                realm.createObject(TimeStamp.class).setTimeStamp(timestamp);
-                realm.commitTransaction();
+                realm.executeTransaction(new Realm.Transaction() {
+                    @Override
+                    public void execute(Realm realm) {
+                        realm.createObject(TimeStamp.class).setTimeStamp(timestamp);
+                    }
+                });
                 break;
             case REMOVE_TIMESTAMP:
-                realm.beginTransaction();
-                realm.where(TimeStamp.class).equalTo("timeStamp", timestamp).findAll().clear();
-                realm.commitTransaction();
+                realm.executeTransaction(new Realm.Transaction() {
+                    @Override
+                    public void execute(Realm realm) {
+                        realm.where(TimeStamp.class).equalTo("timeStamp", timestamp).findAll().clear();
+                    }
+                });
                 break;
         }
     }

--- a/examples/encryptionExample/src/main/java/io/realm/examples/encryptionexample/EncryptionExampleActivity.java
+++ b/examples/encryptionExample/src/main/java/io/realm/examples/encryptionexample/EncryptionExampleActivity.java
@@ -53,13 +53,16 @@ public class EncryptionExampleActivity extends Activity {
         realm = Realm.getInstance(realmConfiguration);
 
         // Everything continues to work as normal except for that the file is encrypted on disk
-        realm.beginTransaction();
-        Person person = realm.createObject(Person.class);
-        person.setName("Happy Person");
-        person.setAge(14);
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                Person person = realm.createObject(Person.class);
+                person.setName("Happy Person");
+                person.setAge(14);
+            }
+        });
 
-        person = realm.where(Person.class).findFirst();
+        Person person = realm.where(Person.class).findFirst();
         Log.i(TAG, String.format("Person name: %s", person.getName()));
     }
 

--- a/examples/gridViewExample/src/main/java/io/realm/examples/realmgridview/GridViewExampleActivity.java
+++ b/examples/gridViewExample/src/main/java/io/realm/examples/realmgridview/GridViewExampleActivity.java
@@ -145,12 +145,15 @@ public class GridViewExampleActivity extends Activity implements AdapterView.OnI
         City modifiedCity = (City)mAdapter.getItem(position);
 
         // Acquire the RealmObject matching the name of the clicked City.
-        City city = realm.where(City.class).equalTo("name", modifiedCity.getName()).findFirst();
+        final City city = realm.where(City.class).equalTo("name", modifiedCity.getName()).findFirst();
 
         // Create a transaction to increment the vote count for the selected City in the realm
-        realm.beginTransaction();
-        city.setVotes(city.getVotes() + 1);
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                city.setVotes(city.getVotes() + 1);
+            }
+        });
 
         updateCities();
     }

--- a/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
+++ b/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
@@ -92,32 +92,40 @@ public class IntroExampleActivity extends Activity {
         showStatus("Perform basic Create/Read/Update/Delete (CRUD) operations...");
 
         // All writes must be wrapped in a transaction to facilitate safe multi threading
-        realm.beginTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                // Add a person
+                Person person = realm.createObject(Person.class);
+                person.setId(1);
+                person.setName("Young Person");
+                person.setAge(14);
 
-        // Add a person
-        Person person = realm.createObject(Person.class);
-        person.setId(1);
-        person.setName("Young Person");
-        person.setAge(14);
-
-        // When the transaction is committed, all changes a synced to disk.
-        realm.commitTransaction();
+            }
+        });
 
         // Find the first person (no query conditions) and read a field
-        person = realm.where(Person.class).findFirst();
+        final Person person = realm.where(Person.class).findFirst();
         showStatus(person.getName() + ":" + person.getAge());
 
         // Update person in a transaction
-        realm.beginTransaction();
-        person.setName("Senior Person");
-        person.setAge(99);
-        showStatus(person.getName() + " got older: " + person.getAge());
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                person.setName("Senior Person");
+                person.setAge(99);
+                showStatus(person.getName() + " got older: " + person.getAge());
+                realm.commitTransaction();
+            }
+        });
 
         // Delete all persons
-        realm.beginTransaction();
-        realm.allObjects(Person.class).clear();
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.allObjects(Person.class).clear();
+            }
+        });
     }
 
     private void basicQuery(Realm realm) {
@@ -146,29 +154,32 @@ public class IntroExampleActivity extends Activity {
         Realm realm = Realm.getInstance(realmConfig);
 
         // Add ten persons in one transaction
-        realm.beginTransaction();
-        Dog fido = realm.createObject(Dog.class);
-        fido.name = "fido";
-        for (int i = 0; i < 10; i++) {
-            Person person = realm.createObject(Person.class);
-            person.setId(i);
-            person.setName("Person no. " + i);
-            person.setAge(i);
-            person.setDog(fido);
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                Dog fido = realm.createObject(Dog.class);
+                fido.name = "fido";
+                for (int i = 0; i < 10; i++) {
+                    Person person = realm.createObject(Person.class);
+                    person.setId(i);
+                    person.setName("Person no. " + i);
+                    person.setAge(i);
+                    person.setDog(fido);
 
-            // The field tempReference is annotated with @Ignore.
-            // This means setTempReference sets the Person tempReference
-            // field directly. The tempReference is NOT saved as part of
-            // the RealmObject:
-            person.setTempReference(42);
+                    // The field tempReference is annotated with @Ignore.
+                    // This means setTempReference sets the Person tempReference
+                    // field directly. The tempReference is NOT saved as part of
+                    // the RealmObject:
+                    person.setTempReference(42);
 
-            for (int j = 0; j < i; j++) {
-                Cat cat = realm.createObject(Cat.class);
-                cat.name = "Cat_" + j;
-                person.getCats().add(cat);
+                    for (int j = 0; j < i; j++) {
+                        Cat cat = realm.createObject(Cat.class);
+                        cat.name = "Cat_" + j;
+                        person.getCats().add(cat);
+                    }
+                }
             }
-        }
-        realm.commitTransaction();
+        });
 
         // Implicit read transactions allow you to access your objects
         status += "\nNumber of persons: " + realm.allObjects(Person.class).size();

--- a/examples/jsonExample/src/main/java/io/realm/examples/json/JsonExampleActivity.java
+++ b/examples/jsonExample/src/main/java/io/realm/examples/json/JsonExampleActivity.java
@@ -115,18 +115,24 @@ public class JsonExampleActivity extends Activity {
         Map<String, String> city = new HashMap<String, String>();
         city.put("name", "København");
         city.put("votes", "9");
-        JSONObject json = new JSONObject(city);
+        final JSONObject json = new JSONObject(city);
 
-        realm.beginTransaction();
-        realm.createObjectFromJson(City.class, json);
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createObjectFromJson(City.class, json);
+            }
+        });
     }
 
     private void loadJsonFromString() {
-        String json = "{ name: \"Aarhus\", votes: 99 }";
+        final String json = "{ name: \"Aarhus\", votes: 99 }";
 
-        realm.beginTransaction();
-        realm.createObjectFromJson(City.class, json);
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createObjectFromJson(City.class, json);
+            }
+        });
     }
 }

--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
-    ext.kotlin_version = '1.0.0-rc-1036'
+    ext.kotlin_version = '1.0.0'
     repositories {
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
@@ -98,27 +98,24 @@ public class KotlinExampleActivity : Activity() {
         showStatus("Perform basic Create/Read/Update/Delete (CRUD) operations...")
 
         // All writes must be wrapped in a transaction to facilitate safe multi threading
-        realm.beginTransaction()
-
-        // Add a person
-        var person = realm.createObject(Person::class.java)
-        person.id = 1
-        person.name = "Young Person"
-        person.age = 14
-
-        // When the transaction is committed, all changes a synced to disk.
-        realm.commitTransaction()
+        realm.executeTransaction {
+            // Add a person
+            var person = realm.createObject(Person::class.java)
+            person.id = 1
+            person.name = "Young Person"
+            person.age = 14
+        }
 
         // Find the first person (no query conditions) and read a field
-        person = realm.where(Person::class.java).findFirst()
+        var person = realm.where(Person::class.java).findFirst()
         showStatus(person.name + ": " + person.age)
 
         // Update person in a transaction
-        realm.beginTransaction()
-        person.name = "Senior Person"
-        person.age = 99
-        showStatus(person.name + " got older: " + person.age)
-        realm.commitTransaction()
+        realm.executeTransaction {
+            person.name = "Senior Person"
+            person.age = 99
+            showStatus(person.name + " got older: " + person.age)
+        }
     }
 
     private fun basicQuery(realm: Realm) {
@@ -147,29 +144,29 @@ public class KotlinExampleActivity : Activity() {
         val realm = Realm.getInstance(realmConfig)
 
         // Add ten persons in one transaction
-        realm.beginTransaction()
-        val fido = realm.createObject(Dog::class.java)
-        fido.name = "fido"
-        for (i in 0..9) {
-            val person = realm.createObject(Person::class.java)
-            person.id = i.toLong()
-            person.name = "Person no. $i"
-            person.age = i
-            person.dog = fido
+        realm.executeTransaction {
+            val fido = realm.createObject(Dog::class.java)
+            fido.name = "fido"
+            for (i in 0..9) {
+                val person = realm.createObject(Person::class.java)
+                person.id = i.toLong()
+                person.name = "Person no. $i"
+                person.age = i
+                person.dog = fido
 
-            // The field tempReference is annotated with @Ignore.
-            // This means setTempReference sets the Person tempReference
-            // field directly. The tempReference is NOT saved as part of
-            // the RealmObject:
-            person.tempReference = 42
+                // The field tempReference is annotated with @Ignore.
+                // This means setTempReference sets the Person tempReference
+                // field directly. The tempReference is NOT saved as part of
+                // the RealmObject:
+                person.tempReference = 42
 
-            for (j in 0..i - 1) {
-                val cat = realm.createObject(Cat::class.java)
-                cat.name = "Cat_$j"
-                person.cats.add(cat)
+                for (j in 0..i - 1) {
+                    val cat = realm.createObject(Cat::class.java)
+                    cat.name = "Cat_$j"
+                    person.cats.add(cat)
+                }
             }
         }
-        realm.commitTransaction()
 
         // Implicit read transactions allow you to access your objects
         status += "\nNumber of persons: ${realm.allObjects(Person::class.java).size}"

--- a/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
+++ b/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
@@ -78,7 +78,7 @@ public class ModulesExampleActivity extends Activity {
         // Multiple Realms can be open at the same time
         showStatus("Opening multiple Realms");
         Realm defaultRealm = Realm.getInstance(defaultConfig);
-        Realm farmRealm = Realm.getInstance(farmAnimalsConfig);
+        final Realm farmRealm = Realm.getInstance(farmAnimalsConfig);
         Realm exoticRealm = Realm.getInstance(exoticAnimalsConfig);
 
         // Objects can be added to each Realm independantly
@@ -120,10 +120,14 @@ public class ModulesExampleActivity extends Activity {
         showStatus("Copy objects between Realms");
         showStatus("Number of pigs on the farm : " + farmRealm.where(Pig.class).count());
         showStatus("Copy pig from defaultRealm to farmRealm");
-        Pig defaultPig = defaultRealm.where(Pig.class).findFirst();
-        farmRealm.beginTransaction();
-        farmRealm.copyToRealm(defaultPig);
-        farmRealm.commitTransaction();
+        final Pig defaultPig = defaultRealm.where(Pig.class).findFirst();
+        farmRealm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.copyToRealm(defaultPig);
+            }
+        });
+
         showStatus("Number of pigs on the farm : " + farmRealm.where(Pig.class).count());
 
         // Each Realm is restricted to only accept the classes in their schema.

--- a/examples/moduleExample/library/src/main/java/io/realm/examples/librarymodules/Zoo.java
+++ b/examples/moduleExample/library/src/main/java/io/realm/examples/librarymodules/Zoo.java
@@ -52,13 +52,16 @@ public class Zoo {
         return realm.where(Cat.class).count();
     }
 
-    public void addAnimals(int count) {
-        realm.beginTransaction();
-        for (int i = 0; i < count; i++) {
-            Cat cat = realm.createObject(Cat.class);
-            cat.setName("Cat " + i);
-        }
-        realm.commitTransaction();
+    public void addAnimals(final int count) {
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                for (int i = 0; i < count; i++) {
+                    Cat cat = realm.createObject(Cat.class);
+                    cat.setName("Cat " + i);
+                }
+            }
+        });
     }
 
     public void close() {

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/AsyncTaskFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/AsyncTaskFragment.java
@@ -86,15 +86,18 @@ public class AsyncTaskFragment extends Fragment {
         protected Integer doInBackground(Void... params) {
             Realm realm = Realm.getDefaultInstance();
 
-            realm.beginTransaction();
-            realm.clear(Score.class);
-            for (int i = 0; i < TEST_OBJECTS; i++) {
-                if (isCancelled()) break;
-                Score score = realm.createObject(Score.class);
-                score.setName("Name" + i);
-                score.setScore(i);
-            }
-            realm.commitTransaction();
+            realm.executeTransaction(new Realm.Transaction() {
+                @Override
+                public void execute(Realm realm) {
+                    realm.clear(Score.class);
+                    for (int i = 0; i < TEST_OBJECTS; i++) {
+                        if (isCancelled()) break;
+                        Score score = realm.createObject(Score.class);
+                        score.setName("Name" + i);
+                        score.setScore(i);
+                    }
+                }
+            });
 
             Number sum = realm.allObjects(Score.class).sum("score");
             realm.close();

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/PassingObjectsFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/PassingObjectsFragment.java
@@ -97,13 +97,15 @@ public class PassingObjectsFragment extends Fragment {
         super.onActivityCreated(savedInstanceState);
 
         realm = Realm.getDefaultInstance();
-        realm.beginTransaction();
-        person = realm.createObject(Person.class);
-        person.setName("Jane");
-        person.setAge(42);
-        person.setId(UUID.randomUUID().toString());
-        realm.commitTransaction();
-
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                person = realm.createObject(Person.class);
+                person.setName("Jane");
+                person.setAge(42);
+                person.setId(UUID.randomUUID().toString());
+            }
+        });
         textContent.setText(person.toString());
     }
 

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
@@ -76,18 +76,24 @@ public class ThreadFragment extends Fragment {
         switch(item.getItemId()) {
             case R.id.action_add_dot:
                 // Add blue dot from the UI thread
-                realm.beginTransaction();
-                Dot dot = realm.createObject(Dot.class);
-                dot.setX(random.nextInt(100));
-                dot.setY(random.nextInt(100));
-                dot.setColor(getResources().getColor(R.color.realm_blue));
-                realm.commitTransaction();
+                realm.executeTransaction(new Realm.Transaction() {
+                    @Override
+                    public void execute(Realm realm) {
+                        Dot dot = realm.createObject(Dot.class);
+                        dot.setX(random.nextInt(100));
+                        dot.setY(random.nextInt(100));
+                        dot.setColor(getResources().getColor(R.color.realm_blue));
+                    }
+                });
                 return true;
 
             case R.id.action_clear:
-                realm.beginTransaction();
-                realm.clear(Dot.class);
-                realm.commitTransaction();
+                realm.executeTransaction(new Realm.Transaction() {
+                    @Override
+                    public void execute(Realm realm) {
+                        realm.clear(Dot.class);
+                    }
+                });
                 return true;
 
             default:
@@ -125,17 +131,19 @@ public class ThreadFragment extends Fragment {
             public void run() {
                 // Realm instances cannot be shared between threads, so we need to create a new
                 // instance on the background thread.
-                int redColor = getResources().getColor(R.color.realm_red);
-                Realm backgroundThreadRealm = Realm.getDefaultInstance();
+                final int redColor = getResources().getColor(R.color.realm_red);
+                final Realm backgroundThreadRealm = Realm.getDefaultInstance();
                 while (!backgroundThread.isInterrupted()) {
-                    backgroundThreadRealm.beginTransaction();
-
-                    // Add red dot from the background thread
-                    Dot dot = backgroundThreadRealm.createObject(Dot.class);
-                    dot.setX(random.nextInt(100));
-                    dot.setY(random.nextInt(100));
-                    dot.setColor(redColor);
-                    backgroundThreadRealm.commitTransaction();
+                    backgroundThreadRealm.executeTransaction(new Realm.Transaction() {
+                        @Override
+                        public void execute(Realm realm) {
+                            // Add red dot from the background thread
+                            Dot dot = backgroundThreadRealm.createObject(Dot.class);
+                            dot.setX(random.nextInt(100));
+                            dot.setY(random.nextInt(100));
+                            dot.setColor(redColor);
+                        }
+                    });
 
                     // Wait 0.5 sec. before adding the next dot.
                     SystemClock.sleep(500);

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
@@ -85,9 +85,12 @@ public class ExampleActivity extends Activity {
 
     private void cleanUp() {
         // Delete all persons
-        realm.beginTransaction();
-        realm.allObjects(Person.class).clear();
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.allObjects(Person.class).clear();
+            }
+        });
     }
 
     @Override
@@ -107,40 +110,45 @@ public class ExampleActivity extends Activity {
         showStatus("Perform basic Create/Read/Update/Delete (CRUD) operations...");
 
         // All writes must be wrapped in a transaction to facilitate safe multi threading
-        realm.beginTransaction();
-
-        // Add a person
-        Person person = realm.createObject(Person.class);
-        person.setId(1);
-        person.setName("John Young");
-        person.setAge(14);
-
-        // When the transaction is committed, all changes a synced to disk.
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                // Add a person
+                Person person = realm.createObject(Person.class);
+                person.setId(1);
+                person.setName("John Young");
+                person.setAge(14);
+            }
+        });
 
         // Find the first person (no query conditions) and read a field
-        person = realm.where(Person.class).findFirst();
+        final Person person = realm.where(Person.class).findFirst();
         showStatus(person.getName() + ":" + person.getAge());
 
         // Update person in a transaction
-        realm.beginTransaction();
-        person.setName("John Senior");
-        person.setAge(89);
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                person.setName("John Senior");
+                person.setAge(89);
+            }
+        });
+
         showStatus(person.getName() + " got older: " + person.getAge());
-        realm.commitTransaction();
 
         // Add two more people
-        realm.beginTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                Person jane = realm.createObject(Person.class);
+                jane.setName("Jane");
+                jane.setAge(27);
 
-        Person jane = realm.createObject(Person.class);
-        jane.setName("Jane");
-        jane.setAge(27);
-
-        Person doug = realm.createObject(Person.class);
-        doug.setName("Robert");
-        doug.setAge(42);
-
-        realm.commitTransaction();
+                Person doug = realm.createObject(Person.class);
+                doug.setName("Robert");
+                doug.setAge(42);
+            }
+        });
 
         RealmResults<Person> people = realm.where(Person.class).findAll();
         showStatus(String.format("Found %s people", people.size()));

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepositoryImpl.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepositoryImpl.java
@@ -22,12 +22,15 @@ import io.realm.examples.unittesting.model.Dog;
 
 public class DogRepositoryImpl implements DogRepository {
     @Override
-    public void createDog(String name) {
+    public void createDog(final String name) {
         Realm realm = Realm.getDefaultInstance();
-        realm.beginTransaction();
-        Dog dog = realm.createObject(Dog.class);
-        dog.setName(name);
-        realm.commitTransaction();
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                Dog dog = realm.createObject(Dog.class);
+                dog.setName(name);
+            }
+        });
         realm.close();
     }
 }

--- a/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
+++ b/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
@@ -180,15 +181,13 @@ public class ExampleActivityTest {
         Realm.getInstance(any(RealmConfiguration.class));
 
         // verify that we have four begin and commit transaction calls
-        verify(mockRealm, times(4)).beginTransaction();
-        verify(mockRealm, times(4)).commitTransaction();
+        verify(mockRealm, times(4)).executeTransaction(Mockito.any(Realm.Transaction.class));
 
         // Click the clean up button
         activity.findViewById(R.id.clean_up).performClick();
 
         // Verify that begin and commit transaction were called (been called a total of 5 times now)
-        verify(mockRealm, times(5)).beginTransaction();
-        verify(mockRealm, times(5)).commitTransaction();
+        verify(mockRealm, times(5)).executeTransaction(Mockito.any(Realm.Transaction.class));
 
         // Verify that we queried for all Person instance two times in this run (in the original
         // onCreate, and then again in the button click). Was called two times previously in the

--- a/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
+++ b/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
@@ -31,7 +31,6 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
-import java.lang.Exception;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,24 +39,23 @@ import io.realm.RealmConfiguration;
 import io.realm.RealmObject;
 import io.realm.RealmQuery;
 import io.realm.RealmResults;
-import io.realm.examples.unittesting.ExampleActivity;
 import io.realm.examples.unittesting.model.Person;
 import io.realm.internal.RealmCore;
-
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
@@ -169,6 +167,8 @@ public class ExampleActivityTest {
 
     @Test
     public void shouldBeAbleToAccessActivityAndVerifyRealmInteractions() {
+        doCallRealMethod().when(mockRealm).executeTransaction(Mockito.any(Realm.Transaction.class));
+
         // Create activity
         ActivityController<ExampleActivity> controller =
                 Robolectric.buildActivity(ExampleActivity.class).setup();
@@ -181,13 +181,15 @@ public class ExampleActivityTest {
         Realm.getInstance(any(RealmConfiguration.class));
 
         // verify that we have four begin and commit transaction calls
-        verify(mockRealm, times(4)).executeTransaction(Mockito.any(Realm.Transaction.class));
+        // Do not verify partial mock invocation count: https://github.com/jayway/powermock/issues/649
+        //verify(mockRealm, times(4)).executeTransaction(Mockito.any(Realm.Transaction.class));
 
         // Click the clean up button
         activity.findViewById(R.id.clean_up).performClick();
 
         // Verify that begin and commit transaction were called (been called a total of 5 times now)
-        verify(mockRealm, times(5)).executeTransaction(Mockito.any(Realm.Transaction.class));
+        // Do not verify partial mock invocation count: https://github.com/jayway/powermock/issues/649
+        //verify(mockRealm, times(5)).executeTransaction(Mockito.any(Realm.Transaction.class));
 
         // Verify that we queried for all Person instance two times in this run (in the original
         // onCreate, and then again in the button click). Was called two times previously in the
@@ -205,6 +207,44 @@ public class ExampleActivityTest {
         // in onDestroy
         verify(mockRealm, times(2)).close();
     }
+
+    /**
+     * Have to verify the transaction execution in a different test because
+     * of a problem with Powermock: https://github.com/jayway/powermock/issues/649
+     */
+    @Test
+    public void shouldBeAbleToVerifyTransactionCalls() {
+
+        // Create activity
+        ActivityController<ExampleActivity> controller =
+                Robolectric.buildActivity(ExampleActivity.class).setup();
+        ExampleActivity activity = controller.get();
+
+        assertThat(activity.getTitle().toString(), is("Unit Test Example"));
+
+        // Verify that two Realm.getInstance() calls took place.
+        verifyStatic(times(2));
+        Realm.getInstance(any(RealmConfiguration.class));
+
+        // verify that we have four begin and commit transaction calls
+        // Do not verify partial mock invocation count: https://github.com/jayway/powermock/issues/649
+        verify(mockRealm, times(4)).executeTransaction(Mockito.any(Realm.Transaction.class));
+
+        // Click the clean up button
+        activity.findViewById(R.id.clean_up).performClick();
+
+        // Verify that begin and commit transaction were called (been called a total of 5 times now)
+        // Do not verify partial mock invocation count: https://github.com/jayway/powermock/issues/649
+        verify(mockRealm, times(5)).executeTransaction(Mockito.any(Realm.Transaction.class));
+
+        // Call the destroy method so we can verify that the .close() method was called (below)
+        controller.destroy();
+
+        // Verify that the realm got closed 2 separate times. Once in the AsyncTask, once
+        // in onDestroy
+        verify(mockRealm, times(2)).close();
+    }
+
 
     @SuppressWarnings("unchecked")
     private <T extends RealmObject> RealmQuery<T> mockRealmQuery() {

--- a/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleRealmTest.java
+++ b/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleRealmTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -91,7 +92,9 @@ public class ExampleRealmTest {
      * This test verifies the behavior in the {@link DogRepositoryImpl} class.
      */
     @Test
-    public void shouldVerifyTransactionWasCreated() {
+    public void shouldVerifyThatDogWasCreated() {
+
+        doCallRealMethod().when(mockRealm).executeTransaction(Mockito.any(Realm.Transaction.class));
 
         Dog dog = mock(Dog.class);
         when(mockRealm.createObject(Dog.class)).thenReturn(dog);
@@ -99,14 +102,35 @@ public class ExampleRealmTest {
         DogRepository dogRepo = new DogRepositoryImpl();
         dogRepo.createDog("Spot");
 
-        // Verify that the begin transaction was called only once
-        verify(mockRealm, times(1)).executeTransaction(Mockito.any(Realm.Transaction.class));
+        // Attempting to verify that a method was called (executeTransaction) on a partial
+        // mock will return unexpected resultes due to the partial mock. For example,
+        // verifying that `executeTransaction` was called only once will fail as Powermock
+        // actually calls the method 3 times for some reason. I cannot determine why at this
+        // point.
+
 
         // Verify that Realm#createObject was called only once
         verify(mockRealm, times(1)).createObject(Dog.class); // Verify that a Dog was in fact created.
 
         // Verify that Dog#setName() is called only once
         verify(dog, times(1)).setName(Mockito.anyString()); // Any string will do
+
+        // Verify that the Realm was closed only once.
+        verify(mockRealm, times(1)).close();
+    }
+
+    /**
+     * Have to verify the {@link Realm#executeTransaction(Realm.Transaction)} call in a different
+     * test because of a problem with Powermock: https://github.com/jayway/powermock/issues/649
+     */
+    @Test
+    public void shouldVerifyThatTransactionWasExecuted() {
+
+        DogRepository dogRepo = new DogRepositoryImpl();
+        dogRepo.createDog("Spot");
+
+        // Verify that the begin transaction was called only once
+        verify(mockRealm, times(1)).executeTransaction(Mockito.any(Realm.Transaction.class));
 
         // Verify that the Realm was closed only once.
         verify(mockRealm, times(1)).close();

--- a/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleRealmTest.java
+++ b/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleRealmTest.java
@@ -100,16 +100,13 @@ public class ExampleRealmTest {
         dogRepo.createDog("Spot");
 
         // Verify that the begin transaction was called only once
-        verify(mockRealm, times(1)).beginTransaction();
+        verify(mockRealm, times(1)).executeTransaction(Mockito.any(Realm.Transaction.class));
 
         // Verify that Realm#createObject was called only once
         verify(mockRealm, times(1)).createObject(Dog.class); // Verify that a Dog was in fact created.
 
         // Verify that Dog#setName() is called only once
         verify(dog, times(1)).setName(Mockito.anyString()); // Any string will do
-
-        // Verify that the transaction was committed only once
-        verify(mockRealm, times(1)).commitTransaction();
 
         // Verify that the Realm was closed only once.
         verify(mockRealm, times(1)).close();

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -57,7 +57,7 @@ import rx.Observable;
 /**
  * The Realm class is the storage and transactional manager of your object persistent store. It is in charge of creating
  * instances of your RealmObjects. Objects within a Realm can be queried and read at any time. Creating, modifying, and
- * deleting objects must be done while inside a transaction. See {@link #beginTransaction()}
+ * deleting objects must be done while inside a transaction. See {@link #executeTransaction(Transaction)}
  * <p>
  * The transactions ensure that multiple instances (on multiple threads) can access the same objects in a consistent
  * state with full ACID guarantees.

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -63,7 +63,7 @@ import rx.Observable;
  * @param <E> The class of objects in this list.
  * @see RealmQuery#findAll()
  * @see Realm#allObjects(Class)
- * @see io.realm.Realm#beginTransaction()
+ * @see io.realm.Realm#executeTransaction(Realm.Transaction)
  */
 public final class RealmResults<E extends RealmObject> extends AbstractList<E> {
 


### PR DESCRIPTION
Updated all the examples to use `executeTransaction`. Also updated the comments in the Realm javadocs to use `executeTransaction`. There are a few `executeTransaction` calls that remain in the examples: 

```
Targets
    Occurrences of '.beginTransaction' in Project
Found Occurrences  (3 usages found)
    Unclassified occurrence  (3 usages found)
        io.realm.examples.appmodules  (1 usage found)
            ModulesExampleActivity.java  (1 usage found)
                onCreate(Bundle)  (1 usage found)
                    ModulesExampleActivity.java  (1 usage found)
                        (135: 21) defaultRealm.beginTransaction();
        io.realm.examples.json  (1 usage found)
            JsonExampleActivity.java  (1 usage found)
                loadJsonFromStream()  (1 usage found)
                    JsonExampleActivity.java  (1 usage found)
                        (100: 14) realm.beginTransaction();
        io.realm.examples.realmgridview  (1 usage found)
            GridViewExampleActivity.java  (1 usage found)
                loadCities()  (1 usage found)
                    GridViewExampleActivity.java  (1 usage found)
                        (126: 14) realm.beginTransaction();
```


These are all special cases, therefore I left them using the manual `begin`, `commit` and `cancel` methods.