### PR TITLE
Free object on nativeBatchUpdateQueries after each iteration.

### DIFF
--- a/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -1183,17 +1183,17 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
 
         // Step3: Run & export the queries against the latest shared group
         for (size_t i = 0; i < number_of_queries; ++i) {
-            JniLongArray query_param_array(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
-            switch (query_param_array[0]) { // 0, index of the type of query, the next indicies are parameters
+            JniLongArray* query_param_array = new JniLongArray(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
+            switch ((*query_param_array)[0]) { // 0, index of the type of query, the next indicies are parameters
                 case QUERY_TYPE_FIND_ALL: {// nativeFindAllWithHandover
                     exported_handover_tableview_array[i] =
                             findAllWithHandover
                                     (env,
                                      bgSharedGroupPtr,
                                      std::move(queries[i]),
-                                     query_param_array[1]/*start*/,
-                                     query_param_array[2]/*end*/,
-                                     query_param_array[3]/*limit*/);
+                                     (*query_param_array)[1]/*start*/,
+                                     (*query_param_array)[2]/*end*/,
+                                     (*query_param_array)[3]/*limit*/);
                     break;
                 }
                 case QUERY_TYPE_DISTINCT: {// nativeGetDistinctViewWithHandover
@@ -1202,7 +1202,7 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
                                     (env,
                                      bgSharedGroupPtr,
                                      std::move(queries[i]),
-                                     query_param_array[1]/*columnIndex*/);
+                                     (*query_param_array)[1]/*columnIndex*/);
                     break;
                 }
                 case QUERY_TYPE_FIND_ALL_SORTED: {// nativeFindAllSortedWithHandover
@@ -1211,11 +1211,11 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
                                     (env,
                                      bgSharedGroupPtr,
                                      std::move(queries[i]),
-                                     query_param_array[1]/*start*/,
-                                     query_param_array[2]/*end*/,
-                                     query_param_array[3]/*limit*/,
-                                     query_param_array[4]/*columnIndex*/,
-                                     query_param_array[5] == 1/*ascending order*/);
+                                     (*query_param_array)[1]/*start*/,
+                                     (*query_param_array)[2]/*end*/,
+                                     (*query_param_array)[3]/*limit*/,
+                                     (*query_param_array)[4]/*columnIndex*/,
+                                     (*query_param_array)[5] == 1/*ascending order*/);
                     break;
                 }
                 case QUERY_TYPE_FIND_ALL_MULTI_SORTED: {// nativeFindAllMultiSortedWithHandover
@@ -1228,9 +1228,9 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
                                     (env,
                                      bgSharedGroupPtr,
                                      std::move(queries[i]),
-                                     query_param_array[1]/*start*/,
-                                     query_param_array[2]/*end*/,
-                                     query_param_array[3]/*limit*/,
+                                     (*query_param_array)[1]/*start*/,
+                                     (*query_param_array)[2]/*end*/,
+                                     (*query_param_array)[3]/*limit*/,
                                      column_indices_array/*columnIndices*/,
                                      column_order_array/*ascending orders*/);
                     break;
@@ -1239,6 +1239,7 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
                     ThrowException(env, FatalError, "Unknown type of query.");
                     return NULL;
             }
+            delete query_param_array;
         }
 
         jlongArray exported_handover_tableview = env->NewLongArray(number_of_queries);

--- a/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -1240,7 +1240,6 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
                     ThrowException(env, FatalError, "Unknown type of query.");
                     return NULL;
             }
-            delete query_param_array;
         }
 
         jlongArray exported_handover_tableview = env->NewLongArray(number_of_queries);

--- a/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -1183,7 +1183,8 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
 
         // Step3: Run & export the queries against the latest shared group
         for (size_t i = 0; i < number_of_queries; ++i) {
-            JniLongArray* query_param_array = new JniLongArray(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
+            std::unique_ptr<JniLongArray> query_param_array(
+                new JniLongArray(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
             switch ((*query_param_array)[0]) { // 0, index of the type of query, the next indicies are parameters
                 case QUERY_TYPE_FIND_ALL: {// nativeFindAllWithHandover
                     exported_handover_tableview_array[i] =

--- a/realm/realm-jni/src/util.hpp
+++ b/realm/realm-jni/src/util.hpp
@@ -578,6 +578,7 @@ public:
     ~JniLongArray()
     {
         m_env->ReleaseLongArrayElements(m_javaArray, m_array, m_releaseMode);
+        m_env->DeleteLocalRef(m_javaArray);
     }
 
     inline jsize len() const noexcept


### PR DESCRIPTION
Currently nativeBatchUpdateQueries method fails with overflow of jni table,
as there are more than 500 items passed to JNI if realm needs to update frequently.
That is why we need to free the objects after they are used (= after each iteration).
