### PR TITLE
add proguardFiles configuration to modulesExample/app project

### DIFF
--- a/examples/moduleExample/app/build.gradle
+++ b/examples/moduleExample/app/build.gradle
@@ -27,6 +27,8 @@ android {
     buildTypes {
         release {
             minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'),
+                    'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
     }


### PR DESCRIPTION
ProGuard example should have `proguardFiles` configuration which enables
app to have application specific configurations for ProGurad since
real app needs to have configuration for it's library in most cases.

@realm/java 