### PR TITLE
use apt if already in use regardless if Kotlin is installed.

### DIFF
--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -39,11 +39,15 @@ class Realm implements Plugin<Project> {
             throw new GradleException('Realm gradle plugin only supports android gradle plugin 1.5.0 or later.')
         }
 
-        def isKotlinProject = project.plugins.find {
+        def hasKotlinPlugin = project.plugins.find {
             it.getClass().name == 'org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper'
         }
 
-        if (!isKotlinProject) {
+        def usesAptPlugin = project.plugins.findPlugin('com.neenbedankt.android-apt') != null
+
+        def isKaptProject = hasKotlinPlugin && !usesAptPlugin
+
+        if (!isKaptProject) {
             project.plugins.apply(AndroidAptPlugin)
         }
 
@@ -51,7 +55,7 @@ class Realm implements Plugin<Project> {
         project.repositories.add(project.getRepositories().jcenter())
         project.dependencies.add("compile", "io.realm:realm-android-library:${Version.VERSION}")
         project.dependencies.add("compile", "io.realm:realm-annotations:${Version.VERSION}")
-        if (isKotlinProject) {
+        if (isKaptProject) {
             project.dependencies.add("kapt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("kapt", "io.realm:realm-annotations-processor:${Version.VERSION}")
         } else {

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -39,10 +39,7 @@ class Realm implements Plugin<Project> {
             throw new GradleException('Realm gradle plugin only supports android gradle plugin 1.5.0 or later.')
         }
 
-        def hasKotlinPlugin = project.plugins.find {
-            it.getClass().name == 'org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper'
-        }
-
+        def hasKotlinPlugin = project.plugins.findPlugin('kotlin-android') != null
         def usesAptPlugin = project.plugins.findPlugin('com.neenbedankt.android-apt') != null
 
         def isKaptProject = hasKotlinPlugin && !usesAptPlugin


### PR DESCRIPTION
Fix for #2491. If `apt` is already is use use `apt` instead of `kapt` when kotlin plugin is installed.