### PR TITLE
Use the motherboard identifier instead of the BIOS one for Windows machines

### DIFF
--- a/realm-transformer/src/main/java/io/realm/transformer/ComputerIdentifierGenerator.java
+++ b/realm-transformer/src/main/java/io/realm/transformer/ComputerIdentifierGenerator.java
@@ -94,7 +94,7 @@ public class ComputerIdentifierGenerator {
 
     private static String getWindowsIdentifier() throws IOException, NoSuchAlgorithmException {
         Runtime runtime = Runtime.getRuntime();
-        Process process = runtime.exec(new String[] { "wmic", "bios", "get", "serialnumber" });
+        Process process = runtime.exec(new String[] { "wmic", "csproduct", "get", "UUID" });
 
         String result = null;
         InputStream is = process.getInputStream();
@@ -102,7 +102,7 @@ public class ComputerIdentifierGenerator {
         try {
             while (sc.hasNext()) {
                 String next = sc.next();
-                if ("SerialNumber".equals(next)) {
+                if (next.contains("UUID")) {
                     result = sc.next().trim();
                     break;
                 }


### PR DESCRIPTION
The solution relying on the BIOS turned out to be not too solid.