### PR TITLE
Updated beginTransaction doc

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -308,8 +308,8 @@ abstract class BaseRealm implements Closeable {
      * {@link io.realm.Realm#cancelTransaction()}. Transactions are used to atomically create, update and delete objects
      * within a Realm.
      * <p>
-     * Writing to a Realm always happen on the latest version of the data. So before beginning a transaction, this
-     * instance of Realm is updated to the latest version that include changes from all threads. This update does not
+     * Writing to a Realm always happens on the latest version of the data. So before beginning a transaction, this
+     * instance of Realm is updated to the latest version that includes changes from all threads. This update does not
      * trigger any registered {@link RealmChangeListener}.
      * <p>
      * For that reason, it is best practise to query for any data that should be modified from inside the
@@ -323,7 +323,7 @@ abstract class BaseRealm implements Closeable {
      * persons.first().setName("John");
      * realm.commitTransaction;
      *
-     * // But this
+     * // Do this instead
      * realm.beginTransaction();
      * RealResults<Person> persons = realm.where(Person.class).findAll();
      * persons.first().setName("John");

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -308,11 +308,11 @@ abstract class BaseRealm implements Closeable {
      * {@link io.realm.Realm#cancelTransaction()}. Transactions are used to atomically create, update and delete objects
      * within a Realm.
      * <p>
-     * Before beginning a transaction the Realm instance is updated to the latest version, which included all the
-     * changes from the other threads. This update does not trigger any registered {@link RealmChangeListener}.
+     * Before beginning a transaction, the Realm instance is updated to the latest version in order to include all
+     * changes from other threads. This update does not trigger any registered {@link RealmChangeListener}.
      * <p>
-     * It is therefore recommended to query for the data that should be modified from inside the transaction, otherwise
-     * there is a risk that data have been deleted or modified when the transaction begins.
+     * It is therefore recommended to query for the items that should be modified from inside the transaction. Otherwise
+     * there is a risk that some of the results have been deleted or modified when the transaction begins.
      * <p>
      * <pre>
      * {@code

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -308,12 +308,11 @@ abstract class BaseRealm implements Closeable {
      * {@link io.realm.Realm#cancelTransaction()}. Transactions are used to atomically create, update and delete objects
      * within a Realm.
      * <p>
-     * Writing to a Realm always happens on the latest version of the data. So before beginning a transaction, this
-     * instance of Realm is updated to the latest version that includes changes from all threads. This update does not
-     * trigger any registered {@link RealmChangeListener}.
+     * Before beginning a transaction the Realm instance is updated to the latest version, which included all the
+     * changes from the other threads. This update does not trigger any registered {@link RealmChangeListener}.
      * <p>
-     * For that reason, it is best practise to query for any data that should be modified from inside the
-     * transaction, otherwise there is a risk those data have been deleted or modified when the transaction begins.
+     * It is therefore recommended to query for the data that should be modified from inside the transaction, otherwise
+     * there is a risk that data have been deleted or modified when the transaction begins.
      * <p>
      * <pre>
      * {@code

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -317,14 +317,14 @@ abstract class BaseRealm implements Closeable {
      * <pre>
      * {@code
      * // Don't do this
-     * RealResults<Person> persons = realm.where(Person.class).findAll();
+     * RealmResults<Person> persons = realm.where(Person.class).findAll();
      * realm.beginTransaction();
      * persons.first().setName("John");
      * realm.commitTransaction;
      *
      * // Do this instead
      * realm.beginTransaction();
-     * RealResults<Person> persons = realm.where(Person.class).findAll();
+     * RealmResults<Person> persons = realm.where(Person.class).findAll();
      * persons.first().setName("John");
      * realm.commitTransaction;
      * }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -313,7 +313,7 @@ abstract class BaseRealm implements Closeable {
      * trigger any registered {@link RealmChangeListener}.
      * <p>
      * For that reason, it is best practise to query for any data that should be modified from inside the
-     * transaction, otherwise there is a risk those data have been deleted when the transaction begins.
+     * transaction, otherwise there is a risk those data have been deleted or modified when the transaction begins.
      * <p>
      * <pre>
      * {@code

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -308,8 +308,28 @@ abstract class BaseRealm implements Closeable {
      * {@link io.realm.Realm#cancelTransaction()}. Transactions are used to atomically create, update and delete objects
      * within a Realm.
      * <p>
-     * Before beginning the transaction, {@link io.realm.Realm#beginTransaction()} updates the Realm in the case of
-     * pending updates from other threads.
+     * Writing to a Realm always happen on the latest version of the data. So before beginning a transaction, this
+     * instance of Realm is updated to the latest version that include changes from all threads. This update does not
+     * trigger any registered {@link RealmChangeListener}.
+     * <p>
+     * For that reason, it is best practise to query for any data that should be modified from inside the
+     * transaction, otherwise there is a risk those data have been deleted when the transaction begins.
+     * <p>
+     * <pre>
+     * {@code
+     * // Don't do this
+     * RealResults<Person> persons = realm.where(Person.class).findAll();
+     * realm.beginTransaction();
+     * persons.first().setName("John");
+     * realm.commitTransaction;
+     *
+     * // But this
+     * realm.beginTransaction();
+     * RealResults<Person> persons = realm.where(Person.class).findAll();
+     * persons.first().setName("John");
+     * realm.commitTransaction;
+     * }
+     * </pre>
      * <p>
      * Notice: it is not possible to nest transactions. If you start a transaction within a transaction an exception is
      * thrown.


### PR DESCRIPTION
We recently had a number of questions around refreshing and modifying data.
I extended the `beginTransaction` Javadoc to be very explicit about what happens and what the best practise is around this.

@realm/java 