### PR TITLE
Upload native lib with symbols to s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,10 +172,6 @@ task distributionPackage(type:Zip) {
     from('changelog.txt')
     from('LICENSE')
     from('version.txt')
-    from("${buildDir}/outputs/gradle") {
-        include "realm-android-${currentVersion}.jar"
-        into 'gradle'
-    }
     from('realm/realm-library/build/libs') {
         include 'realm-android-${currentVersion}-javadoc.jar'
         into 'docs'
@@ -189,6 +185,19 @@ task distributionPackage(type:Zip) {
         exclude '**/.gradle'
         exclude '**/build'
         into 'examples'
+    }
+}
+
+task distributionJniUnstrippedPackage(type:Zip) {
+    description = 'Generate native libs package with debug symbols'
+    dependsOn assembleRealm
+
+    group = 'Artifact'
+    archiveName = "realm-java-jni-libs-unstripped-${currentVersion}.zip"
+    destinationDir = file("${buildDir}/outputs/distribution")
+
+    from("realm/realm-jni/build/outputs/jniLibs-unstripped") {
+        include '**/*.so'
     }
 }
 
@@ -238,7 +247,9 @@ task uploadDistributionPackage(type: Exec) {
     group = 'Release'
     description = 'Upload the distribution package to S3'
     dependsOn distributionPackage
+    dependsOn distributionJniUnstrippedPackage
     commandLine 's3cmd', 'put', "${buildDir}/outputs/distribution/realm-java-${currentVersion}.zip", 's3://static.realm.io/downloads/java/'
+    commandLine 's3cmd', 'put', "${buildDir}/outputs/distribution/realm-java-jni-libs-unstripped-${currentVersion}.zip", 's3://static.realm.io/downloads/java/'
 }
 
 task createEmptyFile(type: Exec) {

--- a/realm/realm-jni/build.gradle
+++ b/realm/realm-jni/build.gradle
@@ -327,7 +327,7 @@ targets.each { target ->
         // Store the unstripped version
         copy {
             from "${projectDir}/src/librealm-jni-${target.name}${getDebugExt()}.so"
-            into "${projectDir}/../build/output/jniLibs-unstripped/${target.abi}"
+            into "${buildDir}/outputs/jniLibs-unstripped/${target.abi}"
             rename "librealm-jni-${target.name}${getDebugExt()}.so", 'librealm-jni.so'
         }
     }
@@ -347,7 +347,6 @@ task clean(type: Delete) {
     delete project.buildDir
 
     delete fileTree(dir: "${projectDir}/../realm-library/src/main/jniLibs/", include: '**/librealm-jni*.so')
-    delete fileTree(dir: "${projectDir}/../build/output/jniLibs-unstripped/", include: '**/librealm-jni*.so')
     delete fileTree(dir: "${projectDir}/src/", include: '**/librealm-jni*-stripped.so')
 
     doLast {


### PR DESCRIPTION
And remove some useless lines

Unfortunately crashlytics's symbols uploading is not what we want. It would be useful if user is using ndk and 3rd party libs exist in the `lib` dir. I couldn't make it work.

Having debug so on s3 would be good enough for us right now.

TODO:
- [ ] Update wiki about decode symbols 

**PS. Haven't successfully tested the uploading part since it always fails in my network :(**