### PR TITLE
Make all methods on RealmObject and all classes in public API final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking changes
 
 * Removed `HandlerController` from the public API.
+* Marked all methods on `RealmObject` and all public classes final (#1594).
 
 ### Deprecated
 

--- a/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
  * case of a configuration change for example (to avoid memory leak, as the transaction will post the result to the
  * caller's thread callback).
  */
-public class RealmAsyncTask {
+public final class RealmAsyncTask {
     private final Future<?> pendingQuery;
     private volatile boolean isCancelled = false;
 

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -30,7 +30,7 @@ import io.realm.internal.log.RealmLog;
  * One {@link RealmCache} is created for each {@link RealmConfiguration}, and it caches all the {@link Realm} and
  * {@link DynamicRealm} instances which are created from the same {@link RealmConfiguration}.
  */
-class RealmCache {
+final class RealmCache {
 
     interface Callback {
         void onResult(int count);

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -54,7 +54,7 @@ import io.realm.rx.RxObservableFactory;
  * - It is saved in Context.getFilesDir()
  * - It has its schema version set to 0.
  */
-public class RealmConfiguration {
+public final class RealmConfiguration {
 
     public static final String DEFAULT_REALM_NAME = "default.realm";
     public static final int KEY_LENGTH = 64;
@@ -311,7 +311,7 @@ public class RealmConfiguration {
     /**
      * RealmConfiguration.Builder used to construct instances of a RealmConfiguration in a fluent manner.
      */
-    public static class Builder {
+    public static final class Builder {
         private File folder;
         private String fileName;
         private byte[] key;

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -89,7 +89,7 @@ public abstract class RealmObject implements RealmModel {
      * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
      * @see #isValid()
      */
-    public void deleteFromRealm() {
+    public final void deleteFromRealm() {
         deleteFromRealm(this);
     }
     
@@ -327,7 +327,7 @@ public abstract class RealmObject implements RealmModel {
      * corresponding Realm instance doesn't support RxJava.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>
      */
-    public <E extends RealmObject> Observable<E> asObservable() {
+    public final <E extends RealmObject> Observable<E> asObservable() {
         return (Observable<E>) RealmObject.asObservable(this);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -675,7 +675,7 @@ public final class RealmObjectSchema {
         }
     }
 
-    static class DynamicColumnMap implements Map<String, Long> {
+    static final class DynamicColumnMap implements Map<String, Long> {
         private final Table table;
 
         public DynamicColumnMap(Table table) {

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -59,7 +59,7 @@ import io.realm.internal.log.RealmLog;
  * @see Realm#where(Class)
  * @see RealmResults#where()
  */
-public class RealmQuery<E extends RealmModel> {
+public final class RealmQuery<E extends RealmModel> {
 
     private BaseRealm realm;
     private Class<E> clazz;

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmError.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmError.java
@@ -23,7 +23,7 @@ import io.realm.internal.Keep;
  * RealmError should never be caught or ignored. By doing so, the Realm could possibly get corrupted.
  */
 @Keep
-public class RealmError extends Error {
+public final class RealmError extends Error {
     public RealmError(String detailMessage) {
         super(detailMessage);
     }

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmException.java
@@ -22,7 +22,7 @@ import io.realm.internal.Keep;
  * RealmException is Realm specific exceptions.
  */
 @Keep
-public class RealmException extends RuntimeException {
+public final class RealmException extends RuntimeException {
 
     public RealmException(String detailMessage) {
         super(detailMessage);

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmIOException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmIOException.java
@@ -22,7 +22,7 @@ import io.realm.internal.Keep;
  * Class for reporting problems with Realm files.
  */
 @Keep
-public class RealmIOException extends RuntimeException {
+public final class RealmIOException extends RuntimeException {
 
     public RealmIOException(Throwable cause) {
         super(cause);

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
@@ -21,7 +21,7 @@ import java.io.File;
 import io.realm.internal.Keep;
 
 @Keep
-public class RealmMigrationNeededException extends RuntimeException {
+public final class RealmMigrationNeededException extends RuntimeException {
 
     private final String canonicalRealmPath;
 

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmPrimaryKeyConstraintException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmPrimaryKeyConstraintException.java
@@ -24,7 +24,7 @@ import io.realm.internal.Keep;
  * @see io.realm.annotations.PrimaryKey
  */
 @Keep
-public class RealmPrimaryKeyConstraintException extends RuntimeException {
+public final class RealmPrimaryKeyConstraintException extends RuntimeException {
     public RealmPrimaryKeyConstraintException(String message) {
         super(message);
     }


### PR DESCRIPTION
Part of #1594. Merge all together in one release.

@realm/java

Final commit note:
-----

Title: Make all methods on RealmObject and all classes in public API final

We should mark all methods that should not be overridden final.
We should mark all classes that should not be inherited final.