### PR TITLE
introduce `buildTargetABIs` property to realm-jni project in order to allow to build only specified ABI(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ That command will generate:
  * `./gradlew monkeyExamples` will run the monkey tests on all the examples
  * `./gradlew installRealmJava` will install the Realm library and plugin to mavenLocal()
  * `./gradlew clean -PdontCleanJniFiles` will remove all generated files except for JNI related files. This saves recompilation time a lot.
+ * `./gradlew connectedCheck -PbuildTargetABIs=$(adb shell getprop ro.product.cpu.abi)` will build JNI files only for the ABI which corresponds to the connected device.
 
 Generating the Javadoc using the command above will report a large number of warnings. The Javadoc is generated, and we will fix the issue in the near future.
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ task assembleRealm(type:GradleBuild) {
     dependsOn installTransformer
     buildFile = file('realm/build.gradle')
     tasks = ['assemble', 'javadocJar', 'sourcesJar']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task check(type:GradleBuild) {
@@ -61,6 +64,9 @@ task check(type:GradleBuild) {
     description = 'Run the JVM tests and checks Realm project'
     buildFile = file('realm/build.gradle')
     tasks = ['check']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task connectedCheck(type:GradleBuild) {
@@ -69,6 +75,9 @@ task connectedCheck(type:GradleBuild) {
     dependsOn installTransformer
     buildFile = file('realm/build.gradle')
     tasks = ['connectedCheck']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task installRealm(type:GradleBuild) {
@@ -77,6 +86,9 @@ task installRealm(type:GradleBuild) {
     dependsOn installTransformer
     buildFile = file('realm/build.gradle')
     tasks = ['install']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task assembleGradlePlugin(type:GradleBuild) {
@@ -127,6 +139,9 @@ task javadoc(type:GradleBuild) {
     group = 'Docs'
     buildFile = file('realm/build.gradle')
     tasks = ['javadocJar']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task sourcesJar(type:GradleBuild) {
@@ -134,6 +149,9 @@ task sourcesJar(type:GradleBuild) {
     group = 'Docs'
     buildFile = file('realm/build.gradle')
     tasks = ['sourcesJar']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task assemble {
@@ -179,8 +197,11 @@ task cleanRealm(type:GradleBuild) {
     group = 'Clean'
     buildFile = file('realm/build.gradle')
     tasks = ['clean']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
     if (project.hasProperty('dontCleanJniFiles')) {
-        startParameter.projectProperties = [dontCleanJniFiles: ""]
+        startParameter.projectProperties += [dontCleanJniFiles: project.getProperty('dontCleanJniFiles')]
     }
 }
 
@@ -256,6 +277,9 @@ task bintrayRealm(type: GradleBuild) {
     group = 'Publishing'
     buildFile = file('realm/build.gradle')
     tasks = ['bintrayUpload']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task bintrayAnnotations(type: GradleBuild) {
@@ -293,6 +317,9 @@ task ojoRealm(type: GradleBuild) {
     group = 'Publishing'
     buildFile = file('realm/build.gradle')
     tasks = ['artifactoryPublish']
+    if (project.hasProperty('buildTargetABIs')) {
+        startParameter.projectProperties += [buildTargetABIs: project.getProperty('buildTargetABIs')]
+    }
 }
 
 task ojoAnnotations(type: GradleBuild) {

--- a/realm/realm-jni/build.gradle
+++ b/realm/realm-jni/build.gradle
@@ -16,6 +16,9 @@ ext.stripSymbols = project.hasProperty('stripSymbols') ? project.getProperty('st
 ext.coreSourcePath = project.hasProperty('coreSourcePath') ? project.getProperty('coreSourcePath') : null
 // The location of core archive.
 ext.coreArchiveDir = System.getenv("REALM_CORE_DOWNLOAD_DIR")
+// target ABIs to build(null means all).
+// To obtain the ABI of the connected device, execute "adb shell getprop ro.product.cpu.abi"
+ext.buildTargetAbis = project.hasProperty('buildTargetABIs') ? project.getProperty('buildTargetABIs').split(',').collect {it.trim()} : null
 
 def commonCflags = [ '-Os', '-std=c++11' ]
 // LTO and debugging don't play well together
@@ -51,8 +54,9 @@ class Target {
     // The name of the target. This is used for the task names
     String name
 
-    // The name of the folder the Android Gradle plugin expects to find the shared library
-    String jniFolder
+    // The name of the abi. It is also the name of the folder where the Android Gradle plugin
+    // expects to find the shared library
+    String abi
 
     // The toolchain associated to this target
     Toolchain toolchain
@@ -70,14 +74,29 @@ def toolchains = [
     new Toolchain( name:'x86_64', fullName:'x86_64', commandPrefix:'x86_64-linux-android', version:[ (Compiler.GCC):'4.9', (Compiler.CLANG):'3.5' ], platform:21 )
 ]
 
-def targets = [
-    new Target( name:'arm', jniFolder:'armeabi', toolchain:toolchains.find{it.name == 'arm'}, cflags:[ '-mthumb' ] ),
-    new Target( name:'arm-v7a', jniFolder:'armeabi-v7a', toolchain:toolchains.find{it.name == 'arm'}, cflags:[ '-mthumb', '-march=armv7-a', '-mfloat-abi=softfp', '-mfpu=vfpv3-d16' ] ),
-    new Target( name:'arm64', jniFolder:'arm64-v8a', toolchain:toolchains.find{it.name == 'arm64'}, cflags:[] ),
-    new Target( name:'mips', jniFolder:'mips', toolchain:toolchains.find{it.name == 'mips'}, cflags:[] ),
-    new Target( name:'x86', jniFolder:'x86', toolchain:toolchains.find{it.name == 'x86'}, cflags:[] ),
-    new Target( name:'x86_64', jniFolder:'x86_64', toolchain:toolchains.find{it.name == 'x86_64'}, cflags:[] )
+def allTargets = [
+    new Target( name:'arm',     abi:'armeabi',     toolchain:toolchains.find {it.name == 'arm'},    cflags:[ '-mthumb' ] ),
+    new Target( name:'arm-v7a', abi:'armeabi-v7a', toolchain:toolchains.find {it.name == 'arm'},    cflags:[ '-mthumb', '-march=armv7-a', '-mfloat-abi=softfp', '-mfpu=vfpv3-d16' ] ),
+    new Target( name:'arm64',   abi:'arm64-v8a',   toolchain:toolchains.find {it.name == 'arm64'},  cflags:[] ),
+    new Target( name:'mips',    abi:'mips',        toolchain:toolchains.find {it.name == 'mips'},   cflags:[] ),
+    new Target( name:'x86',     abi:'x86',         toolchain:toolchains.find {it.name == 'x86'},    cflags:[] ),
+    new Target( name:'x86_64',  abi:'x86_64',      toolchain:toolchains.find {it.name == 'x86_64'}, cflags:[] )
 ]
+
+def targets
+if (ext.buildTargetAbis == null) {
+    targets = allTargets;
+} else {
+    targets = ext.buildTargetAbis.collect { targetAbi ->
+        def target = allTargets.find {it.abi == targetAbi}
+        if (!target) {
+            throw new GradleException("Warning: no target ABIs found for '${targetAbi}'." +
+                    " Please check 'buildTargetABIs' property." +
+                    " Supprted ABIs are ${allTargets.collect {it.abi}. join(', ')}.")
+        }
+        return target
+    }
+}
 
 buildscript {
     repositories {
@@ -301,14 +320,14 @@ targets.each { target ->
     task "copyAndroidJni${target.name.capitalize()}"(dependsOn: "buildAndroidJni${target.name.capitalize()}") << {
         copy {
             from "${projectDir}/src/librealm-jni-${target.name}${getDebugExt()}${getStrippedExt()}.so"
-            into "${projectDir}/../realm-library/src/main/jniLibs/${target.jniFolder}"
+            into "${projectDir}/../realm-library/src/main/jniLibs/${target.abi}"
             rename "librealm-jni-${target.name}${getDebugExt()}${getStrippedExt()}.so", 'librealm-jni.so'
         }
 
         // Store the unstripped version
         copy {
             from "${projectDir}/src/librealm-jni-${target.name}${getDebugExt()}.so"
-            into "${projectDir}/../build/output/jniLibs-unstripped/${target.jniFolder}"
+            into "${projectDir}/../build/output/jniLibs-unstripped/${target.abi}"
             rename "librealm-jni-${target.name}${getDebugExt()}.so", 'librealm-jni.so'
         }
     }


### PR DESCRIPTION
example(only build jni files for arm64 and x86_64):
```
./gradlew assemble -PbuildTargetABIs=arm64,x86_64
```

example(build jni files for connected device and execute connectedCheck):
```
./gradlew connectedCheck -PbuildTargetABIs=$(adb shell getprop ro.product.cpu.abi)
```

@realm/java 