### PR TITLE
Objects not in Realm are now called unmananged everywhere.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,7 +288,7 @@
 * BREAKING CHANGE: Realm.executeTransaction() now directly throws any RuntimeException instead of wrapping it in a RealmException (#1682).
 * BREAKING CHANGE: RealmQuery.isNull() and RealmQuery.isNotNull() now throw IllegalArgumentException instead of RealmError if the fieldname is a linked field and the last element is a link (#1693).
 * Added Realm.isEmpty().
-* Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid (standalone, removed, closed, from different Realm) object (#1749).
+* Setters in managed object for RealmObject and RealmList now throw IllegalArgumentException if the value contains an invalid (unmanaged, removed, closed, from different Realm) object (#1749).
 * Attempting to refresh a Realm while a transaction is in process will now throw an IllegalStateException (#1712).
 * The Realm AAR now also contains the ProGuard configuration (#1767). (Thank you @skyisle)
 * Updated Realm Core to 0.95.
@@ -383,7 +383,7 @@
 * Deprecated Realm.migrateRealmAtPath(). It has been replaced by Realm.migrateRealm(RealmConfiguration).
 * Deprecated Realm.deleteFile(). It has been replaced by Realm.deleteRealm(RealmConfiguration).
 * Deprecated Realm.compactFile(). It has been replaced by Realm.compactRealm(RealmConfiguration).
-* RealmList.add(), RealmList.addAt() and RealmList.set() now copy standalone objects transparently into Realm.
+* RealmList.add(), RealmList.addAt() and RealmList.set() now copy unmanaged objects transparently into Realm.
 * Realm now works with Kotlin (M12+). (Thank you @cypressious)
 * Fixed a performance regression introduced in 0.80.3 occurring during the validation of the Realm schema.
 * Added a check to give a better error message when null is used as value for a primary key.
@@ -471,7 +471,7 @@
 * Added Realm.allObjectsSorted() and RealmQuery.findAllSorted() and extending RealmResults.sort() for multi-field sorting.
 * Added more logging capabilities at the JNI level.
 * Added proper encryption support. NOTE: The key has been increased from 32 bytes to 64 bytes (see example).
-* Added support for standalone objects and custom constructors.
+* Added support for unmanaged objects and custom constructors.
 * Added more precise imports in proxy classes to avoid ambiguous references.
 * Added support for executing a transaction with a closure using Realm.executeTransaction().
 * Added RealmObject.isValid() to test if an object is still accessible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ When writing unit tests, use the following guide lines:
 5) Use the `@RunInLooperThread` rule for any test that depends on Realms notification system. 
 
 6) Input-parameters should be boundary tested. Especially `Null/NotNull`, but also the state of Realm objects like
-   standalone objects, deleted objects, objects from other threads.
+   unmanaged objects, deleted objects, objects from other threads.
 
 7) Unit tests are not required to only have 1 test. It is acceptable to combine multiple tests into one unit test, but
    if it fails, it should be clear why it failed. E.g. you can group related tests with the same setup like negative 

--- a/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/gotchas/GotchasActivity.java
+++ b/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/gotchas/GotchasActivity.java
@@ -144,7 +144,7 @@ public class GotchasActivity extends Activity {
 
         // buffer() caches objects until the buffer is full. Due to Realms auto-update of all objects it means
         // that all objects in the cache will contain the same data.
-        // Either avoid using buffer or copy data into an un-managed object.
+        // Either avoid using buffer or copy data into an unmanaged object.
         return personObserver
                 .buffer(2)
                 .subscribe(new Action1<List<Person>>() {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -661,45 +661,45 @@ public class AllTypesRealmProxy extends AllTypes
             return null;
         }
         CacheData<RealmModel> cachedObject = cache.get(realmObject);
-        AllTypes standaloneObject;
+        AllTypes unmanagedObject;
         if (cachedObject != null) {
             // Reuse cached object or recreate it because it was encountered at a lower depth.
             if (currentDepth >= cachedObject.minDepth) {
                 return (AllTypes)cachedObject.object;
             } else {
-                standaloneObject = (AllTypes)cachedObject.object;
+                unmanagedObject = (AllTypes)cachedObject.object;
                 cachedObject.minDepth = currentDepth;
             }
         } else {
-            standaloneObject = new AllTypes();
-            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, standaloneObject));
+            unmanagedObject = new AllTypes();
+            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, unmanagedObject));
         }
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnString(((AllTypesRealmProxyInterface) realmObject).realmGet$columnString());
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnLong(((AllTypesRealmProxyInterface) realmObject).realmGet$columnLong());
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnFloat(((AllTypesRealmProxyInterface) realmObject).realmGet$columnFloat());
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnDouble(((AllTypesRealmProxyInterface) realmObject).realmGet$columnDouble());
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnBoolean(((AllTypesRealmProxyInterface) realmObject).realmGet$columnBoolean());
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnDate(((AllTypesRealmProxyInterface) realmObject).realmGet$columnDate());
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnBinary(((AllTypesRealmProxyInterface) realmObject).realmGet$columnBinary());
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnString(((AllTypesRealmProxyInterface) realmObject).realmGet$columnString());
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnLong(((AllTypesRealmProxyInterface) realmObject).realmGet$columnLong());
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnFloat(((AllTypesRealmProxyInterface) realmObject).realmGet$columnFloat());
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnDouble(((AllTypesRealmProxyInterface) realmObject).realmGet$columnDouble());
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnBoolean(((AllTypesRealmProxyInterface) realmObject).realmGet$columnBoolean());
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnDate(((AllTypesRealmProxyInterface) realmObject).realmGet$columnDate());
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnBinary(((AllTypesRealmProxyInterface) realmObject).realmGet$columnBinary());
 
         // Deep copy of columnObject
-        ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnObject(AllTypesRealmProxy.createDetachedCopy(((AllTypesRealmProxyInterface) realmObject).realmGet$columnObject(), currentDepth + 1, maxDepth, cache));
+        ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnObject(AllTypesRealmProxy.createDetachedCopy(((AllTypesRealmProxyInterface) realmObject).realmGet$columnObject(), currentDepth + 1, maxDepth, cache));
 
         // Deep copy of columnRealmList
         if (currentDepth == maxDepth) {
-            ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnRealmList(null);
+            ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnRealmList(null);
         } else {
             RealmList<AllTypes> managedcolumnRealmListList = ((AllTypesRealmProxyInterface) realmObject).realmGet$columnRealmList();
-            RealmList<AllTypes> standalonecolumnRealmListList = new RealmList<AllTypes>();
-            ((AllTypesRealmProxyInterface) standaloneObject).realmSet$columnRealmList(standalonecolumnRealmListList);
+            RealmList<AllTypes> unmanagedcolumnRealmListList = new RealmList<AllTypes>();
+            ((AllTypesRealmProxyInterface) unmanagedObject).realmSet$columnRealmList(unmanagedcolumnRealmListList);
             int nextDepth = currentDepth + 1;
             int size = managedcolumnRealmListList.size();
             for (int i = 0; i < size; i++) {
                 AllTypes item = AllTypesRealmProxy.createDetachedCopy(managedcolumnRealmListList.get(i), nextDepth, maxDepth, cache);
-                standalonecolumnRealmListList.add(item);
+                unmanagedcolumnRealmListList.add(item);
             }
         }
-        return standaloneObject;
+        return unmanagedObject;
     }
 
     static AllTypes update(Realm realm, AllTypes realmObject, AllTypes newObject, Map<RealmModel, RealmObjectProxy> cache) {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -294,24 +294,24 @@ public class BooleansRealmProxy extends Booleans
             return null;
         }
         CacheData<RealmModel> cachedObject = cache.get(realmObject);
