### PR TITLE
Finalizer optimization: Replace hashmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * Throws an IllegalArgumentExcpetion when calling Realm.copyToRealm()/Realm.copyToRealmOrUpdate() with a RealmObject which belongs to another Realm instance in a different thread.
+* Improves speed of cleaning up native resources (#2496).
 
 ### Bug fixes
 

--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -52,8 +52,7 @@ public class CheckedRow extends UncheckedRow {
     public static CheckedRow get(Context context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.nativePtr, index);
         CheckedRow row = new CheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
-                Context.NATIVE_REFERENCES_VALUE);
+        context.addReference(NativeObjectReference.TYPE_ROW, row);
         return row;
     }
 
@@ -69,8 +68,7 @@ public class CheckedRow extends UncheckedRow {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativePointer, index);
         CheckedRow row = new CheckedRow(context, linkView.getTargetTable(),
                 nativeRowPointer);
-        context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
-                Context.NATIVE_REFERENCES_VALUE);
+        context.addReference(NativeObjectReference.TYPE_ROW, row);
         return row;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
@@ -24,18 +24,6 @@ import java.lang.ref.ReferenceQueue;
  */
 public class LinkView extends NativeObject {
 
-    private static class LinkViewReference extends NativeObjectReference {
-
-        public LinkViewReference(NativeObject referent, ReferenceQueue<? super NativeObject> referenceQueue) {
-            super(referent, referenceQueue);
-        }
-
-        @Override
-        protected void cleanup() {
-            nativeClose(nativePointer);
-        }
-    }
-
     private final Context context;
     final Table parent;
     final long columnIndexInParent;
@@ -46,8 +34,8 @@ public class LinkView extends NativeObject {
         this.columnIndexInParent = columnIndexInParent;
         this.nativePointer = nativeLinkViewPtr;
 
-        context.cleanNativeReferences();
-        context.rowReferences.put(new LinkViewReference(this, context.referenceQueue), Context.NATIVE_REFERENCES_VALUE);
+        context.executeDelayedDisposal();
+        context.addReference(NativeObjectReference.TYPE_LINK_VIEW, this);
     }
 
     /**
@@ -172,7 +160,7 @@ public class LinkView extends NativeObject {
         }
     }
 
-    private static native void nativeClose(long nativeLinkViewPtr);
+    static native void nativeClose(long nativeLinkViewPtr);
     native long nativeGetRow(long nativeLinkViewPtr, long pos);
     private native long nativeGetTargetRowIndex(long nativeLinkViewPtr, long pos);
     private native void nativeAdd(long nativeLinkViewPtr, long rowIndex);

--- a/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
@@ -32,18 +32,6 @@ import io.realm.RealmFieldType;
  */
 public class UncheckedRow extends NativeObject implements Row {
 
-    protected static class UncheckedRowNativeObjectReference extends NativeObjectReference {
-        public UncheckedRowNativeObjectReference(NativeObject referent,
-                                                 ReferenceQueue<? super NativeObject> referenceQueue) {
-            super(referent, referenceQueue);
-        }
-
-        @Override
-        protected void cleanup() {
-            nativeClose(nativePointer);
-        }
-    }
-
     final Context context; // This is only kept because for now it's needed by the constructor of LinkView
     final Table parent;
 
@@ -52,7 +40,7 @@ public class UncheckedRow extends NativeObject implements Row {
         this.parent = parent;
         this.nativePointer = nativePtr;
 
-        context.cleanNativeReferences();
+        context.executeDelayedDisposal();
     }
 
     /**
@@ -66,8 +54,7 @@ public class UncheckedRow extends NativeObject implements Row {
     public static UncheckedRow getByRowIndex(Context context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.nativePtr, index);
         UncheckedRow row = new UncheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
-                Context.NATIVE_REFERENCES_VALUE);
+        context.addReference(NativeObjectReference.TYPE_ROW, row);
         return row;
     }
 
@@ -81,8 +68,7 @@ public class UncheckedRow extends NativeObject implements Row {
      */
     public static UncheckedRow getByRowPointer(Context context, Table table, long nativeRowPointer) {
         UncheckedRow row = new UncheckedRow(context, table, nativeRowPointer);
-        context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
-                Context.NATIVE_REFERENCES_VALUE);
+        context.addReference(NativeObjectReference.TYPE_ROW, row);
         return row;
     }
 
@@ -98,8 +84,7 @@ public class UncheckedRow extends NativeObject implements Row {
         long nativeRowPointer = linkView.nativeGetRow(linkView.nativePointer, index);
         UncheckedRow row = new UncheckedRow(context, linkView.getTargetTable(),
                 nativeRowPointer);
-        context.rowReferences.put(new UncheckedRowNativeObjectReference(row, context.referenceQueue),
-                Context.NATIVE_REFERENCES_VALUE);
+        context.addReference(NativeObjectReference.TYPE_ROW, row);
         return row;
     }
 
@@ -327,7 +312,7 @@ public class UncheckedRow extends NativeObject implements Row {
     protected native void nativeSetMixed(long nativeRowPtr, long columnIndex, Mixed data);
     protected native void nativeSetLink(long nativeRowPtr, long columnIndex, long value);
     protected native void nativeNullifyLink(long nativeRowPtr, long columnIndex);
-    private static native void nativeClose(long nativeRowPtr);
+    static native void nativeClose(long nativeRowPtr);
     protected native boolean nativeIsAttached(long nativeRowPtr);
     protected native boolean nativeHasColumn(long nativeRowPtr, String columnName);
     protected native boolean nativeIsNull(long nativeRowPtr, long columnIndex);


### PR DESCRIPTION
Problems we had by using hashmap:
 1. Hashmap is not thread safe and we access the same hashmap in
 finalizer thread and caller thread of Row's constructor.
 2. Removing reference from the hashmap is a little bit slower when
 there are many references waited to be GCed.

Refactor the NativeObjectReference, make it as a final class and calling
native resource's deallocation directly inside the class. This is needed
for further optimization, like batch delete native pointers to avoid
multiple JNI calls.

* On Genymotion Nexus 6 5.1.0 this improves around 50%
* On Huawei Honor 7 Android M this only improves **-2**% - 9%
* On ARMv7 4.1.2 this improves around 30%

Some benchmark comparison using the array solution vs hashmap solution:
(Benchmark running on Genymotion Nexus 6 5.1.0)

```
(hashmap) Creating 200000 rows - in avg 10000 rows takes 65ms
(array) Creating 200000 rows - in avg 10000 rows takes 67ms
(hashmap) Deleting 200000 rows - in avg 10000 rows takes 8ms
(array) Deleting 200000 rows - in avg 10000 rows takes 4ms

(hashmap) Creating 2000000 rows - in avg 10000 rows takes 30ms
(array) Creating 2000000 rows - in avg 10000 rows takes 28ms
(hashmap) Deleting 200000 rows - in avg 10000 rows takes 95ms
(array) Deleting 200000 rows - in avg 10000 rows takes 46ms

(hashmap) Creating 10000000 rows - in avg 10000 rows takes 33ms
(array) Creating 10000000 rows - in avg 10000 rows takes 28ms
(hashmap) Deleting 1000000 rows - in avg 10000 rows takes 62ms
(array) Deleting 1000000 rows - in avg 10000 rows takes 23ms
```