### PR TITLE
RealmResults.isLoaded description fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1
+
+### Bug fixes
+
+* Revised `RealmResults.isLoaded()` description (#2895).
+
 # 1.0.0
 
 No changes since 0.91.1.

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -851,7 +851,7 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
     }
 
     /**
-     * Returns {@code false} if the results are not yet loaded or still being loaded, {@code true} otherwise. Synchronous
+     * Returns {@code false} if the results are not yet loaded, {@code true} if they are loaded. Synchronous
      * query methods like findAll() will always return {@code true}, while asynchronous query methods like
      * findAllAsync() will return {@code false} until the results are available.
      * This will return {@code true} if called for an unmanaged object (created outside of Realm).

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -851,12 +851,12 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
     }
 
     /**
-     * Returns {@code true} if the results are not yet loaded, {@code false} if they are still loading. Synchronous
+     * Returns {@code false} if the results are not yet loaded, or they are still being loaded. Synchronous
      * query methods like findAll() will always return {@code true}, while asynchronous query methods like
      * findAllAsync() will return {@code false} until the results are available.
      * This will return {@code true} if called for an unmanaged object (created outside of Realm).
      *
-     * @return {@code true} if the query has completed and the data is available {@code false} if the query is still
+     * @return {@code true} if the query has completed and the data is available, {@code false} if the query is still
      * running.
      */
     public boolean isLoaded() {

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -851,7 +851,7 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
     }
 
     /**
-     * Returns {@code false} if the results are not yet loaded, or they are still being loaded. Synchronous
+     * Returns {@code false} if the results are not yet loaded or still being loaded. Synchronous
      * query methods like findAll() will always return {@code true}, while asynchronous query methods like
      * findAllAsync() will return {@code false} until the results are available.
      * This will return {@code true} if called for an unmanaged object (created outside of Realm).

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -851,7 +851,7 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
     }
 
     /**
-     * Returns {@code false} if the results are not yet loaded or still being loaded. Synchronous
+     * Returns {@code false} if the results are not yet loaded or still being loaded, {@code true} otherwise. Synchronous
      * query methods like findAll() will always return {@code true}, while asynchronous query methods like
      * findAllAsync() will return {@code false} until the results are available.
      * This will return {@code true} if called for an unmanaged object (created outside of Realm).

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -854,7 +854,6 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      * Returns {@code false} if the results are not yet loaded, {@code true} if they are loaded. Synchronous
      * query methods like findAll() will always return {@code true}, while asynchronous query methods like
      * findAllAsync() will return {@code false} until the results are available.
-     * This will return {@code true} if called for an unmanaged object (created outside of Realm).
      *
      * @return {@code true} if the query has completed and the data is available, {@code false} if the query is still
      * running.


### PR DESCRIPTION
`RealmResults.isLoaded()` description fix. Closes #2895.

@realm/java 