### PR TITLE
Give async related vars better names

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -701,7 +701,7 @@ public class RealmAsyncQueryTests {
             }
         };
         realm.setHandler(handler);
-        Realm.asyncQueryExecutor.pause();
+        Realm.asyncTaskExecutor.pause();
 
         // Create async queries and check they haven't completed
         final RealmResults<AllTypes> realmResults1 = realm.where(AllTypes.class)
@@ -725,7 +725,7 @@ public class RealmAsyncQueryTests {
                 realm.commitTransaction();
             }
         }.awaitOrFail();
-        Realm.asyncQueryExecutor.resume();
+        Realm.asyncTaskExecutor.resume();
 
         // Setup change listeners
         final Runnable signalCallbackDone = new Runnable() {
@@ -1025,7 +1025,7 @@ public class RealmAsyncQueryTests {
         };
         realm.setHandler(handler);
 
-        // 3. This will add a task to the paused asyncQueryExecutor
+        // 3. This will add a task to the paused asyncTaskExecutor
         final RealmResults<AllTypes> realmResults = realm.where(AllTypes.class)
                 .between("columnLong", 4, 8)
                 .findAllSortedAsync("columnString", Sort.ASCENDING);
@@ -1410,7 +1410,7 @@ public class RealmAsyncQueryTests {
     public void combiningAsyncAndSync() {
         populateTestRealm(looperThread.realm, 10);
 
-        Realm.asyncQueryExecutor.pause();
+        Realm.asyncTaskExecutor.pause();
         final RealmResults<AllTypes> allTypesAsync = looperThread.realm.where(AllTypes.class).greaterThan("columnLong", 5).findAllAsync();
         final RealmResults<AllTypes> allTypesSync = allTypesAsync.where().greaterThan("columnLong", 3).findAll();
 
@@ -1424,7 +1424,7 @@ public class RealmAsyncQueryTests {
                 looperThread.testComplete();
             }
         });
-        Realm.asyncQueryExecutor.resume();
+        Realm.asyncTaskExecutor.resume();
         looperThread.keepStrongReference.add(allTypesAsync);
     }
 
