### PR TITLE
add a null check to addChangeListener and removeChangeListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug fixes
 
 * Calling RealmResults.deleteAllFromRealm() might lead to native crash (#2759).
-* added null check to `addChangeListener` and `removeChangeListener` in `Realm` and `DynamicRealm` (#2772).
+* Added null check to `addChangeListener` and `removeChangeListener` in `Realm` and `DynamicRealm` (#2772).
 
 ## 0.90.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * Calling RealmResults.deleteAllFromRealm() might lead to native crash (#2759).
+* added null check to `addChangeListener` and `removeChangeListener` in `Realm` and `DynamicRealm` (#2772).
 
 ## 0.90.1
 

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -591,4 +591,74 @@ public class DynamicRealmTests {
         assertEquals(0, list.size());
         assertEquals(0, realm.where(Dog.CLASS_NAME).count());
     }
+
+    @Test
+    @RunTestInLooperThread
+    public void addChangeListener_throwOnAddingNullListenerFromLooperThread() {
+        final DynamicRealm dynamicRealm = initializeDynamicRealm();
+
+        //noinspection TryFinallyCanBeTryWithResources
+        try {
+            dynamicRealm.addChangeListener(null);
+            fail("adding null change listener must throw an exception.");
+        } catch (IllegalArgumentException ignore) {
+        } finally {
+            dynamicRealm.close();
+            looperThread.testComplete();
+        }
+    }
+
+    @Test
+    public void addChangeListener_throwOnAddingNullListenerFromNonLooperThread() throws Throwable {
+        TestHelper.executeOnNonLooperThread(new TestHelper.Task() {
+            @Override
+            public void run() throws Exception {
+                final DynamicRealm dynamicRealm = DynamicRealm.getInstance(defaultConfig);
+
+                //noinspection TryFinallyCanBeTryWithResources
+                try {
+                    dynamicRealm.addChangeListener(null);
+                    fail("adding null change listener must throw an exception.");
+                } catch (IllegalArgumentException ignore) {
+                } finally {
+                    dynamicRealm.close();
+                }
+            }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void removeChangeListener_throwOnRemovingNullListenerFromLooperThread() {
+        final DynamicRealm dynamicRealm = initializeDynamicRealm();
+
+        //noinspection TryFinallyCanBeTryWithResources
+        try {
+            dynamicRealm.removeChangeListener(null);
+            fail("removing null change listener must throw an exception.");
+        } catch (IllegalArgumentException ignore) {
+        } finally {
+            dynamicRealm.close();
+            looperThread.testComplete();
+        }
+    }
+
+    @Test
+    public void removeChangeListener_throwOnRemovingNullListenerFromNonLooperThread() throws Throwable {
+        TestHelper.executeOnNonLooperThread(new TestHelper.Task() {
+            @Override
+            public void run() throws Exception {
+                final DynamicRealm dynamicRealm = DynamicRealm.getInstance(defaultConfig);
+
+                //noinspection TryFinallyCanBeTryWithResources
+                try {
+                    dynamicRealm.removeChangeListener(null);
+                    fail("removing null change listener must throw an exception.");
+                } catch (IllegalArgumentException ignore) {
+                } finally {
+                    dynamicRealm.close();
+                }
+            }
+        });
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1577,10 +1577,11 @@ public class RealmObjectTests {
             @Override
             public void run() throws Exception {
                 final Realm realm = Realm.getInstance(realmConfig);
+                final Dog dog = createManagedDogObjectFromRealmInstance(realm);
 
                 //noinspection TryFinallyCanBeTryWithResources
                 try {
-                    createManagedDogObjectFromRealmInstance(realm).addChangeListener(null);
+                    dog.addChangeListener(null);
                     fail("adding null change listener must throw an exception.");
                 } catch (IllegalArgumentException ignore) {
                 } finally {
@@ -1629,10 +1630,11 @@ public class RealmObjectTests {
             @Override
             public void run() throws Exception {
                 final Realm realm = Realm.getInstance(realmConfig);
+                final Dog dog = createManagedDogObjectFromRealmInstance(realm);
 
                 //noinspection TryFinallyCanBeTryWithResources
                 try {
-                    createManagedDogObjectFromRealmInstance(realm).removeChangeListener(null);
+                    dog.removeChangeListener(null);
                     fail("removing null change listener must throw an exception.");
                 } catch (IllegalArgumentException ignore) {
                 } finally {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1558,16 +1558,36 @@ public class RealmObjectTests {
 
     @Test
     @RunTestInLooperThread
-    public void addChangeListener_throwOnAddingNullListener() {
+    public void addChangeListener_throwOnAddingNullListenerFromLooperThread() {
         final Realm realm = looperThread.realm;
         Dog dog = createManagedDogObjectFromRealmInstance(realm);
 
         try {
-            dog.addChangeListener((RealmChangeListener) null);
-            fail("Failed on adding null change listener.");
+            dog.addChangeListener(null);
+            fail("adding null change listener must throw an exception.");
         } catch (IllegalArgumentException ignore) {
+        } finally {
             looperThread.testComplete();
         }
+    }
+
+    @Test
+    public void addChangeListener_throwOnAddingNullListenerFromNonLooperThread() throws Throwable {
+        TestHelper.executeOnNonLooperThread(new TestHelper.Task() {
+            @Override
+            public void run() throws Exception {
+                final Realm realm = Realm.getInstance(realmConfig);
+
+                //noinspection TryFinallyCanBeTryWithResources
+                try {
+                    createManagedDogObjectFromRealmInstance(realm).addChangeListener(null);
+                    fail("adding null change listener must throw an exception.");
+                } catch (IllegalArgumentException ignore) {
+                } finally {
+                    realm.close();
+                }
+            }
+        });
     }
 
     @Test
@@ -1581,24 +1601,45 @@ public class RealmObjectTests {
                 public void onChange(Dog object) {
                 }
             });
-            fail("Failed on adding listener on null realm.");
+            fail("adding change listener on unmanaged object must throw an exception.");
         } catch (IllegalArgumentException ignore) {
+        } finally {
             looperThread.testComplete();
         }
     }
 
     @Test
     @RunTestInLooperThread
-    public void removeChangeListener_throwOnRemovingNullListener() {
+    public void removeChangeListener_throwOnRemovingNullListenerFromLooperThread() {
         final Realm realm = looperThread.realm;
         Dog dog = createManagedDogObjectFromRealmInstance(realm);
 
         try {
-            dog.removeChangeListener((RealmChangeListener) null);
-            fail("Failed on adding null change listener.");
+            dog.removeChangeListener(null);
+            fail("removing null change listener must throw an exception.");
         } catch (IllegalArgumentException ignore) {
+        } finally {
             looperThread.testComplete();
         }
+    }
+
+    @Test
+    public void removeChangeListener_throwOnRemovingNullListenerFromNonLooperThread() throws Throwable {
+        TestHelper.executeOnNonLooperThread(new TestHelper.Task() {
+            @Override
+            public void run() throws Exception {
+                final Realm realm = Realm.getInstance(realmConfig);
+
+                //noinspection TryFinallyCanBeTryWithResources
+                try {
+                    createManagedDogObjectFromRealmInstance(realm).removeChangeListener(null);
+                    fail("removing null change listener must throw an exception.");
+                } catch (IllegalArgumentException ignore) {
+                } finally {
+                    realm.close();
+                }
+            }
+        });
     }
 
     /**

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2996,6 +2996,72 @@ public class RealmTests {
     }
 
     @Test
+    @RunTestInLooperThread
+    public void addChangeListener_throwOnAddingNullListenerFromLooperThread() {
+        final Realm realm = looperThread.realm;
+
+        try {
+            realm.addChangeListener(null);
+            fail("adding null change listener must throw an exception.");
+        } catch (IllegalArgumentException ignore) {
+        } finally {
+            looperThread.testComplete();
+        }
+    }
+
+    @Test
+    public void addChangeListener_throwOnAddingNullListenerFromNonLooperThread() throws Throwable {
+        TestHelper.executeOnNonLooperThread(new TestHelper.Task() {
+            @Override
+            public void run() throws Exception {
+                final Realm realm = Realm.getInstance(realmConfig);
+
+                //noinspection TryFinallyCanBeTryWithResources
+                try {
+                    realm.addChangeListener(null);
+                    fail("adding null change listener must throw an exception.");
+                } catch (IllegalArgumentException ignore) {
+                } finally {
+                    realm.close();
+                }
+            }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void removeChangeListener_throwOnRemovingNullListenerFromLooperThread() {
+        final Realm realm = looperThread.realm;
+
+        try {
+            realm.removeChangeListener(null);
+            fail("removing null change listener must throw an exception.");
+        } catch (IllegalArgumentException ignore) {
+        } finally {
+            looperThread.testComplete();
+        }
+    }
+
+    @Test
+    public void removeChangeListener_throwOnRemovingNullListenerFromNonLooperThread() throws Throwable {
+        TestHelper.executeOnNonLooperThread(new TestHelper.Task() {
+            @Override
+            public void run() throws Exception {
+                final Realm realm = Realm.getInstance(realmConfig);
+
+                //noinspection TryFinallyCanBeTryWithResources
+                try {
+                    realm.removeChangeListener(null);
+                    fail("removing null change listener must throw an exception.");
+                } catch (IllegalArgumentException ignore) {
+                } finally {
+                    realm.close();
+                }
+            }
+        });
+    }
+
+    @Test
     public void removeChangeListenerThrowExceptionOnNonLooperThread() {
         final CountDownLatch signalTestFinished = new CountDownLatch(1);
         Thread thread = new Thread(new Runnable() {

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -41,6 +41,7 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
@@ -977,4 +978,31 @@ public class TestHelper {
         }
     }
 
+    public static abstract class Task {
+        public abstract void run() throws Exception;
+    }
+
+    public static void executeOnNonLooperThread(final Task task) throws Throwable {
+        final AtomicReference<Throwable> thrown = new AtomicReference<Throwable>();
+        final Thread thread = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    task.run();
+                } catch (Throwable e) {
+                    thrown.set(e);
+                    if (e instanceof Error) {
+                        throw (Error) e;
+                    }
+                }
+            }
+        };
+        thread.start();
+        thread.join();
+
+        final Throwable throwable = thrown.get();
+        if (throwable != null) {
+            throw throwable;
+        }
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -126,6 +126,9 @@ abstract class BaseRealm implements Closeable {
     }
 
     protected void addListener(RealmChangeListener<? extends BaseRealm> listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("Listener should not be null");
+        }
         checkIfValid();
         if (!handlerController.isAutoRefreshEnabled()) {
             throw new IllegalStateException("You can't register a listener from a non-Looper thread ");
@@ -137,10 +140,14 @@ abstract class BaseRealm implements Closeable {
      * Removes the specified change listener.
      *
      * @param listener the change listener to be removed.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
      * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      * @see io.realm.RealmChangeListener
      */
     public void removeChangeListener(RealmChangeListener<? extends BaseRealm> listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("Listener should not be null");
+        }
         checkIfValid();
         if (!handlerController.isAutoRefreshEnabled()) {
             throw new IllegalStateException("You can't remove a listener from a non-Looper thread ");

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -131,6 +131,7 @@ public final class DynamicRealm extends BaseRealm {
      * or {@link #removeAllChangeListeners()} which removes all listeners including the ones added via anonymous classes.
      *
      * @param listener the change listener.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
      * @throws IllegalStateException if you try to register a listener from a non-Looper Thread.
      * @see io.realm.RealmChangeListener
      * @see #removeChangeListener(RealmChangeListener)

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -967,6 +967,7 @@ public final class Realm extends BaseRealm {
      * or {@link #removeAllChangeListeners()} which removes all listeners including the ones added via anonymous classes.
      *
      * @param listener the change listener.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
      * @throws IllegalStateException if you try to register a listener from a non-Looper Thread.
      * @see io.realm.RealmChangeListener
      * @see #removeChangeListener(RealmChangeListener)

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -227,7 +227,7 @@ public abstract class RealmObject implements RealmModel {
      * Adds a change listener to this RealmObject.
      *
      * @param listener the change listener to be notified.
-     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalArgumentException if the change listener is {@code null} or the object is an unmanaged object.
      * @throws IllegalArgumentException if object is an un-managed RealmObject.
      */
     public final <E extends RealmModel> void addChangeListener(RealmChangeListener<E> listener) {
@@ -277,8 +277,7 @@ public abstract class RealmObject implements RealmModel {
      * Removes a previously registered listener.
      *
      * @param listener the instance to be removed.
-     * @throws IllegalArgumentException if the change listener is {@code null}.
-     * @throws IllegalArgumentException if object is an un-managed RealmObject.
+     * @throws IllegalArgumentException if the change listener is {@code null} or the object is an unmanaged object.
      * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      */
     public final void removeChangeListener(RealmChangeListener listener) {

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -227,6 +227,7 @@ public abstract class RealmObject implements RealmModel {
      * Adds a change listener to this RealmObject.
      *
      * @param listener the change listener to be notified.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
      * @throws IllegalArgumentException if object is an un-managed RealmObject.
      */
     public final <E extends RealmModel> void addChangeListener(RealmChangeListener<E> listener) {
@@ -238,9 +239,14 @@ public abstract class RealmObject implements RealmModel {
      *
      * @param object RealmObject to add listener to.
      * @param listener the change listener to be notified.
+     * @throws IllegalArgumentException if the {@code object} or the change listener is {@code null}.
      * @throws IllegalArgumentException if object is an un-managed RealmObject.
+     * @throws IllegalStateException if you try to add a listener from a non-Looper Thread.
      */
     public static <E extends RealmModel> void addChangeListener(E object, RealmChangeListener<E> listener) {
+        if (object == null) {
+            throw new IllegalArgumentException("Object should not be null");
+        }
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }
@@ -271,6 +277,9 @@ public abstract class RealmObject implements RealmModel {
      * Removes a previously registered listener.
      *
      * @param listener the instance to be removed.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalArgumentException if object is an un-managed RealmObject.
+     * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      */
     public final void removeChangeListener(RealmChangeListener listener) {
         RealmObject.removeChangeListener(this, listener);
@@ -281,8 +290,14 @@ public abstract class RealmObject implements RealmModel {
      *
      * @param object RealmObject to remove listener from.
      * @param listener the instance to be removed.
+     * @throws IllegalArgumentException if the {@code object} or the change listener is {@code null}.
+     * @throws IllegalArgumentException if object is an un-managed RealmObject.
+     * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      */
     public static <E extends RealmModel> void removeChangeListener(E object, RealmChangeListener listener) {
+        if (object == null) {
+            throw new IllegalArgumentException("Object should not be null");
+        }
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -939,6 +939,8 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      * Adds a change listener to this RealmResults.
      *
      * @param listener the change listener to be notified.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalStateException if you try to add a listener from a non-Looper Thread.
      */
     public void addChangeListener(RealmChangeListener<RealmResults<E>> listener) {
         if (listener == null) {
@@ -957,11 +959,13 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      * Removes a previously registered listener.
      *
      * @param listener the instance to be removed.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      */
     public void removeChangeListener(RealmChangeListener listener) {
-        if (listener == null)
+        if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
-
+        }
         realm.checkIfValid();
         listeners.remove(listener);
     }


### PR DESCRIPTION
fixes #2772

`{Realm,DynamicRealm}.{add,remove}ChangeListener()` accept `null` as a listener.
And then Crash will happen when it is called.

I added `null` check to those methods(corresponding methods in `RealmObject` and `RealmResults` already check `null`).

Please review this @realm/java 