### PR TITLE
@PrimaryKey + @Required annotation generates inappropriate type cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.89.1
 
-### Buf fixes
+### Bug fixes
 
-* @PrimaryKey + @Required doesn't create inappropriate type cast when a primary key field type is `String` (#2644).
+* @PrimaryKey + @Required doesn't create inappropriate type cast when a primary key field type is `String` (#2653).
 
 ## 0.89.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.89.1
+
+### Buf fixes
+
+* @PrimaryKey + @Required doesn't create inappropriate type cast when a primary key field type is `String` (#2644).
+
 ## 0.89.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* @PrimaryKey + @Required creates appropriate type cast when a primary key field type is `String` (#2653).
+* @PrimaryKey + @Required on String type primary key no longer throws when using copyToRealm or copyToRealmOrUpdate (#2653).
 
 ## 0.89.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* @PrimaryKey + @Required doesn't create inappropriate type cast when a primary key field type is `String` (#2653).
+* @PrimaryKey + @Required creates appropriate type cast when a primary key field type is `String` (#2653).
 
 ## 0.89.0
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -639,8 +639,9 @@ public class RealmProxyClassGenerator {
                         .endControlFlow();
                 }
             } else {
-                writer.emitStatement("long rowIndex = table.findFirstLong(pkColumnIndex, ((%s) object).%s())",
-                        interfaceName, primaryKeyGetter);
+                String pkType = Utils.isString(metadata.getPrimaryKey()) ? "String" : "Long";
+                writer.emitStatement("long rowIndex = table.findFirst%s(pkColumnIndex, ((%s) object).%s())",
+                        pkType, interfaceName, primaryKeyGetter);
             }
 
             writer

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmNullPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmNullPrimaryKeyTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+import io.realm.entities.PrimaryKeyRequiredAsBoxedByte;
+import io.realm.entities.PrimaryKeyRequiredAsBoxedInteger;
+import io.realm.entities.PrimaryKeyRequiredAsBoxedLong;
+import io.realm.entities.PrimaryKeyRequiredAsBoxedShort;
+import io.realm.entities.PrimaryKeyRequiredAsString;
+import io.realm.objectid.NullPrimaryKey;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class RealmNullPrimaryKeyTests {
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+
+    protected Realm realm;
+
+    @Before
+    public void setUp() {
+        RealmConfiguration realmConfig = configFactory.createConfiguration();
+        realm = Realm.getInstance(realmConfig);
+    }
+
+    @After
+    public void tearDown() {
+        if (realm != null) {
+            realm.close();
+        }
+    }
+
+    // parameters for testing null/non-null primary key value. PrimaryKey field is explicitly null or absent.
+    @Parameterized.Parameters
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                 {PrimaryKeyRequiredAsString.class,       String.class,  "424123",              String.class, "secondaryFieldValue"}
+                ,{PrimaryKeyRequiredAsBoxedByte.class,    Byte.class,    Byte.valueOf("67"),    String.class, "secondaryFieldValue"}
+                ,{PrimaryKeyRequiredAsBoxedShort.class,   Short.class,   Short.valueOf("1729"), String.class, "secondaryFieldValue"}
+                ,{PrimaryKeyRequiredAsBoxedInteger.class, Integer.class, Integer.valueOf("19"), String.class, "secondaryFieldValue"}
+                ,{PrimaryKeyRequiredAsBoxedLong.class,    Long.class,    Long.valueOf("62914"), String.class, "secondaryFieldValue"}
+        });
+    }
+
+    final private Class<? extends RealmObject> testClazz;
+    final private Class primaryKeyFieldType;
+    final private Object primaryKeyFieldValue;
+    final private Class secondaryFieldType;
+    final private Object secondaryFieldValue;
+
+    public RealmNullPrimaryKeyTests(Class<? extends RealmObject> testClazz, Class primaryKeyFieldType, Object primaryKeyFieldValue, Class secondaryFieldType, Object secondaryFieldValue) {
+        this.testClazz = testClazz;
+        this.primaryKeyFieldType = primaryKeyFieldType;
+        this.primaryKeyFieldValue = primaryKeyFieldValue;
+        this.secondaryFieldType = secondaryFieldType;
+        this.secondaryFieldValue = secondaryFieldValue;
+    }
+
+    // @PrimaryKey + @Required annotation accept not-null value properly as a primary key value for Realm version 0.89.1+
+    @Test
+    public void copyToRealmOrUpdate_requiredPrimaryKey() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        RealmObject obj = (RealmObject)testClazz.getConstructor(primaryKeyFieldType, secondaryFieldType).newInstance(primaryKeyFieldValue, secondaryFieldValue);
+        realm.beginTransaction();
+        realm.copyToRealmOrUpdate(obj);
+        realm.commitTransaction();
+
+        RealmResults results = realm.allObjects(testClazz);
+        assertEquals(1, results.size());
+        assertEquals(primaryKeyFieldValue, ((NullPrimaryKey)results.first()).getId());
+        assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());
+    }
+
+    // @PrimaryKey + @Required annotation does accept null as a primary key value for Realm version 0.89.1+
+    @Test
+    public void copyToRealmOrUpdate_requiredPrimaryKeyThrows() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        try {
+            realm.beginTransaction();
+            RealmObject obj = (RealmObject)testClazz.getConstructor(primaryKeyFieldType, secondaryFieldType).newInstance(null, null);
+            realm.copyToRealmOrUpdate(obj);
+            fail("@PrimaryKey + @Required field cannot be null");
+        } catch (RuntimeException expected) {
+            if (testClazz.equals(PrimaryKeyRequiredAsString.class)) {
+                assertTrue(expected instanceof IllegalArgumentException);
+            } else {
+                assertTrue(expected instanceof NullPointerException);
+            }
+
+        } finally {
+            realm.cancelTransaction();
+        }
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmPrimaryKeyTests.java
@@ -58,15 +58,21 @@ public class RealmPrimaryKeyTests {
         }
     }
 
