### PR TITLE
Listeners can call un-synchronized RealmResults (Async queries)

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -1208,8 +1208,8 @@ public class NotificationsTest {
     }
 
 
-    // RealmResults are opdated just before their change listener is notified, this means that synchronous RealmResults
-    // might accidentially reference another RealmResults that have been advance_read, but not called sync_if_needed.
+    // If RealmResults are updated just before their change listener are notified, one change listener might
+    // reference another RealmResults that have been advance_read, but not yet called sync_if_needed.
     // This can result in accessing detached rows and other errors.
     @Test
     @RunTestInLooperThread

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -269,7 +269,7 @@ final class HandlerController implements Handler.Callback {
         }
         // It is very important to notify the global listeners last.
         // We don't sync RealmResults in realmChanged, instead, they are synced in notifySyncRealmResultsCallbacks.
-        // This is because of we need to compare the TableView version in order to decide if it changes. Thus, we cannot
+        // This is because we need to compare the TableView version in order to decide if it changes. Thus, we cannot
         // sync the RealmResults together with advance read - the result's listener won't get called.
         // NotificationTest.callingOrdersOfListeners will fail if orders change.
         notifyGlobalListeners();
@@ -462,7 +462,9 @@ final class HandlerController implements Handler.Callback {
         SharedGroup.VersionID callerVersionID = realm.sharedGroupManager.getVersion();
         int compare = callerVersionID.compareTo(result.versionID);
         if (compare > 0) {
-            // if the caller thread is advanced i.e it already sent a REALM_CHANGE that will update the queries
+            // if the caller thread is more advanced than the worker thread, it means it did a local commit.
+            // This should also have put a REALM_CHANGED event on the Looper queue, so ignoring this result should
+            // be safe as all async queries will be rerun when processing the REALM_CHANGED event.
             RealmLog.d("COMPLETED_UPDATE_ASYNC_QUERIES realm:" + HandlerController.this + " caller is more advanced, Looper will updates queries");
 
         } else {

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -615,6 +615,14 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
         }
     }
 
+    /**
+     * Syncs this RealmResults, so it is update to date after `advance_read` has been called.
+     * Not doing so can leave detached accessors in the table view.
+     *
+     * By design, we should only call this on looper events.
+     *
+     * NOTE: Calling this is a prerequisite to calling {@link #notifyChangeListeners(boolean)}.
+     */
     void syncIfNeeded() {
         long newVersion = table.syncIfNeeded();
         viewUpdated = newVersion != currentTableViewVersion;
@@ -896,7 +904,7 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
             // this should handle more complex use cases like retry, ignore etc
             table = query.importHandoverTableView(tvHandover, realm.sharedGroupManager.getNativePointer());
             asyncQueryCompleted = true;
-            notifyChangeListeners(false, true);
+            notifyChangeListeners(true);
         } catch (Exception e) {
             RealmLog.d(e.getMessage());
             return false;
@@ -993,15 +1001,10 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
 
     /**
      * Notifies all registered listeners.
+     *
+     * NOTE: Remember to call `syncIfNeeded` before calling this method.
      */
-    void notifyChangeListeners() {
-        notifyChangeListeners(true, false);
-    }
-
-    private void notifyChangeListeners(boolean syncBeforeNotifying, boolean forceNotify) {
-        if (syncBeforeNotifying) {
-            syncIfNeeded();
-        }
+    void notifyChangeListeners(boolean forceNotify) {
         if (!listeners.isEmpty()) {
             // table might be null (if the async query didn't complete
             // but we have already registered listeners for it)


### PR DESCRIPTION
When async queries are updated, they call listeners in a specific order. This currently has a very subtle bug, so accessing synchronous RealmResults from inside a async RealmResult listener might hit a detached row accessor.

Reason being is that the Realm is advanced, then all listeners called in order, but RealmResults are not synchronised until just before listener is called. This was discovered when investigating #2901, but I doubt it is the root cause.