### PR TITLE
Better exception message when using custom migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * `RealmObjectSchema.getPrimaryKey()`. (#2636)
 * `Realm.createObject(Class, Object)` for creating objects with a primary key directly.
 * Unit tests in Android library projects now detect Realm model classes.
+* Better error message if `equals()` and `hashCode()` are not properly overridden in custom Migration classes.
 
 ### Credits
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -779,4 +779,27 @@ public class RealmConfigurationTests {
         realm.close();
         verify(transaction, never()).execute(realm);
     }
+
+    private static class MigrationWithNoEquals implements RealmMigration {
+        @Override
+        public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+            // Do nothing
+        }
+    }
+
+    @Test
+    public void detectMissingEqualsInCustomMigration() {
+        RealmConfiguration config1 = configFactory.createConfigurationBuilder().migration(new MigrationWithNoEquals()).build();
+        RealmConfiguration config2 = configFactory.createConfigurationBuilder().migration(new MigrationWithNoEquals()).build();
+
+        Realm realm = Realm.getInstance(config1);
+        try {
+            Realm.getInstance(config2);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("The most likely cause are that equals() and hashCode() are not overridden"));
+        } finally {
+            realm.close();
+        }
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -797,7 +797,7 @@ public class RealmConfigurationTests {
             Realm.getInstance(config2);
             fail();
         } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("The most likely cause are that equals() and hashCode() are not overridden"));
+            assertTrue(e.getMessage().contains("The most likely cause is that equals() and hashCode() are not overridden"));
         } finally {
             realm.close();
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -227,9 +227,12 @@ final class RealmCache {
             // Try to detect this problem specifically so we can throw a better error message.
             RealmMigration newMigration = newConfiguration.getMigration();
             RealmMigration oldMigration = configuration.getMigration();
-            if (oldMigration != null && newMigration != null && oldMigration.getClass().equals(newMigration.getClass())) {
+            if (oldMigration != null 
+                && newMigration != null 
+                && oldMigration.getClass().equals(newMigration.getClass())
+                && !newMigration.equals(oldMigration)) {
                 throw new IllegalArgumentException("Configurations cannot be different if used to open the same file. " +
-                        "The most likely cause are that equals() and hashCode() are not overridden in the " +
+                        "The most likely cause is that equals() and hashCode() are not overridden in the " +
                         "migration class: " + newConfiguration.getMigration().getClass().getCanonicalName());
             }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -223,6 +223,16 @@ final class RealmCache {
         if (!Arrays.equals(configuration.getEncryptionKey(), newConfiguration.getEncryptionKey())) {
             throw new IllegalArgumentException(DIFFERENT_KEY_MESSAGE);
         } else {
+            // A common problem is that people are forgetting to override `equals` in their custom migration class.
+            // Try to detect this problem specifically so we can throw a better error message.
+            RealmMigration newMigration = newConfiguration.getMigration();
+            RealmMigration oldMigration = configuration.getMigration();
+            if (oldMigration != null && newMigration != null && oldMigration.getClass().equals(newMigration.getClass())) {
+                throw new IllegalArgumentException("Configurations cannot be different if used to open the same file. " +
+                        "The most likely cause are that equals() and hashCode() are not overridden in the " +
+                        "migration class: " + newConfiguration.getMigration().getClass().getCanonicalName());
+            }
+
             throw new IllegalArgumentException("Configurations cannot be different if used to open the same file. " +
                     "\nCached configuration: \n" + configuration +
                     "\n\nNew configuration: \n" + newConfiguration);


### PR DESCRIPTION
People not overriding `equals` in their custom Migration class is a common source of errors if people are creating multiple RealmConfiguration instances (which they shouldn't in the first place), but at least this gives better hints to what is wrong.

@realm/java 
