### PR TITLE
Listeners can call un-synchronized RealmResults (Async queries)

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.Dog;
 import io.realm.internal.log.Logger;
@@ -946,20 +947,20 @@ public class NotificationsTest {
     public void asyncRealmObjectShouldNotBlockBackgroundCommitNotification() {
         final AtomicInteger numberOfRealmCallbackInvocation = new AtomicInteger(0);
         final CountDownLatch signalClosedRealm = new CountDownLatch(1);
-        looperThread.realm.addChangeListener(new RealmChangeListener<Realm>() {
+        final Realm realm = looperThread.realm;
+        realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
                 switch (numberOfRealmCallbackInvocation.incrementAndGet()) {
                     case 1: {
                         // first commit
-                        Dog dog = looperThread.realm.where(Dog.class).findFirstAsync();
+                        Dog dog = realm.where(Dog.class).findFirstAsync();
                         assertTrue(dog.load());
                         dog.addChangeListener(new RealmChangeListener<Dog>() {
                             @Override
                             public void onChange(Dog dog) {
                             }
                         });
-                        looperThread.keepStrongReference.add(dog);
 
                         new Thread() {
                             @Override
@@ -987,9 +988,9 @@ public class NotificationsTest {
         looperThread.postRunnable(new Runnable() {
             @Override
             public void run() {
-                looperThread.realm.beginTransaction();
-                looperThread.realm.createObject(Dog.class);
-                looperThread.realm.commitTransaction();
+                realm.beginTransaction();
+                realm.createObject(Dog.class);
+                realm.commitTransaction();
             }
         });
     }
@@ -1168,5 +1169,65 @@ public class NotificationsTest {
             }
         };
         realm.addChangeListener(initListener);
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void accessingSyncRealmResultInsideAsyncResultListener() {
+        final Realm realm = looperThread.realm;
+        final AtomicInteger asyncResultCallback = new AtomicInteger(0);
+
+        final RealmResults<AllTypes> syncResults = realm.where(AllTypes.class).findAll();
+
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
+        results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> results) {
+                switch (asyncResultCallback.incrementAndGet()) {
+                    case 1:
+                        // 1. Called when first async query completes
+                        assertEquals(0, results.size());
+                        realm.executeTransactionAsync(new Realm.Transaction() {
+                            @Override
+                            public void execute(Realm realm) {
+                                realm.createObject(AllTypes.class);
+                            }
+                        });
+                        break;
+
+                    case 2:
+                        // 2. Called after async transaction completes, A REALM_CHANGED event has been triggered,
+                        // async queries have rerun, and listeners are triggered again
+                        assertEquals(1, results.size());
+                        assertEquals(1, syncResults.size());
+                        looperThread.testComplete();
+                        break;
+                }
+            }
+        });
+    }
+
+
+    // If RealmResults are updated just before their change listener are notified, one change listener might
+    // reference another RealmResults that have been advance_read, but not yet called sync_if_needed.
+    // This can result in accessing detached rows and other errors.
+    @Test
+    @RunTestInLooperThread
+    public void accessingSyncRealmResultsInsideResultListener() {
+        final Realm realm = looperThread.realm;
+        final RealmResults<AllTypes> syncResults1 = realm.where(AllTypes.class).findAll();
+        final RealmResults<AllTypes> syncResults2 = realm.where(AllTypes.class).findAll();
+        syncResults1.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> element) {
+                assertEquals(1, syncResults1.size());
+                assertEquals(1, syncResults2.size()); // If syncResults2 is not in sync yet, this will fail.
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        realm.createObject(AllTypes.class);
+        realm.commitTransaction();
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -268,44 +268,50 @@ final class HandlerController implements Handler.Callback {
             updateAsyncEmptyRealmObject();
         }
         // It is very important to notify the global listeners last.
-        // We don't sync RealmResults in realmChanged, instead, they are synced in notifySyncRealmResultsCallbacks.
-        // This is because of we need to compare the TableView version in order to decide if it changes. Thus, we cannot
+        // We don't sync RealmResults in realmChanged, instead, they are synced in collectSyncRealmResultsCallbacks.
+        // This is because we need to compare the TableView version in order to decide if it changes. Thus, we cannot
         // sync the RealmResults together with advance read - the result's listener won't get called.
         // NotificationTest.callingOrdersOfListeners will fail if orders change.
         notifyGlobalListeners();
     }
 
     private void notifyTypeBasedListeners() {
-        notifyAsyncRealmResultsCallbacks();
-        notifySyncRealmResultsCallbacks();
+        // Collect all type based listeners before notifying them. As part of collecting them, the RealmResults
+        // will also be updated as needed, which means that when we finally call the listeners all RealmResults
+        // will be up to date which means that referencing each other inside the listeners is safe.
+        List<RealmResults<? extends RealmModel>> resultsToBeNotified = new ArrayList<RealmResults<? extends RealmModel>>();
+        collectAsyncRealmResultsCallbacks(resultsToBeNotified);
+        collectSyncRealmResultsCallbacks(resultsToBeNotified);
+        for (Iterator<RealmResults<? extends RealmModel>> it = resultsToBeNotified.iterator(); it.hasNext() && !realm.isClosed(); ) {
+            RealmResults<? extends RealmModel> realmResults = it.next();
+            realmResults.notifyChangeListeners(false); // PREREQUISITE: syncIfNeeded was called when collecting the listeners.
+        }
         notifyRealmObjectCallbacks();
     }
 
-    private void notifyAsyncRealmResultsCallbacks() {
-        notifyRealmResultsCallbacks(asyncRealmResults.keySet().iterator());
+    private void collectAsyncRealmResultsCallbacks(List<RealmResults<? extends RealmModel>> resultsToBeNotified) {
+        collectRealmResultsCallbacks(asyncRealmResults.keySet().iterator(), resultsToBeNotified);
     }
 
-    private void notifySyncRealmResultsCallbacks() {
-        notifyRealmResultsCallbacks(syncRealmResults.keySet().iterator());
+    private void collectSyncRealmResultsCallbacks(List<RealmResults<? extends RealmModel>> resultsToBeNotified) {
+        collectRealmResultsCallbacks(syncRealmResults.keySet().iterator(), resultsToBeNotified);
     }
 
-    private void notifyRealmResultsCallbacks(Iterator<WeakReference<RealmResults<? extends RealmModel>>> iterator) {
-        List<RealmResults<? extends RealmModel>> resultsToBeNotified =
-                new ArrayList<RealmResults<? extends RealmModel>>();
+
+    private void collectRealmResultsCallbacks(Iterator<WeakReference<RealmResults<? extends RealmModel>>> iterator,
+                                              List<RealmResults<? extends RealmModel>> resultsToBeNotified) {
         while (iterator.hasNext()) {
             WeakReference<RealmResults<? extends RealmModel>> weakRealmResults = iterator.next();
             RealmResults<? extends RealmModel> realmResults = weakRealmResults.get();
             if (realmResults == null) {
                 iterator.remove();
             } else {
-                // It should be legal to modify asyncRealmResults and syncRealmResults in the listener
+                // Sync the RealmResult so it is completely up to date.
+                // This is a prerequisite to calling the listener, so when the listener is finally triggered, all
+                // RealmResults will be up to date.
+                realmResults.syncIfNeeded();
                 resultsToBeNotified.add(realmResults);
             }
-        }
-
-        for (Iterator<RealmResults<? extends RealmModel>> it = resultsToBeNotified.iterator(); it.hasNext() && !realm.isClosed(); ) {
-            RealmResults<? extends RealmModel> realmResults = it.next();
-            realmResults.notifyChangeListeners();
         }
     }
 
@@ -412,7 +418,8 @@ final class HandlerController implements Handler.Callback {
                         // swap pointer
                         realmResults.swapTableViewPointer(result.updatedTableViews.get(weakRealmResults));
                         // notify callbacks
-                        realmResults.notifyChangeListeners();
+                        realmResults.syncIfNeeded();
+                        realmResults.notifyChangeListeners(false);
                     } else {
                         RealmLog.d("[COMPLETED_ASYNC_REALM_RESULTS "+ weakRealmResults + "] , realm:"+ HandlerController.this + " ignoring result the RealmResults (is already loaded)");
                     }
@@ -462,7 +469,9 @@ final class HandlerController implements Handler.Callback {
         SharedGroup.VersionID callerVersionID = realm.sharedGroupManager.getVersion();
         int compare = callerVersionID.compareTo(result.versionID);
         if (compare > 0) {
-            // if the caller thread is advanced i.e it already sent a REALM_CHANGE that will update the queries
+            // if the caller thread is more advanced than the worker thread, it means it did a local commit.
+            // This should also have put a REALM_CHANGED event on the Looper queue, so ignoring this result should
+            // be safe as all async queries will be rerun when processing the REALM_CHANGED event.
             RealmLog.d("COMPLETED_UPDATE_ASYNC_QUERIES realm:" + HandlerController.this + " caller is more advanced, Looper will updates queries");
 
         } else {
@@ -487,7 +496,9 @@ final class HandlerController implements Handler.Callback {
                 }
             }
 
-            ArrayList<RealmResults<? extends RealmModel>> callbacksToNotify = new ArrayList<RealmResults<? extends RealmModel>>(result.updatedTableViews.size());
+
+            //
+            ArrayList<RealmResults<? extends RealmModel>> resultsToBeNotified = new ArrayList<RealmResults<? extends RealmModel>>(result.updatedTableViews.size());
             // use updated TableViews pointers for the existing async RealmResults
             for (Map.Entry<WeakReference<RealmResults<? extends RealmModel>>, Long> query : result.updatedTableViews.entrySet()) {
                 WeakReference<RealmResults<? extends RealmModel>> weakRealmResults = query.getKey();
@@ -499,25 +510,26 @@ final class HandlerController implements Handler.Callback {
                 } else {
                     // update the instance with the new pointer
                     realmResults.swapTableViewPointer(query.getValue());
+                    realmResults.syncIfNeeded();
 
                     // it's dangerous to notify the callback about new results before updating
                     // the pointers, because the callback may use another RealmResults not updated yet
                     // this is why we defer the notification until we're done updating all pointers
-                    callbacksToNotify.add(realmResults);
+                    resultsToBeNotified.add(realmResults);
 
                     RealmLog.d("COMPLETED_UPDATE_ASYNC_QUERIES realm:"+ HandlerController.this + " updating RealmResults " + weakRealmResults);
                 }
             }
-
-            for (RealmResults<? extends RealmModel> query : callbacksToNotify) {
-                query.notifyChangeListeners();
-            }
+            collectSyncRealmResultsCallbacks(resultsToBeNotified);
 
             // We need to notify the rest of listeners, since the original REALM_CHANGE
             // was delayed/swallowed in order to be able to update async queries
-            notifyGlobalListeners();
-            notifySyncRealmResultsCallbacks();
+            for (Iterator<RealmResults<? extends RealmModel>> it = resultsToBeNotified.iterator(); it.hasNext() && !realm.isClosed(); ) {
+                RealmResults<? extends RealmModel> realmResults = it.next();
+                realmResults.notifyChangeListeners(false); // PREREQUISITE: syncIfNeeded was called when collecting the listeners.
+            }
             notifyRealmObjectCallbacks();
+            notifyGlobalListeners();
 
             updateAsyncQueriesTask = null;
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -615,6 +615,14 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
         }
     }
 
+    /**
+     * Syncs this RealmResults, so it is update to date after `advance_read` has been called.
+     * Not doing so can leave detached accessors in the table view.
+     *
+     * By design, we should only call this on looper events.
+     *
+     * NOTE: Calling this is a prerequisite to calling {@link #notifyChangeListeners(boolean)}.
+     */
     void syncIfNeeded() {
         long newVersion = table.syncIfNeeded();
         viewUpdated = newVersion != currentTableViewVersion;
@@ -897,7 +905,7 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
             // this should handle more complex use cases like retry, ignore etc
             table = query.importHandoverTableView(tvHandover, realm.sharedGroupManager.getNativePointer());
             asyncQueryCompleted = true;
-            notifyChangeListeners(false, true);
+            notifyChangeListeners(true);
         } catch (Exception e) {
             RealmLog.d(e.getMessage());
             return false;
@@ -994,15 +1002,10 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
 
     /**
      * Notifies all registered listeners.
+     *
+     * NOTE: Remember to call `syncIfNeeded` before calling this method.
      */
-    void notifyChangeListeners() {
-        notifyChangeListeners(true, false);
-    }
-
-    private void notifyChangeListeners(boolean syncBeforeNotifying, boolean forceNotify) {
-        if (syncBeforeNotifying) {
-            syncIfNeeded();
-        }
+    void notifyChangeListeners(boolean forceNotify) {
         if (!listeners.isEmpty()) {
             // table might be null (if the async query didn't complete
             // but we have already registered listeners for it)


### PR DESCRIPTION
When async queries are updated, they call listeners in a specific order. This currently has a very subtle bug, so accessing synchronous RealmResults from inside a async RealmResult listener might hit a detached row accessor.

Reason being is that the Realm is advanced, then all listeners called in order, but RealmResults are not synchronised until just before listener is called. This was discovered when investigating #2901, but I doubt it is the root cause.