### PR TITLE
Javadoc for using Realm with SubscribedOn() 

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -163,7 +163,7 @@ abstract class BaseRealm implements Closeable {
      * </pre>
      *
      * <p>Note that when the Realm is accessed on threads other than where it was created, {@link IllegalStateException}
-     * will be thrown. Please avoid using {@code subscribeOn()}, and use {@code Realm.where().findAllAsync*()} methods instead.
+     * will be thrown. Please avoid using {@code subscribeOn()}, and use {@code Realm.where().*Async()} methods instead.
      *
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -162,7 +162,7 @@ abstract class BaseRealm implements Closeable {
      * }
      * </pre>
      *
-     * <p>Note that when the Realm is accessed on threads other than where it was created, {@link IllegalStateException}
+     * <p>Note that when the Realm is accessed from threads other than where it was created, {@link IllegalStateException}
      * will be thrown. Please avoid using {@code subscribeOn()}, and use {@code Realm.where().*Async()} methods instead.
      *
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -162,6 +162,9 @@ abstract class BaseRealm implements Closeable {
      * }
      * </pre>
      *
+     * <p>Note that when the Realm is accessed on threads other than where it was created, {@link IllegalStateException}
+     * will be thrown. Please avoid using {@code subscribeOn()}, and use {@code Realm.where().findAllAsync*()} methods instead.
+     *
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -162,9 +162,6 @@ abstract class BaseRealm implements Closeable {
      * }
      * </pre>
      *
-     * <p>Note that when the Realm is accessed from threads other than where it was created, {@link IllegalStateException}
-     * will be thrown. Please avoid using {@code subscribeOn()}, and use {@code Realm.where().*Async()} methods instead.
-     *
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
      * @see <a href="https://realm.io/docs/java/latest/#rxjava">RxJava and Realm</a>

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -328,8 +328,9 @@ public abstract class RealmObject implements RealmModel {
      * </pre>
      *
      * <p>Note that when the {@link Realm} is accessed from threads other than where it was created,
-     * {@link IllegalStateException} will be thrown. Please avoid using {@code subscribeOn()}, and use
-     * {@code RealmQuery.*Async()} methods instead.
+     * {@link IllegalStateException} will be thrown. Care should be taken when using different schedulers
+     * with {@code subscribeOn()} and {@code observeOn()}. Consider using {@code Realm.where().find*Async()}
+     * instead.
      *
      * @param <E> RealmObject class that is being observed. Must be this class or its super types.
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -327,6 +327,10 @@ public abstract class RealmObject implements RealmModel {
      * }
      * </pre>
      *
+     * <p>Note that when the {@link Realm} is accessed from threads other than where it was created,
+     * {@link IllegalStateException} will be thrown. Please avoid using {@code subscribeOn()}, and use
+     * {@code RealmQuery.*Async()} methods instead.
+     *
      * @param <E> RealmObject class that is being observed. Must be this class or its super types.
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath or the

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -991,6 +991,10 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      * }
      * </pre>
      *
+     * <p>Note that when the {@link Realm} is accessed from threads other than where it was created,
+     * {@link IllegalStateException} will be thrown. Please avoid using {@code subscribeOn()}, and use
+     * {@code RealmQuery.*Async()} methods instead.
+     *
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath or the
      * corresponding Realm instance doesn't support RxJava.

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -992,8 +992,9 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      * </pre>
      *
      * <p>Note that when the {@link Realm} is accessed from threads other than where it was created,
-     * {@link IllegalStateException} will be thrown. Please avoid using {@code subscribeOn()}, and use
-     * {@code RealmQuery.*Async()} methods instead.
+     * {@link IllegalStateException} will be thrown. Care should be taken when using different schedulers
+     * with {@code subscribeOn()} and {@code observeOn()}. Consider using {@code Realm.where().find*Async()}
+     * instead.
      *
      * @return RxJava Observable that only calls {@code onNext}. It will never call {@code onComplete} or {@code OnError}.
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath or the


### PR DESCRIPTION
It is recommended to use Realm.where().find*Async() instead of SubscribedOn() to avoid Realm being accessed from different threads.

This PR addresses issue #2607.
@realm/java 