### PR TITLE
A note on the behavior of RealmObject.isValid() added

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -127,11 +127,18 @@ public abstract class RealmObject implements RealmModel {
      * Checks if the RealmObject is still valid to use i.e. the RealmObject hasn't been deleted nor has the
      * {@link io.realm.Realm} been closed. It will always return false for stand alone objects.
      *
-     * <p>Note that a notification for Observer will <em>not</em> be triggered when a {@link RealmQuery}
-     * completes with an invalid RealmObject. Subscribe a {@link RealmResults} and filter the result
-     * instead for an appropriate reaction.
+     * <p>Note that this can be used to check the validity of certain conditions such as being null
+     * when observed.
+     * <pre>
+     * {@code
+     * realm.where(BannerRealm.class).equalTo("type", type).findFirstAsync().asObservable()
+     *      .filter(result.isLoaded() && result.isValid())
+     *      .first()
+     * }
+     * </pre>
      *
      * @return {@code true} if the object is still accessible, {@code false} otherwise or if it is a standalone object.
+     * @see <a href="https://github.com/realm/realm-java/tree/master/examples/rxJavaExample">Examples using Realm with RxJava</a>
      */
     public final boolean isValid() {
         return RealmObject.isValid(this);

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -127,9 +127,9 @@ public abstract class RealmObject implements RealmModel {
      * Checks if the RealmObject is still valid to use i.e. the RealmObject hasn't been deleted nor has the
      * {@link io.realm.Realm} been closed. It will always return false for stand alone objects.
      *
-     * <p>Note that a notification for {@link rx.Observer} will <em>not</em> be triggered when a
-     * {@link RealmQuery} completes with an invalid RealmObject. Subscribe a {@link RealmResults}
-     * and filter the result instead for an appropriate reaction.
+     * <p>Note that a notification for Observer will <em>not</em> be triggered when a {@link RealmQuery}
+     * completes with an invalid RealmObject. Subscribe a {@link RealmResults} and filter the result
+     * instead for an appropriate reaction.
      *
      * @return {@code true} if the object is still accessible, {@code false} otherwise or if it is a standalone object.
      */

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -127,6 +127,10 @@ public abstract class RealmObject implements RealmModel {
      * Checks if the RealmObject is still valid to use i.e. the RealmObject hasn't been deleted nor has the
      * {@link io.realm.Realm} been closed. It will always return false for stand alone objects.
      *
+     * <p>Note that a notification for {@link rx.Observer} will <em>not</em> be triggered when a
+     * {@link RealmQuery} completes with an invalid RealmObject. Subscribe a {@link RealmResults}
+     * and filter the result instead for an appropriate reaction.
+     *
      * @return {@code true} if the object is still accessible, {@code false} otherwise or if it is a standalone object.
      */
     public final boolean isValid() {


### PR DESCRIPTION
Title : A note on the behavior of RealmObject.isValid() 

When an invalid `RealmObject` is subscribed, no proper notification will be triggered for `rx.Observer`.

This PR addresses the issue #2158. 
@realm/java 