### PR TITLE
Table.toString() message for debugging Table with PrimaryKey

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITransactions.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITransactions.java
@@ -451,4 +451,17 @@ public class JNITransactions {
         }
         db.close();
     }
+
+    // Test if toString() returns a correct PrimaryKey field description from a Table
+    public void testTableToStringWithPrimaryKey() {
+        Table t = getTableWithStringPrimaryKey();
+        t.addColumn(RealmFieldType.INTEGER, "intCol");
+        t.addColumn(RealmFieldType.BOOLEAN, "boolCol");
+
+        t.add("s1", 1, true);
+        t.add("s2", 2, false);
+
+        String expected = "The Table has 'colName' field as a PrimaryKey, and contains 3 columns: colName, intCol, boolCol. And 2 rows.";
+        assertEquals(expected, t.toString());
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -1387,6 +1387,10 @@ public class Table implements TableOrView, TableSchema, Closeable {
             stringBuilder.append(getName());
             stringBuilder.append(" ");
         }
+        if (hasPrimaryKey()) {
+            String pkFieldName = getColumnName(getPrimaryKey());
+            stringBuilder.append("has \'" + pkFieldName + "\' field as a PrimaryKey, and ");
+        }
         stringBuilder.append("contains ");
         stringBuilder.append(columnCount);
         stringBuilder.append(" columns: ");


### PR DESCRIPTION
This PR is to enhance `toString()` message for `Table` debugging.