### PR TITLE
mark constructor of RealmAsyncTask package protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * All JSON methods on Realm now only wraps JSONException in RealmException. All other Exceptions are thrown as they are.
 * Removed `HandlerController` from the public API.
 * Marked all methods on `RealmObject` and all public classes final (#1594).
+* Removed constructor of `RealmAsyncTask` from the public API8 (#1594).
 
 ### Deprecated
 

--- a/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
@@ -29,7 +29,7 @@ public final class RealmAsyncTask {
     private final Future<?> pendingQuery;
     private volatile boolean isCancelled = false;
 
-    public RealmAsyncTask(Future<?> pendingQuery) {
+    RealmAsyncTask(Future<?> pendingQuery) {
         this.pendingQuery = pendingQuery;
     }
 


### PR DESCRIPTION
Part of #1594. Merge all together in one release.

@realm/java

Final commit note:
----

Title: mark constructor of RealmAsyncTask package protected

Removed constructor from the public API as the method is not useful for public use and we want to keep the public API as clean as possible