-        Booleans standaloneObject;
+        Booleans unmanagedObject;
         if (cachedObject != null) {
             // Reuse cached object or recreate it because it was encountered at a lower depth.
             if (currentDepth >= cachedObject.minDepth) {
                 return (Booleans)cachedObject.object;
             } else {
-                standaloneObject = (Booleans)cachedObject.object;
+                unmanagedObject = (Booleans)cachedObject.object;
                 cachedObject.minDepth = currentDepth;
             }
         } else {
-            standaloneObject = new Booleans();
-            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, standaloneObject));
+            unmanagedObject = new Booleans();
+            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, unmanagedObject));
         }
-        ((BooleansRealmProxyInterface) standaloneObject).realmSet$done(((BooleansRealmProxyInterface) realmObject).realmGet$done());
-        ((BooleansRealmProxyInterface) standaloneObject).realmSet$isReady(((BooleansRealmProxyInterface) realmObject).realmGet$isReady());
-        ((BooleansRealmProxyInterface) standaloneObject).realmSet$mCompleted(((BooleansRealmProxyInterface) realmObject).realmGet$mCompleted());
-        ((BooleansRealmProxyInterface) standaloneObject).realmSet$anotherBoolean(((BooleansRealmProxyInterface) realmObject).realmGet$anotherBoolean());
-        return standaloneObject;
+        ((BooleansRealmProxyInterface) unmanagedObject).realmSet$done(((BooleansRealmProxyInterface) realmObject).realmGet$done());
+        ((BooleansRealmProxyInterface) unmanagedObject).realmSet$isReady(((BooleansRealmProxyInterface) realmObject).realmGet$isReady());
+        ((BooleansRealmProxyInterface) unmanagedObject).realmSet$mCompleted(((BooleansRealmProxyInterface) realmObject).realmGet$mCompleted());
+        ((BooleansRealmProxyInterface) unmanagedObject).realmSet$anotherBoolean(((BooleansRealmProxyInterface) realmObject).realmGet$anotherBoolean());
+        return unmanagedObject;
     }
 
     @Override

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1137,43 +1137,43 @@ public class NullTypesRealmProxy extends NullTypes
             return null;
         }
         CacheData<RealmModel> cachedObject = cache.get(realmObject);
-        NullTypes standaloneObject;
+        NullTypes unmanagedObject;
         if (cachedObject != null) {
             // Reuse cached object or recreate it because it was encountered at a lower depth.
             if (currentDepth >= cachedObject.minDepth) {
                 return (NullTypes)cachedObject.object;
             } else {
-                standaloneObject = (NullTypes)cachedObject.object;
+                unmanagedObject = (NullTypes)cachedObject.object;
                 cachedObject.minDepth = currentDepth;
             }
         } else {
-            standaloneObject = new NullTypes();
-            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, standaloneObject));
+            unmanagedObject = new NullTypes();
+            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, unmanagedObject));
         }
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldStringNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldStringNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldStringNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldStringNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldBooleanNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBooleanNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldBooleanNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBooleanNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldBytesNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBytesNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldBytesNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBytesNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldByteNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldByteNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldByteNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldByteNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldShortNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldShortNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldShortNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldShortNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldIntegerNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldIntegerNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldIntegerNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldIntegerNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldLongNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldLongNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldLongNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldLongNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldFloatNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldFloatNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldFloatNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldFloatNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldDoubleNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDoubleNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldDoubleNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDoubleNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldDateNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDateNotNull());
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldDateNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDateNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldStringNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldStringNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldStringNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldStringNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldBooleanNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBooleanNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldBooleanNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBooleanNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldBytesNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBytesNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldBytesNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldBytesNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldByteNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldByteNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldByteNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldByteNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldShortNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldShortNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldShortNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldShortNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldIntegerNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldIntegerNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldIntegerNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldIntegerNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldLongNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldLongNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldLongNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldLongNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldFloatNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldFloatNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldFloatNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldFloatNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldDoubleNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDoubleNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldDoubleNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDoubleNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldDateNotNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDateNotNull());
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldDateNull(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldDateNull());
 
         // Deep copy of fieldObjectNull
-        ((NullTypesRealmProxyInterface) standaloneObject).realmSet$fieldObjectNull(NullTypesRealmProxy.createDetachedCopy(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldObjectNull(), currentDepth + 1, maxDepth, cache));
-        return standaloneObject;
+        ((NullTypesRealmProxyInterface) unmanagedObject).realmSet$fieldObjectNull(NullTypesRealmProxy.createDetachedCopy(((NullTypesRealmProxyInterface) realmObject).realmGet$fieldObjectNull(), currentDepth + 1, maxDepth, cache));
+        return unmanagedObject;
     }
 
     @Override

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -216,22 +216,22 @@ public class SimpleRealmProxy extends Simple
             return null;
         }
         CacheData<RealmModel> cachedObject = cache.get(realmObject);
-        Simple standaloneObject;
+        Simple unmanagedObject;
         if (cachedObject != null) {
             // Reuse cached object or recreate it because it was encountered at a lower depth.
             if (currentDepth >= cachedObject.minDepth) {
                 return (Simple)cachedObject.object;
             } else {
-                standaloneObject = (Simple)cachedObject.object;
+                unmanagedObject = (Simple)cachedObject.object;
                 cachedObject.minDepth = currentDepth;
             }
         } else {
-            standaloneObject = new Simple();
-            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, standaloneObject));
+            unmanagedObject = new Simple();
+            cache.put(realmObject, new RealmObjectProxy.CacheData(currentDepth, unmanagedObject));
         }
-        ((SimpleRealmProxyInterface) standaloneObject).realmSet$name(((SimpleRealmProxyInterface) realmObject).realmGet$name());
-        ((SimpleRealmProxyInterface) standaloneObject).realmSet$age(((SimpleRealmProxyInterface) realmObject).realmGet$age());
-        return standaloneObject;
+        ((SimpleRealmProxyInterface) unmanagedObject).realmSet$name(((SimpleRealmProxyInterface) realmObject).realmGet$name());
+        ((SimpleRealmProxyInterface) unmanagedObject).realmSet$age(((SimpleRealmProxyInterface) realmObject).realmGet$age());
+        return unmanagedObject;
     }
 
     @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
@@ -37,7 +37,7 @@ public abstract class CollectionTests {
         MANAGED_REALMLIST, UNMANAGED_REALMLIST, REALMRESULTS
     }
 
