### PR TITLE
Use RealmConfig.modules() instead of RealmConfig.setModules()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.90.0
+
+### Deprecated
+
+* `RealmConfiguration.setModules()`. Use `RealmConfiguration.modules()` instead.
+
 ## 0.89.0
 
 ### Breaking changes

--- a/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
+++ b/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
@@ -65,14 +65,14 @@ public class ModulesExampleActivity extends Activity {
         // Spider, Cat, Dog }
         RealmConfiguration farmAnimalsConfig = new RealmConfiguration.Builder(this)
                 .name("farm.realm")
-                .setModules(Realm.getDefaultModule(), new DomesticAnimalsModule())
+                .modules(Realm.getDefaultModule(), new DomesticAnimalsModule())
                 .build();
 
         // Or you can completely replace the default schema.
         // This Realm contains the following classes: { Elephant, Lion, Zebra, Snake, Spider }
         RealmConfiguration exoticAnimalsConfig = new RealmConfiguration.Builder(this)
                 .name("exotic.realm")
-                .setModules(new ZooAnimalsModule(), new CreepyAnimalsModule())
+                .modules(new ZooAnimalsModule(), new CreepyAnimalsModule())
                 .build();
 
         // Multiple Realms can be open at the same time

--- a/examples/moduleExample/library/src/main/java/io/realm/examples/librarymodules/Zoo.java
+++ b/examples/moduleExample/library/src/main/java/io/realm/examples/librarymodules/Zoo.java
@@ -35,7 +35,7 @@ public class Zoo {
     public Zoo(Context context) {
         realmConfig = new RealmConfiguration.Builder(context) // Beware this is the app context
                 .name("library.zoo.realm")                    // So always use a unique name
-                .setModules(new AllAnimalsModule())           // Always use explicit modules in library projects
+                .modules(new AllAnimalsModule())           // Always use explicit modules in library projects
                 .build();
 
         // Reset Realm

--- a/realm-annotations/src/main/java/io/realm/annotations/RealmModule.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/RealmModule.java
@@ -47,7 +47,7 @@ import java.lang.annotation.Target;
  * Library authors are responsible for avoiding this conflict by using explicit modules where {@code library = true} is
  * set. This disables the generation of the DefaultRealmModule for the library project and allows the library to be
  * included in the app project that also uses Realm. This means that library projects that uses Realm internally are
- * required to specify a specific module using {@code RealmConfiguration.setModules()}.
+ * required to specify a specific module using {@code RealmConfiguration.modules()}.
  * <p>
  * App developers are not required to specify any modules, as they implicitly use the {@code DefaultRealmModule}, but
  * they now has the option of adding the library project classes to their schema using

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -258,23 +258,23 @@ public class RealmConfigurationTests {
     public void setModules_nonRealmModulesThrows() {
         // Test first argument
         try {
-            new RealmConfiguration.Builder(configFactory.getRoot()).setModules(new Object());
+            new RealmConfiguration.Builder(configFactory.getRoot()).modules(new Object());
             fail();
         } catch (IllegalArgumentException ignored) {
         }
 
         // Test second argument
         try {
-            new RealmConfiguration.Builder(configFactory.getRoot()).setModules(Realm.getDefaultModule(), new Object());
+            new RealmConfiguration.Builder(configFactory.getRoot()).modules(Realm.getDefaultModule(), new Object());
             fail();
         } catch (IllegalArgumentException ignored) {
         }
     }
 
     @Test
-    public void setModules() {
+    public void modules() {
         RealmConfiguration realmConfig = new RealmConfiguration.Builder(configFactory.getRoot())
-                .setModules(Realm.getDefaultModule(), (Object) null).build();
+                .modules(Realm.getDefaultModule(), (Object) null).build();
         realm = Realm.getInstance(realmConfig);
         assertNotNull(realm.getTable(AllTypes.class));
     }
@@ -381,11 +381,11 @@ public class RealmConfigurationTests {
     @Test
     public void equals_withCustomModules() {
         RealmConfiguration config1 = new RealmConfiguration.Builder(configFactory.getRoot())
-                .setModules(new HumanModule(), new AnimalModule())
+                .modules(new HumanModule(), new AnimalModule())
                 .build();
 
         RealmConfiguration config2 = new RealmConfiguration.Builder(configFactory.getRoot())
-                .setModules(new AnimalModule(), new HumanModule())
+                .modules(new AnimalModule(), new HumanModule())
                 .build();
 
         assertTrue(config1.equals(config2));
@@ -394,10 +394,10 @@ public class RealmConfigurationTests {
     @Test
     public void hashCode_withCustomModules() {
         RealmConfiguration config1 = new RealmConfiguration.Builder(configFactory.getRoot())
-                .setModules(new HumanModule(), new AnimalModule())
+                .modules(new HumanModule(), new AnimalModule())
                 .build();
         RealmConfiguration config2 = new RealmConfiguration.Builder(configFactory.getRoot())
-                .setModules(new AnimalModule(), new HumanModule())
+                .modules(new AnimalModule(), new HumanModule())
                 .build();
 
         assertEquals(config1.hashCode(), config2.hashCode());
@@ -558,7 +558,7 @@ public class RealmConfigurationTests {
     @Test
     public void modelClasses_forGeneratedMediator() throws Exception {
         final RealmConfiguration config = new RealmConfiguration.Builder(configFactory.getRoot())
-                .setModules(new HumanModule()).build();
+                .modules(new HumanModule()).build();
         assertTrue(config.getSchemaMediator() instanceof HumanModuleMediator);
 
         final Set<Class<? extends RealmObject>> realmClasses = config.getRealmObjectClasses();
@@ -578,7 +578,7 @@ public class RealmConfigurationTests {
     @Test
     public void modelClasses_forCompositeMediator() throws Exception {
         final RealmConfiguration config = new RealmConfiguration.Builder(configFactory.getRoot())
-                .setModules(new HumanModule(), new AnimalModule()).build();
+                .modules(new HumanModule(), new AnimalModule()).build();
         assertTrue(config.getSchemaMediator() instanceof CompositeMediator);
 
         final Set<Class<? extends RealmObject>> realmClasses = config.getRealmObjectClasses();

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1549,7 +1549,7 @@ public final class Realm extends BaseRealm {
      *
      * @return the default Realm module or null if no default module exists.
      * @throws RealmException if unable to create an instance of the module.
-     * @see io.realm.RealmConfiguration.Builder#setModules(Object, Object...)
+     * @see io.realm.RealmConfiguration.Builder#modules(Object, Object...)
      */
     public static Object getDefaultModule() {
         String moduleName = "io.realm.DefaultRealmModule";

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -458,6 +458,15 @@ public class RealmConfiguration {
         }
 
         /**
+         * DEPRECATED: Use {@link #modules(Object, Object...)} instead.
+         */
+        @Deprecated
+        public Builder setModules(Object baseModule, Object... additionalModules) {
+            modules(baseModule, additionalModules);
+            return this;
+        }
+
+        /**
          * Replaces the existing module(s) with one or more {@link RealmModule}s. Using this method will replace the
          * current schema for this Realm with the schema defined by the provided modules.
          *
@@ -465,14 +474,14 @@ public class RealmConfiguration {
          * can be found using {@link Realm#getDefaultModule()}. Combining the schema from the app project and a library
          * dependency is thus done using the following code:
          *
-         * {@code builder.setModules(Realm.getDefaultMode(), new MyLibraryModule()); }
+         * {@code builder.modules(Realm.getDefaultMode(), new MyLibraryModule()); }
          *
          * @param baseModule the first Realm module (required).
          * @param additionalModules the additional Realm modules
          * @throws IllegalArgumentException if any of the modules doesn't have the {@link RealmModule} annotation.
          * @see Realm#getDefaultModule()
          */
-        public Builder setModules(Object baseModule, Object... additionalModules) {
+        public Builder modules(Object baseModule, Object... additionalModules) {
             modules.clear();
             addModule(baseModule);
             if (additionalModules != null) {


### PR DESCRIPTION
Part of #1594. Merge all together in one release.

@realm/java 


Final commit message:
------
Title: Replace setModules() with modules()

This PR deprecates RealmConfiguration.setModules() in favour of RealmConfiguration.modules(). The reason being using the setter terminology is not common in builders. See Effective Java item 2.