### PR TITLE
@PrimaryKey + @Required annotation generates inappropriate type cast

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -639,8 +639,9 @@ public class RealmProxyClassGenerator {
                         .endControlFlow();
                 }
             } else {
-                writer.emitStatement("long rowIndex = table.findFirstLong(pkColumnIndex, ((%s) object).%s())",
-                        interfaceName, primaryKeyGetter);
+                String pkType = Utils.isString(metadata.getPrimaryKey()) ? "String" : "Long";
+                writer.emitStatement("long rowIndex = table.findFirst%s(pkColumnIndex, ((%s) object).%s())",
+                        pkType, interfaceName, primaryKeyGetter);
             }
 
             writer

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -56,6 +56,7 @@ import io.realm.internal.Table;
 import io.realm.internal.TableOrView;
 import io.realm.internal.async.RealmThreadPoolExecutor;
 import io.realm.internal.log.Logger;
+import io.realm.objectid.NullPrimaryKey;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static junit.framework.Assert.fail;

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -56,7 +56,6 @@ import io.realm.internal.Table;
 import io.realm.internal.TableOrView;
 import io.realm.internal.async.RealmThreadPoolExecutor;
 import io.realm.internal.log.Logger;
-import io.realm.objectid.NullPrimaryKey;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static junit.framework.Assert.fail;

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedByte.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedByte.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedByte extends RealmObject implements NullPrimaryKey<Byte, String> {
+
+    @PrimaryKey
+    @Required
+    private Byte id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedByte() {}
+    public PrimaryKeyRequiredAsBoxedByte(Byte id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Byte getId() {
+        return id;
+    }
+
+    public void setId(Byte id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedInteger.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedInteger.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedInteger extends RealmObject implements NullPrimaryKey<Integer, String> {
+
+    @PrimaryKey
+    @Required
+    private Integer id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedInteger() {}
+    public PrimaryKeyRequiredAsBoxedInteger(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedLong.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedLong.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedLong extends RealmObject implements NullPrimaryKey<Long, String> {
+
+    @PrimaryKey
+    @Required
+    private Long id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedLong() {}
+    public PrimaryKeyRequiredAsBoxedLong(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedShort.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedShort.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedShort extends RealmObject implements NullPrimaryKey<Short, String> {
+
+    @PrimaryKey
+    @Required
+    private Short id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedShort() {}
+    public PrimaryKeyRequiredAsBoxedShort(Short id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Short getId() {
+        return id;
+    }
+
+    public void setId(Short id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsString.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsString.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsString extends RealmObject implements NullPrimaryKey<String, String> {
+
+    @PrimaryKey
+    @Required
+    private String id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsString(){}
+    public PrimaryKeyRequiredAsString(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
In issue #2637 where `@PrimaryKey` and `@Required` annotations are applied together on `String` type field, inappropriate type cast is generated to cause compilation fail. This PR addresses the issue.

@realm/java please review.