-    // Enumerate all current supported collections that can be in un-managed mode.
+    // Enumerate all current supported collections that can be in unmanaged mode.
     protected enum UnManagedCollection {
         UNMANAGED_REALMLIST
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.fail;
 /**
  * Test class for all methods part of the the {@link RealmCollection} interface.
  * This class only tests collections that are managed by Realm. See {@link UnManagedRealmCollectionTests} for
- * all tests targeting un-managed collections.
+ * all tests targeting unmanaged collections.
  *
  * Methods tested in this class:
  *

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
@@ -263,7 +263,7 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
             return;
         }
 
-        // un-managed objects are always invalid, but cannot be GC'ed while we have a reference.
+        // Unmanaged objects are always invalid, but cannot be GC'ed while we have a reference.
         // managed objects should not be deleted (= invalid).
         assertNotEquals(CollectionClass.REALMRESULTS, collectionClass);
         assertTrue(obj.isValid());
@@ -286,7 +286,7 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
                 assertEquals(TEST_SIZE - 1, collection.size());
                 break;
 
-            // Un-managed collections are not affected by changes to Realm and RealmResult should maintain a stable
+            // Unmanaged collections are not affected by changes to Realm and RealmResult should maintain a stable
             // view until next time sync_if_needed is called.
             case UNMANAGED_REALMLIST:
             case REALMRESULTS:

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
- * Test class for all methods specific to OrderedRealmCollections no matter if they are managed or un-managed.
+ * Test class for all methods specific to OrderedRealmCollections no matter if they are managed or unmanaged.
  *
  * Methods tested in this class:
  *

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -328,7 +328,7 @@ public class RealmAsyncQueryTests {
     }
 
     @Test
-    public void standaloneObjectAsyncBehaviour() {
+    public void unmanagedObjectAsyncBehaviour() {
         Dog dog = new Dog();
         dog.setName("Akamaru");
         dog.setAge(10);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -86,7 +86,7 @@ public class RealmListTests extends CollectionTests {
         }
     }
 
-    private RealmList<Dog> createNonManagedDogList() {
+    private RealmList<Dog> createUnmanagedDogList() {
         RealmList<Dog> list = new RealmList<Dog>();
         for (int i = 0; i < TEST_SIZE; i++) {
             list.add(new Dog("Dog " + i));
@@ -106,25 +106,25 @@ public class RealmListTests extends CollectionTests {
 
             //noinspection TryWithIdenticalCatches
     /*********************************************************
-     * Un-managed mode tests                                *
+     * Unmanaged mode tests                                *
      *********************************************************/
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_nonManaged_null() {
+    public void constructor_unmanaged_null() {
         AllTypes[] args = null;
         //noinspection ConstantConditions
         new RealmList<AllTypes>(args);
     }
 
     @Test
-    public void isValid_nonManagedMode() {
+    public void isValid_unmanagedMode() {
         //noinspection MismatchedQueryAndUpdateOfCollection
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         assertFalse(list.isValid());
     }
 
     @Test
-    public void add_nonManagedMode() {
+    public void add_unmanagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         AllTypes object = new AllTypes();
         object.setColumnString("String");
@@ -134,12 +134,12 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void add_nullInNonManagedMode() {
+    public void add_nullInUnmanagedMode() {
         new RealmList<AllTypes>().add(null);
     }
 
     @Test
-    public void add_managedObjectInNonManagedMode() {
+    public void add_managedObjectInUnmanagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         realm.beginTransaction();
         AllTypes managedAllTypes = realm.createObject(AllTypes.class);
@@ -150,7 +150,7 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test
-    public void add_standaloneObjectAtIndexInNonManagedMode() {
+    public void add_unmanagedObjectAtIndexInUnmanagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         AllTypes object = new AllTypes();
         object.setColumnString("String");
@@ -160,7 +160,7 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test
-    public void add_managedObjectAtIndexInNonManagedMode() {
+    public void add_managedObjectAtIndexInUnmanagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         list.add(new AllTypes());
         realm.beginTransaction();
@@ -182,12 +182,12 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void add_nullAtIndexInNonManagedMode() {
+    public void add_nullAtIndexInUnmanagedMode() {
         new RealmList<AllTypes>().add(0, null);
     }
 
     @Test
-    public void set_nonManagedMode() {
+    public void set_unmanagedMode() {
         RealmList<Dog> list = new RealmList<Dog>();
         Dog dog1 = new Dog("dog1");
         Dog dog2 = new Dog("dog2");
@@ -214,7 +214,7 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test
-    public void set_nullInNonManagedMode() {
+    public void set_nullInUnmanagedMode() {
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         list.add(new AllTypes());
@@ -223,7 +223,7 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test
-    public void set_managedObjectInNonManagedMode() {
+    public void set_managedObjectInUnmanagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         list.add(new AllTypes());
         realm.beginTransaction();
@@ -235,7 +235,7 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test
-    public void clear_nonManagedMode() {
+    public void clear_unmanagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         list.add(new AllTypes());
         assertEquals(1, list.size());
@@ -244,7 +244,7 @@ public class RealmListTests extends CollectionTests {
     }
 
     @Test
-    public void remove_nonManagedMode() {
+    public void remove_unmanagedMode() {
         RealmList<AllTypes> list = new RealmList<AllTypes>();
         AllTypes object1 = new AllTypes();
         list.add(object1);
@@ -281,8 +281,8 @@ public class RealmListTests extends CollectionTests {
 
     // Test move where oldPosition > newPosition
     @Test
-    public void move_downInNonManagedMode() {
-        RealmList<Dog> dogs = createNonManagedDogList();
+    public void move_downInUnmanagedMode() {
+        RealmList<Dog> dogs = createUnmanagedDogList();
         Dog dog1 = dogs.get(1);
         dogs.move(1, 0);
 
@@ -291,8 +291,8 @@ public class RealmListTests extends CollectionTests {
 
     // Test move where oldPosition < newPosition
     @Test
-    public void move_upInNonManagedMode() {
-        RealmList<Dog> dogs = createNonManagedDogList();
+    public void move_upInUnmanagedMode() {
+        RealmList<Dog> dogs = createUnmanagedDogList();
         int oldIndex = TEST_SIZE / 2;
         int newIndex = oldIndex + 1;
         Dog dog = dogs.get(oldIndex);
@@ -371,9 +371,9 @@ public class RealmListTests extends CollectionTests {
         assertEquals(1, realm.where(Owner.class).findFirst().getDogs().size());
     }
 
-    // Test that add correctly uses Realm.copyToRealm() on standalone objects.
+    // Test that add correctly uses Realm.copyToRealm() on unmanaged objects.
     @Test
-    public void add_nonManagedObjectToManagedList() {
+    public void add_unmanagedObjectToManagedList() {
         realm.beginTransaction();
         CyclicType parent = realm.createObject(CyclicType.class);
         RealmList<CyclicType> children = parent.getObjects();
@@ -382,9 +382,9 @@ public class RealmListTests extends CollectionTests {
         assertEquals(1, realm.where(CyclicType.class).findFirst().getObjects().size());
     }
 
-    // Make sure that standalone objects with a primary key are added using copyToRealmOrUpdate
+    // Make sure that unmanaged objects with a primary key are added using copyToRealmOrUpdate
     @Test
-    public void add_nonManagedPrimaryKeyObjectToManagedList() {
+    public void add_unmanagedPrimaryKeyObjectToManagedList() {
         realm.beginTransaction();
         realm.copyToRealm(new CyclicTypePrimaryKey(2, "original"));
         RealmList<CyclicTypePrimaryKey> children = realm.copyToRealm(new CyclicTypePrimaryKey(1)).getObjects();
@@ -395,9 +395,9 @@ public class RealmListTests extends CollectionTests {
         assertEquals("new", realm.where(CyclicTypePrimaryKey.class).equalTo("id", 2).findFirst().getName());
     }
 
-    // Test that set correctly uses Realm.copyToRealm() on standalone objects.
+    // Test that set correctly uses Realm.copyToRealm() on unmanaged objects.
     @Test
-    public void set_nonManagedObjectToManagedList() {
+    public void set_unmanagedObjectToManagedList() {
         realm.beginTransaction();
         CyclicType parent = realm.copyToRealm(new CyclicType("Parent"));
         RealmList<CyclicType> children = parent.getObjects();
@@ -413,9 +413,9 @@ public class RealmListTests extends CollectionTests {
         assertEquals(5, realm.where(CyclicType.class).count());
     }
 
-    // Test that set correctly uses Realm.copyToRealmOrUpdate() on standalone objects with a primary key.
+    // Test that set correctly uses Realm.copyToRealmOrUpdate() on unmanaged objects with a primary key.
     @Test
-    public void set_nonManagedPrimaryKeyObjectToManagedList() {
+    public void set_unmanagedPrimaryKeyObjectToManagedList() {
         realm.beginTransaction();
         CyclicTypePrimaryKey parent = realm.copyToRealm(new CyclicTypePrimaryKey(1, "Parent"));
         RealmList<CyclicTypePrimaryKey> children = parent.getObjects();
@@ -594,7 +594,7 @@ public class RealmListTests extends CollectionTests {
 
     @Test
     public void removeAll_unmanaged_wrongClass() {
-        RealmList<Dog> list = createNonManagedDogList();
+        RealmList<Dog> list = createUnmanagedDogList();
         //noinspection SuspiciousMethodCalls
         assertFalse(list.removeAll(Collections.singletonList(new Cat())));
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
@@ -123,15 +123,15 @@ public class RealmModelTests {
         populateTestRealm(realm, TEST_DATA_SIZE);
 
         AllTypesRealmModel realmObject = realm.where(AllTypesRealmModel.class).findAllSorted(AllTypesRealmModel.FIELD_LONG).first();
-        AllTypesRealmModel standaloneObject = realm.copyFromRealm(realmObject);
-        assertArrayEquals(realmObject.columnBinary, standaloneObject.columnBinary);
-        assertEquals(realmObject.columnString, standaloneObject.columnString);
-        assertEquals(realmObject.columnLong, standaloneObject.columnLong);
-        assertEquals(realmObject.columnFloat, standaloneObject.columnFloat, 0.00000000001);
-        assertEquals(realmObject.columnDouble, standaloneObject.columnDouble, 0.00000000001);
-        assertEquals(realmObject.columnBoolean, standaloneObject.columnBoolean);
-        assertEquals(realmObject.columnDate, standaloneObject.columnDate);
-        assertEquals(realmObject.hashCode(), standaloneObject.hashCode());
+        AllTypesRealmModel unmanagedObject = realm.copyFromRealm(realmObject);
+        assertArrayEquals(realmObject.columnBinary, unmanagedObject.columnBinary);
+        assertEquals(realmObject.columnString, unmanagedObject.columnString);
+        assertEquals(realmObject.columnLong, unmanagedObject.columnLong);
+        assertEquals(realmObject.columnFloat, unmanagedObject.columnFloat, 0.00000000001);
+        assertEquals(realmObject.columnDouble, unmanagedObject.columnDouble, 0.00000000001);
+        assertEquals(realmObject.columnBoolean, unmanagedObject.columnBoolean);
+        assertEquals(realmObject.columnDate, unmanagedObject.columnDate);
+        assertEquals(realmObject.hashCode(), unmanagedObject.hashCode());
 
     }
 
@@ -260,7 +260,7 @@ public class RealmModelTests {
     }
 
     // Test the behaviour of a RealmModel, containing a RealmList
-    // of other RealmModel, in managed and un-managed mode
+    // of other RealmModel, in managed and unmanaged mode
     @Test
     public void realmModelWithRealmListOfRealmModel() {
         RealmList<AllTypesRealmModel> allTypesRealmModels = new RealmList<AllTypesRealmModel>();
@@ -289,7 +289,7 @@ public class RealmModelTests {
     }
 
     // Test the behaviour of a RealmModel, containing a RealmList
-    // of RealmObject, in managed and un-managed mode
+    // of RealmObject, in managed and unmanaged mode
     @Test
     public void realmModelWithRealmListOfRealmObject() {
         RealmList<AllTypes> allTypes = new RealmList<AllTypes>();
@@ -318,7 +318,7 @@ public class RealmModelTests {
     }
 
     // Test the behaviour of a RealmObject, containing a RealmList
-    // of RealmModel, in managed and un-managed mode
+    // of RealmModel, in managed and unmanaged mode
     @Test
     public void realmObjectWithRealmListOfRealmModel() {
         RealmList<AllTypesRealmModel> allTypesRealmModel = new RealmList<AllTypesRealmModel>();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -769,7 +769,7 @@ public class RealmObjectTests {
 
             RealmList<CyclicType> list = new RealmList<>();
             list.add(realm.createObject(CyclicType.class));
-            list.add(unmanaged); // List contains a unmanaged object
+            list.add(unmanaged); // List contains an unmanaged object
             list.add(realm.createObject(CyclicType.class));
 
             try {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -389,7 +389,7 @@ public class RealmObjectTests {
     }
 
     @Test
-    public void equals_standAloneObject() {
+    public void equals_unmanagedObject() {
         realm.beginTransaction();
         CyclicType ct1 = realm.createObject(CyclicType.class);
         ct1.setName("Foo");
@@ -625,15 +625,15 @@ public class RealmObjectTests {
     }
 
     @Test
-    public void setter_link_standaloneObject() {
-        CyclicType standalone = new CyclicType();
+    public void setter_link_unmanagedObject() {
+        CyclicType unmanaged = new CyclicType();
 
         realm.beginTransaction();
         try {
             CyclicType target = realm.createObject(CyclicType.class);
 
             try {
-                target.setObject(standalone);
+                target.setObject(unmanaged);
                 fail();
             } catch (IllegalArgumentException ignored) {
             }
@@ -760,8 +760,8 @@ public class RealmObjectTests {
     }
 
     @Test
-    public void setter_list_withStandaloneObject() {
-        CyclicType standalone = new CyclicType();
+    public void setter_list_withUnmanagedObject() {
+        CyclicType unmanaged = new CyclicType();
 
         realm.beginTransaction();
         try {
@@ -769,7 +769,7 @@ public class RealmObjectTests {
 
             RealmList<CyclicType> list = new RealmList<>();
             list.add(realm.createObject(CyclicType.class));
-            list.add(standalone); // List contains a standalone object
+            list.add(unmanaged); // List contains a unmanaged object
             list.add(realm.createObject(CyclicType.class));
 
             try {
@@ -931,7 +931,7 @@ public class RealmObjectTests {
     }
 
     @Test
-    public void isValid_standaloneObject() {
+    public void isValid_unmanagedObject() {
         AllTypes allTypes = new AllTypes();
         assertFalse(allTypes.isValid());
     }
@@ -1381,18 +1381,18 @@ public class RealmObjectTests {
 
     @Test
     public void conflictingFieldName_readAndUpdate() {
-        final ConflictingFieldName standalone = new ConflictingFieldName();
-        standalone.setRealm("realm");
-        standalone.setRow("row");
-        standalone.setIsCompleted("isCompleted");
-        standalone.setListeners("listeners");
-        standalone.setPendingQuery("pendingQuery");
-        standalone.setCurrentTableVersion("currentTableVersion");
+        final ConflictingFieldName unmanaged = new ConflictingFieldName();
+        unmanaged.setRealm("realm");
+        unmanaged.setRow("row");
+        unmanaged.setIsCompleted("isCompleted");
+        unmanaged.setListeners("listeners");
+        unmanaged.setPendingQuery("pendingQuery");
+        unmanaged.setCurrentTableVersion("currentTableVersion");
 
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
-                realm.copyToRealm(standalone);
+                realm.copyToRealm(unmanaged);
             }
         });
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -1237,7 +1237,7 @@ public class RealmTests {
         childObj.setName("Child");
         childObj.setId(1);
 
-        // Parent object is a unmanaged object
+        // Parent object is an unmanaged object
         CyclicTypePrimaryKey parentObj = new CyclicTypePrimaryKey(2);
         parentObj.setObject(childObj);
 
@@ -1503,7 +1503,7 @@ public class RealmTests {
     }
 
 
-    // Checks that a unmanaged object with only default values can override data
+    // Checks that an unmanaged object with only default values can override data
     @Test
     public void copyToRealmOrUpdate_defaultValuesOverrideExistingData() {
         realm.executeTransaction(new Realm.Transaction() {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -1237,7 +1237,7 @@ public class RealmTests {
         childObj.setName("Child");
         childObj.setId(1);
 
-        // Parent object is a standalone object
+        // Parent object is a unmanaged object
         CyclicTypePrimaryKey parentObj = new CyclicTypePrimaryKey(2);
         parentObj.setObject(childObj);
 
@@ -1503,7 +1503,7 @@ public class RealmTests {
     }
 
 
-    // Checks that a standalone object with only default values can override data
+    // Checks that a unmanaged object with only default values can override data
     @Test
     public void copyToRealmOrUpdate_defaultValuesOverrideExistingData() {
         realm.executeTransaction(new Realm.Transaction() {
@@ -1940,7 +1940,7 @@ public class RealmTests {
     @Test
     public void callMutableMethodOutsideTransaction() throws JSONException, IOException {
 
-        // Prepare standalone object data
+        // Prepare unmanaged object data
         AllTypesPrimaryKey t = new AllTypesPrimaryKey();
         List<AllTypesPrimaryKey> ts = Arrays.asList(t, t);
 
@@ -2508,24 +2508,24 @@ public class RealmTests {
     public void copyFromRealm() {
         populateTestRealm();
         AllTypes realmObject = realm.where(AllTypes.class).findAllSorted("columnLong").first();
-        AllTypes standaloneObject = realm.copyFromRealm(realmObject);
-        assertArrayEquals(realmObject.getColumnBinary(), standaloneObject.getColumnBinary());
-        assertEquals(realmObject.getColumnString(), standaloneObject.getColumnString());
-        assertEquals(realmObject.getColumnLong(), standaloneObject.getColumnLong());
-        assertEquals(realmObject.getColumnFloat(), standaloneObject.getColumnFloat(), 0.00000000001);
-        assertEquals(realmObject.getColumnDouble(), standaloneObject.getColumnDouble(), 0.00000000001);
-        assertEquals(realmObject.isColumnBoolean(), standaloneObject.isColumnBoolean());
-        assertEquals(realmObject.getColumnDate(), standaloneObject.getColumnDate());
+        AllTypes unmanagedObject = realm.copyFromRealm(realmObject);
+        assertArrayEquals(realmObject.getColumnBinary(), unmanagedObject.getColumnBinary());
+        assertEquals(realmObject.getColumnString(), unmanagedObject.getColumnString());
+        assertEquals(realmObject.getColumnLong(), unmanagedObject.getColumnLong());
+        assertEquals(realmObject.getColumnFloat(), unmanagedObject.getColumnFloat(), 0.00000000001);
+        assertEquals(realmObject.getColumnDouble(), unmanagedObject.getColumnDouble(), 0.00000000001);
+        assertEquals(realmObject.isColumnBoolean(), unmanagedObject.isColumnBoolean());
+        assertEquals(realmObject.getColumnDate(), unmanagedObject.getColumnDate());
     }
 
     @Test
     public void copyFromRealm_newCopyEachTime() {
         populateTestRealm();
         AllTypes realmObject = realm.where(AllTypes.class).findAllSorted("columnLong").first();
-        AllTypes standaloneObject1 = realm.copyFromRealm(realmObject);
-        AllTypes standaloneObject2 = realm.copyFromRealm(realmObject);
-        assertFalse(standaloneObject1 == standaloneObject2);
-        assertNotSame(standaloneObject1, standaloneObject2);
+        AllTypes unmanagedObject1 = realm.copyFromRealm(realmObject);
+        AllTypes unmanagedObject2 = realm.copyFromRealm(realmObject);
+        assertFalse(unmanagedObject1 == unmanagedObject2);
+        assertNotSame(unmanagedObject1, unmanagedObject2);
     }
 
     // Test that the object graph is copied as it is and no extra copies are made

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -49,7 +49,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
 
         if (!RealmObject.isValid(obj)) {
             throw new IllegalArgumentException("An object managed by Realm must be provided. This " +
-                    "is a standalone object or it was deleted.");
+                    "is an unmanaged object or it was deleted.");
         }
 
         RealmObjectProxy proxy = (RealmObjectProxy) obj;
@@ -575,7 +575,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         String tableName = proxyState.getRow$realm().getTable().getName();
         boolean typeValidated;
         if (list.className == null && list.clazz == null) {
-            // Standalone lists don't know anything about the types they contain. They might even hold objects of
+            // Unmanaged lists don't know anything about the types they contain. They might even hold objects of
             // multiple types :(, so we have to check each item in the list.
             typeValidated = false;
         } else {

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollection.java
@@ -50,7 +50,7 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      * @return a new sorted {@link RealmResults} will be created and returned. The original collection stays unchanged.
      * @throws java.lang.IllegalArgumentException if field name does not exist or it has an invalid type.
      * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
-     *                                         an un-managed collection.
+     *                                         an unmanaged collection.
      */
     RealmResults<E> sort(String fieldName);
 
@@ -63,7 +63,7 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      * @return a new sorted {@link RealmResults} will be created and returned. The original collection stays unchanged.
      * @throws java.lang.IllegalArgumentException if field name does not exist or has an invalid type.
      * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
-     *                                         an un-managed collection.
+     *                                         an unmanaged collection.
      */
     RealmResults<E> sort(String fieldName, Sort sortOrder);
 
@@ -79,7 +79,7 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      * @return a new sorted {@link RealmResults} will be created and returned. The original collection stays unchanged.
      * @throws java.lang.IllegalArgumentException if a field name does not exist or has an invalid type.
      * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
-     *                                         an un-managed collection.
+     *                                         an unmanaged collection.
      */
     RealmResults<E> sort(String fieldName1, Sort sortOrder1, String fieldName2, Sort sortOrder2);
 
@@ -92,7 +92,7 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      * @return a new sorted {@link RealmResults} will be created and returned. The original collection stays unchanged.
      * @throws java.lang.IllegalArgumentException if a field name does not exist or has an invalid type.
      * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
-     *                                         an un-managed collection.
+     *                                         an unmanaged collection.
      */
     RealmResults<E> sort(String[] fieldNames, Sort[] sortOrders);
 
@@ -102,7 +102,7 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      * @param location the array index identifying the object to be removed.
      * @throws IndexOutOfBoundsException if {@code location < 0 || location >= size()}.
      * @throws java.lang.IllegalStateException if the Realm is closed or the method is called from the wrong thread.
-     * @throws UnsupportedOperationException if the collection is un-managed.
+     * @throws UnsupportedOperationException if the collection is unmanaged.
      */
     void deleteFromRealm(int location);
 
@@ -111,7 +111,7 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      *
      * @return {@code true} if an object was deleted, {@code false} otherwise.
      * @throws java.lang.IllegalStateException if the Realm is closed or the method is called on the wrong thread.
-     * @throws UnsupportedOperationException if the collection is un-managed.
+     * @throws UnsupportedOperationException if the collection is unmanaged.
      */
     boolean deleteFirstFromRealm();
 
@@ -120,7 +120,7 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      *
      * @return {@code true} if an object was deleted, {@code false} otherwise.
      * @throws java.lang.IllegalStateException if the Realm is closed or the method is called from the wrong thread.
-     * @throws UnsupportedOperationException if the collection is un-managed.
+     * @throws UnsupportedOperationException if the collection is unmanaged.
      */
     boolean deleteLastFromRealm();
 }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -807,7 +807,7 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Makes a standalone in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
+     * Makes a unmanaged in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
      * referenced objects.
      *
      * The copied objects are all detached from Realm so they will no longer be automatically updated. This means
@@ -828,7 +828,7 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Makes a standalone in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
+     * Makes a unmanaged in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
      * referenced objects up to the defined depth.
      *
      * The copied objects are all detached from Realm so they will no longer be automatically updated. This means
@@ -854,18 +854,18 @@ public final class Realm extends BaseRealm {
             return new ArrayList<E>(0);
         }
 
-        ArrayList<E> standaloneObjects = new ArrayList<E>();
+        ArrayList<E> unmanagedObjects = new ArrayList<E>();
         Map<RealmModel, RealmObjectProxy.CacheData<RealmModel>> listCache = new HashMap<RealmModel, RealmObjectProxy.CacheData<RealmModel>>();
         for (E object : realmObjects) {
             checkValidObjectForDetach(object);
-            standaloneObjects.add(createDetachedCopy(object, maxDepth, listCache));
+            unmanagedObjects.add(createDetachedCopy(object, maxDepth, listCache));
         }
 
-        return standaloneObjects;
+        return unmanagedObjects;
     }
 
     /**
-     * Makes a standalone in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
+     * Makes a unmanaged in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
      * all referenced objects.
      *
      * The copied object(s) are all detached from Realm so they will no longer be automatically updated. This means
@@ -886,7 +886,7 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Makes a standalone in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
+     * Makes a unmanaged in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
      * all referenced objects up to the defined depth.
      *
      * The copied object(s) are all detached from Realm so they will no longer be automatically updated. This means

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -807,7 +807,7 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Makes a unmanaged in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
+     * Makes an unmanaged in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
      * referenced objects.
      *
      * The copied objects are all detached from Realm so they will no longer be automatically updated. This means
@@ -828,7 +828,7 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Makes a unmanaged in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
+     * Makes an unmanaged in-memory copy of already persisted RealmObjects. This is a deep copy that will copy all
      * referenced objects up to the defined depth.
      *
      * The copied objects are all detached from Realm so they will no longer be automatically updated. This means
@@ -865,7 +865,7 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Makes a unmanaged in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
+     * Makes an unmanaged in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
      * all referenced objects.
      *
      * The copied object(s) are all detached from Realm so they will no longer be automatically updated. This means
@@ -886,7 +886,7 @@ public final class Realm extends BaseRealm {
     }
 
     /**
-     * Makes a unmanaged in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
+     * Makes an unmanaged in-memory copy of an already persisted {@link RealmObject}. This is a deep copy that will copy
      * all referenced objects up to the defined depth.
      *
      * The copied object(s) are all detached from Realm so they will no longer be automatically updated. This means

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -137,7 +137,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      * end.
      * <ol>
      * <li><b>Unmanaged RealmLists:</b> It is possible to add both managed and unmanaged objects. If adding managed
-     * objects to a unmanaged RealmList they will not be copied to the Realm again if using
+     * objects to an unmanaged RealmList they will not be copied to the Realm again if using
      * {@link Realm#copyToRealm(RealmModel)} afterwards.</li>
      *
      * <li><b>Managed RealmLists:</b> It is possible to add unmanaged objects to a RealmList that is already managed. In
@@ -170,7 +170,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      * Adds the specified object at the end of this List.
      * <ol>
      * <li><b>Unmanaged RealmLists:</b> It is possible to add both managed and unmanaged objects. If adding managed
-     * objects to a unmanaged RealmList they will not be copied to the Realm again if using
+     * objects to an unmanaged RealmList they will not be copied to the Realm again if using
      * {@link Realm#copyToRealm(RealmModel)} afterwards.</li>
      *
      * <li><b>Managed RealmLists:</b> It is possible to add unmanaged objects to a RealmList that is already managed. In
@@ -200,7 +200,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      * Replaces the element at the specified location in this list with the specified object.
      * <ol>
      * <li><b>Unmanaged RealmLists:</b> It is possible to add both managed and unmanaged objects. If adding managed
-     * objects to a unmanaged RealmList they will not be copied to the Realm again if using
+     * objects to an unmanaged RealmList they will not be copied to the Realm again if using
      * {@link Realm#copyToRealm(RealmModel)} afterwards.</li>
      *
      * <li><b>Managed RealmLists:</b> It is possible to add unmanaged objects to a RealmList that is already managed.
@@ -229,7 +229,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
         return oldObject;
     }
 
-    // Transparently copies a unmanaged object or managed object from another Realm to the Realm backing this RealmList.
+    // Transparently copies an unmanaged object or managed object from another Realm to the Realm backing this RealmList.
     private E copyToRealmIfNeeded(E object) {
         if (object instanceof RealmObjectProxy) {
             RealmObjectProxy proxy = (RealmObjectProxy) object;

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -39,9 +39,9 @@ import io.realm.internal.RealmObjectProxy;
  * Only Realm can create managed RealmLists. Managed RealmLists will automatically update the content whenever the
  * underlying Realm is updated, and can only be accessed using the getter of a {@link io.realm.RealmObject}.
  * <p>
- * Non-managed RealmLists can be created by the user and can contain both managed and non-managed RealmObjects. This is
+ * Unmanaged RealmLists can be created by the user and can contain both managed and non-managed RealmObjects. This is
  * useful when dealing with JSON deserializers like GSON or other frameworks that inject values into a class.
- * Non-managed elements in this list can be added to a Realm using the {@link Realm#copyToRealm(Iterable)} method.
+ * Unmanaged elements in this list can be added to a Realm using the {@link Realm#copyToRealm(Iterable)} method.
  * <p>
  * {@link RealmList} can contain more elements than {@code Integer.MAX_VALUE}.
  * In that case, you can access only first {@code Integer.MAX_VALUE} elements in it.
@@ -60,7 +60,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
     protected String className;
     protected LinkView view;
     protected BaseRealm realm;
-    private List<E> nonManagedList;
+    private List<E> unmanagedList;
 
     /**
      * Creates a RealmList in non-managed mode, where the elements are not controlled by a Realm.
@@ -71,7 +71,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      */
     public RealmList() {
         managedMode = false;
-        nonManagedList = new ArrayList<E>();
+        unmanagedList = new ArrayList<E>();
     }
 
     /**
@@ -88,8 +88,8 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             throw new IllegalArgumentException("The objects argument cannot be null");
         }
         managedMode = false;
-        nonManagedList = new ArrayList<E>(objects.length);
-        Collections.addAll(nonManagedList, objects);
+        unmanagedList = new ArrayList<E>(objects.length);
+        Collections.addAll(unmanagedList, objects);
     }
 
     /**
@@ -117,7 +117,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      * Checks if the {@link RealmList} is managed by Realm and contains valid data i.e. the {@link io.realm.Realm}
      * instance hasn't been closed.
      *
-     * @return {@code true} if still valid to use, {@code false} otherwise or if it's an un-managed list.
+     * @return {@code true} if still valid to use, {@code false} otherwise or if it's an unmanaged list.
      */
     public boolean isValid() {
         //noinspection SimplifiableIfStatement
@@ -136,11 +136,11 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      * element at the specified location. If the location is equal to the size of this List, the object is added at the
      * end.
      * <ol>
-     * <li><b>Un-managed RealmLists:</b> It is possible to add both managed and un-managed objects. If adding managed
-     * objects to a un-managed RealmList they will not be copied to the Realm again if using
+     * <li><b>Unmanaged RealmLists:</b> It is possible to add both managed and unmanaged objects. If adding managed
+     * objects to a unmanaged RealmList they will not be copied to the Realm again if using
      * {@link Realm#copyToRealm(RealmModel)} afterwards.</li>
      *
-     * <li><b>Managed RealmLists:</b> It is possible to add un-managed objects to a RealmList that is already managed. In
+     * <li><b>Managed RealmLists:</b> It is possible to add unmanaged objects to a RealmList that is already managed. In
      * that case the object will transparently be copied to Realm using {@link Realm#copyToRealm(RealmModel)}
      * or {@link Realm#copyToRealmOrUpdate(RealmModel)} if it has a primary key.</li>
      * </ol>
@@ -161,7 +161,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             RealmObjectProxy proxy = (RealmObjectProxy) copyToRealmIfNeeded(object);
             view.insert(location, proxy.realmGet$proxyState().getRow$realm().getIndex());
         } else {
-            nonManagedList.add(location, object);
+            unmanagedList.add(location, object);
         }
         modCount++;
     }
@@ -169,11 +169,11 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
     /**
      * Adds the specified object at the end of this List.
      * <ol>
-     * <li><b>Un-managed RealmLists:</b> It is possible to add both managed and un-managed objects. If adding managed
-     * objects to a un-managed RealmList they will not be copied to the Realm again if using
+     * <li><b>Unmanaged RealmLists:</b> It is possible to add both managed and unmanaged objects. If adding managed
+     * objects to a unmanaged RealmList they will not be copied to the Realm again if using
      * {@link Realm#copyToRealm(RealmModel)} afterwards.</li>
      *
-     * <li><b>Managed RealmLists:</b> It is possible to add un-managed objects to a RealmList that is already managed. In
+     * <li><b>Managed RealmLists:</b> It is possible to add unmanaged objects to a RealmList that is already managed. In
      * that case the object will transparently be copied to Realm using {@link Realm#copyToRealm(RealmModel)}
      * or {@link Realm#copyToRealmOrUpdate(RealmModel)} if it has a primary key.</li>
      * </ol>
@@ -190,7 +190,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             RealmObjectProxy proxy = (RealmObjectProxy) copyToRealmIfNeeded(object);
             view.add(proxy.realmGet$proxyState().getRow$realm().getIndex());
         } else {
-            nonManagedList.add(object);
+            unmanagedList.add(object);
         }
         modCount++;
         return true;
@@ -199,11 +199,11 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
     /**
      * Replaces the element at the specified location in this list with the specified object.
      * <ol>
-     * <li><b>Un-managed RealmLists:</b> It is possible to add both managed and un-managed objects. If adding managed
-     * objects to a un-managed RealmList they will not be copied to the Realm again if using
+     * <li><b>Unmanaged RealmLists:</b> It is possible to add both managed and unmanaged objects. If adding managed
+     * objects to a unmanaged RealmList they will not be copied to the Realm again if using
      * {@link Realm#copyToRealm(RealmModel)} afterwards.</li>
      *
-     * <li><b>Managed RealmLists:</b> It is possible to add un-managed objects to a RealmList that is already managed.
+     * <li><b>Managed RealmLists:</b> It is possible to add unmanaged objects to a RealmList that is already managed.
      * In that case the object will transparently be copied to Realm using {@link Realm#copyToRealm(RealmModel)} or
      * {@link Realm#copyToRealmOrUpdate(RealmModel)} if it has a primary key.</li>
      * </ol>
@@ -224,12 +224,12 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             view.set(location, proxy.realmGet$proxyState().getRow$realm().getIndex());
             return oldObject;
         } else {
-            oldObject = nonManagedList.set(location, object);
+            oldObject = unmanagedList.set(location, object);
         }
         return oldObject;
     }
 
-    // Transparently copies a standalone object or managed object from another Realm to the Realm backing this RealmList.
+    // Transparently copies a unmanaged object or managed object from another Realm to the Realm backing this RealmList.
     private E copyToRealmIfNeeded(E object) {
         if (object instanceof RealmObjectProxy) {
             RealmObjectProxy proxy = (RealmObjectProxy) object;
@@ -291,11 +291,11 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
         } else {
             checkIndex(oldPos);
             checkIndex(newPos);
-            E object = nonManagedList.remove(oldPos);
+            E object = unmanagedList.remove(oldPos);
             if (newPos > oldPos) {
-                nonManagedList.add(newPos - 1, object);
+                unmanagedList.add(newPos - 1, object);
             } else {
-                nonManagedList.add(newPos, object);
+                unmanagedList.add(newPos, object);
             }
         }
     }
@@ -314,7 +314,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             checkValidView();
             view.clear();
         } else {
-            nonManagedList.clear();
+            unmanagedList.clear();
         }
         modCount++;
     }
@@ -335,7 +335,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             removedItem = get(location);
             view.remove(location);
         } else {
-            removedItem = nonManagedList.remove(location);
+            removedItem = unmanagedList.remove(location);
         }
         modCount++;
         return removedItem;
@@ -441,7 +441,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             long rowIndex = view.getTargetRowIndex(location);
             return realm.get(clazz, className, rowIndex);
         } else {
-            return nonManagedList.get(location);
+            return unmanagedList.get(location);
         }
     }
 
@@ -457,8 +457,8 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             if (!view.isEmpty()) {
                 return get(0);
             }
-        } else if (nonManagedList != null && nonManagedList.size() > 0) {
-            return nonManagedList.get(0);
+        } else if (unmanagedList != null && unmanagedList.size() > 0) {
+            return unmanagedList.get(0);
         }
         throw new IndexOutOfBoundsException("The list is empty.");
     }
@@ -475,8 +475,8 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             if (!view.isEmpty()) {
                 return get((int) view.size() - 1);
             }
-        } else if (nonManagedList != null && nonManagedList.size() > 0) {
-            return nonManagedList.get(nonManagedList.size() - 1);
+        } else if (unmanagedList != null && unmanagedList.size() > 0) {
+            return unmanagedList.get(unmanagedList.size() - 1);
         }
         throw new IndexOutOfBoundsException("The list is empty.");
     }
@@ -548,7 +548,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
             long size = view.size();
             return size < Integer.MAX_VALUE ? (int) size : Integer.MAX_VALUE;
         } else {
-            return nonManagedList.size();
+            return unmanagedList.size();
         }
     }
 
@@ -664,7 +664,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      */
     @Override
     public boolean isLoaded() {
-        return true; // Managed RealmLists are always loaded, Un-managed RealmLists return true pr. the contract.
+        return true; // Managed RealmLists are always loaded, Unmanaged RealmLists return true pr. the contract.
     }
 
     /**
@@ -672,7 +672,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
      */
     @Override
     public boolean load() {
-        return true; // Managed RealmLists are always loaded, Un-managed RealmLists return true pr. the contract.
+        return true; // Managed RealmLists are always loaded, Unmanaged RealmLists return true pr. the contract.
     }
 
     /**
@@ -697,7 +697,7 @@ public final class RealmList<E extends RealmModel> extends AbstractList<E> imple
                 }
             }
         } else {
-            contains = nonManagedList.contains(object);
+            contains = unmanagedList.contains(object);
         }
         return contains;
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -150,7 +150,7 @@ public abstract class RealmObject implements RealmModel {
     /**
      * Determines if the current RealmObject is obtained synchronously or asynchronously (from a worker thread).
      * Synchronous RealmObjects are by definition blocking hence this method will always return {@code true} for them.
-     * This will return {@code true} if called for a unmanaged object (created outside of Realm).
+     * This will return {@code true} if called for an unmanaged object (created outside of Realm).
      *
      * @return {@code true} if the query has completed and the data is available {@code false} if the query is in
      * progress.
@@ -162,7 +162,7 @@ public abstract class RealmObject implements RealmModel {
     /**
      * Determines if the RealmObject is obtained synchronously or asynchronously (from a worker thread).
      * Synchronous RealmObjects are by definition blocking hence this method will always return {@code true} for them.
-     * This will return {@code true} if called for a unmanaged object (created outside of Realm).
+     * This will return {@code true} if called for an unmanaged object (created outside of Realm).
      *
      * @param object RealmObject to check.
      * @return {@code true} if the query has completed and the data is available {@code false} if the query is in

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -123,7 +123,7 @@ public abstract class RealmObject implements RealmModel {
      * }
      * </pre>
      *
-     * @return {@code true} if the object is still accessible, {@code false} otherwise or if it is a standalone object.
+     * @return {@code true} if the object is still accessible, {@code false} otherwise or if it is an unmanaged object.
      * @see <a href="https://github.com/realm/realm-java/tree/master/examples/rxJavaExample">Examples using Realm with RxJava</a>
      */
     public final boolean isValid() {
@@ -135,7 +135,7 @@ public abstract class RealmObject implements RealmModel {
      * {@link io.realm.Realm} been closed. It will always return false for stand alone objects.
      *
      * @param object RealmObject to check validity for.
-     * @return {@code true} if the object is still accessible, {@code false} otherwise or if it is a standalone object.
+     * @return {@code true} if the object is still accessible, {@code false} otherwise or if it is an unmanaged object.
      */
     public static <E extends RealmModel> boolean isValid(E object) {
         if (object instanceof RealmObjectProxy) {
@@ -150,7 +150,7 @@ public abstract class RealmObject implements RealmModel {
     /**
      * Determines if the current RealmObject is obtained synchronously or asynchronously (from a worker thread).
      * Synchronous RealmObjects are by definition blocking hence this method will always return {@code true} for them.
-     * This will return {@code true} if called for a standalone object (created outside of Realm).
+     * This will return {@code true} if called for a unmanaged object (created outside of Realm).
      *
      * @return {@code true} if the query has completed and the data is available {@code false} if the query is in
      * progress.
@@ -162,7 +162,7 @@ public abstract class RealmObject implements RealmModel {
     /**
      * Determines if the RealmObject is obtained synchronously or asynchronously (from a worker thread).
      * Synchronous RealmObjects are by definition blocking hence this method will always return {@code true} for them.
-     * This will return {@code true} if called for a standalone object (created outside of Realm).
+     * This will return {@code true} if called for a unmanaged object (created outside of Realm).
      *
      * @param object RealmObject to check.
      * @return {@code true} if the query has completed and the data is available {@code false} if the query is in
@@ -180,7 +180,7 @@ public abstract class RealmObject implements RealmModel {
 
     /**
      * Makes an asynchronous query blocking. This will also trigger any registered listeners.
-     * Note: This will return {@code true} if called for a standalone object (created outside of Realm).
+     * Note: This will return {@code true} if called for an unmanaged object (created outside of Realm).
      *
      * @return {@code true} if it successfully completed the query, {@code false} otherwise.
      */
@@ -190,7 +190,7 @@ public abstract class RealmObject implements RealmModel {
 
     /**
      * Makes an asynchronous query blocking. This will also trigger any registered listeners.
-     * Note: This will return {@code true} if called for a standalone object (created outside of Realm).
+     * Note: This will return {@code true} if called for an unmanaged object (created outside of Realm).
      *
      * @param object RealmObject to force load.
      * @return {@code true} if it successfully completed the query, {@code false} otherwise.
@@ -214,7 +214,7 @@ public abstract class RealmObject implements RealmModel {
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null} or the object is an unmanaged object.
-     * @throws IllegalArgumentException if object is an un-managed RealmObject.
+     * @throws IllegalArgumentException if object is an unmanaged RealmObject.
      */
     public final <E extends RealmModel> void addChangeListener(RealmChangeListener<E> listener) {
         RealmObject.addChangeListener((E) this, listener);
@@ -226,7 +226,7 @@ public abstract class RealmObject implements RealmModel {
      * @param object RealmObject to add listener to.
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the {@code object} or the change listener is {@code null}.
-     * @throws IllegalArgumentException if object is an un-managed RealmObject.
+     * @throws IllegalArgumentException if object is an unmanaged RealmObject.
      * @throws IllegalStateException if you try to add a listener from a non-Looper Thread.
      */
     public static <E extends RealmModel> void addChangeListener(E object, RealmChangeListener<E> listener) {
@@ -276,7 +276,7 @@ public abstract class RealmObject implements RealmModel {
      * @param object RealmObject to remove listener from.
      * @param listener the instance to be removed.
      * @throws IllegalArgumentException if the {@code object} or the change listener is {@code null}.
-     * @throws IllegalArgumentException if object is an un-managed RealmObject.
+     * @throws IllegalArgumentException if object is an unmanaged RealmObject.
      * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      */
     public static <E extends RealmModel> void removeChangeListener(E object, RealmChangeListener listener) {
@@ -314,7 +314,7 @@ public abstract class RealmObject implements RealmModel {
             proxy.realmGet$proxyState().getRealm$realm().checkIfValid();
             proxy.realmGet$proxyState().getListeners$realm().clear();
         } else {
-            throw new IllegalArgumentException("Cannot remove listeners from this un-managed RealmObject (created outside of Realm)");
+            throw new IllegalArgumentException("Cannot remove listeners from this unmanaged RealmObject (created outside of Realm)");
         }
     }
 
@@ -396,7 +396,7 @@ public abstract class RealmObject implements RealmModel {
             }
         } else {
             // TODO Is this true? Should we just return Observable.just(object) ?
-            throw new IllegalArgumentException("Cannot create Observables from un-managed RealmObjects");
+            throw new IllegalArgumentException("Cannot create Observables from unmanaged RealmObjects");
         }
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -854,7 +854,7 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      * Returns {@code true} if the results are not yet loaded, {@code false} if they are still loading. Synchronous
      * query methods like findAll() will always return {@code true}, while asynchronous query methods like
      * findAllAsync() will return {@code false} until the results are available.
-     * This will return {@code true} if called for a standalone object (created outside of Realm).
+     * This will return {@code true} if called for an unmanaged object (created outside of Realm).
      *
      * @return {@code true} if the query has completed and the data is available {@code false} if the query is still
      * running.
@@ -869,7 +869,7 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      * the query completes.
      *
      * @return {@code true} if it successfully completed the query, {@code false} otherwise. {@code true} will always
-     *         be returned for standalone objects.
+     *         be returned for unmanaged objects.
      */
     public boolean load() {
         //noinspection SimplifiableIfStatement

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -99,7 +99,7 @@ public abstract class RealmProxyMediator {
      * @param object the object to copy properties from.
      * @param update {@code true} if object has a primary key and should try to update already existing data,
      * {@code false} otherwise.
-     * @param cache the cache for mapping between standalone objects and their {@link RealmObjectProxy} representation.
+     * @param cache the cache for mapping between unmanaged objects and their {@link RealmObjectProxy} representation.
      * @return the managed Realm object.
      */
     public abstract <E extends RealmModel> E copyOrUpdate(Realm realm, E object, boolean update, Map<RealmModel, RealmObjectProxy> cache);
@@ -129,13 +129,13 @@ public abstract class RealmProxyMediator {
     public abstract <E extends RealmModel> E createUsingJsonStream(Class<E> clazz, Realm realm, JsonReader reader) throws java.io.IOException;
 
     /**
-     * Creates a deep standalone copy of a RealmObject. This is a deep copy so all links will be copied as well.
+     * Creates a deep unmanaged copy of a RealmObject. This is a deep copy so all links will be copied as well.
      * The depth can be restricted to a maximum depth after which all links will be turned into null values instead.
      *
      * @param realmObject RealmObject to copy. It must be a valid object.
      * @param maxDepth restrict the depth of the copy to this level. The root object is depth {@code 0}.
-     * @param cache cache used to make sure standalone objects are reused correctly.
-     * @return a standalone copy of the given object.
+     * @param cache cache used to make sure unmanaged objects are reused correctly.
+     * @return an unmanaged copy of the given object.
      */
     public abstract <E extends RealmModel> E createDetachedCopy(E realmObject, int maxDepth, Map<RealmModel, RealmObjectProxy.CacheData<RealmModel>> cache);
 


### PR DESCRIPTION
Fixes #2789 

This PR changes the terminology on the Java side so object not in Realm are called "unmanaged" everywhere:

- Changlog
- Unit tests
- variables
- Javadoc / comments / exception messages


The following terms have been converted:
- un-managed
- standalone
- non-managed
- nonmanaged

@realm/java