### PR TITLE
PrimaryKey index rearrangement in migration revisited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed a crash when calling Table.toString() in debugger (#2429).
 * Revised `RealmResults.isLoaded()` description (#2895).
+* Fixed a bug when migration loses tracking of primary key field in `RealmObjectSchema.removeField()` and `RealmObjectSchema.renameField()` (#2829).
 
 ## 1.0.0
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AnnotationTypes;
 import io.realm.entities.FieldOrder;
@@ -224,6 +225,55 @@ public class RealmMigrationTests {
                 realm.close();
             }
         }
+    }
+
+    @Test
+    public void removePriorIndexesOrRenamingPrimaryKey() {
+        // Create v0 of the Realm
+        RealmConfiguration originalConfig = configFactory.createConfigurationBuilder()
+                .schema(AllJavaTypes.class)
+                .build();
+        Realm.getInstance(originalConfig).close();
+
+        RealmMigration migration = new RealmMigration() {
+            @Override
+            public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+                RealmSchema schema = realm.getSchema();
+                
+                schema.rename("AllJavaTypes", "PrimaryKeyAsLong")
+                        // There are three columns coming prior to the PK field 'fieldLong', and
+                        // removing "fieldString", "fieldShort" & "fieldInt" should not rearrange the PK
+                        .removeField("fieldString")
+                        .removeField("fieldShort")
+                        .removeField("fieldInt")
+
+                        // removal of rest fields should not affect PK attribute
+                        .removeField("fieldByte")
+                        .removeField("fieldFloat")
+                        .removeField("fieldDouble")
+                        .removeField("fieldBoolean")
+                        .removeField("fieldDate")
+                        .removeField("fieldBinary")
+                        .removeField("fieldObject")
+                        .removeField("fieldList")
+
+                        // Renaming PK field should not affect PK attribute as well.
+                        .renameField("fieldLong", "id")
+                        .addField("name",String.class);
+            }
+        };
+
+        RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()
+                .schemaVersion(1)
+                .schema(PrimaryKeyAsLong.class)
+                .migration(migration)
+                .build();
+
+        realm = Realm.getInstance(realmConfig);
+        Table table = realm.getTable(PrimaryKeyAsLong.class);
+        assertEquals(2, table.getColumnCount());
+        assertTrue(table.hasPrimaryKey());
+        assertTrue(table.hasSearchIndex(table.getColumnIndex("id")));
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -238,9 +238,8 @@ public class RealmMigrationTests {
         RealmMigration migration = new RealmMigration() {
             @Override
             public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
-                RealmSchema schema = realm.getSchema();
-                
-                schema.rename("AllJavaTypes", "PrimaryKeyAsLong")
+                realm.getSchema()
+                        .rename("AllJavaTypes", "PrimaryKeyAsLong")
                         // There are three columns coming prior to the PK field 'fieldLong', and
                         // removing "fieldString", "fieldShort" & "fieldInt" should not rearrange the PK
                         .removeField("fieldString")

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import android.text.TextUtils;
+
 import io.realm.annotations.Required;
 import io.realm.internal.ImplicitTransaction;
 import io.realm.internal.Table;
@@ -203,6 +205,14 @@ public final class RealmObjectSchema {
         long columnIndex = getColumnIndex(fieldName);
         if (table.getPrimaryKey() == columnIndex) {
             table.setPrimaryKey(null);
+        }
+        // When PK does not exist (-2) this cannot happen. Meanwhile a removal target has a smaller
+        // index than the PK index, we can expect an rearrangement.
+        if (columnIndex < table.getPrimaryKey()) {
+            String pkField = getPrimaryKey();
+            table.removeColumn(columnIndex);
+            table.setPrimaryKey(pkField);
+            return this;
         }
         table.removeColumn(columnIndex);
         return this;

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -16,8 +16,6 @@
 
 package io.realm;
 
-import android.text.TextUtils;
-
 import io.realm.annotations.Required;
 import io.realm.internal.ImplicitTransaction;
 import io.realm.internal.Table;

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -204,6 +204,16 @@ public class Table implements TableOrView, TableSchema, Closeable {
     @Override
     public void renameColumn(long columnIndex, String newName) {
         verifyColumnName(newName);
+        if (getPrimaryKey() == columnIndex) {
+            Table pkTable = getPrimaryKeyTable();
+            String className = tableNameToClassName(getName());
+            long rowIndex = pkTable.findFirstString(PRIMARY_KEY_CLASS_COLUMN_INDEX, className);
+            if (rowIndex != NO_MATCH) {
+                pkTable.getUncheckedRow(rowIndex).setString(PRIMARY_KEY_FIELD_COLUMN_INDEX, newName);
+            } else {
+                throw new IllegalStateException("PrimaryKey field is not properly recorded for " + className + ".");
+            }
+        }
         nativeRenameColumn(nativePtr, columnIndex, newName);
     }
 


### PR DESCRIPTION
This PR fixes followings. 

1. When a column with a smaller index than that of a primary key field gets removed, the primary key field index decrements, which causes a cached primary key index to point a wrong field. 

2. When a primary key field is renamed, primary key table is not updated accordingly.

Closes #2829. 