@@ -1789,7 +1789,7 @@ public class RealmAsyncQueryTests {
         final CountDownLatch signalClosedRealm = new CountDownLatch(1);
 
         populateTestRealm(looperThread.realm, 10);
-        Realm.asyncQueryExecutor.pause();
+        Realm.asyncTaskExecutor.pause();
 
         final AllTypes firstAsync = looperThread.realm.where(AllTypes.class).findFirstAsync();
         firstAsync.addChangeListener(new RealmChangeListener<AllTypes>() {
@@ -1809,7 +1809,7 @@ public class RealmAsyncQueryTests {
                 // Advancing the Realm without generating notifications
                 bgRealm.sharedGroupManager.promoteToWrite();
                 bgRealm.sharedGroupManager.commitAndContinueAsRead();
-                Realm.asyncQueryExecutor.resume();
+                Realm.asyncTaskExecutor.resume();
                 bgRealm.close();
                 signalClosedRealm.countDown();
             }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -2359,7 +2359,7 @@ public class RealmQueryTests {
 
                 Realm asyncRealm = null;
                 try {
-                    Realm.asyncQueryExecutor.pause();
+                    Realm.asyncTaskExecutor.pause();
                     asyncRealm = openRealmInstance("testDistinctAsyncQueryWithNull");
                     final long numberOfBlocks = 25;
                     final long numberOfObjects = 10; // must be greater than 1
@@ -2376,7 +2376,7 @@ public class RealmQueryTests {
                     assertTrue(distinctString.isValid());
                     assertTrue(distinctString.isEmpty());
 
-                    Realm.asyncQueryExecutor.resume();
+                    Realm.asyncTaskExecutor.resume();
 
                     distinctDate.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
                         @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -951,7 +951,7 @@ public class TestHelper {
      * @param executor {@link RealmThreadPoolExecutor} that should replace the current one
      */
     public static RealmThreadPoolExecutor replaceRealmThreadExectutor(RealmThreadPoolExecutor executor) throws NoSuchFieldException, IllegalAccessException {
-        Field field = BaseRealm.class.getDeclaredField("asyncQueryExecutor");
+        Field field = BaseRealm.class.getDeclaredField("asyncTaskExecutor");
         field.setAccessible(true);
         RealmThreadPoolExecutor oldExecutor = (RealmThreadPoolExecutor) field.get(null);
         field.set(field, executor);

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -58,7 +58,7 @@ abstract class BaseRealm implements Closeable {
     protected static final Map<Handler, String> handlers = new ConcurrentHashMap<Handler, String>();
 
     // Thread pool for all async operations (Query & transaction)
-    static final RealmThreadPoolExecutor asyncQueryExecutor = RealmThreadPoolExecutor.newDefaultExecutor();
+    static final RealmThreadPoolExecutor asyncTaskExecutor = RealmThreadPoolExecutor.newDefaultExecutor();
 
     final long threadId;
     protected RealmConfiguration configuration;

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -235,7 +235,7 @@ final class HandlerController implements Handler.Callback {
         while (iterator.hasNext()) {
             Map.Entry<WeakReference<RealmObjectProxy>, RealmQuery<?>> next = iterator.next();
             if (next.getKey().get() != null) {
-                Realm.asyncQueryExecutor
+                Realm.asyncTaskExecutor
                         .submit(QueryUpdateTask.newBuilder()
                                 .realmConfiguration(realm.getConfiguration())
                                 .addObject(next.getKey(),
@@ -326,7 +326,7 @@ final class HandlerController implements Handler.Callback {
         if (updateAsyncQueriesTask != null && !updateAsyncQueriesTask.isDone()) {
             // try to cancel any pending update since we're submitting a new one anyway
             updateAsyncQueriesTask.cancel(true);
-            Realm.asyncQueryExecutor.getQueue().remove(updateAsyncQueriesTask);
+            Realm.asyncTaskExecutor.getQueue().remove(updateAsyncQueriesTask);
             RealmLog.d("REALM_CHANGED realm:" + HandlerController.this + " cancelling pending COMPLETED_UPDATE_ASYNC_QUERIES updates");
         }
         RealmLog.d("REALM_CHANGED realm:"+ HandlerController.this + " updating async queries, total: " + asyncRealmResults.size());
@@ -363,7 +363,7 @@ final class HandlerController implements Handler.Callback {
             QueryUpdateTask queryUpdateTask = realmResultsQueryStep
                     .sendToHandler(realm.handler, COMPLETED_UPDATE_ASYNC_QUERIES)
                     .build();
-            updateAsyncQueriesTask = Realm.asyncQueryExecutor.submit(queryUpdateTask);
+            updateAsyncQueriesTask = Realm.asyncTaskExecutor.submit(queryUpdateTask);
         }
     }
 
@@ -428,7 +428,7 @@ final class HandlerController implements Handler.Callback {
                                 .sendToHandler(realm.handler, COMPLETED_ASYNC_REALM_RESULTS)
                                 .build();
 
-                        Realm.asyncQueryExecutor.submit(queryUpdateTask);
+                        Realm.asyncTaskExecutor.submit(queryUpdateTask);
 
                     } else {
                         // UC covered by this test: RealmAsyncQueryTests#testFindAllCallerIsAdvanced
@@ -556,7 +556,7 @@ final class HandlerController implements Handler.Callback {
                                 .sendToHandler(realm.handler, COMPLETED_ASYNC_REALM_OBJECT)
                                 .build();
 
-                        Realm.asyncQueryExecutor.submit(queryUpdateTask);
+                        Realm.asyncTaskExecutor.submit(queryUpdateTask);
                     }
                 } else {
                     // should not happen, since the the background thread position itself against the provided version

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1128,7 +1128,7 @@ public final class Realm extends BaseRealm {
         // to perform the transaction
         final RealmConfiguration realmConfiguration = getConfiguration();
 
-        final Future<?> pendingQuery = asyncQueryExecutor.submit(new Runnable() {
+        final Future<?> pendingTransaction = asyncTaskExecutor.submit(new Runnable() {
             @Override
             public void run() {
                 if (Thread.currentThread().isInterrupted()) {
@@ -1192,7 +1192,7 @@ public final class Realm extends BaseRealm {
             }
         });
 
-        return new RealmAsyncTask(pendingQuery);
+        return new RealmAsyncTask(pendingTransaction);
     }
 
     /**
@@ -1269,7 +1269,7 @@ public final class Realm extends BaseRealm {
         // to perform the transaction
         final RealmConfiguration realmConfiguration = getConfiguration();
 
-        final Future<?> pendingQuery = asyncQueryExecutor.submit(new Runnable() {
+        final Future<?> pendingTransaction= asyncTaskExecutor.submit(new Runnable() {
             @Override
             public void run() {
                 if (Thread.currentThread().isInterrupted()) {
@@ -1363,7 +1363,7 @@ public final class Realm extends BaseRealm {
             }
         });
 
-        return new RealmAsyncTask(pendingQuery);
+        return new RealmAsyncTask(pendingTransaction);
     }
 
 

--- a/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmAsyncTask.java
@@ -49,7 +49,7 @@ public final class RealmAsyncTask {
         // first thread is attempting to purge the queue the attempt to purge
         // the queue fails and the cancelled object remain in the queue.
         // A better way to cancel objects with thread pools is to use the remove()
-        Realm.asyncQueryExecutor.getQueue().remove(pendingQuery);
+        Realm.asyncTaskExecutor.getQueue().remove(pendingQuery);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1162,7 +1162,7 @@ public final class RealmQuery<E extends RealmModel> {
 
         final WeakReference<RealmResults<? extends RealmModel>> weakRealmResults = realm.handlerController.addToAsyncRealmResults(realmResults, this);
 
-        final Future<Long> pendingQuery = Realm.asyncQueryExecutor.submit(new Callable<Long>() {
+        final Future<Long> pendingQuery = Realm.asyncTaskExecutor.submit(new Callable<Long>() {
             @Override
             public Long call() throws Exception {
                 if (!Thread.currentThread().isInterrupted()) {
@@ -1469,7 +1469,7 @@ public final class RealmQuery<E extends RealmModel> {
 
         final WeakReference<RealmResults<? extends RealmModel>> weakRealmResults = realm.handlerController.addToAsyncRealmResults(realmResults, this);
 
-        final Future<Long> pendingQuery = Realm.asyncQueryExecutor.submit(new Callable<Long>() {
+        final Future<Long> pendingQuery = Realm.asyncTaskExecutor.submit(new Callable<Long>() {
             @Override
             public Long call() throws Exception {
                 if (!Thread.currentThread().isInterrupted()) {
@@ -1587,7 +1587,7 @@ public final class RealmQuery<E extends RealmModel> {
         final WeakReference<RealmResults<? extends RealmModel>> weakRealmResults =
                 realm.handlerController.addToAsyncRealmResults(realmResults, this);
 
-        final Future<Long> pendingQuery = Realm.asyncQueryExecutor.submit(new Callable<Long>() {
+        final Future<Long> pendingQuery = Realm.asyncTaskExecutor.submit(new Callable<Long>() {
             @Override
             public Long call() throws Exception {
                 if (!Thread.currentThread().isInterrupted()) {
@@ -1760,7 +1760,7 @@ public final class RealmQuery<E extends RealmModel> {
 
             final WeakReference<RealmResults<? extends RealmModel>> weakRealmResults = realm.handlerController.addToAsyncRealmResults(realmResults, this);
 
-            final Future<Long> pendingQuery = Realm.asyncQueryExecutor.submit(new Callable<Long>() {
+            final Future<Long> pendingQuery = Realm.asyncTaskExecutor.submit(new Callable<Long>() {
                 @Override
                 public Long call() throws Exception {
                     if (!Thread.currentThread().isInterrupted()) {
@@ -1920,7 +1920,7 @@ public final class RealmQuery<E extends RealmModel> {
         proxy.realmGet$proxyState().setRealm$realm(realm);
         proxy.realmGet$proxyState().setRow$realm(Row.EMPTY_ROW);
 
-        final Future<Long> pendingQuery = Realm.asyncQueryExecutor.submit(new Callable<Long>() {
+        final Future<Long> pendingQuery = Realm.asyncTaskExecutor.submit(new Callable<Long>() {
             @Override
             public Long call() throws Exception {
                 if (!Thread.currentThread().isInterrupted()) {


### PR DESCRIPTION
asyncQueryExecutor and pendingQuery seem to be very confusing since they
are used for async transaction as well.