### PR TITLE
Upgrading to core 0.100.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.91.0
+
+* Updated Realm Core to 0.100.2.
+
+### Bug fixes
+
+* Opening a Realm while closing a Realm in another thread could lead to a race condition.
+* Automatic migration to the new file format could in rare circumstances lead to a crash.
+
 ## 0.90.0
 
 * Updated Realm Core to 0.100.0.

--- a/realm/realm-jni/build.gradle
+++ b/realm/realm-jni/build.gradle
@@ -1,8 +1,8 @@
 import java.security.MessageDigest
 
-ext.coreVersion = '0.100.0'
+ext.coreVersion = '0.100.2'
 // empty or comment out this to disable hash checking
-ext.coreSha256Hash = 'f3bb8564a8bab7eca8dc85f1c508a35e125b93a104f964105558739bd1032d98'
+ext.coreSha256Hash = '081907973e45da61ea6e42b0ff05aacebbc02d28afddba0cede96362c070cce7'
 ext.forceDownloadCore =
         project.hasProperty('forceDownloadCore') ? project.getProperty('forceDownloadCore').toBoolean() : false
 // gcc is default for the NDK. It also produces smaller binaries


### PR DESCRIPTION
The storage engine (aka core) has been fixed a number of bugs.

@realm/java 