### PR TITLE
Fix unexistent method call

### DIFF
--- a/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
+++ b/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
@@ -116,7 +116,7 @@ public class IntroExampleActivity extends Activity {
 
         // Delete all persons
         realm.beginTransaction();
-        realm.allObjects(Person.class).deleteAllFromRealm();
+        realm.allObjects(Person.class).clear();
         realm.commitTransaction();
     }
 


### PR DESCRIPTION
The method deleteAllFromRealm does not exist in class RealmResults. Instead, **clear** must be used. (Already verified with the [API documentation](https://realm.io/docs/java/latest/api/io/realm/RealmResults.html))