-    // parameters for testing null/non-null primary key value. PrimaryKey field is explicitly null or absent.
+    /**
+     * Base parameters for testing null/not-null primary key value. The parameters are aligned in an
+     * order of 1) a test target class, 2) a primary key field class, 3) a primary Key value, 4) a
+     * secondary field class, and 5) a secondary field value, accommodating {@interface NullPrimaryKey}
+     * to condense unit tests.
+     */
     @Parameterized.Parameters
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                 {PrimaryKeyRequiredAsString.class,       String.class,  "424123",              String.class, "SomeSecondaryValue"}
-                ,{PrimaryKeyRequiredAsBoxedByte.class,    Byte.class,    Byte.valueOf("67"),    String.class, "This-Is-Second-One"}
-                ,{PrimaryKeyRequiredAsBoxedShort.class,   Short.class,   Short.valueOf("1729"), String.class, "AnyValueIsAccepted"}
-                ,{PrimaryKeyRequiredAsBoxedInteger.class, Integer.class, Integer.valueOf("19"), String.class, "PlayWithSeondFied!"}
-                ,{PrimaryKeyRequiredAsBoxedLong.class,    Long.class,    Long.valueOf("62914"), String.class, "Let's name a value"}
+                // 1) Test target class                  2) PK Class    3) PK value            4) 2nd Class  5) 2nd field value
+                {PrimaryKeyRequiredAsString.class,       String.class,  "424123",              String.class, "SomeSecondaryValue"},
+                {PrimaryKeyRequiredAsBoxedByte.class,    Byte.class,    Byte.valueOf("67"),    String.class, "This-Is-Second-One"},
+                {PrimaryKeyRequiredAsBoxedShort.class,   Short.class,   Short.valueOf("1729"), String.class, "AnyValueIsAccepted"},
+                {PrimaryKeyRequiredAsBoxedInteger.class, Integer.class, Integer.valueOf("19"), String.class, "PlayWithSeondFied!"},
+                {PrimaryKeyRequiredAsBoxedLong.class,    Long.class,    Long.valueOf("62914"), String.class, "Let's name a value"}
         });
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmPrimaryKeyTests.java
@@ -92,7 +92,7 @@ public class RealmPrimaryKeyTests {
         realm.copyToRealmOrUpdate(obj);
         realm.commitTransaction();
 
-        RealmResults results = realm.allObjects(testClazz);
+        RealmResults results = realm.where(testClazz).findAll();
         assertEquals(1, results.size());
         assertEquals(primaryKeyFieldValue, ((NullPrimaryKey)results.first()).getId());
         assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());
