### PR TITLE
Add getPrimaryKey() method to RealmObjectSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * `RealmConfiguration.setModules()`. Use `RealmConfiguration.modules()` instead.
 
+### Enhancements
+
+* `RealmObjectSchema.getPrimaryKey()` (#2636)
+
 ## 0.89.0
 
 ### Breaking changes

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -29,7 +29,10 @@ import org.junit.runner.RunWith;
 import java.util.Date;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class RealmObjectSchemaTests {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -17,7 +17,8 @@
 package io.realm;
 
 import android.support.test.runner.AndroidJUnit4;
-
+import io.realm.entities.AllJavaTypes;
+import io.realm.rule.TestRealmConfigurationFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -28,13 +29,7 @@ import org.junit.runner.RunWith;
 import java.util.Date;
 import java.util.Set;
 
-import io.realm.entities.AllJavaTypes;
-import io.realm.rule.TestRealmConfigurationFactory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class RealmObjectSchemaTests {
@@ -318,6 +313,7 @@ public class RealmObjectSchemaTests {
             schema.addField(fieldName, fieldType.getType(), FieldAttribute.PRIMARY_KEY);
             assertTrue(schema.hasPrimaryKey());
             assertTrue(schema.isPrimaryKey(fieldName));
+            assertEquals(fieldName, schema.getPrimaryKey());
             switch (fieldType) {
                 case BYTE:
                 case SHORT:
@@ -706,6 +702,11 @@ public class RealmObjectSchemaTests {
     @Test(expected = IllegalArgumentException.class)
     public void isPrimaryKey_nonExistFieldThrows() {
         schema.isPrimaryKey("I don't exist");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void getPrimaryKey_nonExistFieldThrows() {
+        schema.getPrimaryKey();
     }
 
     private interface FieldRunnable {

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -419,7 +419,7 @@ public final class RealmObjectSchema {
      * Returns the name of the primary key field.
      *
      * @return the name of the primary key field.
-     * @throws IllegalArgumentException if the class doesn't have a primary key defined.
+     * @throws IllegalStateException if the class doesn't have a primary key defined.
      */
     public String getPrimaryKey() {
         if (!table.hasPrimaryKey()) {

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -16,18 +16,12 @@
 
 package io.realm;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-
 import io.realm.annotations.Required;
 import io.realm.internal.ImplicitTransaction;
 import io.realm.internal.Table;
 import io.realm.internal.TableOrView;
+
+import java.util.*;
 
 /**
  * Class for interacting with the schema for a given RealmObject class. This makes it possible to
@@ -419,6 +413,19 @@ public final class RealmObjectSchema {
      */
     public boolean hasPrimaryKey() {
         return table.hasPrimaryKey();
+    }
+
+    /**
+     * Returns the name of the primary key field.
+     *
+     * @return the name of the primary key field.
+     * @throws IllegalArgumentException if the class doesn't have a primary key defined.
+     */
+    public String getPrimaryKey() {
+        if (!table.hasPrimaryKey()) {
+            throw new IllegalStateException(getClassName() + " doesn't have a primary key.");
+        }
+        return table.getColumnName(table.getPrimaryKey());
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -21,7 +21,13 @@ import io.realm.internal.ImplicitTransaction;
 import io.realm.internal.Table;
 import io.realm.internal.TableOrView;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Class for interacting with the schema for a given RealmObject class. This makes it possible to


### PR DESCRIPTION
Resolves #2636: this PR adds a `getPrimaryKey()` method to `RealmObjectSchema`.

`getPrimaryKey()` returns the name of the primary key field if the model has a primary key, or throws an `IllegalStateException` if the model doesn't have a primary key field (using the same message that `removePrimaryKey()` uses in such a situation).

I've also modified/added tests in `RealmObjectSchemaTests.java` in order to attain 100% coverage for `getPrimaryKey()`.

I'm new to GitHub pull requests, so if I've done something wrong here please don't hesitate to tell me!