### PR TITLE
APT is now correctly applied for unit tests in library projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 * `RealmObjectSchema.getPrimaryKey()`. (#2636)
 * `Realm.createObject(Class, Object)` for creating objects with a primary key directly.
-* Unit tests in Android library projects now detects Realm model classes.
+* Unit tests in Android library projects now detect Realm model classes.
 
 ### Credits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * `RealmObjectSchema.getPrimaryKey()`. (#2636)
 * `Realm.createObject(Class, Object)` for creating objects with a primary key directly.
+* Unit tests in Android library projects now detects Realm model classes.
 
 ### Credits
 

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -57,6 +57,8 @@ class Realm implements Plugin<Project> {
         } else {
             project.dependencies.add("apt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("apt", "io.realm:realm-annotations-processor:${Version.VERSION}")
+            project.dependencies.add("androidTestApt", "io.realm:realm-annotations:${Version.VERSION}")
+            project.dependencies.add("androidTestApt", "io.realm:realm-annotations-processor:${Version.VERSION}")
         }
     }
 


### PR DESCRIPTION
Apparently just having "apt" is not enough if you have a library project with unit tests that uses Realm.
Explicitly adding the annotation processor to `androidTestApt` fixes that.

I am guessing we also need to do the same for JVM tests with `testApt`, but since we don't support that yet. I didn't do that in this PR.

@realm/java 