### PR TITLE
update proguard configuration no to depend on Android's default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Enhancements
 
 * Enhanced `Table.toString()` to show a PrimaryKey field details (#2903).
-* Updated ProGuard configuration in order not to depend on Andtoid's default configuraion(#2972).
+* Updated ProGuard configuration in order not to depend on Android's default configuraion (#2972).
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * Enhanced `Table.toString()` to show a PrimaryKey field details (#2903).
+* Updated ProGuard configuration in order not to depend on Andtoid's default configuraion(#2972).
 
 ## 1.0.1
 

--- a/realm/realm-library/proguard-rules.pro
+++ b/realm/realm-library/proguard-rules.pro
@@ -6,3 +6,6 @@
 -dontwarn io.realm.**
 -keep class io.realm.RealmCollection
 -keep class io.realm.OrderedRealmCollection
+-keepclasseswithmembernames class io.realm.internal.** {
+    native <methods>;
+}


### PR DESCRIPTION
related to #2927

This PR adds a ProGuard configuration for native methods.

In normal cases, users include android's default ProGuard configuration and it contains a configuration for native methods.
But including default configuration is not mandatory and users freely write their own configurations from scratch.

To allow such a usage, ProGuard configuration provided by Realm should not depend on default configuration.
