### PR TITLE
Avoid Table.nativeToString/nativeRowToString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* Fixed a crash when calling Table.toString in debugger (#2429).
+* Fixed a crash when calling Table.toString() in debugger (#2429).
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 1.0.0
+## 1.0.1
+
+### Bug fixes
+
+* Fixed a crash when calling Table.toString in debugger (#2429).
+
+## 1.0.0
 
 No changes since 0.91.1.
 

--- a/realm/realm-jni/src/io_realm_internal_Table.h
+++ b/realm/realm-jni/src/io_realm_internal_Table.h
@@ -799,22 +799,6 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToJson
 
 /*
  * Class:     io_realm_internal_Table
- * Method:    nativeToString
- * Signature: (JJ)Ljava/lang/String;
- */
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToString
-  (JNIEnv *, jobject, jlong, jlong);
-
-/*
- * Class:     io_realm_internal_Table
- * Method:    nativeRowToString
- * Signature: (JJ)Ljava/lang/String;
- */
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeRowToString
-  (JNIEnv *, jobject, jlong, jlong);
-
-/*
- * Class:     io_realm_internal_Table
  * Method:    nativeHasSameSchema
  * Signature: (JJ)Z
  */

--- a/realm/realm-jni/src/io_realm_internal_TableView.h
+++ b/realm/realm-jni/src/io_realm_internal_TableView.h
@@ -513,22 +513,6 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeToJson
 
 /*
  * Class:     io_realm_internal_TableView
- * Method:    nativeToString
- * Signature: (JJ)Ljava/lang/String;
- */
-JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeToString
-  (JNIEnv *, jobject, jlong, jlong);
-
-/*
- * Class:     io_realm_internal_TableView
- * Method:    nativeRowToString
- * Signature: (JJ)Ljava/lang/String;
- */
-JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeRowToString
-  (JNIEnv *, jobject, jlong, jlong);
-
-/*
- * Class:     io_realm_internal_TableView
  * Method:    nativeWhere
  * Signature: (J)J
  */

--- a/realm/realm-jni/src/io_realm_internal_table.cpp
+++ b/realm/realm-jni/src/io_realm_internal_table.cpp
@@ -1512,36 +1512,6 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToJson(
     return NULL;
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToString(
-    JNIEnv *env, jobject, jlong nativeTablePtr, jlong maxRows)
-{
-    Table* table = TBL(nativeTablePtr);
-    if (!TABLE_VALID(env, table))
-        return NULL;
-    try {
-        ostringstream ss;
-        table->to_string(ss, S(maxRows));
-        const string str = ss.str();
-        return to_jstring(env, str);
-    } CATCH_STD()
-    return NULL;
-}
-
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeRowToString(
-    JNIEnv *env, jobject, jlong nativeTablePtr, jlong rowIndex)
-{
-    Table* table = TBL(nativeTablePtr);
-    if (!TBL_AND_ROW_INDEX_VALID(env, table, rowIndex))
-        return NULL;
-    try {
-        ostringstream ss;
-        table->row_to_string(S(rowIndex), ss);
-        const string str = ss.str();
-        return to_jstring(env, str);
-    } CATCH_STD()
-    return NULL;
-}
-
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeEquals(
     JNIEnv* env, jobject, jlong nativeTablePtr, jlong nativeTableToComparePtr)
 {

--- a/realm/realm-jni/src/io_realm_internal_tableview.cpp
+++ b/realm/realm-jni/src/io_realm_internal_tableview.cpp
@@ -1027,37 +1027,6 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeToJson(
     return NULL;
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeToString(
-    JNIEnv *env, jobject, jlong nativeViewPtr, jlong maxRows)
-{
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return NULL;
-
-        std::ostringstream ss;
-        ss.sync_with_stdio(false); // for performance
-        TV(nativeViewPtr)->to_string(ss, S(maxRows));
-        const std::string str = ss.str();
-        return to_jstring(env, str);
-    } CATCH_STD()
-    return NULL;
-}
-
-JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeRowToString(
-    JNIEnv *env, jobject, jlong nativeViewPtr, jlong rowIndex)
-{
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) || !ROW_INDEX_VALID(env, TV(nativeViewPtr), rowIndex))
-            return NULL;
-
-        std::ostringstream ss;
-        TV(nativeViewPtr)->row_to_string(S(rowIndex), ss);
-        const std::string str = ss.str();
-        return to_jstring(env, str);
-    } CATCH_STD()
-    return NULL;
-}
-
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeWhere(
     JNIEnv *env, jobject, jlong nativeViewPtr)
 {

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -49,7 +49,7 @@ public class JNITableTest extends AndroidTestCase {
         t.add("s1", 1, true);
         t.add("s2", 2, false);
 
-        String expected = "Table contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
+        String expected = "The Table contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
         assertEquals(expected, t.toString());
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -49,7 +49,7 @@ public class JNITableTest extends AndroidTestCase {
         t.add("s1", 1, true);
         t.add("s2", 2, false);
 
-        String expected = "Table  contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
+        String expected = "Table contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
         assertEquals(expected, t.toString());
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableTest.java
@@ -49,11 +49,7 @@ public class JNITableTest extends AndroidTestCase {
         t.add("s1", 1, true);
         t.add("s2", 2, false);
 
-        String expected =
-"    stringCol  intCol  boolCol\n" +
-"0:  s1              1     true\n" +
-"1:  s2              2    false\n" ;
-
+        String expected = "Table  contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
         assertEquals(expected, t.toString());
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIViewTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIViewTest.java
@@ -375,10 +375,7 @@ public class JNIViewTest extends TestCase {
 
         TableView view = t.where().findAll();
 
-        String expected =
-                "    stringCol  intCol  boolCol\n" +
-                        "0:  s1              1     true\n" +
-                        "1:  s2              2    false\n" ;
+        String expected = "This TableView contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
 
         assertEquals(expected, view.toString());
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIViewTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIViewTest.java
@@ -375,7 +375,7 @@ public class JNIViewTest extends TestCase {
 
         TableView view = t.where().findAll();
 
-        String expected = "This TableView contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
+        String expected = "The TableView contains 3 columns: stringCol, intCol, boolCol. And 2 rows.";
 
         assertEquals(expected, view.toString());
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -1381,9 +1381,13 @@ public class Table implements TableOrView, TableSchema, Closeable {
     @Override
     public String toString() {
         long columnCount = getColumnCount();
+        String name = getName();
         StringBuilder stringBuilder = new StringBuilder("Table ");
-        stringBuilder.append(getName());
-        stringBuilder.append(" contains ");
+        if (name != null && !name.isEmpty()) {
+            stringBuilder.append(getName());
+            stringBuilder.append(" ");
+        }
+        stringBuilder.append("contains ");
         stringBuilder.append(columnCount);
         stringBuilder.append(" columns: ");
 

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -1382,7 +1382,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
     public String toString() {
         long columnCount = getColumnCount();
         String name = getName();
-        StringBuilder stringBuilder = new StringBuilder("Table ");
+        StringBuilder stringBuilder = new StringBuilder("The Table ");
         if (name != null && !name.isEmpty()) {
             stringBuilder.append(getName());
             stringBuilder.append(" ");

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -1407,16 +1407,6 @@ public class Table implements TableOrView, TableSchema, Closeable {
     }
 
     @Override
-    public String toString(long maxRows) {
-        return nativeToString(nativePtr, maxRows);
-    }
-
-    @Override
-    public String rowToString(long rowIndex) {
-        return nativeRowToString(nativePtr, rowIndex);
-    }
-
-    @Override
     public long syncIfNeeded() {
         throw new RuntimeException("Not supported for tables");
     }
@@ -1560,8 +1550,6 @@ public class Table implements TableOrView, TableSchema, Closeable {
     private native String nativeGetName(long nativeTablePtr);
     private native void nativeOptimize(long nativeTablePtr);
     private native String nativeToJson(long nativeTablePtr);
-    private native String nativeToString(long nativeTablePtr, long maxRows);
     private native boolean nativeHasSameSchema(long thisTable, long otherTable);
     private native long nativeVersion(long nativeTablePtr);
-    private native String nativeRowToString(long nativeTablePtr, long rowIndex);
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -1380,7 +1380,26 @@ public class Table implements TableOrView, TableSchema, Closeable {
 
     @Override
     public String toString() {
-        return nativeToString(nativePtr, INFINITE);
+        long columnCount = getColumnCount();
+        StringBuilder stringBuilder = new StringBuilder("Table ");
+        stringBuilder.append(getName());
+        stringBuilder.append(" contains ");
+        stringBuilder.append(columnCount);
+        stringBuilder.append(" columns: ");
+
+        for (int i = 0; i < columnCount; i++) {
+            if (i != 0) {
+                stringBuilder.append(", ");
+            }
+            stringBuilder.append(getColumnName(i));
+        }
+        stringBuilder.append(".");
+
+        stringBuilder.append(" And ");
+        stringBuilder.append(size());
+        stringBuilder.append(" rows.");
+
+        return stringBuilder.toString();
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/TableOrView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableOrView.java
@@ -334,8 +334,12 @@ public interface TableOrView {
 
     String toString();
 
+    // For testing purpose only. It might crash in UTF16 conversion.
+    @Deprecated
     String toString(long maxRows);
 
+    // For testing purpose only. It might crash in UTF16 conversion.
+    @Deprecated
     String rowToString(long rowIndex);
 
     TableQuery where();

--- a/realm/realm-library/src/main/java/io/realm/internal/TableOrView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableOrView.java
@@ -334,14 +334,6 @@ public interface TableOrView {
 
     String toString();
 
-    // For testing purpose only. It might crash in UTF16 conversion.
-    @Deprecated
-    String toString(long maxRows);
-
-    // For testing purpose only. It might crash in UTF16 conversion.
-    @Deprecated
-    String rowToString(long rowIndex);
-
     TableQuery where();
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/internal/TableView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableView.java
@@ -746,16 +746,6 @@ public class TableView implements TableOrView, Closeable {
     }
 
     @Override
-    public String toString(long maxRows) {
-        return nativeToString(nativePtr, maxRows);
-    }
-
-    @Override
-    public String rowToString(long rowIndex) {
-        return nativeRowToString(nativePtr, rowIndex);
-    }
-
-    @Override
     public TableQuery where() {
         // Execute the disposal of abandoned realm objects each time a new realm object is created
         this.context.executeDelayedDisposal();
@@ -914,8 +904,6 @@ public class TableView implements TableOrView, Closeable {
     private native void nativeSortMulti(long nativeTableViewPtr, long columnIndices[], boolean ascending[]);
     private native long createNativeTableView(Table table, long nativeTablePtr);
     private native String nativeToJson(long nativeViewPtr);
-    private native String nativeToString(long nativeTablePtr, long maxRows);
-    private native String nativeRowToString(long nativeTablePtr, long rowIndex);
     private native long nativeWhere(long nativeViewPtr);
     private native void nativePivot(long nativeTablePtr, long stringCol, long intCol, int pivotType, long result);
     private native long nativeDistinct(long nativeViewPtr, long columnIndex);

--- a/realm/realm-library/src/main/java/io/realm/internal/TableView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableView.java
@@ -725,7 +725,7 @@ public class TableView implements TableOrView, Closeable {
     @Override
     public String toString() {
         long columnCount = getColumnCount();
-        StringBuilder stringBuilder = new StringBuilder("This TableView ");
+        StringBuilder stringBuilder = new StringBuilder("The TableView ");
         stringBuilder.append("contains ");
         stringBuilder.append(columnCount);
         stringBuilder.append(" columns: ");

--- a/realm/realm-library/src/main/java/io/realm/internal/TableView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableView.java
@@ -724,7 +724,25 @@ public class TableView implements TableOrView, Closeable {
 
     @Override
     public String toString() {
-        return nativeToString(nativePtr, 500);
+        long columnCount = getColumnCount();
+        StringBuilder stringBuilder = new StringBuilder("This TableView ");
+        stringBuilder.append("contains ");
+        stringBuilder.append(columnCount);
+        stringBuilder.append(" columns: ");
+
+        for (int i = 0; i < columnCount; i++) {
+            if (i != 0) {
+                stringBuilder.append(", ");
+            }
+            stringBuilder.append(getColumnName(i));
+        }
+        stringBuilder.append(".");
+
+        stringBuilder.append(" And ");
+        stringBuilder.append(size());
+        stringBuilder.append(" rows.");
+
+        return stringBuilder.toString();
     }
 
     @Override


### PR DESCRIPTION
Table::row_to_string Table::to_string are for debugging purpose only, it
calls string::substr which might truncate an UTF-8 string at any char.
Thus a crash could happend in JNI when converting to UTF-16.

This will only happen when user attach a debugger and the debugger is
trying to call Table.toString.

Close #2429