### PR TITLE
Asset file provided in configuration should not be deleted in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed a race condition which would cause some `RealmResults` to not be properly updated inside a `RealmChangeListener`. This could result in crashes when accessing items from those results (#2926/#2951).
 * Fixed a bug that could cause Realm to lose track of primary key when using `RealmObjectSchema.removeField()` and `RealmObjectSchema.renameField()` (#2829).lts (#2926).
 * Updated ProGuard configuration in order not to depend on Android's default configuration (#2972).
+* Fixed a bug that allows both `RealmConfiguration.Builder.assetFile()`/`deleteRealmIfMigrationNeeded()` to be called at the same time which leads to delete the provided asset file in migrations (#2933).
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fixed a race condition which would cause some `RealmResults` to not be properly updated inside a `RealmChangeListener`. This could result in crashes when accessing items from those results (#2926/#2951).
 * Fixed a bug that could cause Realm to lose track of primary key when using `RealmObjectSchema.removeField()` and `RealmObjectSchema.renameField()` (#2829).lts (#2926).
 * Updated ProGuard configuration in order not to depend on Android's default configuration (#2972).
-* Fixed a bug that allows both `RealmConfiguration.Builder.assetFile()`/`deleteRealmIfMigrationNeeded()` to be called at the same time which leads to delete the provided asset file in migrations (#2933).
+* Fixed a bug that allowed both `RealmConfiguration.Builder.assetFile()`/`deleteRealmIfMigrationNeeded()` to be configured at the same time, which leads to the asset file accidentally being deleted in migrations (#2933).
 
 ### Enhancements
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -353,7 +353,7 @@ public class RealmConfigurationTests {
                     .deleteRealmIfMigrationNeeded();
             fail();
         } catch (IllegalStateException expected) {
-            assertEquals("Realm cannot clear its schema when previously configured to use an asset file.",
+            assertEquals("Realm cannot clear its schema when previously configured to use an asset file by calling assetFile().",
                     expected.getMessage());
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -342,6 +342,26 @@ public class RealmConfigurationTests {
     }
 
     @Test
+    public void deleteRealmIfMigrationNeeded_failsWhenAssetFileProvided() {
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+
+        // Ensure that there is no data
+        Realm.deleteRealm(new RealmConfiguration.Builder(context).build());
+
+        // have a builder instance to isolate codepath
+        RealmConfiguration.Builder builder = new RealmConfiguration.Builder(context);
+        try {
+            builder
+                    .assetFile(context, "asset_file.realm")
+                    .deleteRealmIfMigrationNeeded();
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Realm cannot clear its schema when previously configured to use an asset file.",
+                    expected.getMessage());
+        }
+    }
+
+    @Test
     public void upgradeVersionWithNoMigration() {
         realm = Realm.getInstance(defaultConfig);
         assertEquals(0, realm.getVersion());
@@ -854,6 +874,26 @@ public class RealmConfigurationTests {
 
         Realm.deleteRealm(configuration);
         assertFalse(realmFile.exists());
+    }
+
+    @Test
+    public void assetFile_failsWhenDeleteRealmIfMigrationNeededCalled() {
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+
+        // Ensure that there is no data
+        Realm.deleteRealm(new RealmConfiguration.Builder(context).build());
+
+        // have a builder instance to isolate codepath
+        RealmConfiguration.Builder builder = new RealmConfiguration.Builder(context);
+        try {
+            builder
+                    .deleteRealmIfMigrationNeeded()
+                    .assetFile(context, "asset_file.realm");
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Realm cannot use an asset file when previously configured to clear its schema in migration by calling deleteRealmIfMigrationNeeded().",
+                    expected.getMessage());
+        }
     }
 
     private static class MigrationWithNoEquals implements RealmMigration {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -345,9 +345,6 @@ public class RealmConfigurationTests {
     public void deleteRealmIfMigrationNeeded_failsWhenAssetFileProvided() {
         Context context = InstrumentationRegistry.getInstrumentation().getContext();
 
-        // Ensure that there is no data
-        Realm.deleteRealm(new RealmConfiguration.Builder(context).build());
-
         // have a builder instance to isolate codepath
         RealmConfiguration.Builder builder = new RealmConfiguration.Builder(context);
         try {
@@ -877,11 +874,8 @@ public class RealmConfigurationTests {
     }
 
     @Test
-    public void assetFile_failsWhenDeleteRealmIfMigrationNeededCalled() {
+    public void assetFile_failsWhenDeleteRealmIfMigrationNeededConfigured() {
         Context context = InstrumentationRegistry.getInstrumentation().getContext();
-
-        // Ensure that there is no data
-        Realm.deleteRealm(new RealmConfiguration.Builder(context).build());
 
         // have a builder instance to isolate codepath
         RealmConfiguration.Builder builder = new RealmConfiguration.Builder(context);

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -481,8 +481,8 @@ public final class RealmConfiguration {
          * @throws IllegalStateException if configured to use an asset file by calling {@link #assetFile(Context, String)} previously.
          */
         public Builder deleteRealmIfMigrationNeeded() {
-            if (this.assetFilePath != null || this.assetFilePath.length() != 0) {
-                throw new IllegalStateException("Realm cannot clear its schema when previously configured to use an asset file.");
+            if (this.assetFilePath != null && this.assetFilePath.length() != 0) {
+                throw new IllegalStateException("Realm cannot clear its schema when previously configured to use an asset file by calling assetFile().");
             }
 
             this.deleteRealmIfMigrationNeeded = true;

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -473,12 +473,12 @@ public final class RealmConfiguration {
          * {@link io.realm.exceptions.RealmMigrationNeededException} the on-disc Realm will be cleared and recreated
          * with the new Realm schema.
          *
-         * <p>This cannot be configured to use an asset file at the same time by calling
-         * {@link #assetFile(Context, String)} as the provided asset file will be cleared in migrations.
+         * <p>This cannot be configured to have an asset file at the same time by calling
+         * {@link #assetFile(Context, String)} as the provided asset file will be deleted in migrations.
          *
          * <b>WARNING!</b> This will result in loss of data.
          *
-         * @throws IllegalStateException if configured to use an asset file by calling assetFile() previously.
+         * @throws IllegalStateException if configured to use an asset file by calling {@link #assetFile(Context, String)} previously.
          */
         public Builder deleteRealmIfMigrationNeeded() {
             if (this.assetFilePath != null || this.assetFilePath.length() != 0) {
@@ -563,14 +563,14 @@ public final class RealmConfiguration {
          * the Realm file will be copied from the provided asset file and used instead.
          *
          * <p>This cannot be configured to clear and recreate schema by calling {@link #deleteRealmIfMigrationNeeded()}
-         * as doing so will delete the copied asset schema.
+         * at the same time as doing so will delete the copied asset schema.
          *
          * <p>
          * WARNING: This could potentially be a lengthy operation and should ideally be done on a background thread.
          *
          * @param context Android application context.
          * @param assetFile path to the asset database file.
-         * @throws IllegalStateException if this is configured to clear its schema by calling deleteRealmIfMigrationNeeded().
+         * @throws IllegalStateException if this is configured to clear its schema by calling {@link #deleteRealmIfMigrationNeeded()}.
          */
         public Builder assetFile(Context context, final String assetFile) {
             if (context == null) {

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -476,7 +476,7 @@ public final class RealmConfiguration {
          * <p>This cannot be configured to have an asset file at the same time by calling
          * {@link #assetFile(Context, String)} as the provided asset file will be deleted in migrations.
          *
-         * <b>WARNING!</b> This will result in loss of data.
+         * <p><b>WARNING!</b> This will result in loss of data.
          *
          * @throws IllegalStateException if configured to use an asset file by calling {@link #assetFile(Context, String)} previously.
          */

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -473,9 +473,18 @@ public final class RealmConfiguration {
          * {@link io.realm.exceptions.RealmMigrationNeededException} the on-disc Realm will be cleared and recreated
          * with the new Realm schema.
          *
+         * <p>This cannot be configured to use an asset file at the same time by calling
+         * {@link #assetFile(Context, String)} as the provided asset file will be cleared in migrations.
+         *
          * <b>WARNING!</b> This will result in loss of data.
+         *
+         * @throws IllegalStateException if configured to use an asset file by calling assetFile() previously.
          */
         public Builder deleteRealmIfMigrationNeeded() {
+            if (this.assetFilePath != null || this.assetFilePath.length() != 0) {
+                throw new IllegalStateException("Realm cannot clear its schema when previously configured to use an asset file.");
+            }
+
             this.deleteRealmIfMigrationNeeded = true;
             return this;
         }
@@ -551,12 +560,17 @@ public final class RealmConfiguration {
          * Copies the Realm file from the given asset file path.
          * <p>
          * When opening the Realm for the first time, instead of creating an empty file,
-         * the Realm file will be copied from the provided assets file and used instead.
+         * the Realm file will be copied from the provided asset file and used instead.
+         *
+         * <p>This cannot be configured to clear and recreate schema by calling {@link #deleteRealmIfMigrationNeeded()}
+         * as doing so will delete the copied asset schema.
+         *
          * <p>
          * WARNING: This could potentially be a lengthy operation and should ideally be done on a background thread.
          *
          * @param context Android application context.
          * @param assetFile path to the asset database file.
+         * @throws IllegalStateException if this is configured to clear its schema by calling deleteRealmIfMigrationNeeded().
          */
         public Builder assetFile(Context context, final String assetFile) {
             if (context == null) {
@@ -567,6 +581,9 @@ public final class RealmConfiguration {
             }
             if (durability == SharedGroup.Durability.MEM_ONLY) {
                 throw new RealmException("Realm can not use in-memory configuration if asset file is present.");
+            }
+            if (this.deleteRealmIfMigrationNeeded) {
+                throw new IllegalStateException("Realm cannot use an asset file when previously configured to clear its schema in migration by calling deleteRealmIfMigrationNeeded().");
             }
 
             this.contextWeakRef = new WeakReference<>(context);


### PR DESCRIPTION
RealmConfiguration.Builder.assetFile() and deleteRealmIfMigrationNeeded() should not be called at the same time to prevent the provided asset file from deletion in migrations.

Closes  #2933.