### PR TITLE
RealmResults is not synced in global listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fixed a crash when calling Table.toString() in debugger (#2429).
+* Fixed a crash that RealmResults was not updated in Realm's change listener by adjusting the calling orders of listeners on Realm, RealmObject and RealmResults (#2926).
 
 ### Enhancements
 

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -255,7 +255,8 @@ public class NotificationsTest {
         final AtomicBoolean isRealmOpen = new AtomicBoolean(true);
         final Map<Integer, Integer> results = new ConcurrentHashMap<Integer, Integer>();
         final Looper[] looper = new Looper[1];
-        final RealmChangeListener<Realm> listener[] = new RealmChangeListener[1];
+        //noinspection unchecked
+        final RealmChangeListener<Realm>[] listener = new RealmChangeListener[1];
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
@@ -1043,5 +1044,124 @@ public class NotificationsTest {
                 looperThread.testComplete();
             }
         });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void realmListener_realmResultShouldBeSynced() {
+        final AtomicBoolean changedOnce = new AtomicBoolean(false);
+        final Realm realm = looperThread.realm;
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createObject(AllTypes.class);
+            }
+        });
+        final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
+        assertEquals(1, results.size());
+
+        realm.addChangeListener(new RealmChangeListener<Realm>() {
+            @Override
+            public void onChange(Realm element) {
+                if (!changedOnce.get()) {
+                    // Change event triggered by populating
+                    assertEquals(1, realm.where(AllTypes.class).count());
+                    assertEquals(1, results.size());
+
+                    realm.executeTransactionAsync(new Realm.Transaction() {
+                        @Override
+                        public void execute(Realm realm) {
+                            AllTypes allTypes = realm.where(AllTypes.class).findFirst();
+                            assertNotNull(allTypes);
+                            allTypes.deleteFromRealm();
+                            final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
+                            assertEquals(0, results.size());
+                        }
+                    });
+                    changedOnce.set(true);
+                } else {
+                    // Change event triggered by deletion in async transaction.
+                    assertEquals(0, realm.where(AllTypes.class).count());
+                    assertEquals(0, results.size());
+                    realm.close();
+                    looperThread.testComplete();
+                }
+            }
+        });
+    }
+
+    // We precisely depend on the order of triggering change listeners right now.
+    // So it should be:
+    // 1. Synced object listener
+    // 2. Synced results listener
+    // 3. Global listener
+    // If this case fails on your code, think more before changing the test!
+    // https://github.com/realm/realm-java/issues/2408 is related with this test!
+    @Test
+    @RunTestInLooperThread
+    public void callingOrdersOfListeners() {
+        final Realm realm = looperThread.realm;
+        final AtomicInteger count = new AtomicInteger(0);
+
+        final RealmChangeListener<RealmResults<AllTypes>> syncedResultsListener =
+                new RealmChangeListener<RealmResults<AllTypes>>() {
+                    @Override
+                    public void onChange(RealmResults<AllTypes> element) {
+                        // First called
+                        assertEquals(0, count.getAndAdd(1));
+                    }
+                };
+
+        final RealmChangeListener<AllTypes> syncedObjectListener = new RealmChangeListener<AllTypes>() {
+            @Override
+            public void onChange(AllTypes element) {
+                // Second called
+                assertEquals(1, count.getAndAdd(1));
+            }
+        };
+        final RealmChangeListener<Realm> globalListener = new RealmChangeListener<Realm>() {
+            @Override
+            public void onChange(Realm element) {
+                // third called
+                assertEquals(2, count.getAndAdd(1));
+                looperThread.testComplete();
+            }
+        };
+
+
+        realm.beginTransaction();
+        final AllTypes allTypes = realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+
+        // We need to create one objects first and let the pass the first change event
+        final RealmChangeListener<Realm> initListener = new RealmChangeListener<Realm>() {
+            @Override
+            public void onChange(Realm element) {
+                looperThread.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        // Clear the change listeners
+                        realm.removeAllChangeListeners();
+
+                        // Now we can start testing
+                        allTypes.addChangeListener(syncedObjectListener);
+                        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
+                        results.addChangeListener(syncedResultsListener);
+                        realm.addChangeListener(globalListener);
+
+                        // Now we trigger those listeners
+                        realm.executeTransactionAsync(new Realm.Transaction() {
+                            @Override
+                            public void execute(Realm realm) {
+                                AllTypes allTypes = realm.where(AllTypes.class).findFirst();
+                                assertNotNull(allTypes);
+                                allTypes.setColumnLong(42);
+                            }
+                        });
+                    }
+                });
+            }
+        };
+        realm.addChangeListener(initListener);
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -1063,7 +1063,7 @@ public class NotificationsTest {
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm element) {
-                switch (changeCounter.getAndAdd(1)) {
+                switch (changeCounter.getAndIncrement()) {
                     case 0:
                         // Change event triggered by populating
                         assertEquals(1, realm.where(AllTypes.class).count());
@@ -1113,7 +1113,7 @@ public class NotificationsTest {
                     @Override
                     public void onChange(RealmResults<AllTypes> element) {
                         // First called
-                        assertEquals(0, count.getAndAdd(1));
+                        assertEquals(0, count.getAndIncrement());
                     }
                 };
 
@@ -1121,14 +1121,14 @@ public class NotificationsTest {
             @Override
             public void onChange(AllTypes element) {
                 // Second called
-                assertEquals(1, count.getAndAdd(1));
+                assertEquals(1, count.getAndIncrement());
             }
         };
         final RealmChangeListener<Realm> globalListener = new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm element) {
                 // third called
-                assertEquals(2, count.getAndAdd(1));
+                assertEquals(2, count.getAndIncrement());
                 looperThread.testComplete();
             }
         };

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -258,7 +258,6 @@ final class HandlerController implements Handler.Callback {
     }
 
     void notifyAllListeners() {
-        notifyGlobalListeners();
         notifyTypeBasedListeners();
 
         // empty async RealmObject shouldn't block the realm to advance
@@ -268,6 +267,12 @@ final class HandlerController implements Handler.Callback {
         if (!realm.isClosed() && threadContainsAsyncEmptyRealmObject()) {
             updateAsyncEmptyRealmObject();
         }
+        // It is very important to notify the global listeners last.
+        // We don't sync RealmResults in realmChanged, instead, they are synced in notifySyncRealmResultsCallbacks.
+        // This is because of we need to compare the table view version to decide if it changes. Thus, we cannot sync
+        // the RealmResults together with advance read - the result's listener won't get called.
+        // NotificationTest.callingOrdersOfListeners will fail if orders change.
+        notifyGlobalListeners();
     }
 
     private void notifyTypeBasedListeners() {

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -269,8 +269,8 @@ final class HandlerController implements Handler.Callback {
         }
         // It is very important to notify the global listeners last.
         // We don't sync RealmResults in realmChanged, instead, they are synced in notifySyncRealmResultsCallbacks.
-        // This is because of we need to compare the table view version to decide if it changes. Thus, we cannot sync
-        // the RealmResults together with advance read - the result's listener won't get called.
+        // This is because of we need to compare the TableView version in order to decide if it changes. Thus, we cannot
+        // sync the RealmResults together with advance read - the result's listener won't get called.
         // NotificationTest.callingOrdersOfListeners will fail if orders change.
         notifyGlobalListeners();
     }


### PR DESCRIPTION
Close #2408

RealmResults are synced when calling its listener, since we need to
check the table version before calling the listener. So sync it just
after advance read won't be an option - in that way, the result's
listener won't be triggered.

So we notify the global listeners as the last thing to do, at that
point, result will be synced already.

Also a test case is added to ensure the calling sequence of synced
listeners.