### PR TITLE
Workaround to add android.jar for transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.91.0
+## 0.90.1
 
 * Updated Realm Core to 0.100.2.
 
@@ -7,6 +7,7 @@
 * Opening a Realm while closing a Realm in another thread could lead to a race condition.
 * Automatic migration to the new file format could in rare circumstances lead to a crash.
 * Fixing a race condition that may occur when using Async API (#2724).
+* Fixed CannotCompileException when related class definition in android.jar cannot be found (#2703).
 
 ### Enhancements
 

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -47,7 +47,7 @@ class Realm implements Plugin<Project> {
             project.plugins.apply(AndroidAptPlugin)
         }
 
-        project.android.registerTransform(new RealmTransformer())
+        project.android.registerTransform(new RealmTransformer(project))
         project.repositories.add(project.getRepositories().jcenter())
         project.dependencies.add("compile", "io.realm:realm-android-library:${Version.VERSION}")
         project.dependencies.add("compile", "io.realm:realm-annotations:${Version.VERSION}")


### PR DESCRIPTION
==== Final commit message === 

Close #2703

While javassit manipulating the method, it requires all of the classed
used in the method can be found in the class pool. But android.jar will
not be passed to the transform -- It is not in any of
QualifiedContent.Scope definitions.

We use project.android.bootClasspath which is public right now to get
the path to android.jar. Project is passed from gradle.
See https://android.googlesource.com/platform/tools/base/+/studio-master-dev/build-system/gradle/src/main/groovy/com/android/build/gradle/BaseExtension.java#737