@@ -102,8 +102,8 @@ public class RealmPrimaryKeyTests {
     @Test
     public void copyToRealmOrUpdate_requiredPrimaryKeyThrows() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
         try {
-            realm.beginTransaction();
             RealmObject obj = (RealmObject)testClazz.getConstructor(primaryKeyFieldType, secondaryFieldType).newInstance(null, null);
+            realm.beginTransaction();
             realm.copyToRealmOrUpdate(obj);
             fail("@PrimaryKey + @Required field cannot be null");
         } catch (RuntimeException expected) {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmPrimaryKeyTests.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
-public class RealmNullPrimaryKeyTests {
+public class RealmPrimaryKeyTests {
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
 
@@ -62,11 +62,11 @@ public class RealmNullPrimaryKeyTests {
     @Parameterized.Parameters
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                 {PrimaryKeyRequiredAsString.class,       String.class,  "424123",              String.class, "secondaryFieldValue"}
-                ,{PrimaryKeyRequiredAsBoxedByte.class,    Byte.class,    Byte.valueOf("67"),    String.class, "secondaryFieldValue"}
-                ,{PrimaryKeyRequiredAsBoxedShort.class,   Short.class,   Short.valueOf("1729"), String.class, "secondaryFieldValue"}
-                ,{PrimaryKeyRequiredAsBoxedInteger.class, Integer.class, Integer.valueOf("19"), String.class, "secondaryFieldValue"}
-                ,{PrimaryKeyRequiredAsBoxedLong.class,    Long.class,    Long.valueOf("62914"), String.class, "secondaryFieldValue"}
+                 {PrimaryKeyRequiredAsString.class,       String.class,  "424123",              String.class, "SomeSecondaryValue"}
+                ,{PrimaryKeyRequiredAsBoxedByte.class,    Byte.class,    Byte.valueOf("67"),    String.class, "This-Is-Second-One"}
+                ,{PrimaryKeyRequiredAsBoxedShort.class,   Short.class,   Short.valueOf("1729"), String.class, "AnyValueIsAccepted"}
+                ,{PrimaryKeyRequiredAsBoxedInteger.class, Integer.class, Integer.valueOf("19"), String.class, "PlayWithSeondFied!"}
+                ,{PrimaryKeyRequiredAsBoxedLong.class,    Long.class,    Long.valueOf("62914"), String.class, "Let's name a value"}
         });
     }
 
@@ -76,7 +76,7 @@ public class RealmNullPrimaryKeyTests {
     final private Class secondaryFieldType;
     final private Object secondaryFieldValue;
 
-    public RealmNullPrimaryKeyTests(Class<? extends RealmObject> testClazz, Class primaryKeyFieldType, Object primaryKeyFieldValue, Class secondaryFieldType, Object secondaryFieldValue) {
+    public RealmPrimaryKeyTests(Class<? extends RealmObject> testClazz, Class primaryKeyFieldType, Object primaryKeyFieldValue, Class secondaryFieldType, Object secondaryFieldValue) {
         this.testClazz = testClazz;
         this.primaryKeyFieldType = primaryKeyFieldType;
         this.primaryKeyFieldValue = primaryKeyFieldValue;

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedByte.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedByte.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedByte extends RealmObject implements NullPrimaryKey<Byte, String> {
+
+    @PrimaryKey
+    @Required
+    private Byte id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedByte() {}
+    public PrimaryKeyRequiredAsBoxedByte(Byte id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Byte getId() {
+        return id;
+    }
+
+    public void setId(Byte id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedInteger.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedInteger.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedInteger extends RealmObject implements NullPrimaryKey<Integer, String> {
+
+    @PrimaryKey
+    @Required
+    private Integer id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedInteger() {}
+    public PrimaryKeyRequiredAsBoxedInteger(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedLong.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedLong.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedLong extends RealmObject implements NullPrimaryKey<Long, String> {
+
+    @PrimaryKey
+    @Required
+    private Long id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedLong() {}
+    public PrimaryKeyRequiredAsBoxedLong(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedShort.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsBoxedShort.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsBoxedShort extends RealmObject implements NullPrimaryKey<Short, String> {
+
+    @PrimaryKey
+    @Required
+    private Short id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsBoxedShort() {}
+    public PrimaryKeyRequiredAsBoxedShort(Short id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Short getId() {
+        return id;
+    }
+
+    public void setId(Short id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsString.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyRequiredAsString.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyRequiredAsString extends RealmObject implements NullPrimaryKey<String, String> {
+
+    @PrimaryKey
+    @Required
+    private String id;
+
+    private String name;
+
+    public PrimaryKeyRequiredAsString(){}
+    public PrimaryKeyRequiredAsString(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
When `@PrimaryKey` and `@Required` annotations are applied together on `String` type field, inappropriate type cast is generated to cause compilation fail. This PR addresses the issue.

All the review points in #2644 are now addressed. 

@realm/java please review.

<hr/>

Final Commit Message : 

Title : A combination of @PrimaryKey and @Required annotation now generates appropriate type cast when a primary key field type is `String`.

When `RealmProxyClassGenerator.emitCopyOrUpdateMethod()` is generating code for checking `@PrimaryKey` value for not-nullable types (i.e. primitive types  or marked with `@Required`), it now generates appropriate type casts according to the field types.

