### PR TITLE
Remove unused imports in generated proxy class

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -68,17 +68,14 @@ public class RealmProxyClassGenerator {
         imports.add("io.realm.internal.TableOrView");
         imports.add("io.realm.internal.ImplicitTransaction");
         imports.add("io.realm.internal.LinkView");
-        imports.add("io.realm.internal.android.JsonUtils");
         imports.add("java.io.IOException");
         imports.add("java.util.ArrayList");
         imports.add("java.util.Collections");
         imports.add("java.util.List");
-        imports.add("java.util.Date");
         imports.add("java.util.Map");
         imports.add("java.util.HashMap");
         imports.add("org.json.JSONObject");
         imports.add("org.json.JSONException");
-        imports.add("org.json.JSONArray");
         imports.add(metadata.getFullyQualifiedClassName());
 
         for (VariableElement field : metadata.getFields()) {


### PR DESCRIPTION
It seems that those three imports are never used in the generated proxy class.