### PR TITLE
Increase code coverage createXXXFromJson methods in RealmJsonTests.

### DIFF
--- a/realm/realm-library/src/androidTest/assets/all_types_invalid.json
+++ b/realm/realm-library/src/androidTest/assets/all_types_invalid.json
@@ -1,0 +1,2 @@
+{
+  "columnString" : null,

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import io.realm.entities.AllTypes;
+import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.AnnotationIndexTypes;
 import io.realm.entities.NullTypes;
 import io.realm.entities.StringOnly;
@@ -642,6 +643,15 @@ public class TestHelper {
         DynamicRealmObject object3 = realm.createObject(AllTypes.CLASS_NAME);
         object3.setLong(AllTypes.FIELD_LONG, 4);
         object3.setString(AllTypes.FIELD_STRING, "Adam");
+        realm.commitTransaction();
+    }
+
+    public static void populateSimpleAllTypesPrimaryKey(Realm realm) {
+        realm.beginTransaction();
+        AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
+        obj.setColumnLong(1);
+        obj.setColumnString("Foo");
+        realm.copyToRealm(obj);
         realm.commitTransaction();
     }
 


### PR DESCRIPTION
 * createAllFromJson(Class<E>, String)
 * createObjectFromJson(Class<E>, InputStream)
 * createOrUpdateObjectFromJson(Class<E>, InputStream)
 * createOrUpdateObjectFromJson(Class<E>, JSONObject)
 * createOrUpdateObjectFromJson(Class<E>, String)

In progress, I've rearranged some methods. Without rearrangements, I cannot figure out what methods are not covered.