### PR TITLE
Redundant addIndex(fieldName) removed

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -490,9 +490,8 @@ public final class RealmObjectSchema {
                 }
 
                 if (containsAttribute(attributes, FieldAttribute.PRIMARY_KEY)) {
-                    addIndex(fieldName);
-                    indexAdded = true;
                     addPrimaryKey(fieldName);
+                    indexAdded = true;
                 }
 
                 // REQUIRED is being handled when adding the column using addField through the nullable parameter.

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -490,6 +490,7 @@ public final class RealmObjectSchema {
                 }
 
                 if (containsAttribute(attributes, FieldAttribute.PRIMARY_KEY)) {
+                    // Note : adding primary key implies application of FieldAttribute.INDEXED attribute.
                     addPrimaryKey(fieldName);
                     indexAdded = true;
                 }


### PR DESCRIPTION
In `RealmObjectSchema.addModifiers()` there is a redundant `addIndex(fieldName)` called before `addPrimaryKey(fieldName)`. This should have been removed at #2832. 