### PR TITLE
Enable custom equals(), toString() and hashCode()

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -831,6 +831,9 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitToStringMethod(JavaWriter writer) throws IOException {
+        if (metadata.containsToString()) {
+            return;
+        }
         writer.emitAnnotation("Override");
         writer.beginMethod("String", "toString", EnumSet.of(Modifier.PUBLIC));
         writer.beginControlFlow("if (!isValid())");
@@ -879,6 +882,9 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitHashcodeMethod(JavaWriter writer) throws IOException {
+        if (metadata.containsHashCode()) {
+            return;
+        }
         writer.emitAnnotation("Override");
         writer.beginMethod("int", "hashCode", EnumSet.of(Modifier.PUBLIC));
         writer.emitStatement("String realmName = ((RealmObject) this).realm.getPath()");
@@ -895,6 +901,9 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitEqualsMethod(JavaWriter writer) throws IOException {
+        if (metadata.containsEquals()) {
+            return;
+        }
         String proxyClassName = className + Constants.PROXY_SUFFIX;
         writer.emitAnnotation("Override");
         writer.beginMethod("boolean", "equals", EnumSet.of(Modifier.PUBLIC), "Object", "o");

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.ConflictingFieldName;
+import io.realm.entities.CustomMethods;
 import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.NullTypes;
@@ -403,12 +404,34 @@ public class RealmObjectTests {
     }
 
     @Test
+    public void equals_customMethod() {
+        realm.beginTransaction();
+        CustomMethods cm = realm.createObject(CustomMethods.class);
+        cm.setName("Foo");
+        realm.commitTransaction();
+
+        CustomMethods cm1 = realm.where(CustomMethods.class).findFirst();
+        CustomMethods cm2 = realm.where(CustomMethods.class).findFirst();
+        assertFalse(cm1.equals(cm2));
+    }
+
+    @Test
     public void toString_cyclicObject() {
         realm.beginTransaction();
         CyclicType foo = createCyclicData();
         realm.commitTransaction();
         String expected = "CyclicType = [{id:0},{name:Foo},{date:null},{object:CyclicType},{otherObject:null},{objects:RealmList<CyclicType>[0]}]";
         assertEquals(expected, foo.toString());
+    }
+
+    @Test
+    public void toString_customMethod() {
+        realm.beginTransaction();
+        CustomMethods cm = realm.createObject(CustomMethods.class);
+        cm.setName("Foo");
+        realm.commitTransaction();
+        String expected = "custom toString";
+        assertEquals(expected, cm.toString());
     }
 
     @Test
@@ -463,6 +486,15 @@ public class RealmObjectTests {
         } finally {
             realm_differentPath.close();
         }
+    }
+
+    @Test
+    public void hashCode_customMethod() {
+        realm.beginTransaction();
+        CustomMethods cm = realm.createObject(CustomMethods.class);
+        cm.setName("Foo");
+        realm.commitTransaction();
+        assertEquals(1, cm.hashCode());
     }
 
     private CyclicType createCyclicData(Realm realm) {

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/CustomMethods.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/CustomMethods.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+
+public class CustomMethods extends RealmObject {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "custom toString";
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+}


### PR DESCRIPTION
Custom methods such as equals(), toString() and hashCode() are not being called correctly. Fix it. (#2545)