### PR TITLE
StopWaitForChange exception in Javadoc

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -315,6 +315,8 @@ abstract class BaseRealm implements Closeable {
      * <p>
      * This method is thread-safe and should _only_ be called from another thread than the one that
      * called waitForChange.
+     *
+     * @throws IllegalStateException if the {@link io.realm.Realm} instance has already been closed.
      */
     public void stopWaitForChange() {
         RealmCache.invokeWithLock(new RealmCache.Callback0() {


### PR DESCRIPTION
`BaseRealm.stopWaitForChange()` exception description in Javadoc.

@realm/java 