### PR TITLE
Remove all deprecated methods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.91.0
+
+### Breaking changes
+
+* Removed all `@Deprecated` methods.
+
 ## 0.90.1
 
 * Updated Realm Core to 0.100.2.

--- a/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
+++ b/examples/introExample/src/main/java/io/realm/examples/intro/IntroExampleActivity.java
@@ -123,14 +123,14 @@ public class IntroExampleActivity extends Activity {
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
-                realm.allObjects(Person.class).deleteAllFromRealm();
+                realm.delete(Person.class);
             }
         });
     }
 
     private void basicQuery(Realm realm) {
         showStatus("\nPerforming basic Query operation...");
-        showStatus("Number of persons: " + realm.allObjects(Person.class).size());
+        showStatus("Number of persons: " + realm.where(Person.class).count());
 
         RealmResults<Person> results = realm.where(Person.class).equalTo("age", 99).findAll();
 
@@ -139,7 +139,7 @@ public class IntroExampleActivity extends Activity {
 
     private void basicLinkQuery(Realm realm) {
         showStatus("\nPerforming basic Link Query operation...");
-        showStatus("Number of persons: " + realm.allObjects(Person.class).size());
+        showStatus("Number of persons: " + realm.where(Person.class).count());
 
         RealmResults<Person> results = realm.where(Person.class).equalTo("cats.name", "Tiger").findAll();
 
@@ -182,10 +182,10 @@ public class IntroExampleActivity extends Activity {
         });
 
         // Implicit read transactions allow you to access your objects
-        status += "\nNumber of persons: " + realm.allObjects(Person.class).size();
+        status += "\nNumber of persons: " + realm.where(Person.class).count();
 
         // Iterate over all objects
-        for (Person pers : realm.allObjects(Person.class)) {
+        for (Person pers : realm.where(Person.class).findAll()) {
             String dogName;
             if (pers.getDog() == null) {
                 dogName = "None";
@@ -196,9 +196,8 @@ public class IntroExampleActivity extends Activity {
         }
 
         // Sorting
-        RealmResults<Person> sortedPersons = realm.allObjects(Person.class);
-        sortedPersons.sort("age", Sort.DESCENDING);
-        status += "\nSorting " + sortedPersons.last().getName() + " == " + realm.allObjects(Person.class).first()
+        RealmResults<Person> sortedPersons = realm.where(Person.class).findAllSorted("age", Sort.DESCENDING);
+        status += "\nSorting " + sortedPersons.last().getName() + " == " + realm.where(Person.class).findFirst()
                 .getName();
 
         realm.close();
@@ -209,7 +208,7 @@ public class IntroExampleActivity extends Activity {
         String status = "\n\nPerforming complex Query operation...";
 
         Realm realm = Realm.getInstance(realmConfig);
-        status += "\nNumber of persons: " + realm.allObjects(Person.class).size();
+        status += "\nNumber of persons: " + realm.where(Person.class).count();
 
         // Find all persons where age between 7 and 9 and name begins with "Person".
         RealmResults<Person> results = realm.where(Person.class)

--- a/examples/jsonExample/src/main/java/io/realm/examples/json/JsonExampleActivity.java
+++ b/examples/jsonExample/src/main/java/io/realm/examples/json/JsonExampleActivity.java
@@ -88,7 +88,7 @@ public class JsonExampleActivity extends Activity {
         loadJsonFromJsonObject();
         loadJsonFromString();
 
-        return realm.allObjects(City.class);
+        return realm.where(City.class).findAll();
     }
 
     private void loadJsonFromStream() throws IOException {

--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.1-2'
+    ext.kotlin_version = '1.0.2'
     repositories {
         jcenter()
         mavenCentral()
@@ -52,6 +52,6 @@ android {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
-    compile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
+//    compile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
     compile 'org.jetbrains.anko:anko-sdk15:0.8.2'
 }

--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -52,6 +52,5 @@ android {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
-//    compile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
     compile 'org.jetbrains.anko:anko-sdk15:0.8.2'
 }

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
@@ -66,7 +66,7 @@ class KotlinExampleActivity : Activity() {
         // Using executeTransaction with a lambda reduces code size and makes it impossible
         // to forget to commit the transaction.
         realm.executeTransaction {
-            realm.allObjects(Person::class.java).deleteAllFromRealm()
+            realm.delete(Person::class.java)
         }
 
         // More complex operations can be executed on another thread, for example using
@@ -120,7 +120,7 @@ class KotlinExampleActivity : Activity() {
 
     private fun basicQuery(realm: Realm) {
         showStatus("\nPerforming basic Query operation...")
-        showStatus("Number of persons: ${realm.allObjects(Person::class.java).size}")
+        showStatus("Number of persons: ${realm.where(Person::class.java).count()}")
 
         val results = realm.where(Person::class.java).equalTo("age", 99).findAll()
 
@@ -129,7 +129,7 @@ class KotlinExampleActivity : Activity() {
 
     private fun basicLinkQuery(realm: Realm) {
         showStatus("\nPerforming basic Link Query operation...")
-        showStatus("Number of persons: ${realm.allObjects(Person::class.java).size}")
+        showStatus("Number of persons: ${realm.where(Person::class.java).count()}")
 
         val results = realm.where(Person::class.java).equalTo("cats.name", "Tiger").findAll()
 
@@ -169,10 +169,10 @@ class KotlinExampleActivity : Activity() {
         }
 
         // Implicit read transactions allow you to access your objects
-        status += "\nNumber of persons: ${realm.allObjects(Person::class.java).size}"
+        status += "\nNumber of persons: ${realm.where(Person::class.java).count()}"
 
         // Iterate over all objects
-        for (person in realm.allObjects(Person::class.java)) {
+        for (person in realm.where(Person::class.java).findAll()) {
             val dogName: String = person?.dog?.name ?: "None"
 
             status += "\n${person.name}: ${person.age} : $dogName : ${person.cats.size}"
@@ -184,10 +184,9 @@ class KotlinExampleActivity : Activity() {
         }
 
         // Sorting
-        val sortedPersons = realm.allObjects(Person::class.java)
-        sortedPersons.sort("age", Sort.DESCENDING)
-        check(realm.allObjects(Person::class.java).last().name == sortedPersons.first().name)
-        status += "\nSorting ${sortedPersons.last().name} == ${realm.allObjects(Person::class.java).first().name}"
+        val sortedPersons = realm.where(Person::class.java).findAllSorted("age", Sort.DESCENDING);
+        check(realm.where(Person::class.java).findAll().last().name == sortedPersons.first().name)
+        status += "\nSorting ${sortedPersons.last().name} == ${realm.where(Person::class.java).findAll().first().name}"
 
         realm.close()
         return status
@@ -200,7 +199,7 @@ class KotlinExampleActivity : Activity() {
         // extension method 'use' (pun intended).
         Realm.getInstance(realmConfig).use {
             // 'it' is the implicit lambda parameter of type Realm
-            status += "\nNumber of persons: ${it.allObjects(Person::class.java).size}"
+            status += "\nNumber of persons: ${it.where(Person::class.java).count()}"
 
             // Find all persons where age between 7 and 9 and name begins with "Person".
             val results = it

--- a/examples/migrationExample/src/main/java/io/realm/examples/realmmigrationexample/MigrationExampleActivity.java
+++ b/examples/migrationExample/src/main/java/io/realm/examples/realmmigrationexample/MigrationExampleActivity.java
@@ -121,7 +121,7 @@ public class MigrationExampleActivity extends Activity {
 
     private String realmString(Realm realm) {
         StringBuilder stringBuilder = new StringBuilder();
-        for (Person person : realm.allObjects(Person.class)) {
+        for (Person person : realm.where(Person.class).findAll()) {
             stringBuilder.append(person.toString()).append("\n");
         }
 

--- a/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/gotchas/GotchasActivity.java
+++ b/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/gotchas/GotchasActivity.java
@@ -77,7 +77,7 @@ public class GotchasActivity extends Activity {
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
-                realm.allObjectsSorted(Person.class, "name", Sort.ASCENDING).get(0).setAge(new Random().nextInt(100));
+                realm.where(Person.class).findAllSorted( "name", Sort.ASCENDING).get(0).setAge(new Random().nextInt(100));
             }
         });
 

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/AsyncTaskFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/AsyncTaskFragment.java
@@ -89,7 +89,7 @@ public class AsyncTaskFragment extends Fragment {
             realm.executeTransaction(new Realm.Transaction() {
                 @Override
                 public void execute(Realm realm) {
-                    realm.clear(Score.class);
+                    realm.delete(Score.class);
                     for (int i = 0; i < TEST_OBJECTS; i++) {
                         if (isCancelled()) break;
                         Score score = realm.createObject(Score.class);
@@ -99,7 +99,7 @@ public class AsyncTaskFragment extends Fragment {
                 }
             });
 
-            Number sum = realm.allObjects(Score.class).sum("score");
+            Number sum = realm.where(Score.class).sum("score");
             realm.close();
             return sum.intValue();
         }

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/PassingObjectsFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/PassingObjectsFragment.java
@@ -113,7 +113,7 @@ public class PassingObjectsFragment extends Fragment {
     public void onDestroy() {
         super.onDestroy();
         // Clear out all Person instances.
-        realm.clear(Person.class);
+        realm.delete(Person.class);
         realm.close();
     }
 }

--- a/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
+++ b/examples/threadExample/src/main/java/io/realm/examples/threads/ThreadFragment.java
@@ -91,7 +91,7 @@ public class ThreadFragment extends Fragment {
                 realm.executeTransaction(new Realm.Transaction() {
                     @Override
                     public void execute(Realm realm) {
-                        realm.clear(Dot.class);
+                        realm.delete(Dot.class);
                     }
                 });
                 return true;
@@ -114,7 +114,7 @@ public class ThreadFragment extends Fragment {
         // Note that the query gets updated by rerunning it on the thread it was
         // created. This can negatively effect frame rates if it is a complicated query or a very
         // large data set.
-        dotsView.setRealmResults(realm.allObjects(Dot.class));
+        dotsView.setRealmResults(realm.where(Dot.class).findAll());
     }
 
     @Override

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
@@ -88,7 +88,7 @@ public class ExampleActivity extends Activity {
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
-                realm.allObjects(Person.class).deleteAllFromRealm();
+                realm.delete(Person.class);
             }
         });
     }
@@ -161,7 +161,7 @@ public class ExampleActivity extends Activity {
         String status = "\n\nPerforming complex Query operation...";
 
         Realm realm = Realm.getInstance(realmConfig);
-        status += "\nNumber of people in the DB: " + realm.allObjects(Person.class).size();
+        status += "\nNumber of people in the DB: " + realm.where(Person.class).count();
 
         // Find all persons where age between 1 and 99 and name begins with "J".
         RealmResults<Person> results = realm.where(Person.class)

--- a/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
+++ b/examples/unitTestExample/src/test/java/io/realm/examples/unittesting/ExampleActivityTest.java
@@ -137,7 +137,7 @@ public class ExampleActivityTest {
         RealmResults<Person> people = mockRealmResults();
 
         // When we ask Realm for all of the Person instances, return the mock RealmResults
-        when(mockRealm.allObjects(Person.class)).thenReturn(people);
+        when(mockRealm.where(Person.class).findAll()).thenReturn(people);
 
         // When a between query is performed with any string as the field and any int as the
         // value, then return the personQuery itself
@@ -191,14 +191,13 @@ public class ExampleActivityTest {
         // Do not verify partial mock invocation count: https://github.com/jayway/powermock/issues/649
         //verify(mockRealm, times(5)).executeTransaction(Mockito.any(Realm.Transaction.class));
 
-        // Verify that we queried for all Person instance two times in this run (in the original
-        // onCreate, and then again in the button click). Was called two times previously in the
-        // setup, therefore we need to check if it was called again.
-        verify(mockRealm, times(3)).allObjects(Person.class);
+        // Verify that we queried for Person instances five times in this run (2 in basicCrud(),
+        // 2 in complexQuery() and 1 in the button click)
+        verify(mockRealm, times(5)).where(Person.class);
 
-        // Verify that the clear method was called. Clear is also called in the start of the
+        // Verify that the delete method was called. Delete is also called in the start of the
         // activity to ensure we start with a clean db.
-        verify(people, times(2)).deleteAllFromRealm();
+        verify(mockRealm, times(2)).delete(Person.class);
 
         // Call the destroy method so we can verify that the .close() method was called (below)
         controller.destroy();

--- a/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
@@ -190,16 +190,16 @@ public abstract class CollectionTests {
         realm.beginTransaction();
         realm.deleteAll();
         switch (collectionClass) {
-            case MANAGED_REALMLIST:
+            case REALMRESULTS:
                 int id = 0;
                 for (String arg : args) {
                     AllJavaTypes obj = realm.createObject(AllJavaTypes.class, id++);
                     obj.setFieldString(arg);
                 }
                 realm.commitTransaction();
-                return realm.allObjects(AllJavaTypes.class);
+                return realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_STRING);
 
-            case REALMRESULTS:
+            case MANAGED_REALMLIST:
                 AllJavaTypes first = realm.createObject(AllJavaTypes.class);
                 first.setFieldString(args[0]);
                 first.getFieldList().add(first);

--- a/realm/realm-library/src/androidTest/java/io/realm/IOSRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/IOSRealmTests.java
@@ -79,7 +79,7 @@ public class IOSRealmTests {
             configFactory.copyRealmFromAssets(context,
                     "ios/" + iosVersion + "-alltypes.realm", REALM_NAME);
             realm = Realm.getDefaultInstance();
-            RealmResults<IOSAllTypes> result = realm.allObjectsSorted(IOSAllTypes.class, "id", Sort.ASCENDING);
+            RealmResults<IOSAllTypes> result = realm.where(IOSAllTypes.class).findAllSorted("id", Sort.ASCENDING);
             // Verify metadata
             Table table = realm.getTable(IOSAllTypes.class);
             assertTrue(table.hasPrimaryKey());
@@ -113,7 +113,7 @@ public class IOSRealmTests {
                     "ios/" + iosVersion + "-alltypes-default.realm", REALM_NAME);
             realm = Realm.getDefaultInstance();
 
-            IOSAllTypes obj = realm.allObjects(IOSAllTypes.class).first();
+            IOSAllTypes obj = realm.where(IOSAllTypes.class).findFirst();
             assertFalse(obj.isBoolCol());
             assertEquals(0, obj.getShortCol());
             assertEquals(0, obj.getIntCol());
@@ -136,7 +136,7 @@ public class IOSRealmTests {
                     "ios/" + iosVersion + "-alltypes-null-value.realm", REALM_NAME);
             realm = Realm.getDefaultInstance();
 
-            IOSAllTypes obj = realm.allObjects(IOSAllTypes.class).first();
+            IOSAllTypes obj = realm.where(IOSAllTypes.class).findFirst();
             assertEquals(null, obj.getByteCol());
             assertEquals(null, obj.getStringCol());
             assertEquals(null, obj.getDateCol());
@@ -152,7 +152,7 @@ public class IOSRealmTests {
                     "ios/" + iosVersion + "-alltypes-min.realm", REALM_NAME);
             realm = Realm.getDefaultInstance();
 
-            IOSAllTypes obj = realm.allObjects(IOSAllTypes.class).first();
+            IOSAllTypes obj = realm.where(IOSAllTypes.class).findFirst();
             assertFalse(obj.isBoolCol());
             assertEquals(Short.MIN_VALUE, obj.getShortCol());
             assertEquals(Integer.MIN_VALUE, obj.getIntCol());
@@ -173,7 +173,7 @@ public class IOSRealmTests {
                     "ios/" + iosVersion + "-alltypes-max.realm", REALM_NAME);
             realm = Realm.getDefaultInstance();
 
-            IOSAllTypes obj = realm.allObjects(IOSAllTypes.class).first();
+            IOSAllTypes obj = realm.where(IOSAllTypes.class).findFirst();
             assertEquals(Short.MAX_VALUE, obj.getShortCol());
             assertEquals(Integer.MAX_VALUE, obj.getIntCol());
             assertEquals(Integer.MAX_VALUE, obj.getLongCol());
@@ -198,7 +198,7 @@ public class IOSRealmTests {
                     .build();
             realm = Realm.getInstance(realmConfig);
 
-            IOSAllTypes obj = realm.allObjects(IOSAllTypes.class).first();
+            IOSAllTypes obj = realm.where(IOSAllTypes.class).findFirst();
             assertFalse(obj.isBoolCol());
             assertEquals(0, obj.getShortCol());
             assertEquals(0, obj.getIntCol());

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedOrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedOrderedRealmCollectionTests.java
@@ -159,7 +159,7 @@ public class ManagedOrderedRealmCollectionTests extends CollectionTests {
                         .getFieldList();
 
             case REALMRESULTS:
-                return realm.allObjects(AllJavaTypes.class);
+                return realm.where(AllJavaTypes.class).findAll();
 
             default:
                 throw new AssertionError("Unsupported class: " + collectionClass);
@@ -296,7 +296,7 @@ public class ManagedOrderedRealmCollectionTests extends CollectionTests {
         switch (collectionClass) {
             case MANAGED_REALMLIST:
                 realm.beginTransaction();
-                RealmResults<NullTypes> objects = realm.allObjects(NullTypes.class);
+                RealmResults<NullTypes> objects = realm.where(NullTypes.class).findAll();
                 NullTypes parent = realm.createObject(NullTypes.class, 0);
                 for (int i = 0; i < objects.size(); i++) {
                     NullTypes object = objects.get(i);
@@ -310,8 +310,8 @@ public class ManagedOrderedRealmCollectionTests extends CollectionTests {
                 break;
 
             case REALMRESULTS:
-                original = realm.allObjects(NullTypes.class);
-                copy = realm.allObjects(NullTypes.class);
+                original = realm.where(NullTypes.class).findAll();
+                copy = realm.where(NullTypes.class).findAll();
                 break;
 
             default:
@@ -594,7 +594,7 @@ public class ManagedOrderedRealmCollectionTests extends CollectionTests {
                     dog.setName("Dog " + i);
                 }
                 realm.commitTransaction();
-                return realm.allObjects(Dog.class);
+                return realm.where(Dog.class).findAll();
 
             default:
                 throw new AssertionError("Unknown collection class: " + collectionClass);

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
@@ -128,7 +128,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
                         .getFieldList();
 
             case REALMRESULTS:
-                return realm.allObjectsSorted(AllJavaTypes.class, AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
+                return realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
 
             default:
                 throw new AssertionError("Unsupported class: " + collectionClass);
@@ -154,7 +154,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
         TestHelper.populateAllNullRowsForNumericTesting(realm);
         switch (collectionClass) {
             case MANAGED_REALMLIST:
-                RealmResults<NullTypes> results = realm.allObjects(NullTypes.class);
+                RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
                 RealmList<NullTypes> list = results.get(0).getFieldListNull();
                 realm.beginTransaction();
                 for (int i = 0; i < results.size(); i++) {
@@ -173,7 +173,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
         populatePartialNullRowsForNumericTesting(realm);
         switch (collectionClass) {
             case MANAGED_REALMLIST:
-                RealmResults<NullTypes> results = realm.allObjects(NullTypes.class);
+                RealmResults<NullTypes> results = realm.where(NullTypes.class).findAll();
                 RealmList<NullTypes> list = results.get(0).getFieldListNull();
                 realm.beginTransaction();
                 int size = results.size();
@@ -195,7 +195,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
 
             case MANAGED_REALMLIST:
                 realm.beginTransaction();
-                RealmResults<NonLatinFieldNames> results = realm.allObjects(NonLatinFieldNames.class);
+                RealmResults<NonLatinFieldNames> results = realm.where(NonLatinFieldNames.class).findAll();
                 RealmList<NonLatinFieldNames> list = results.get(0).getChildren();
                 for (int i = 0; i < results.size(); i++) {
                     list.add(results.get(i));
@@ -204,7 +204,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
                 return list;
 
             case REALMRESULTS:
-                return realm.allObjects(NonLatinFieldNames.class);
+                return realm.where(NonLatinFieldNames.class).findAll();
 
             default:
                 throw new AssertionError("Unknown collection: " + collectionClass);

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -267,7 +267,7 @@ public class NotificationsTest {
                 Realm realm = null;
                 try {
                     realm = Realm.getInstance(realmConfig);
-                    final RealmResults<Dog> dogs = realm.allObjects(Dog.class);
+                    final RealmResults<Dog> dogs = realm.where(Dog.class).findAll();
                     assertEquals(0, dogs.size());
                     listener[0] = new RealmChangeListener<Realm>() {
                         @Override
@@ -302,7 +302,7 @@ public class NotificationsTest {
             dog.setName("Rex " + i);
         }
         realm.commitTransaction();
-        assertEquals(TEST_SIZE, realm.allObjects(Dog.class).size());
+        assertEquals(TEST_SIZE, realm.where(Dog.class).count());
         realm.close();
 
         try {
@@ -341,7 +341,7 @@ public class NotificationsTest {
                 backgroundLooperStarted.countDown();
 
                 // Random operation in the client code
-                final RealmResults<Dog> dogs = realm.allObjects(Dog.class);
+                final RealmResults<Dog> dogs = realm.where(Dog.class).findAll();
                 if (dogs.size() != 0) {
                     return false;
                 }
@@ -384,7 +384,7 @@ public class NotificationsTest {
             dog.setName("Rex " + i);
         }
         realm.commitTransaction();
-        assertEquals(TEST_SIZE, realm.allObjects(Dog.class).size());
+        assertEquals(TEST_SIZE, realm.where(Dog.class).count());
         realm.close();
         addHandlerMessages.countDown();
 
@@ -1012,7 +1012,7 @@ public class NotificationsTest {
     @RunTestInLooperThread
     public void realmResultsListenerAddedAfterCommit() {
         Realm realm = looperThread.realm;
-        RealmResults<AllTypes> results = realm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
         realm.beginTransaction();
         realm.createObject(AllTypes.class);
         realm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
@@ -94,14 +94,14 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
 
             case UNMANAGED_REALMLIST:
                 populateRealm(realm, sampleSize);
-                RealmResults<AllJavaTypes> objects = realm.allObjectsSorted(AllJavaTypes.class, AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
+                RealmResults<AllJavaTypes> objects = realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
                 RealmList<AllJavaTypes> inMemoryList = new RealmList<AllJavaTypes>();
                 inMemoryList.addAll(objects);
                 return inMemoryList;
 
             case REALMRESULTS:
                 populateRealm(realm, sampleSize);
-                return realm.allObjectsSorted(AllJavaTypes.class, AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
+                return realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
 
             default:
                 throw new AssertionError("Unsupported class: " + collectionClass);
@@ -313,99 +313,6 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
         it.remove();
     }
 
-    // TODO Remove once waitForChange is introduced
-    @Test
-    public void iterator_refreshWhileIterating_nonLooper() {
-        final CountDownLatch bgDone = new CountDownLatch(1);
-        Iterator<AllJavaTypes> it = collection.iterator();
-        it.next();
-
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                Realm realm = Realm.getInstance(OrderedRealmCollectionIteratorTests.this.realm.getConfiguration());
-                appendElementToCollection(realm, collectionClass);
-                realm.close();
-                bgDone.countDown();
-            }
-        }).start();
-        TestHelper.awaitOrFail(bgDone);
-
-        realm.refresh();
-        switch (collectionClass) {
-            case UNMANAGED_REALMLIST:
-                assertEquals(TEST_SIZE, collection.size());
-                break;
-
-            case MANAGED_REALMLIST:
-            case REALMRESULTS:
-                assertEquals(TEST_SIZE + 1, collection.size());
-                break;
-
-            default:
-                fail("Unknown class: " + collectionClass);
-        }
-    }
-
-    // TODO Remove once waitForChange is introduced
-    @Test
-    @UiThreadTest
-    public void iterator_refreshWhileIterating_looper() {
-        final CountDownLatch bgDone = new CountDownLatch(1);
-        Iterator<AllJavaTypes> it = collection.iterator();
-        it.next();
-
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                Realm realm = Realm.getInstance(OrderedRealmCollectionIteratorTests.this.realm.getConfiguration());
-                appendElementToCollection(realm, collectionClass);
-                realm.close();
-                bgDone.countDown();
-            }
-        }).start();
-        TestHelper.awaitOrFail(bgDone);
-
-        realm.refresh();
-        switch (collectionClass) {
-            case MANAGED_REALMLIST:
-            case UNMANAGED_REALMLIST:
-            case REALMRESULTS:
-                assertEquals(TEST_SIZE, collection.size());
-                break;
-
-            default:
-                fail("Unknown class: " + collectionClass);
-        }
-    }
-
-
-    // TODO Remove once waitForChange is introduced
-    @Test
-    public void iterator_refreshClearsDeletedObjects() {
-        if (skipTest(CollectionClass.UNMANAGED_REALMLIST)) {
-            return;
-        }
-
-        assertEquals(0, collection.iterator().next().getFieldLong());
-        realm.beginTransaction();
-        Iterator<AllJavaTypes> it = collection.iterator();
-        it.next(); // First item is a cyclic reference, avoid deleting that
-        AllJavaTypes obj = it.next();
-        assertEquals(1, obj.getFieldLong());
-        obj.deleteFromRealm();
-        realm.commitTransaction();
-        realm.refresh(); // Force a refresh of all Collections
-
-        assertEquals(TEST_SIZE - 1, collection.size());
-
-        it = collection.iterator();
-        it.next();
-        obj = it.next(); // Iterator can no longer access the deleted object
-        assertTrue(obj.isValid());
-        assertEquals(2, obj.getFieldLong());
-    }
-
     @Test
     public void listIterator_empty() {
         collection = createCollection(realm, collectionClass, 0);
@@ -557,31 +464,6 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
     }
 
     @Test
-    public void listIterator_refreshClearsDeletedObjects() {
-        if (skipTest(CollectionClass.UNMANAGED_REALMLIST)) {
-            return;
-        }
-
-        assertEquals(0, collection.iterator().next().getFieldLong());
-        realm.beginTransaction();
-        Iterator<AllJavaTypes> it = collection.listIterator();
-        it.next(); // First item is a cyclic reference, avoid deleting that
-        AllJavaTypes obj = it.next();
-        assertEquals(1, obj.getFieldLong());
-        obj.deleteFromRealm();
-        realm.commitTransaction();
-        realm.refresh(); // Refresh forces a refresh of all Collections
-
-        assertEquals(TEST_SIZE - 1, collection.size());
-
-        it = collection.iterator();
-        it.next();
-        obj = it.next(); // Iterator can no longer access the deleted object
-        assertTrue(obj.isValid());
-        assertEquals(2, obj.getFieldLong());
-    }
-
-    @Test
     public void listIterator_closedRealm_methods() {
         if (skipTest(CollectionClass.UNMANAGED_REALMLIST)) {
             return;
@@ -627,72 +509,6 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
             assertNotEquals(CollectionClass.REALMRESULTS, collectionClass);
         } catch (UnsupportedOperationException ignored) {
             assertEquals(CollectionClass.REALMRESULTS, collectionClass);
-        }
-    }
-
-    // TODO Remove once waitForChange is introduced
-    @Test
-    public void listIterator_refreshWhileIterating_nonLooper() {
-        final CountDownLatch bgDone = new CountDownLatch(1);
-        Iterator<AllJavaTypes> it = collection.iterator();
-        it.next();
-
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                Realm realm = Realm.getInstance(OrderedRealmCollectionIteratorTests.this.realm.getConfiguration());
-                appendElementToCollection(realm, collectionClass);
-                realm.close();
-                bgDone.countDown();
-            }
-        }).start();
-        TestHelper.awaitOrFail(bgDone);
-
-        realm.refresh();
-        switch (collectionClass) {
-            case UNMANAGED_REALMLIST:
-                assertEquals(TEST_SIZE, collection.size());
-                break;
-
-            case MANAGED_REALMLIST:
-            case REALMRESULTS:
-                assertEquals(TEST_SIZE + 1, collection.size());
-                break;
-
-            default:
-                fail("Unknown class: " + collectionClass);
-        }
-    }
-
-    // TODO Remove once waitForChange is introduced
-    @Test
-    @UiThreadTest
-    public void listIterator_refreshWhileIterating_looper() {
-        final CountDownLatch bgDone = new CountDownLatch(1);
-        Iterator<AllJavaTypes> it = collection.iterator();
-        it.next();
-
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                Realm realm = Realm.getInstance(OrderedRealmCollectionIteratorTests.this.realm.getConfiguration());
-                appendElementToCollection(realm, collectionClass);
-                realm.close();
-                bgDone.countDown();
-            }
-        }).start();
-        TestHelper.awaitOrFail(bgDone);
-
-        realm.refresh();
-        switch (collectionClass) {
-            case MANAGED_REALMLIST:
-            case UNMANAGED_REALMLIST:
-            case REALMRESULTS:
-                assertEquals(TEST_SIZE, collection.size());
-                break;
-
-            default:
-                fail("Unknown class: " + collectionClass);
         }
     }
 
@@ -962,11 +778,20 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
 
         // Verify that ConcurrentModification is correctly detected on non-looper threads
         Iterator<AllJavaTypes> it = collection.iterator();
-        realm.beginTransaction();
-        realm.createObject(AllJavaTypes.class, TEST_SIZE);
-        realm.commitTransaction();
-        realm.refresh();
-
+        final CountDownLatch bgDone = new CountDownLatch(1);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm bgRealm = Realm.getInstance(realm.getConfiguration());
+                bgRealm.beginTransaction();
+                bgRealm.createObject(AllJavaTypes.class, TEST_SIZE);
+                bgRealm.commitTransaction();
+                bgRealm.close();
+                bgDone.countDown();
+            }
+        }).start();
+        TestHelper.awaitOrFail(bgDone);
+        realm.waitForChange();
         try {
             it.next();
             fail();

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
@@ -151,7 +151,7 @@ public class OrderedRealmCollectionTests extends CollectionTests {
 
             case REALMRESULTS:
                 populateRealm(realm, TEST_SIZE);
-                return realm.allObjects(AllJavaTypes.class);
+                return realm.where(AllJavaTypes.class).findAll();
 
             default:
                 throw new AssertionError("Unsupported class: " + collectionClass);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
@@ -241,7 +241,7 @@ public class RealmAnnotationTests {
         anc1.setObject(true);
         realm.commitTransaction();
 
-        AnnotationNameConventions anc2 = realm.allObjects(AnnotationNameConventions.class).first();
+        AnnotationNameConventions anc2 = realm.where(AnnotationNameConventions.class).findFirst();
         assertTrue(anc2.isHasObject());
         assertEquals(1, anc2.getId_object());
         assertEquals(2, anc2.getmObject());

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
@@ -126,7 +126,7 @@ public class RealmCollectionTests extends CollectionTests {
 
             case REALMRESULTS:
                 populateRealm(realm, TEST_SIZE);
-                return realm.allObjects(AllJavaTypes.class);
+                return realm.where(AllJavaTypes.class).findAll();
 
             default:
                 throw new AssertionError("Unsupported class: " + collectionClass);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmInterprocessTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmInterprocessTest.java
@@ -280,8 +280,8 @@ public class RealmInterprocessTest extends AndroidTestCase {
             @Override
             public void run() {
                 // Step 1
-                testRealm = Realm.getInstance(getContext());
-                assertEquals(testRealm.allObjects(AllTypes.class).size(), 0);
+                testRealm = Realm.getInstance(new RealmConfiguration.Builder(getContext()).build());
+                assertEquals(testRealm.where(AllTypes.class).count(), 0);
                 testRealm.beginTransaction();
                 testRealm.createObject(AllTypes.class);
                 testRealm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonNullPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonNullPrimaryKeyTests.java
@@ -93,14 +93,14 @@ public class RealmJsonNullPrimaryKeyTests {
 
         // PrimaryKeyAsString
         if (clazz.equals(PrimaryKeyAsString.class)) {
-            RealmResults<PrimaryKeyAsString> results = realm.allObjects(PrimaryKeyAsString.class);
+            RealmResults<PrimaryKeyAsString> results = realm.where(PrimaryKeyAsString.class).findAll();
             assertEquals(1, results.size());
             assertEquals(Long.valueOf(secondaryFieldValue).longValue(), results.first().getId());
             assertEquals(null, results.first().getName());
 
         // PrimaryKeyAsNumber
         } else {
-            RealmResults results = realm.allObjects(clazz);
+            RealmResults results = realm.where(clazz).findAll();
             assertEquals(1, results.size());
             assertEquals(null, ((NullPrimaryKey)results.first()).getId());
             assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());
@@ -116,14 +116,14 @@ public class RealmJsonNullPrimaryKeyTests {
 
         // PrimaryKeyAsString
         if (clazz.equals(PrimaryKeyAsString.class)) {
-            RealmResults<PrimaryKeyAsString> results = realm.allObjects(PrimaryKeyAsString.class);
+            RealmResults<PrimaryKeyAsString> results = realm.where(PrimaryKeyAsString.class).findAll();
             assertEquals(1, results.size());
             assertEquals(Long.valueOf(secondaryFieldValue).longValue(), results.first().getId());
             assertEquals(null, results.first().getName());
 
         // PrimaryKeyAsNumber
         } else {
-            RealmResults results = realm.allObjects(clazz);
+            RealmResults results = realm.where(clazz).findAll();
             assertEquals(1, results.size());
             assertEquals(null, ((NullPrimaryKey)results.first()).getId());
             assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());
@@ -140,14 +140,14 @@ public class RealmJsonNullPrimaryKeyTests {
 
         // PrimaryKeyAsString
         if (clazz.equals(PrimaryKeyAsString.class)) {
-            RealmResults<PrimaryKeyAsString> results = realm.allObjects(PrimaryKeyAsString.class);
+            RealmResults<PrimaryKeyAsString> results = realm.where(PrimaryKeyAsString.class).findAll();
             assertEquals(1, results.size());
             assertEquals(Long.valueOf(secondaryFieldValue).longValue(), results.first().getId());
             assertEquals(null, results.first().getName());
 
         // PrimaryKeyAsNumber
         } else {
-            RealmResults results = realm.allObjects(clazz);
+            RealmResults results = realm.where(clazz).findAll();
             assertEquals(1, results.size());
             assertEquals(null, ((NullPrimaryKey)results.first()).getId());
             assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
@@ -84,8 +84,8 @@ public class RealmJsonTests {
 
     // Assert that the list of AllTypesPrimaryKey objects where inserted and updated properly.
     private void assertAllTypesPrimaryKeyUpdated() {
-        assertEquals(1, realm.allObjects(AllTypesPrimaryKey.class).size());
-        AllTypesPrimaryKey obj = realm.allObjects(AllTypesPrimaryKey.class).first();
+        assertEquals(1, realm.where(AllTypesPrimaryKey.class).count());
+        AllTypesPrimaryKey obj = realm.where(AllTypesPrimaryKey.class).findFirst();
         assertEquals("Bar", obj.getColumnString());
         assertEquals(2.23F, obj.getColumnFloat(), 0F);
         assertEquals(2.234D, obj.getColumnDouble(), 0D);
@@ -172,13 +172,13 @@ public class RealmJsonTests {
     @Test
     public void createObject_fromJsonNullObject() {
         realm.createObjectFromJson(AllTypes.class, (JSONObject) null);
-        assertEquals(0, realm.allObjects(AllTypes.class).size());
+        assertEquals(0, realm.where(AllTypes.class).count());
     }
 
     @Test
     public void createAllFromJson_nullArray() {
         realm.createAllFromJson(AllTypes.class, (JSONArray) null);
-        assertEquals(0, realm.allObjects(AllTypes.class).size());
+        assertEquals(0, realm.where(AllTypes.class).count());
 
     }
 
@@ -195,7 +195,7 @@ public class RealmJsonTests {
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, json);
         realm.commitTransaction();
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
 
         // Check that all primitive types are imported correctly
         assertEquals("String", obj.getColumnString());
@@ -215,7 +215,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(AllTypes.class, json);
         realm.commitTransaction();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(new Date(1000), obj.getColumnDate());
     }
 
@@ -228,7 +228,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(AllTypes.class, json);
         realm.commitTransaction();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(new Date(1000), obj.getColumnDate());
     }
 
@@ -242,7 +242,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(AllTypes.class, json);
         realm.commitTransaction();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         Calendar cal = GregorianCalendar.getInstance();
         cal.setTimeZone(TimeZone.getTimeZone("Australia/West"));
         cal.set(2015, Calendar.OCTOBER, 03, 14, 45, 33);
@@ -263,7 +263,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(AllTypes.class, allTypesObject);
         realm.commitTransaction();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals("Fido", obj.getColumnRealmObject().getName());
     }
 
@@ -283,7 +283,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(AllTypes.class, allTypesObject);
         realm.commitTransaction();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(3, obj.getColumnRealmList().size());
         assertEquals("Fido-3", obj.getColumnRealmList().get(2).getName());
     }
@@ -298,7 +298,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(AllTypes.class, allTypesObject);
         realm.commitTransaction();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(0, obj.getColumnRealmList().size());
     }
 
@@ -309,7 +309,7 @@ public class RealmJsonTests {
         realm.commitTransaction();
 
         assertEquals("Foo", dog.getName());
-        assertEquals("Foo", realm.allObjects(Dog.class).first().getName());
+        assertEquals("Foo", realm.where(Dog.class).findFirst().getName());
     }
 
     @Test
@@ -332,7 +332,7 @@ public class RealmJsonTests {
 
         //noinspection ConstantConditions
         assertNull(dog);
-        assertEquals(0, realm.allObjects(Dog.class).size());
+        assertEquals(0, realm.where(Dog.class).count());
     }
 
     @Test
@@ -342,7 +342,7 @@ public class RealmJsonTests {
         realm.createAllFromJson(AllTypes.class, array);
         realm.commitTransaction();
 
-        assertEquals(0, realm.allObjects(AllTypes.class).size());
+        assertEquals(0, realm.where(AllTypes.class).count());
     }
 
     @Test
@@ -359,7 +359,7 @@ public class RealmJsonTests {
         realm.createAllFromJson(Dog.class, dogList);
         realm.commitTransaction();
 
-        assertEquals(3, realm.allObjects(Dog.class).size());
+        assertEquals(3, realm.where(Dog.class).count());
         assertEquals(1, realm.where(Dog.class).equalTo("name", "Fido-3").findAll().size());
     }
 
@@ -374,7 +374,7 @@ public class RealmJsonTests {
         realm.commitTransaction();
 
         // Check that all primitive types are imported correctly
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals("", obj.getColumnString());
         assertEquals(0L, obj.getColumnLong());
         assertEquals(0F, obj.getColumnFloat(), 0F);
@@ -401,7 +401,7 @@ public class RealmJsonTests {
             realm.commitTransaction();
         }
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals("Foo", obj.getColumnString());
         assertEquals(new Date(0), obj.getColumnDate());
     }
@@ -417,7 +417,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(AnnotationTypes.class, json);
         realm.commitTransaction();
 
-        AnnotationTypes annotationsObject = realm.allObjects(AnnotationTypes.class).first();
+        AnnotationTypes annotationsObject = realm.where(AnnotationTypes.class).findFirst();
         assertEquals("Foo", annotationsObject.getIndexString());
         assertEquals(null, annotationsObject.getIgnoreString());
     }
@@ -428,7 +428,7 @@ public class RealmJsonTests {
         realm.createAllFromJson(Dog.class, "[{ name: \"Foo\" }, { name: \"Bar\" }]");
         realm.commitTransaction();
 
-        assertEquals(2, realm.allObjects(Dog.class).size());
+        assertEquals(2, realm.where(Dog.class).count());
     }
 
     @Test
@@ -449,7 +449,7 @@ public class RealmJsonTests {
         realm.createAllFromJson(Dog.class, (String) null);
         realm.commitTransaction();
 
-        assertEquals(0, realm.allObjects(Dog.class).size());
+        assertEquals(0, realm.where(Dog.class).count());
     }
 
     @Test
@@ -457,7 +457,7 @@ public class RealmJsonTests {
         realm.beginTransaction();
         realm.createAllFromJson(Dog.class, "");
         realm.commitTransaction();
-        assertEquals(0, realm.allObjects(Dog.class).size());
+        assertEquals(0, realm.where(Dog.class).count());
     }
 
     @Test
@@ -466,14 +466,14 @@ public class RealmJsonTests {
         realm.createAllFromJson(null, "[{ name: \"Foo\" }]");
         realm.commitTransaction();
 
-        assertEquals(0, realm.allObjects(Dog.class).size());
+        assertEquals(0, realm.where(Dog.class).count());
     }
 
 
     @Test
     public void createAllFromJson_streamNull() throws IOException {
         realm.createAllFromJson(AllTypes.class, (InputStream) null);
-        assertEquals(0, realm.allObjects(AllTypes.class).size());
+        assertEquals(0, realm.where(AllTypes.class).count());
     }
 
     @Test
@@ -485,7 +485,7 @@ public class RealmJsonTests {
         in.close();
 
         // Check that all primitive types are imported correctly
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals("String", obj.getColumnString());
         assertEquals(1L, obj.getColumnLong());
         assertEquals(1.23F, obj.getColumnFloat(), 0F);
@@ -503,7 +503,7 @@ public class RealmJsonTests {
         in.close();
 
         // Check that all primitive types are imported correctly
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(new Date(1000), obj.getColumnDate());
     }
 
@@ -516,7 +516,7 @@ public class RealmJsonTests {
         in.close();
 
         // Check that all primitive types are imported correctly
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(new Date(1000), obj.getColumnDate());
     }
 
@@ -534,7 +534,7 @@ public class RealmJsonTests {
         Date date = cal.getTime();
 
         // Check that all primitive types are imported correctly
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(date, obj.getColumnDate());
     }
 
@@ -546,7 +546,7 @@ public class RealmJsonTests {
         realm.commitTransaction();
         in.close();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals("Fido", obj.getColumnRealmObject().getName());
     }
 
@@ -558,7 +558,7 @@ public class RealmJsonTests {
         realm.commitTransaction();
         in.close();
 
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals(0, obj.getColumnRealmList().size());
     }
 
@@ -570,7 +570,7 @@ public class RealmJsonTests {
         realm.commitTransaction();
         in.close();
 
-        assertEquals(3, realm.allObjects(Dog.class).size());
+        assertEquals(3, realm.where(Dog.class).count());
         assertEquals(1, realm.where(Dog.class).equalTo("name", "Fido-3").findAll().size());
     }
 
@@ -581,7 +581,7 @@ public class RealmJsonTests {
         realm.createAllFromJson(Dog.class, in);
         realm.commitTransaction();
 
-        assertEquals(3, realm.allObjects(Dog.class).size());
+        assertEquals(3, realm.where(Dog.class).count());
         assertEquals(1, realm.where(Dog.class).equalTo("name", "Fido-3").findAll().size());
     }
 
@@ -596,7 +596,7 @@ public class RealmJsonTests {
         in.close();
 
         // Check that all primitive types are imported correctly
-        AllTypes obj = realm.allObjects(AllTypes.class).first();
+        AllTypes obj = realm.where(AllTypes.class).findFirst();
         assertEquals("", obj.getColumnString());
         assertEquals(0L, obj.getColumnLong());
         assertEquals(0F, obj.getColumnFloat(), 0F);
@@ -665,7 +665,7 @@ public class RealmJsonTests {
         in.close();
 
         // Check that all primitive types are imported correctly
-        obj = realm.allObjects(AllTypesPrimaryKey.class).first();
+        obj = realm.where(AllTypesPrimaryKey.class).findFirst();
         assertEquals("1", obj.getColumnString());
         assertEquals(1L, obj.getColumnLong());
         assertEquals(1F, obj.getColumnFloat(), 0F);
@@ -751,7 +751,7 @@ public class RealmJsonTests {
         AllTypesPrimaryKey newObj = realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, in);
         realm.commitTransaction();
 
-        assertEquals(1, realm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(1, realm.where(AllTypesPrimaryKey.class).count());
         assertEquals("bar", newObj.getColumnString());
     }
 
@@ -797,7 +797,7 @@ public class RealmJsonTests {
         realm.commitTransaction();
 
         // Check that all primitive types are imported correctly
-        obj = realm.allObjects(AllTypesPrimaryKey.class).first();
+        obj = realm.where(AllTypesPrimaryKey.class).findFirst();
         assertEquals("1", obj.getColumnString());
         assertEquals(1L, obj.getColumnLong());
         assertEquals(1F, obj.getColumnFloat(), 0F);
@@ -842,7 +842,7 @@ public class RealmJsonTests {
         AllTypesPrimaryKey newObj = realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, "{ \"columnLong\" : 1, \"columnString\" : \"bar\" }");
         realm.commitTransaction();
 
-        assertEquals(1, realm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(1, realm.where(AllTypesPrimaryKey.class).count());
         assertEquals("bar", newObj.getColumnString());
     }
 
@@ -908,7 +908,7 @@ public class RealmJsonTests {
 
         realm.commitTransaction();
 
-        assertEquals(1, realm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(1, realm.where(AllTypesPrimaryKey.class).count());
         assertEquals("bar", newObj.getColumnString());
     }
 
@@ -923,7 +923,7 @@ public class RealmJsonTests {
         assertNull(realm.createOrUpdateObjectFromJson(null, json));
         realm.commitTransaction();
 
-        AllTypesPrimaryKey obj2 = realm.allObjects(AllTypesPrimaryKey.class).first();
+        AllTypesPrimaryKey obj2 = realm.where(AllTypesPrimaryKey.class).findFirst();
         assertEquals("Foo", obj2.getColumnString());
     }
 
@@ -932,7 +932,7 @@ public class RealmJsonTests {
         realm.beginTransaction();
         assertNull(realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, (JSONObject) null));
         realm.commitTransaction();
-        assertEquals(0, realm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(0, realm.where(AllTypesPrimaryKey.class).count());
     }
 
     @Test
@@ -949,7 +949,7 @@ public class RealmJsonTests {
         } finally {
             realm.commitTransaction();
         }
-        AllTypesPrimaryKey obj2 = realm.allObjects(AllTypesPrimaryKey.class).first();
+        AllTypesPrimaryKey obj2 = realm.where(AllTypesPrimaryKey.class).findFirst();
         assertEquals("Foo", obj2.getColumnString());
     }
 
@@ -983,13 +983,13 @@ public class RealmJsonTests {
     @Test
     public void createOrUpdateAllFromJson_jsonNullClass() {
         realm.createOrUpdateAllFromJson(null, new JSONArray());
-        assertEquals(0, realm.allObjects(AllTypes.class).size());
+        assertEquals(0, realm.where(AllTypes.class).count());
     }
 
     @Test
     public void createOrUpdateAllFromJson_jsonNullJson() {
         realm.createOrUpdateAllFromJson(AllTypes.class, (JSONArray) null);
-        assertEquals(0, realm.allObjects(AllTypes.class).size());
+        assertEquals(0, realm.where(AllTypes.class).count());
     }
 
     @Test
@@ -1024,7 +1024,7 @@ public class RealmJsonTests {
         realm.beginTransaction();
         realm.createOrUpdateAllFromJson((Class<AllTypesPrimaryKey>) null, "{ \"columnLong\" : 1 }");
         realm.commitTransaction();
-        assertEquals(0, realm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(0, realm.where(AllTypesPrimaryKey.class).count());
     }
 
     @Test
@@ -1032,7 +1032,7 @@ public class RealmJsonTests {
         realm.beginTransaction();
         realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, (String) null);
         realm.commitTransaction();
-        assertEquals(0, realm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(0, realm.where(AllTypesPrimaryKey.class).count());
     }
 
     @Test
@@ -1040,7 +1040,7 @@ public class RealmJsonTests {
         realm.beginTransaction();
         realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, "");
         realm.commitTransaction();
-        assertEquals(0, realm.allObjects(AllTypesPrimaryKey.class).size());
+        assertEquals(0, realm.where(AllTypesPrimaryKey.class).count());
     }
 
     @Test
@@ -1094,7 +1094,7 @@ public class RealmJsonTests {
         realm.createAllFromJson(NullTypes.class, array);
         realm.commitTransaction();
 
-        RealmResults<NullTypes> nullTypesRealmResults = realm.allObjects(NullTypes.class);
+        RealmResults<NullTypes> nullTypesRealmResults = realm.where(NullTypes.class).findAll();
         assertEquals(3, nullTypesRealmResults.size());
 
         NullTypes nullTypes1 = nullTypesRealmResults.where().equalTo("id", 1).findFirst();
@@ -1111,7 +1111,7 @@ public class RealmJsonTests {
         realm.createAllFromJson(NullTypes.class, TestHelper.loadJsonFromAssets(context, "nulltypes.json"));
         realm.commitTransaction();
 
-        RealmResults<NullTypes> nullTypesRealmResults = realm.allObjects(NullTypes.class);
+        RealmResults<NullTypes> nullTypesRealmResults = realm.where(NullTypes.class).findAll();
         assertEquals(3, nullTypesRealmResults.size());
 
         NullTypes nullTypes1 = nullTypesRealmResults.where().equalTo("id", 1).findFirst();
@@ -1138,7 +1138,7 @@ public class RealmJsonTests {
         realm.createObjectFromJson(NullTypes.class, jsonObject);
         realm.commitTransaction();
 
-        RealmResults<NullTypes> nullTypesRealmResults = realm.allObjects(NullTypes.class);
+        RealmResults<NullTypes> nullTypesRealmResults = realm.where(NullTypes.class).findAll();
         assertEquals(2, nullTypesRealmResults.size());
         checkNullableValuesAreNotNull(nullTypesRealmResults.first());
 
@@ -1148,7 +1148,7 @@ public class RealmJsonTests {
         realm.createOrUpdateAllFromJson(NullTypes.class, array);
         realm.commitTransaction();
 
-        nullTypesRealmResults = realm.allObjects(NullTypes.class);
+        nullTypesRealmResults = realm.where(NullTypes.class).findAll();
         assertEquals(3, nullTypesRealmResults.size());
 
         NullTypes nullTypes1 = nullTypesRealmResults.where().equalTo("id", 1).findFirst();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
@@ -82,7 +82,7 @@ public class RealmLinkTests extends AndroidTestCase {
     }
 
     public void testObjects() {
-        RealmResults<Owner> owners = testRealm.allObjects(Owner.class);
+        RealmResults<Owner> owners = testRealm.where(Owner.class).findAll();
         assertEquals(1, owners.size());
         assertEquals(2, owners.first().getDogs().size());
         assertEquals("Pluto", owners.first().getDogs().first().getName());
@@ -90,13 +90,13 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals("Blackie", owners.first().getCat().getName());
         assertEquals(12, owners.first().getCat().getAge());
 
-        RealmResults<Dog> dogs = testRealm.allObjects(Dog.class);
+        RealmResults<Dog> dogs = testRealm.where(Dog.class).findAll();
         assertEquals(2, dogs.size());
         for (Dog dog : dogs) {
             assertEquals("Tim", dog.getOwner().getName());
         }
 
-        RealmResults<Cat> cats = testRealm.allObjects(Cat.class);
+        RealmResults<Cat> cats = testRealm.where(Cat.class).findAll();
         assertEquals(1, cats.size());
         assertEquals("Tim", cats.first().getOwner().getName());
     }
@@ -471,7 +471,7 @@ public class RealmLinkTests extends AndroidTestCase {
     }
 
     public void testWhere() throws Exception {
-        RealmResults<Owner> owners = testRealm.allObjects(Owner.class);
+        RealmResults<Owner> owners = testRealm.where(Owner.class).findAll();
         RealmResults<Dog> dogs = owners.first().getDogs().where().equalTo("name", "Pluto").findAll();
         assertEquals(1, dogs.size());
         assertEquals("Pluto", dogs.first().getName());

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -689,9 +689,9 @@ public class RealmListTests extends CollectionTests {
     public void clear_notDeleting() {
         Owner owner = realm.where(Owner.class).findFirst();
         realm.beginTransaction();
-        assertEquals(TEST_SIZE, realm.allObjects(Dog.class).size());
+        assertEquals(TEST_SIZE, realm.where(Dog.class).count());
         owner.getDogs().clear();
-        assertEquals(TEST_SIZE, realm.allObjects(Dog.class).size());
+        assertEquals(TEST_SIZE, realm.where(Dog.class).count());
         realm.commitTransaction();
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
@@ -106,15 +106,15 @@ public class RealmModelTests {
             realm.commitTransaction();
         }
 
-        RealmResults<AllTypesRealmModel> resultList = realm.allObjects(AllTypesRealmModel.class);
-        assertEquals("Realm.get is returning wrong result set", 42, resultList.size());
+        long size = realm.where(AllTypesRealmModel.class).count();
+        assertEquals("Realm.get is returning wrong result set", 42, size);
     }
 
     @Test
     public void copyToRealm() {
         populateTestRealm(realm, TEST_DATA_SIZE);
-        RealmResults<AllTypesRealmModel> resultList = realm.allObjects(AllTypesRealmModel.class);
-        assertEquals("Realm.get is returning wrong result set", TEST_DATA_SIZE, resultList.size());
+        long size = realm.where(AllTypesRealmModel.class).count();
+        assertEquals("Realm.get is returning wrong result set", TEST_DATA_SIZE, size);
     }
 
 
@@ -151,9 +151,9 @@ public class RealmModelTests {
             }
         });
 
-        assertEquals(1, realm.allObjects(AllTypesRealmModel.class).size());
+        assertEquals(1, realm.where(AllTypesRealmModel.class).count());
 
-        AllTypesRealmModel obj = realm.allObjects(AllTypesRealmModel.class).first();
+        AllTypesRealmModel obj = realm.where(AllTypesRealmModel.class).findFirst();
         assertEquals("Foo", obj.columnString);
     }
 
@@ -163,8 +163,8 @@ public class RealmModelTests {
         realm.createOrUpdateAllFromJson(AllTypesRealmModel.class, TestHelper.loadJsonFromAssets(context, "list_alltypes_primarykey.json"));
         realm.commitTransaction();
 
-        assertEquals(1, realm.allObjects(AllTypesRealmModel.class).size());
-        AllTypesRealmModel obj = realm.allObjects(AllTypesRealmModel.class).first();
+        assertEquals(1, realm.where(AllTypesRealmModel.class).count());
+        AllTypesRealmModel obj = realm.where(AllTypesRealmModel.class).findFirst();
         assertEquals("Bar", obj.columnString);
         assertEquals(2.23F, obj.columnFloat, 0.000000001);
         assertEquals(2.234D, obj.columnDouble, 0.000000001);
@@ -188,9 +188,10 @@ public class RealmModelTests {
     @Test
     @RunTestInLooperThread
     public void async_query() {
-        populateTestRealm(looperThread.realm, TEST_DATA_SIZE);
+        Realm realm = looperThread.realm;
+        populateTestRealm(realm, TEST_DATA_SIZE);
 
-        final RealmResults<AllTypesRealmModel> allTypesRealmModels = looperThread.realm.distinctAsync(AllTypesRealmModel.class, AllTypesRealmModel.FIELD_STRING);
+        final RealmResults<AllTypesRealmModel> allTypesRealmModels = realm.where(AllTypesRealmModel.class).distinctAsync(AllTypesRealmModel.FIELD_STRING);
         allTypesRealmModels.addChangeListener(new RealmChangeListener<RealmResults<AllTypesRealmModel>>() {
             @Override
             public void onChange(RealmResults<AllTypesRealmModel> object) {
@@ -204,7 +205,7 @@ public class RealmModelTests {
     public void dynamicObject() {
         populateTestRealm(realm, TEST_DATA_SIZE);
 
-        AllTypesRealmModel typedObj = realm.allObjects(AllTypesRealmModel.class).first();
+        AllTypesRealmModel typedObj = realm.where(AllTypesRealmModel.class).findFirst();
         DynamicRealmObject dObj = new DynamicRealmObject(typedObj);
 
         realm.beginTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1183,9 +1183,7 @@ public class RealmObjectTests {
 
     @Test
     public void getter_afterDeleteFromOtherThreadThrows() {
-        realm = Realm.getInstance(configFactory.createConfiguration());
         final CountDownLatch bgRealmDone = new CountDownLatch(1);
-
         realm.beginTransaction();
         final AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -639,7 +639,7 @@ public class RealmQueryTests {
         RealmResults<StringOnly> stringOnlies1 = realm.where(StringOnly.class).contains("chars", "მთავარი").findAll();
         assertEquals(1, stringOnlies1.size());
 
-        RealmResults<StringOnly> stringOnlies2 = realm.allObjects(StringOnly.class);
+        RealmResults<StringOnly> stringOnlies2 = realm.where(StringOnly.class).findAll();
         stringOnlies2 = stringOnlies2.sort("chars");
         for (int i = 0; i < stringOnlies2.size(); i++) {
             assertEquals(sorted[i], stringOnlies2.get(i).getChars());
@@ -1722,7 +1722,7 @@ public class RealmQueryTests {
                         public void run() {
                             RealmConfiguration realmConfig = configFactory.createConfiguration();
                             Realm realm = Realm.getInstance(realmConfig);
-                            RealmResults<StringOnly> realmResults = realm.allObjects(StringOnly.class);
+                            RealmResults<StringOnly> realmResults = realm.where(StringOnly.class).findAll();
                             int n = 0;
                             for (StringOnly ignored : realmResults) {
                                 n = n + 1;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -73,7 +73,7 @@ public class RealmResultsTests extends CollectionTests {
         RealmConfiguration realmConfig = configFactory.createConfiguration();
         realm = Realm.getInstance(realmConfig);
         populateTestRealm();
-        collection = realm.allObjectsSorted(AllTypes.class, AllTypes.FIELD_LONG, Sort.ASCENDING);
+        collection = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG, Sort.ASCENDING);
     }
 
     @After
@@ -112,7 +112,7 @@ public class RealmResultsTests extends CollectionTests {
 
     @Test
     public void subList() {
-        RealmResults<AllTypes> list = realm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> list = realm.where(AllTypes.class).findAll();
         list.sort("columnLong");
         List<AllTypes> sublist = list.subList(Math.max(list.size() - 20, 0), list.size());
         assertEquals(TEST_DATA_SIZE - 1, sublist.get(sublist.size() - 1).getColumnLong());
@@ -348,12 +348,12 @@ public class RealmResultsTests extends CollectionTests {
         assertEquals(10, results.size());
 
         // 1. Delete first object from another thread.
-        realm.executeTransaction(new Realm.Transaction() {
+        realm.executeTransactionAsync(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
-                realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 0).findFirst().removeFromRealm();
+                realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 0).findFirst().deleteFromRealm();
             }
-        }, new Realm.Transaction.Callback() {
+        }, new Realm.Transaction.OnSuccess() {
             @Override
             public void onSuccess() {
                 // 2. RealmResults are refreshed before onSuccess is called
@@ -853,7 +853,7 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void addChangeListener() {
         Realm realm = looperThread.realm;
-        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         collection.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
@@ -872,7 +872,7 @@ public class RealmResultsTests extends CollectionTests {
     public void addChangeListener_twice() {
         final AtomicInteger listenersTriggered = new AtomicInteger(0);
         final Realm realm = looperThread.realm;
-        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         RealmChangeListener<RealmResults<AllTypes>> listener = new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
@@ -923,7 +923,7 @@ public class RealmResultsTests extends CollectionTests {
     public void removeChangeListener() {
         final AtomicInteger listenersTriggered = new AtomicInteger(0);
         final Realm realm = looperThread.realm;
-        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         RealmChangeListener<RealmResults<AllTypes>> listener = new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
@@ -967,7 +967,7 @@ public class RealmResultsTests extends CollectionTests {
     public void removeAllChangeListeners() {
         final AtomicInteger listenersTriggered = new AtomicInteger(0);
         final Realm realm = looperThread.realm;
-        RealmResults<AllTypes> collection = realm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         RealmChangeListener<RealmResults<AllTypes>> listenerA = new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -267,7 +267,7 @@ public class RealmTests {
     @Test
     public void getInstance() {
         assertNotNull("Realm.getInstance unexpectedly returns null", realm);
-        assertTrue("Realm.getInstance does not contain expected table", realm.contains(AllTypes.class));
+        assertTrue("Realm.getInstance does not contain expected table", realm.getSchema().contains(AllTypes.CLASS_NAME));
     }
 
     @Test
@@ -1961,7 +1961,6 @@ public class RealmTests {
         try { realm.copyToRealm(ts);                fail(); } catch (IllegalStateException expected) {}
         try { realm.copyToRealmOrUpdate(t);         fail(); } catch (IllegalStateException expected) {}
         try { realm.copyToRealmOrUpdate(ts);        fail(); } catch (IllegalStateException expected) {}
-        try { realm.remove(AllTypes.class, 0);      fail(); } catch (IllegalStateException expected) {}
         try { realm.delete(AllTypes.class);         fail(); } catch (IllegalStateException expected) {}
         try { realm.deleteAll();                    fail(); } catch (IllegalStateException expected) {}
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -271,63 +271,6 @@ public class RealmTests {
     }
 
     @Test
-    public void getInstance_context() {
-        RealmConfiguration config = new RealmConfiguration.Builder(context).build();
-        Realm.deleteRealm(config);
-
-        Realm testRealm = Realm.getInstance(context);
-        assertNotNull("Realm.getInstance unexpectedly returns null", testRealm);
-        assertTrue("Realm.getInstance does not contain expected table", testRealm.contains(AllTypes.class));
-        config = testRealm.getConfiguration();
-        config.getRealmFolder().equals(context.getFilesDir());
-        testRealm.close();
-        Realm.deleteRealm(config);
-    }
-
-    @Test
-    public void getInstance_nullContext() {
-        Realm realm = null;
-        try {
-            realm = Realm.getInstance((Context) null); // throws when context.getFilesDir() is called;
-            // has nothing to do with Realm
-            fail("Should throw an exception");
-        } catch (IllegalArgumentException ignored) {
-        } finally {
-            if (realm != null) {
-                realm.close();
-            }
-        }
-    }
-
-    // Private API
-    @Test
-    public void remove() {
-        populateTestRealm();
-        realm.beginTransaction();
-        realm.remove(AllTypes.class, 0);
-        realm.commitTransaction();
-
-        RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
-        assertEquals(TEST_DATA_SIZE - 1, resultList.size());
-    }
-
-    // Private API
-    @Test
-    public void get() {
-        populateTestRealm();
-        AllTypes allTypes = realm.get(AllTypes.class, 0);
-        assertNotNull(allTypes);
-        assertEquals("test data 0", allTypes.getColumnString());
-    }
-
-    // Private API
-    @Test
-    public void contains() {
-        assertTrue("contains returns false for table that should exists", realm.contains(Dog.class));
-        assertFalse("contains returns true for non-existing table", realm.contains(null));
-    }
-
-    @Test
     public void where() {
         populateTestRealm();
         RealmResults<AllTypes> resultList = realm.where(AllTypes.class).findAll();
@@ -1221,7 +1164,7 @@ public class RealmTests {
         final long SECONDARY_FIELD_VALUE = 34992142L;
         TestHelper.addStringPrimaryKeyObjectToTestRealm(realm, (String) null, SECONDARY_FIELD_VALUE);
 
-        RealmResults<PrimaryKeyAsString> results = realm.allObjects(PrimaryKeyAsString.class);
+        RealmResults<PrimaryKeyAsString> results = realm.where(PrimaryKeyAsString.class).findAll();
         assertEquals(1, results.size());
         assertEquals(null, results.first().getName());
         assertEquals(SECONDARY_FIELD_VALUE, results.first().getId());
@@ -1238,7 +1181,7 @@ public class RealmTests {
         TestHelper.addLongPrimaryKeyObjectToTestRealm(realm,    (Long) null,    SECONDARY_FIELD_VALUE);
 
         for (Class clazz : CLASSES) {
-            RealmResults results = realm.allObjects(clazz);
+            RealmResults results = realm.where(clazz).findAll();
             assertEquals(1, results.size());
             assertEquals(null, ((NullPrimaryKey)results.first()).getId());
             assertEquals(SECONDARY_FIELD_VALUE, ((NullPrimaryKey)results.first()).getName());
@@ -1365,7 +1308,7 @@ public class RealmTests {
         final long SECONDARY_FIELD_UPDATED = 44887612L;
         PrimaryKeyAsString nullPrimaryKeyObj = TestHelper.addStringPrimaryKeyObjectToTestRealm(realm, (String) null, SECONDARY_FIELD_VALUE);
 
-        RealmResults<PrimaryKeyAsString> result = realm.allObjects(PrimaryKeyAsString.class);
+        RealmResults<PrimaryKeyAsString> result = realm.where(PrimaryKeyAsString.class).findAll();
         assertEquals(1, result.size());
         assertEquals(null, result.first().getName());
         assertEquals(SECONDARY_FIELD_VALUE, result.first().getId());
@@ -1376,7 +1319,7 @@ public class RealmTests {
         realm.copyToRealmOrUpdate(nullPrimaryKeyObj);
         realm.commitTransaction();
 
-        assertEquals(SECONDARY_FIELD_UPDATED, realm.allObjects(PrimaryKeyAsString.class).first().getId());
+        assertEquals(SECONDARY_FIELD_UPDATED, realm.where(PrimaryKeyAsString.class).findFirst().getId());
     }
 
     @Test
@@ -1385,7 +1328,7 @@ public class RealmTests {
         final String SECONDARY_FIELD_UPDATED = "nullBytePrimaryKeyObjUpdated";
         PrimaryKeyAsBoxedByte nullPrimaryKeyObj = TestHelper.addBytePrimaryKeyObjectToTestRealm(realm, (Byte) null, SECONDARY_FIELD_VALUE);
 
-        RealmResults<PrimaryKeyAsBoxedByte> result = realm.allObjects(PrimaryKeyAsBoxedByte.class);
+        RealmResults<PrimaryKeyAsBoxedByte> result = realm.where(PrimaryKeyAsBoxedByte.class).findAll();
         assertEquals(1, result.size());
         assertEquals(SECONDARY_FIELD_VALUE, result.first().getName());
         assertEquals(null, result.first().getId());
@@ -1396,7 +1339,7 @@ public class RealmTests {
         realm.copyToRealmOrUpdate(nullPrimaryKeyObj);
         realm.commitTransaction();
 
-        assertEquals(SECONDARY_FIELD_UPDATED, realm.allObjects(PrimaryKeyAsBoxedByte.class).first().getName());
+        assertEquals(SECONDARY_FIELD_UPDATED, realm.where(PrimaryKeyAsBoxedByte.class).findFirst().getName());
     }
 
     @Test
@@ -1405,7 +1348,7 @@ public class RealmTests {
         final String SECONDARY_FIELD_UPDATED = "nullShortPrimaryKeyObjUpdated";
         PrimaryKeyAsBoxedShort nullPrimaryKeyObj = TestHelper.addShortPrimaryKeyObjectToTestRealm(realm, (Short) null, SECONDARY_FIELD_VALUE);
 
-        RealmResults<PrimaryKeyAsBoxedShort> result = realm.allObjects(PrimaryKeyAsBoxedShort.class);
+        RealmResults<PrimaryKeyAsBoxedShort> result = realm.where(PrimaryKeyAsBoxedShort.class).findAll();
         assertEquals(1, result.size());
         assertEquals(SECONDARY_FIELD_VALUE, result.first().getName());
         assertEquals(null, result.first().getId());
@@ -1416,7 +1359,7 @@ public class RealmTests {
         realm.copyToRealmOrUpdate(nullPrimaryKeyObj);
         realm.commitTransaction();
 
-        assertEquals(SECONDARY_FIELD_UPDATED, realm.allObjects(PrimaryKeyAsBoxedShort.class).first().getName());
+        assertEquals(SECONDARY_FIELD_UPDATED, realm.where(PrimaryKeyAsBoxedShort.class).findFirst().getName());
     }
 
     @Test
@@ -1425,7 +1368,7 @@ public class RealmTests {
         final String SECONDARY_FIELD_UPDATED = "nullIntegerPrimaryKeyObjUpdated";
         PrimaryKeyAsBoxedInteger nullPrimaryKeyObj = TestHelper.addIntegerPrimaryKeyObjectToTestRealm(realm, (Integer) null, SECONDARY_FIELD_VALUE);
 
-        RealmResults<PrimaryKeyAsBoxedInteger> result = realm.allObjects(PrimaryKeyAsBoxedInteger.class);
+        RealmResults<PrimaryKeyAsBoxedInteger> result = realm.where(PrimaryKeyAsBoxedInteger.class).findAll();
         assertEquals(1, result.size());
         assertEquals(SECONDARY_FIELD_VALUE, result.first().getName());
         assertEquals(null, result.first().getId());
@@ -1436,7 +1379,7 @@ public class RealmTests {
         realm.copyToRealmOrUpdate(nullPrimaryKeyObj);
         realm.commitTransaction();
 
-        assertEquals(SECONDARY_FIELD_UPDATED, realm.allObjects(PrimaryKeyAsBoxedInteger.class).first().getName());
+        assertEquals(SECONDARY_FIELD_UPDATED, realm.where(PrimaryKeyAsBoxedInteger.class).findFirst().getName());
     }
 
     @Test
@@ -1445,7 +1388,7 @@ public class RealmTests {
         final String SECONDARY_FIELD_UPDATED = "nullLongPrimaryKeyObjUpdated";
         PrimaryKeyAsBoxedLong nullPrimaryKeyObj = TestHelper.addLongPrimaryKeyObjectToTestRealm(realm, (Long) null, SECONDARY_FIELD_VALUE);
 
-        RealmResults<PrimaryKeyAsBoxedLong> result = realm.allObjects(PrimaryKeyAsBoxedLong.class);
+        RealmResults<PrimaryKeyAsBoxedLong> result = realm.where(PrimaryKeyAsBoxedLong.class).findAll();
         assertEquals(1, result.size());
         assertEquals(SECONDARY_FIELD_VALUE, result.first().getName());
         assertEquals(null, result.first().getId());
@@ -1456,7 +1399,7 @@ public class RealmTests {
         realm.copyToRealmOrUpdate(nullPrimaryKeyObj);
         realm.commitTransaction();
 
-        assertEquals(SECONDARY_FIELD_UPDATED, realm.allObjects(PrimaryKeyAsBoxedLong.class).first().getName());
+        assertEquals(SECONDARY_FIELD_UPDATED, realm.where(PrimaryKeyAsBoxedLong.class).findFirst().getName());
     }
 
     @Test
@@ -2384,85 +2327,6 @@ public class RealmTests {
         }
     }
 
-    // This test assures that calling refresh will not trigger local listeners until after the Looper receives a
-    // REALM_CHANGE message
-    @Test
-    public void processRefreshLocalListenersAfterLooperQueueStart() throws Throwable {
-        // Used to validate the result
-        final AtomicBoolean listenerWasCalled = new AtomicBoolean(false);
-        final AtomicBoolean typeListenerWasCalled = new AtomicBoolean(false);
-
-        // Used by the background thread to wait for the main thread to do the write operation
-        final CountDownLatch bgThreadLatch = new CountDownLatch(1);
-        final CountDownLatch bgClosedLatch = new CountDownLatch(2);
-        final CountDownLatch bgThreadReadyLatch = new CountDownLatch(1);
-        final CountDownLatch signalClosedRealm = new CountDownLatch(1);
-
-        final Looper[] looper = new Looper[1];
-        final Throwable[] throwable = new Throwable[1];
-
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                // this will allow to register a listener.
-                // we don't start looping to prevent the callback to be invoked via
-                // the handler mechanism, the purpose of this test is to make sure refresh calls
-                // the listeners.
-                Looper.prepare();
-                looper[0] = Looper.myLooper();
-
-                Realm bgRealm = Realm.getInstance(realmConfig);
-                RealmResults<Dog> dogs = bgRealm.where(Dog.class).findAll();
-                try {
-                    bgRealm.addChangeListener(new RealmChangeListener<Realm>() {
-                        @Override
-                        public void onChange(Realm object) {
-                            listenerWasCalled.set(true);
-                            bgClosedLatch.countDown();
-                        }
-                    });
-                    dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
-                        @Override
-                        public void onChange(RealmResults<Dog> object) {
-                            typeListenerWasCalled.set(true);
-                            bgClosedLatch.countDown();
-                        }
-                    });
-
-                    bgThreadReadyLatch.countDown();
-                    bgThreadLatch.await(); // Wait for the main thread to do a write operation
-                    bgRealm.refresh(); // This should call the listener
-                    assertFalse(listenerWasCalled.get());
-                    assertFalse(typeListenerWasCalled.get());
-
-                    Looper.loop();
-
-                } catch (Throwable e) {
-                    throwable[0] = e;
-
-                } finally {
-                    bgRealm.close();
-                    signalClosedRealm.countDown();
-                }
-            }
-        });
-
-        // Wait until bgThread finishes adding listener to the RealmResults. Otherwise same TableView version won't
-        // trigger the listener.
-        bgThreadReadyLatch.await();
-        realm.beginTransaction();
-        realm.createObject(Dog.class);
-        realm.commitTransaction();
-        bgThreadLatch.countDown();
-        bgClosedLatch.await();
-
-        TestHelper.exitOrThrow(executorService, bgClosedLatch, signalClosedRealm, looper, throwable);
-
-        assertTrue(listenerWasCalled.get());
-        assertTrue(typeListenerWasCalled.get());
-    }
-
     @Test
     public void isInTransaction() {
         assertFalse(realm.isInTransaction());
@@ -2581,13 +2445,6 @@ public class RealmTests {
         if (!exception.isEmpty()) {
             throw exception.get(0);
         }
-    }
-
-    @Test
-    public void refresh_insideTransactionThrows() {
-        realm.beginTransaction();
-        thrown.expect(IllegalStateException.class);
-        realm.refresh();
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
@@ -187,7 +187,7 @@ public class RxJavaTests {
     @UiThreadTest
     public void realmResults_emittedOnSubscribe() {
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
-        final RealmResults<AllTypes> results = realm.allObjects(AllTypes.class);
+        final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
         subscription = results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
             @Override
             public void call(RealmResults<AllTypes> rxResults) {
@@ -204,7 +204,7 @@ public class RxJavaTests {
     public void dynamicRealmResults_emittedOnSubscribe() {
         final DynamicRealm dynamicRealm = DynamicRealm.createInstance(realm.getConfiguration());
         final AtomicBoolean subscribedNotified = new AtomicBoolean(false);
-        final RealmResults<DynamicRealmObject> results = dynamicRealm.allObjects(AllTypes.CLASS_NAME);
+        final RealmResults<DynamicRealmObject> results = dynamicRealm.where(AllTypes.CLASS_NAME).findAll();
         results.asObservable().subscribe(new Action1<RealmResults<DynamicRealmObject>>() {
             @Override
             public void call(RealmResults<DynamicRealmObject> rxResults) {
@@ -222,7 +222,7 @@ public class RxJavaTests {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
         Realm realm = looperThread.realm;
         realm.beginTransaction();
-        RealmResults<AllTypes> results = realm.allObjects(AllTypes.class);
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
         realm.commitTransaction();
 
         subscription = results.asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
@@ -245,7 +245,7 @@ public class RxJavaTests {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
         final DynamicRealm dynamicRealm = DynamicRealm.createInstance(looperThread.realmConfiguration);
         dynamicRealm.beginTransaction();
-        RealmResults<DynamicRealmObject> results = dynamicRealm.allObjects(AllTypes.CLASS_NAME);
+        RealmResults<DynamicRealmObject> results = dynamicRealm.where(AllTypes.CLASS_NAME).findAll();
         dynamicRealm.commitTransaction();
 
         results.asObservable().subscribe(new Action1<RealmResults<DynamicRealmObject>>() {
@@ -491,7 +491,7 @@ public class RxJavaTests {
     @Test
     @UiThreadTest
     public void realmResults_closeInDoOnUnsubscribe() {
-        Observable<RealmResults<AllTypes>> observable = realm.allObjects(AllTypes.class).asObservable()
+        Observable<RealmResults<AllTypes>> observable = realm.where(AllTypes.class).findAll().asObservable()
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
@@ -514,7 +514,7 @@ public class RxJavaTests {
     public void dynamicRealmResults_closeInDoOnUnsubscribe() {
         final DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
 
-        Observable<RealmResults<DynamicRealmObject>> observable = dynamicRealm.allObjects(AllTypes.CLASS_NAME).asObservable()
+        Observable<RealmResults<DynamicRealmObject>> observable = dynamicRealm.where(AllTypes.CLASS_NAME).findAll().asObservable()
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
@@ -539,7 +539,7 @@ public class RxJavaTests {
         realm.createObject(AllTypes.class);
         realm.commitTransaction();
 
-        Observable<AllTypes> observable = realm.allObjects(AllTypes.class).first().<AllTypes>asObservable()
+        Observable<AllTypes> observable = realm.where(AllTypes.class).findFirst().<AllTypes>asObservable()
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
@@ -565,7 +565,7 @@ public class RxJavaTests {
         realm.commitTransaction();
         final DynamicRealm dynamicRealm = DynamicRealm.getInstance(realm.getConfiguration());
 
-        Observable<DynamicRealmObject> observable = dynamicRealm.allObjects(AllTypes.CLASS_NAME).first().<DynamicRealmObject>asObservable()
+        Observable<DynamicRealmObject> observable = dynamicRealm.where(AllTypes.CLASS_NAME).findFirst().<DynamicRealmObject>asObservable()
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -797,7 +797,7 @@ public class TestHelper {
         DynamicRealm dynamicRealm = DynamicRealm.getInstance(typedRealm.getConfiguration());
         populateForMultiSort(dynamicRealm);
         dynamicRealm.close();
-        typedRealm.refresh();
+        typedRealm.waitForChange();
     }
 
     public static void populateForMultiSort(DynamicRealm realm) {

--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
@@ -226,7 +226,7 @@ public class TypeBasedNotificationsTests {
             public void onChange(PrimaryKeyAsLong object) {
                 assertEquals(1, primaryKeyAsLong.getId());
                 assertEquals("Bar", primaryKeyAsLong.getName());
-                assertEquals(1, realm.allObjects(PrimaryKeyAsLong.class).size());
+                assertEquals(1, realm.where(PrimaryKeyAsLong.class).count());
                 typebasedCommitInvocations.incrementAndGet();
             }
         });
@@ -448,7 +448,7 @@ public class TypeBasedNotificationsTests {
         newObj.addChangeListener(new RealmChangeListener<AllTypesPrimaryKey>() {
             @Override
             public void onChange(AllTypesPrimaryKey object) {
-                assertEquals(1, realm.allObjects(AllTypesPrimaryKey.class).size());
+                assertEquals(1, realm.where(AllTypesPrimaryKey.class).count());
                 assertEquals("bar", newObj.getColumnString());
                 assertTrue(newObj.getColumnBoxedBoolean());
                 typebasedCommitInvocations.incrementAndGet();
@@ -1405,12 +1405,12 @@ public class TypeBasedNotificationsTests {
 
         final Realm realm = looperThread.realm;
         // Two results needed to make sure list modification happen while iterating
-        RealmResults<Owner> results1 = realm.allObjects(Owner.class);
-        RealmResults<Cat> results2 = realm.allObjects(Cat.class);
+        RealmResults<Owner> results1 = realm.where(Owner.class).findAll();
+        RealmResults<Cat> results2 = realm.where(Cat.class).findAll();
         RealmChangeListener listener = new RealmChangeListener() {
             @Override
             public void onChange(Object object) {
-                RealmResults<Owner> results = realm.allObjects(Owner.class);
+                RealmResults<Owner> results = realm.where(Owner.class).findAll();
                 boolean foundKey = false;
                 // Check if the results has been added to the syncRealmResults in case of the behaviour of
                 // allObjects changes

--- a/realm/realm-library/src/androidTest/java/io/realm/services/RemoteProcessService.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/services/RemoteProcessService.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.realm.Realm;
+import io.realm.RealmConfiguration;
 import io.realm.entities.AllTypes;
 
 /**
@@ -120,9 +121,9 @@ public class RemoteProcessService extends Service {
 
         @Override
         void run() {
-            thiz.testRealm = Realm.getInstance(thiz);
+            thiz.testRealm = Realm.getInstance(new RealmConfiguration.Builder(thiz).build());
             int expected = 1;
-            int got = thiz.testRealm.allObjects(AllTypes.class).size();
+            long got = thiz.testRealm.where(AllTypes.class).count();
             if (expected == got) {
                 response(null);
             } else {
@@ -136,7 +137,7 @@ public class RemoteProcessService extends Service {
 
         @Override
         void run() {
-            thiz.testRealm = Realm.getInstance(thiz);
+            thiz.testRealm = Realm.getInstance(new RealmConfiguration.Builder(thiz).build());
             thiz.testRealm.close();
             response(null);
             Runtime.getRuntime().exit(0);

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -19,6 +19,8 @@ package io.realm;
 import android.os.Handler;
 import android.os.Looper;
 
+import com.getkeepsafe.relinker.BuildConfig;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -236,30 +238,6 @@ abstract class BaseRealm implements Closeable {
         }
         checkIfValid();
         sharedGroupManager.copyToFile(destination, key);
-    }
-
-    /**
-     * Refreshes the Realm instance and all the RealmResults and RealmObjects instances coming from it.
-     * It also calls the listeners associated to the Realm instance.
-     *
-     * @throws IllegalStateException if attempting to refresh from within a transaction.
-     * @deprecated Please use {@link #waitForChange()} instead.
-     */
-    @SuppressWarnings("UnusedDeclaration")
-    @Deprecated
-    public void refresh() {
-        checkIfValid();
-        if (isInTransaction()) {
-            throw new IllegalStateException(BaseRealm.CANNOT_REFRESH_INSIDE_OF_TRANSACTION_MESSAGE);
-        }
-        if (!handlerController.isAutoRefreshEnabled()) {
-            // non Looper Thread, just advance the Realm
-            // registering listeners is not allowed, hence nothing to notify
-            sharedGroupManager.advanceRead();
-            handlerController.refreshSynchronousTableViews();
-        } else {
-            handlerController.notifyCurrentThreadRealmChanged();
-        }
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -119,13 +119,12 @@ public final class DynamicRealm extends BaseRealm {
     /**
      * Adds a change listener to the Realm.
      * <p>
-     * The listeners will be executed on every loop of a Handler thread if
-     * changes why committed by this or another thread.
+     * The listeners will be executed on every loop of a Handler thread if changes are committed by
+     * this or another thread.
      *
-     * Realm instances are cached, so for that reason it is important to
+     * Realm instances are cached pr. thread, so for that reason it is important to
      * remember to remove listeners again either using {@link #removeChangeListener(RealmChangeListener)}
-     * or {@link #removeAllChangeListeners()}. Not doing so can cause
-     * memory leaks.
+     * or {@link #removeAllChangeListeners()}. Not doing so can cause memory leaks.
      *
      * @param listener the change listener.
      * @throws IllegalStateException if you try to register a listener from a non-Looper Thread.

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -21,7 +21,6 @@ import android.os.Looper;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmIOException;
 import io.realm.internal.Table;
-import io.realm.internal.TableView;
 import io.realm.internal.log.RealmLog;
 import rx.Observable;
 
@@ -120,15 +119,13 @@ public final class DynamicRealm extends BaseRealm {
     /**
      * Adds a change listener to the Realm.
      * <p>
-     * The listeners will be executed:
-     * <ul>
-     * <li>Immediately if a change was committed by the local thread</li>
-     * <li>On every loop of a Handler thread if changes were committed by another thread</li>
-     * <li>On every call to {@link io.realm.Realm#refresh()}</li>
-     * </ul>
+     * The listeners will be executed on every loop of a Handler thread if
+     * changes why committed by this or another thread.
      *
-     * Listeners are stored as a strong reference, you need to remove the added listeners using {@link #removeChangeListener(RealmChangeListener)}
-     * or {@link #removeAllChangeListeners()} which removes all listeners including the ones added via anonymous classes.
+     * Realm instances are cached, so for that reason it is important to
+     * remember to remove listeners again either using {@link #removeChangeListener(RealmChangeListener)}
+     * or {@link #removeAllChangeListeners()}. Not doing so can cause
+     * memory leaks.
      *
      * @param listener the change listener.
      * @throws IllegalStateException if you try to register a listener from a non-Looper Thread.
@@ -138,18 +135,6 @@ public final class DynamicRealm extends BaseRealm {
      */
     public void addChangeListener(RealmChangeListener<DynamicRealm> listener) {
         super.addListener(listener);
-    }
-
-    /**
-     * Removes all objects of the specified class.
-     *
-     * DEPRECATED: Use {@link #delete(String)} instead.
-     *
-     * @param className the class for which all objects should be removed.
-     */
-    @Deprecated
-    public void clear(String className) {
-        delete(className);
     }
 
     /**
@@ -190,55 +175,6 @@ public final class DynamicRealm extends BaseRealm {
     }
 
     /**
-     * DEPRECATED: Use {@code dynamicRealm.where(className).findAll()} instead.
-     */
-    @Deprecated
-    public RealmResults<DynamicRealmObject> allObjects(String className) {
-        return where(className).findAll();
-    }
-
-    /**
-     * DEPRECATED: Use {@code dynamicRealm.where(className).findAll(fieldName, sortOrder)} instead.
-     */
-    @Deprecated
-    public RealmResults<DynamicRealmObject> allObjectsSorted(String className, String fieldName, Sort sortOrder) {
-        checkIfValid();
-        Table table = schema.getTable(className);
-        long columnIndex = table.getColumnIndex(fieldName);
-        if (columnIndex < 0) {
-            throw new IllegalArgumentException(String.format("Field name '%s' does not exist.", fieldName));
-        }
-
-        TableView tableView = table.getSortedView(columnIndex, sortOrder);
-        return RealmResults.createFromDynamicTableOrView(this, tableView, className);
-    }
-
-
-    /**
-     * DEPRECATED: Use {@code dynamicRealm.where(className).findAll(fieldName1, sortOrder1, fieldName2, sortOrder2)} instead.
-     */
-    @Deprecated
-    public RealmResults<DynamicRealmObject> allObjectsSorted(String className, String fieldName1,
-                                                                    Sort sortOrder1, String fieldName2,
-                                                                    Sort sortOrder2) {
-        return allObjectsSorted(className, new String[]{fieldName1, fieldName2}, new Sort[]{sortOrder1,
-                sortOrder2});
-    }
-
-    /**
-     * DEPRECATED: Use {@code dynamicRealm.where(className).findAll(fieldNames[], sortOrders[])} instead.
-     */
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public RealmResults<DynamicRealmObject> allObjectsSorted(String className, String fieldNames[], Sort sortOrders[]) {
-        checkAllObjectsSortedParameters(fieldNames, sortOrders);
-        Table table = schema.getTable(className);
-
-        TableView tableView = doMultiFieldSort(fieldNames, sortOrders, table);
-        return RealmResults.createFromDynamicTableOrView(this, tableView, className);
-    }
-
-    /**
      * Creates a {@link DynamicRealm} instance without checking the existence in the {@link RealmCache}.
      *
      * @return a {@link DynamicRealm} instance.
@@ -246,36 +182,6 @@ public final class DynamicRealm extends BaseRealm {
     static DynamicRealm createInstance(RealmConfiguration configuration) {
         boolean autoRefresh = Looper.myLooper() != null;
         return new DynamicRealm(configuration, autoRefresh);
-    }
-
-    /**
-     * DEPRECATED: Use {@code dynamicRealm.where(className).distinct(fieldName)} instead.
-     */
-    @Deprecated
-    public RealmResults<DynamicRealmObject> distinct(String className, String fieldName) {
-        checkIfValid();
-        Table table = schema.getTable(className);
-        long columnIndex = RealmQuery.getAndValidateDistinctColumnIndex(fieldName, table);
-        TableView tableView = table.getDistinctView(columnIndex);
-        return RealmResults.createFromDynamicTableOrView(this, tableView, className);
-    }
-
-    /**
-     * DEPRECATED: Use {@code dynamicRealm.where(className).distinctAsync(fieldName)} instead.
-     */
-    @Deprecated
-    public RealmResults<DynamicRealmObject> distinctAsync(String className, String fieldName) {
-        checkIfValid();
-        return where(className).distinctAsync(fieldName);
-    }
-
-    /**
-     * DEPRECATED: Use {@code dynamicRealm.where(className).distinct(firstFieldName, remainingFieldNames)} instead.
-     */
-    @Deprecated
-    public RealmResults<DynamicRealmObject> distinct(String className, String firstFieldName, String... remainingFieldNames) {
-        checkIfValid();
-        return where(className).distinct(firstFieldName, remainingFieldNames);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -158,27 +158,6 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Realm static constructor for the default Realm file {@value io.realm.RealmConfiguration#DEFAULT_REALM_NAME}.
-     * This is equivalent to calling {@code Realm.getInstance(new RealmConfiguration(getContext()).build())}.
-     *
-     * This constructor is only provided for convenience. It is recommended to use
-     * {@link #getInstance(RealmConfiguration)} or {@link #getDefaultInstance()}.
-     *
-     * @param context a non-null Android {@link android.content.Context}
-     * @return an instance of the Realm class.
-     * @throws java.lang.IllegalArgumentException if no {@link Context} is provided.
-     * @throws RealmMigrationNeededException if the RealmObject classes no longer match the underlying Realm and it must
-     *         be migrated.
-     * @throws RealmIOException if an error happened when accessing the underlying Realm file.
-     * @deprecated use {@link #getDefaultInstance()} or {@link #getInstance(RealmConfiguration)} instead.
-     */
-    public static Realm getInstance(Context context) {
-        return Realm.getInstance(new RealmConfiguration.Builder(context)
-                .name(DEFAULT_REALM_NAME)
-                .build());
-    }
-
-    /**
      * Realm static constructor that returns the Realm instance defined by the {@link io.realm.RealmConfiguration} set
      * by {@link #setDefaultConfiguration(RealmConfiguration)}
      *

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -74,7 +74,7 @@ import rx.Observable;
  *  onStart/onStop.
  * <p>
  * Realm instances coordinate their state across threads using the {@link android.os.Handler} mechanism. This also means
- * that Realm instances on threads without a {@link android.os.Looper} cannot receive updates unless {@link #refresh()}
+ * that Realm instances on threads without a {@link android.os.Looper} cannot receive updates unless {@link #waitForChange()}
  * is manually called.
  * <p>
  * A standard pattern for working with Realm in Android activities can be seen below:
@@ -956,15 +956,12 @@ public final class Realm extends BaseRealm {
     /**
      * Adds a change listener to the Realm.
      * <p>
-     * The listeners will be executed:
-     * <ul>
-     * <li>Immediately if a change was committed by the local thread</li>
-     * <li>On every loop of a Handler thread if changes were committed by another thread</li>
-     * <li>On every call to {@link io.realm.Realm#refresh()}</li>
-     * </ul>
+     * The listeners will be executed on every loop of a Handler thread if
+     * the current thread or other threads committed changes to the Realm.
      *
-     * Listeners are stored as a strong reference, you need to remove the added listeners using {@link #removeChangeListener(RealmChangeListener)}
-     * or {@link #removeAllChangeListeners()} which removes all listeners including the ones added via anonymous classes.
+     * Realm instances are thread singletons and cached, so listeners should be
+     * removed manually even if calling {@link #close()}, otherwise there is a
+     * risk of memory leaks.
      *
      * @param listener the change listener.
      * @throws IllegalStateException if you try to register a listener from a non-Looper Thread.
@@ -974,100 +971,6 @@ public final class Realm extends BaseRealm {
      */
     public void addChangeListener(RealmChangeListener<Realm> listener) {
         super.addListener(listener);
-    }
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).findAll()} instead.
-     */
-    @Deprecated
-    public <E extends RealmModel> RealmResults<E> allObjects(Class<E> clazz) {
-        return where(clazz).findAll();
-    }
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).findAllSorted(fieldName, sortOrder)} instead.
-     */
-    @Deprecated
-    public <E extends RealmModel> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldName,
-                                                                    Sort sortOrder) {
-        checkIfValid();
-        Table table = getTable(clazz);
-        long columnIndex = schema.columnIndices.getColumnIndex(clazz, fieldName);
-        if (columnIndex < 0) {
-            throw new IllegalArgumentException(String.format("Field name '%s' does not exist.", fieldName));
-        }
-
-        TableView tableView = table.getSortedView(columnIndex, sortOrder);
-        return RealmResults.createFromTableOrView(this, tableView, clazz);
-    }
-
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).findAllSorted(fieldName1, sortOrder1, fieldName2, sortOrder2)} instead.
-     */
-    @Deprecated
-    public <E extends RealmModel> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldName1,
-                                                                    Sort sortOrder1, String fieldName2,
-                                                                    Sort sortOrder2) {
-        return allObjectsSorted(clazz, new String[]{fieldName1, fieldName2}, new Sort[]{sortOrder1,
-                sortOrder2});
-    }
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).findAllSorted(fieldName1, sortOrder1, fieldName2, sortOrder2, fieldName3, sortOrder3)}
-     * instead.
-     */
-    @Deprecated
-    public <E extends RealmModel> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldName1,
-                                                                    Sort sortOrder1,
-                                                                    String fieldName2, Sort sortOrder2,
-                                                                    String fieldName3, Sort sortOrder3) {
-        return allObjectsSorted(clazz, new String[]{fieldName1, fieldName2, fieldName3},
-                new Sort[]{sortOrder1, sortOrder2, sortOrder3});
-    }
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).findAllSorted(fieldNames[], sortOrders[])} instead.
-     */
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public <E extends RealmModel> RealmResults<E> allObjectsSorted(Class<E> clazz, String fieldNames[],
-                                                                    Sort sortOrders[]) {
-        checkAllObjectsSortedParameters(fieldNames, sortOrders);
-        Table table = this.getTable(clazz);
-
-        TableView tableView = doMultiFieldSort(fieldNames, sortOrders, table);
-        return RealmResults.createFromTableOrView(this, tableView, clazz);
-    }
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).distinct(fieldName)} instead.
-     */
-    @Deprecated
-    public <E extends RealmModel> RealmResults<E> distinct(Class<E> clazz, String fieldName) {
-        checkIfValid();
-        Table table = schema.getTable(clazz);
-        long columnIndex = RealmQuery.getAndValidateDistinctColumnIndex(fieldName, table);
-        TableView tableView = table.getDistinctView(columnIndex);
-        return RealmResults.createFromTableOrView(this, tableView, clazz);
-    }
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).distinctAsync(fieldName)} instead.
-     */
-    @Deprecated
-    public <E extends RealmModel> RealmResults<E> distinctAsync(Class<E> clazz, String fieldName) {
-        checkIfValid();
-        return where(clazz).distinctAsync(fieldName);
-    }
-
-    /**
-     * DEPRECATED: Use {@code realm.where(clazz).distinct(firstFieldName, remainingFieldNames)} instead.
-     */
-    @Deprecated
-    public <E extends RealmObject> RealmResults<E> distinct(Class<E> clazz, String firstFieldName, String... remainingFieldNames) {
-        checkIfValid();
-        return where(clazz).distinct(firstFieldName, remainingFieldNames);
     }
 
     /**
@@ -1095,104 +998,6 @@ public final class Realm extends BaseRealm {
             }
             throw e;
         }
-    }
-
-    /**
-     * Similar to {@link #executeTransaction(Transaction)} but runs asynchronously on a worker thread.
-     *
-     * @param transaction {@link io.realm.Realm.Transaction} to execute.
-     * @param callback optional, to receive the result of this query.
-     * @return a {@link RealmAsyncTask} representing a cancellable task.
-     * @throws IllegalArgumentException if the {@code transaction} is {@code null}, or if the realm is opened from
-     *         another thread.
-     * @deprecated replaced by {@link #executeTransactionAsync(Transaction)},
-     * {@link #executeTransactionAsync(Transaction, Transaction.OnSuccess)},
-     * {@link #executeTransactionAsync(Transaction, io.realm.Realm.Transaction.OnError)} and
-     * {@link #executeTransactionAsync(Transaction, Transaction.OnSuccess, Transaction.OnError)}.
-     */
-    @Deprecated
-    public RealmAsyncTask executeTransaction(final Transaction transaction, final Transaction.Callback callback) {
-        checkIfValid();
-        if (transaction == null) {
-            throw new IllegalArgumentException("Transaction should not be null");
-        }
-
-        // If the user provided a Callback then we make sure, the current Realm has a Handler
-        // we can use to deliver the result
-        if (callback != null && handler == null) {
-            throw new IllegalStateException("Your Realm is opened from a thread without a Looper" +
-                    " and you provided a callback, we need a Handler to invoke your callback");
-        }
-
-        // We need to use the same configuration to open a background SharedGroup (i.e Realm)
-        // to perform the transaction
-        final RealmConfiguration realmConfiguration = getConfiguration();
-
-        final Future<?> pendingTransaction = asyncTaskExecutor.submit(new Runnable() {
-            @Override
-            public void run() {
-                if (Thread.currentThread().isInterrupted()) {
-                    return;
-                }
-
-                boolean transactionCommitted = false;
-                final Exception[] exception = new Exception[1];
-                final Realm bgRealm = Realm.getInstance(realmConfiguration);
-                bgRealm.beginTransaction();
-                try {
-                    transaction.execute(bgRealm);
-
-                    if (!Thread.currentThread().isInterrupted()) {
-                        bgRealm.commitTransaction(false, new Runnable() {
-                            @Override
-                            public void run() {
-                                // The bgRealm needs to be closed before post event to caller's handler to avoid
-                                // concurrency problem. eg.: User wants to delete Realm in the callbacks.
-                                // This will close Realm before sending REALM_CHANGED.
-                                bgRealm.close();
-                            }
-                        });
-                        transactionCommitted = true;
-                    }
-                } catch (final Exception e) {
-                    exception[0] = e;
-                } finally {
-                    if (!bgRealm.isClosed()) {
-                        if (bgRealm.isInTransaction()) {
-                            bgRealm.cancelTransaction();
-                        } else if (exception[0] != null) {
-                            RealmLog.w("Could not cancel transaction, not currently in a transaction.");
-                        }
-                        bgRealm.close();
-                    }
-
-                    // Send response as the final step to ensure the bg thread quit before others get the response!
-                    if (callback != null
-                            && handler != null
-                            && !Thread.currentThread().isInterrupted()
-                            && handler.getLooper().getThread().isAlive()) {
-                        if (transactionCommitted) {
-                            handler.post(new Runnable() {
-                                @Override
-                                public void run() {
-                                    callback.onSuccess();
-                                }
-                            });
-                        } else if (exception[0] != null) {
-                            // transaction has not been canceled by there is a exception during transaction.
-                            handler.post(new Runnable() {
-                                @Override
-                                public void run() {
-                                    callback.onError(exception[0]);
-                                }
-                            });
-                        }
-                    }
-                }
-            }
-        });
-
-        return new RealmAsyncTask(pendingTransaction);
     }
 
     /**
@@ -1364,20 +1169,6 @@ public final class Realm extends BaseRealm {
         });
 
         return new RealmAsyncTask(pendingTransaction);
-    }
-
-
-    /**
-     * Removes all objects of the specified class.
-     *
-     * DEPRECATED: Use {@link #delete(Class)} instead.
-     *
-     * @param clazz the class which objects should be removed.
-     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
-     */
-    @Deprecated
-    public void clear(Class<? extends RealmModel> clazz) {
-        delete(clazz);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -930,8 +930,8 @@ public final class Realm extends BaseRealm {
      * The listeners will be executed on every loop of a Handler thread if
      * the current thread or other threads committed changes to the Realm.
      *
-     * Realm instances are thread singletons and cached, so listeners should be
-     * removed manually even if calling {@link #close()}, otherwise there is a
+     * Realm instances are per-thread singletons and cached, so listeners should be
+     * removed manually even if calling {@link #close()}. Otherwise there is a
      * risk of memory leaks.
      *
      * @param listener the change listener.
@@ -977,7 +977,7 @@ public final class Realm extends BaseRealm {
      *
      * @param transaction {@link io.realm.Realm.Transaction} to execute.
      * @return a {@link RealmAsyncTask} representing a cancellable task.
-     * @throws IllegalArgumentException if the {@code transaction} is {@code null}, or if the realm is opened from
+     * @throws IllegalArgumentException if the {@code transaction} is {@code null}, or if the Realm is opened from
      *                                  another thread.
      */
     public RealmAsyncTask executeTransactionAsync(final Transaction transaction) {

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -716,10 +716,6 @@ public final class Realm extends BaseRealm {
         return get(clazz, rowIndex);
     }
 
-    void remove(Class<? extends RealmModel> clazz, long objectIndex) {
-        getTable(clazz).moveLastOver(objectIndex);
-    }
-
     /**
      * Copies a RealmObject to the Realm instance and returns the copy. Any further changes to the original RealmObject
      * will not be reflected in the Realm copy. This is a deep copy, so all referenced objects will be copied. Objects
@@ -914,10 +910,6 @@ public final class Realm extends BaseRealm {
         checkMaxDepth(maxDepth);
         checkValidObjectForDetach(realmObject);
         return createDetachedCopy(realmObject, maxDepth, new HashMap<RealmModel, RealmObjectProxy.CacheData<RealmModel>>());
-    }
-
-    boolean contains(Class<? extends RealmModel> clazz) {
-        return configuration.getSchemaMediator().getModelClasses().contains(clazz);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
@@ -24,9 +24,8 @@ package io.realm;
  * Register against a {@code RealmResults} or {@code RealmObject} to only get notified about changes to them.
  *
  * <p>
- * Realm instances on a thread without an {@link android.os.Looper} (almost all background threads) don't get updated
- * automatically, but have to call {@link Realm#refresh()} manually. This will in turn trigger the RealmChangeListener
- * for that background thread.
+ * Realm instances on a thread without an {@link android.os.Looper} cannot register a RealmChangeListener.
+ *
  * <p>
  * All {@link io.realm.RealmObject} and {@link io.realm.RealmResults} will automatically contain their new values when
  * the {@link #onChange(Object)} method is called. Normally this means that it isn't necessary to query again for those

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -458,15 +458,6 @@ public final class RealmConfiguration {
         }
 
         /**
-         * DEPRECATED: Use {@link #modules(Object, Object...)} instead.
-         */
-        @Deprecated
-        public Builder setModules(Object baseModule, Object... additionalModules) {
-            modules(baseModule, additionalModules);
-            return this;
-        }
-
-        /**
          * Replaces the existing module(s) with one or more {@link RealmModule}s. Using this method will replace the
          * current schema for this Realm with the schema defined by the provided modules.
          *

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -65,20 +65,6 @@ import rx.Observable;
 
 @RealmClass
 public abstract class RealmObject implements RealmModel {
-    /**
-     * DEPRECATED: Use {@link #deleteFromRealm()} instead.
-     *
-     * Removes the object from the Realm it is currently associated to.
-     * <p>
-     * After this method is called the object will be invalid and any operation (read or write) performed on it will
-     * fail with an IllegalStateException
-     *
-     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
-     */
-    @Deprecated
-    public final void removeFromRealm() {
-        deleteFromRealm();
-    }
 
     /**
      * Deletes the object from the Realm it is currently associated to.

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1283,8 +1283,9 @@ public final class RealmQuery<E extends RealmModel> {
      * Calculates the sum of a given field.
      *
      * @param fieldName the field to sum. Only number fields are supported.
-     * @return the sum if no objects exist or they all have {@code null} as the value for the given field, {@code 0}
-     * will be returned. When computing the sum, objects with {@code null} values are ignored.
+     * @return the sum of fields of the matching objects. If no objects exist or they all have {@code null} as the value
+     *         for the given field, {@code 0} will be returned. When computing the sum. Objects with {@code null} values
+     *         are ignored.
      * @throws java.lang.IllegalArgumentException if the field is not a number type.
      */
     public Number sum(String fieldName) {
@@ -1841,28 +1842,6 @@ public final class RealmQuery<E extends RealmModel> {
     public RealmResults<E> findAllSortedAsync(String fieldName1, Sort sortOrder1,
                                               String fieldName2, Sort sortOrder2) {
         return findAllSortedAsync(new String[]{fieldName1, fieldName2}, new Sort[]{sortOrder1, sortOrder2});
-    }
-
-    /**
-     * DEPRECATED: Use {@link #findAllSorted(String[], Sort[])}  instead.
-     */
-    @Deprecated
-    public RealmResults<E> findAllSorted(String fieldName1, Sort sortOrder1,
-                                   String fieldName2, Sort sortOrder2,
-                                   String fieldName3, Sort sortOrder3) {
-        return findAllSorted(new String[]{fieldName1, fieldName2, fieldName3},
-                new Sort[]{sortOrder1, sortOrder2, sortOrder3});
-    }
-
-    /**
-     * DEPRECATED: Use {@link #findAllSortedAsync(String[], Sort[])}  instead.
-     */
-    @Deprecated
-    public RealmResults<E> findAllSortedAsync(String fieldName1, Sort sortOrder1,
-                                              String fieldName2, Sort sortOrder2,
-                                              String fieldName3, Sort sortOrder3) {
-        return findAllSortedAsync(new String[]{fieldName1, fieldName2, fieldName3},
-                new Sort[]{sortOrder1, sortOrder2, sortOrder3});
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1284,7 +1284,7 @@ public final class RealmQuery<E extends RealmModel> {
      *
      * @param fieldName the field to sum. Only number fields are supported.
      * @return the sum of fields of the matching objects. If no objects exist or they all have {@code null} as the value
-     *         for the given field, {@code 0} will be returned. When computing the sum. Objects with {@code null} values
+     *         for the given field, {@code 0} will be returned. When computing the sum, objects with {@code null} values
      *         are ignored.
      * @throws java.lang.IllegalArgumentException if the field is not a number type.
      */

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -45,7 +45,7 @@ import rx.Observable;
  * increases speed.
  * <p>
  * RealmResults are live views, which means that if it is on an {@link android.os.Looper} thread, it will automatically
- * update its query results after a transaction has been committed. If on a non-looper thread, {@link Realm#refresh()}
+ * update its query results after a transaction has been committed. If on a non-looper thread, {@link Realm#waitForChange()}
  * must be called to update the results.
  * <p>
  * Updates to RealmObjects from a RealmResults list must be done from within a transaction and the modified objects are
@@ -64,7 +64,6 @@ import rx.Observable;
  *
  * @param <E> The class of objects in this list.
  * @see RealmQuery#findAll()
- * @see Realm#allObjects(Class)
  * @see io.realm.Realm#executeTransaction(Realm.Transaction)
  */
 public final class RealmResults<E extends RealmModel> extends AbstractList<E> implements OrderedRealmCollection<E> {
@@ -359,24 +358,6 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
         return sort(new String[]{fieldName1, fieldName2}, new Sort[]{sortOrder1, sortOrder2});
     }
 
-    /**
-     * Sorts existing {@link io.realm.RealmResults} using three fields.
-     *
-     * DEPRECATED: Use {@link #sort(String[], Sort[])} instead.
-     *
-     * @param fieldName1 first field name.
-     * @param sortOrder1 sort order for first field.
-     * @param fieldName2 second field name.
-     * @param sortOrder2 sort order for second field.
-     * @param fieldName3 third field name.
-     * @param sortOrder3 sort order for third field.
-     * @throws java.lang.IllegalArgumentException if a field name does not exist.
-     */
-    @Deprecated
-    public void sort(String fieldName1, Sort sortOrder1, String fieldName2, Sort sortOrder2, String fieldName3, Sort sortOrder3) {
-        sort(new String[]{fieldName1, fieldName2, fieldName3}, new Sort[]{sortOrder1, sortOrder2, sortOrder3});
-    }
-
     // Aggregates
 
     /**
@@ -614,18 +595,6 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
     @Override
     public boolean retainAll(Collection<?> collection) {
         throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
-    }
-
-    /**
-     * Removes the last object in the list. This also deletes the object from the underlying Realm.
-     *
-     * DEPRECATED: Use {@link #deleteLastFromRealm()} instead.
-     *
-     * @throws IllegalStateException if the corresponding Realm is closed or in an incorrect thread.
-     */
-    @Deprecated
-    public void removeLast() {
-        deleteLastFromRealm();
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Sort.java
+++ b/realm/realm-library/src/main/java/io/realm/Sort.java
@@ -19,7 +19,6 @@ package io.realm;
 /**
  * This class describes the sorting order used in Realm queries.
  *
- * @see io.realm.Realm#allObjectsSorted(Class, String, Sort)
  * @see io.realm.RealmQuery#findAllSorted(String, Sort)
  */
 public enum Sort {


### PR DESCRIPTION
Fixes #2793 

This PR removes all deprecated method. It also fixes all examples and unit tests that broke because of that.

@realm/java 