### PR TITLE
addPrimaryKey() on RealmObjectSchema misses Index addition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Calling RealmResults.deleteAllFromRealm() might lead to native crash (#2759).
 * Added null check to `addChangeListener` and `removeChangeListener` in `Realm` and `DynamicRealm` (#2772).
+* Calling `RealmObjectSchema.addPrimaryKey()` adds an index to the primary key field, and calling `RealmObjectSchema.removePrimaryKey()` removes the index from the field (#2832).
 
 ### Enhancements
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -226,6 +226,41 @@ public class RealmMigrationTests {
         }
     }
 
+    @Test
+    public void settingPrimaryKeyWithObjectSchema() {
+        // Create v0 of the Realm
+        RealmConfiguration originalConfig = configFactory.createConfigurationBuilder()
+                .schema(AllTypes.class)
+                .build();
+        Realm.getInstance(originalConfig).close();
+
+        RealmMigration migration = new RealmMigration() {
+            @Override
+            public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+                RealmSchema schema = realm.getSchema();
+                schema.create("AnnotationTypes")
+                        .addField("id", long.class)
+                        .addPrimaryKey("id")    // use addPrimaryKey() instead of adding FieldAttribute.PrimaryKey
+                        .addField("indexString", String.class)
+                        .addIndex("indexString") // use addIndex() instead of FieldAttribute.Index
+                        .addField("notIndexString", String.class);
+            }
+        };
+
+        // Create v1 of the Realm
+        RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()
+                .schemaVersion(1)
+                .schema(AllTypes.class, AnnotationTypes.class)
+                .migration(migration)
+                .build();
+
+        realm = Realm.getInstance(realmConfig);
+        RealmObjectSchema schema = realm.getSchema().getSchemaForClass(AnnotationTypes.class);
+        assertTrue(schema.hasPrimaryKey());
+        assertTrue(schema.hasIndex("id"));
+        realm.close();
+    }
+
     // adding search index is idempotent
     @Test
     public void addingSearchIndexTwice() throws IOException {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -255,7 +255,7 @@ public class RealmMigrationTests {
                 .build();
 
         realm = Realm.getInstance(realmConfig);
-        RealmObjectSchema schema = realm.getSchema().getSchemaForClass(AnnotationTypes.class);
+        RealmObjectSchema schema = realm.getSchema().get("AnnotationTypes");
         assertTrue(schema.hasPrimaryKey());
         assertTrue(schema.hasIndex("id"));
         realm.close();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -514,9 +514,11 @@ public class RealmObjectSchemaTests {
             schema.addPrimaryKey(fieldName);
             assertTrue(schema.hasPrimaryKey());
             assertTrue(schema.isPrimaryKey(fieldName));
+            assertTrue(schema.hasIndex(fieldName));
             schema.removePrimaryKey();
             assertFalse(schema.hasPrimaryKey());
             assertFalse(schema.isPrimaryKey(fieldName));
+            assertFalse(schema.hasIndex(fieldName));
             schema.removeField(fieldName);
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -292,7 +292,7 @@ public final class RealmObjectSchema {
 
     /**
      * Adds a primary key to a given field. This is the same as adding the {@link io.realm.annotations.PrimaryKey}
-     * annotation on the field.
+     * annotation on the field. Further, this implicitly adds {@link io.realm.annotations.Index} annotation to the field as well.
      *
      * @param fieldName field to set as primary key.
      * @return the updated schema.
@@ -306,12 +306,17 @@ public final class RealmObjectSchema {
             throw new IllegalStateException("A primary key is already defined");
         }
         table.setPrimaryKey(fieldName);
+        long columnIndex = getColumnIndex(fieldName);
+        if (!table.hasSearchIndex(columnIndex)) {
+            // No exception will be thrown since adding PrimaryKey implies the column has an index.
+            table.addSearchIndex(columnIndex);
+        }
         return this;
     }
 
     /**
      * Removes the primary key from this class. This is the same as removing the {@link io.realm.annotations.PrimaryKey}
-     * annotation from the class.
+     * annotation from the class. Further, this implicitly removes {@link io.realm.annotations.Index} annotation from the field as well.
      *
      * @return the updated schema.
      * @throws IllegalArgumentException if the class doesn't have a primary key defined.
@@ -319,6 +324,10 @@ public final class RealmObjectSchema {
     public RealmObjectSchema removePrimaryKey() {
         if (!table.hasPrimaryKey()) {
             throw new IllegalStateException(getClassName() + " doesn't have a primary key.");
+        }
+        long columnIndex = table.getPrimaryKey();
+        if (table.hasSearchIndex(columnIndex)) {
+            table.removeSearchIndex(columnIndex);
         }
         table.setPrimaryKey("");
         return this;


### PR DESCRIPTION
`RealmObjectSchema.addPrimaryKey()` is supposed to add a search index to its primary key field but it is currently missing.  This is to fix the addition and removal of a search index related to primary key methods in `RealmObjectSchema`. Closes #2819.

@realm/java please review.
