### PR TITLE
Add to realmObjects when addChangeListener called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,14 @@
 
 ### Enhancements
 
-* `RealmObjectSchema.getPrimaryKey()`. (#2636)
+* `RealmObjectSchema.getPrimaryKey()` (#2636).
 * `Realm.createObject(Class, Object)` for creating objects with a primary key directly.
 * Unit tests in Android library projects now detect Realm model classes.
 * `Realm.waitForChange()`/`stopWaitForChange()` and `DynamicRealm.waitForChange()`/`stopWaitForChange()` (#2386).
 
 ### Bug fixes
 
-* `RealmChangeListener` on `RealmObject` is not triggered when adding listener on returned `RealmObject` of `copyToRealmOrUpdate()`. (#2569)
+* `RealmChangeListener` on `RealmObject` is not triggered when adding listener on returned `RealmObject` of `copyToRealmOrUpdate()` (#2569).
 
 ### Credits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 * Unit tests in Android library projects now detect Realm model classes.
 * `Realm.waitForChange()`/`stopWaitForChange()` and `DynamicRealm.waitForChange()`/`stopWaitForChange()` (#2386).
 
+### Bug fixes
+
+* `RealmChangeListener` on `RealmObject` is not triggered when adding listener on returned `RealmObject` of `copyToRealmOrUpdate()`. (#2569)
+
 ### Credits
 
 * Thanks to Brenden Kromhout (@bkromhout) for adding `RealmObjectSchema.getPrimaryKey()`.

--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
@@ -1398,44 +1398,6 @@ public class TypeBasedNotificationsTests {
         TestHelper.awaitOrFail(signalTestFinished);
     }
 
-    // Test modifying realmObjects in RealmObject's change listener
-    @Test
-    @RunTestInLooperThread
-    public void change_realm_objects_map_in_listener() throws InterruptedException {
-        final Realm realm = looperThread.realm;
-        realm.beginTransaction();
-        // At least two objects are needed to make sure list modification happen during iterating.
-        final Cat cat = realm.createObject(Cat.class);
-        final Owner owner = realm.createObject(Owner.class);
-        owner.setCat(cat);
-        realm.commitTransaction();
-
-        RealmChangeListener listener = new RealmChangeListener() {
-            @Override
-            public void onChange(Object object) {
-                Cat cat = owner.getCat();
-                boolean foundKey = false;
-                // Check if cat has been added to the realmObjects in case of the behaviour of getCat changes
-                for (WeakReference<RealmObjectProxy> weakReference : realm.handlerController.realmObjects.keySet()) {
-                    if (weakReference.get() == cat) {
-                        foundKey = true;
-                        break;
-                    }
-                }
-                assertTrue(foundKey);
-                looperThread.testComplete();
-            }
-        };
-
-        cat.addChangeListener(listener);
-        owner.addChangeListener(listener);
-
-        realm.beginTransaction();
-        // To make sure the shared group version changed
-        realm.createObject(Owner.class);
-        realm.commitTransaction();
-    }
-
     // Test modifying syncRealmResults in RealmResults's change listener
     @Test
     @RunTestInLooperThread

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -575,9 +575,6 @@ abstract class BaseRealm implements Closeable {
         proxy.realmGet$proxyState().setRealm$realm(this);
         proxy.realmGet$proxyState().setTableVersion$realm();
 
-        if (handlerController != null) {
-            handlerController.addToRealmObjects(result);
-        }
         return result;
     }
 
@@ -605,7 +602,6 @@ abstract class BaseRealm implements Closeable {
             proxy.realmGet$proxyState().setRow$realm(InvalidRow.INSTANCE);
         }
 
-        handlerController.addToRealmObjects(result);
         return result;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -97,7 +97,6 @@ public final class DynamicRealm extends BaseRealm {
         Table table = schema.getTable(className);
         long index = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
         DynamicRealmObject dynamicRealmObject = new DynamicRealmObject(this, table.getCheckedRow(index));
-        handlerController.addToRealmObjects(dynamicRealmObject);
         return dynamicRealmObject;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -637,9 +637,17 @@ final class HandlerController implements Handler.Callback {
         syncRealmResults.add(realmResultsWeakReference);
     }
 
-    // add to the list of RealmObject to be notified after a commit
-    <E extends RealmModel> void addToRealmObjects(E realmobject) {
-        realmObjects.put(new WeakReference<RealmObjectProxy>((RealmObjectProxy) realmobject), null);
+    // Add to the list of RealmObject to be notified after a commit.
+    // This method will check if the object exists in the list. It won't add the same object multiple times
+    <E extends RealmObjectProxy> void addToRealmObjects(E realmObject) {
+        for (WeakReference<RealmObjectProxy> ref : realmObjects.keySet()) {
+            if (ref.get() == realmObject) {
+                return;
+            }
+        }
+        final WeakReference<RealmObjectProxy> realmObjectWeakReference =
+                new WeakReference<RealmObjectProxy>(realmObject, referenceQueueRealmObject);
+        realmObjects.put(realmObjectWeakReference, null);
     }
 
     <E extends RealmObjectProxy> WeakReference<RealmObjectProxy> addToAsyncRealmObject(E realmObject, RealmQuery<? extends RealmModel> realmQuery) {

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -552,7 +552,6 @@ public final class Realm extends BaseRealm {
         checkHasPrimaryKey(clazz);
         try {
             E realmObject = configuration.getSchemaMediator().createOrUpdateUsingJsonObject(clazz, this, json, true);
-            handlerController.addToRealmObjects(realmObject);
             return realmObject;
         } catch (JSONException e) {
             throw new RealmException("Could not map JSON", e);

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -244,11 +244,11 @@ public abstract class RealmObject implements RealmModel {
             if (!listeners.contains(listener)) {
                 listeners.add(listener);
             }
-            if (isLoaded(object)) {
+            if (isLoaded(proxy)) {
                 // Try to add this object to the realmObjects if it has already been loaded.
                 // For newly created async objects, it will be handled in RealmQuery.findFirstAsync &
                 // HandlerController.completedAsyncRealmObject.
-                realm.handlerController.addToRealmObjects((RealmObjectProxy)object);
+                realm.handlerController.addToRealmObjects(proxy);
             }
         } else {
             throw new IllegalArgumentException("Cannot add listener from this unmanaged RealmObject (created outside of Realm)");

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -244,6 +244,12 @@ public abstract class RealmObject implements RealmModel {
             if (!listeners.contains(listener)) {
                 listeners.add(listener);
             }
+            if (isLoaded(object)) {
+                // Try to add this object to the realmObjects if it has already been loaded.
+                // For newly created async objects, it will be handled in RealmQuery.findFirstAsync &
+                // HandlerController.completedAsyncRealmObject.
+                realm.handlerController.addToRealmObjects((RealmObjectProxy)object);
+            }
         } else {
             throw new IllegalArgumentException("Cannot add listener from this unmanaged RealmObject (created outside of Realm)");
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1878,7 +1878,6 @@ public final class RealmQuery<E extends RealmModel> {
             E realmObject = realm.get(clazz, className, sourceRowIndex);
             WeakReference<RealmObjectProxy> realmObjectWeakReference
                     = new WeakReference<RealmObjectProxy>((RealmObjectProxy) realmObject, realm.handlerController.referenceQueueRealmObject);
-            realm.handlerController.realmObjects.put(realmObjectWeakReference, this);
             return realmObject;
         } else {
             return null;

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1876,8 +1876,6 @@ public final class RealmQuery<E extends RealmModel> {
         long sourceRowIndex = getSourceRowIndexForFirstObject();
         if (sourceRowIndex >= 0) {
             E realmObject = realm.get(clazz, className, sourceRowIndex);
-            WeakReference<RealmObjectProxy> realmObjectWeakReference
-                    = new WeakReference<RealmObjectProxy>((RealmObjectProxy) realmObject, realm.handlerController.referenceQueueRealmObject);
             return realmObject;
         } else {
             return null;


### PR DESCRIPTION
* Only add the RealmObject to HandlerController.realmObjects when
  addChangeListener called. This will avoid we have too many objects in
  the map.
* addToRealmObjects missed reference queue which would lead to the map
  grows always without cleaning.

Close #2569, potentially a fix to #2686 .