### PR TITLE
Builder takes custom directory path and context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ### Enhancements
 
 * Enhanced `Table.toString()` to show a PrimaryKey field details (#2903).
-* Ehhanced `RealmConfiguration.Builder` to have a constructor with Context and a custom folder path (#2900).
+* Enabled ReLinker when loading a Realm from a custom path by adding a `RealmConfiguration.Builder(Context, File)` constructor (#2900).
+
+### Deprecated
+
+* `RealmConfiguration.Builder(File)`. Use `RealmConfiguration.Builder(Context, File)` instead.
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * Enhanced `Table.toString()` to show a PrimaryKey field details (#2903).
+* Ehhanced `RealmConfiguration.Builder` to have a constructor with Context and a custom folder path (#2900).
 
 ## 1.0.1
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -185,6 +185,18 @@ public class RealmTests {
         Realm.getInstance(new RealmConfiguration.Builder(folder).build());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void getInstance_nullContextWithCustomDirThrows() {
+        Realm.getInstance(new RealmConfiguration.Builder((Context) null, configFactory.getRoot()).build());
+    }
+
+    @Test
+    public void getInstance_writeProtectedDirWithContext() {
+        File folder = new File("/");
+        thrown.expect(IllegalArgumentException.class);
+        Realm.getInstance(new RealmConfiguration.Builder(context, folder).build());
+    }
+
     @Test
     public void getInstance_writeProtectedFile() throws IOException {
         String REALM_FILE = "readonly.realm";
@@ -196,6 +208,19 @@ public class RealmTests {
 
         thrown.expect(RealmIOException.class);
         Realm.getInstance(new RealmConfiguration.Builder(folder).name(REALM_FILE).build());
+    }
+
+    @Test
+    public void getInstance_writeProtectedFileWithContext() throws IOException {
+        String REALM_FILE = "readonly.realm";
+        File folder = configFactory.getRoot();
+        File realmFile = new File(folder, REALM_FILE);
+        assertFalse(realmFile.exists());
+        assertTrue(realmFile.createNewFile());
+        assertTrue(realmFile.setWritable(false));
+
+        thrown.expect(RealmIOException.class);
+        Realm.getInstance(new RealmConfiguration.Builder(context, folder).name(REALM_FILE).build());
     }
 
     @Test

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -396,7 +396,7 @@ public final class RealmConfiguration {
          * <p>
          * The Realm file will be saved in the provided folder, and it might require additional permissions.
          *
-         * @param context an Android context.
+         * @param context the Android context.
          * @param folder the folder to save Realm file in. Folder must be writable.
          * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
          */

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -366,6 +366,7 @@ public final class RealmConfiguration {
          *
          * @param folder the folder to save Realm file in. Folder must be writable.
          * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
+         * @deprecated Please use {@link #Builder(Context, File)} instead.
          */
         @Deprecated
         public Builder(File folder) {

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -396,6 +396,7 @@ public final class RealmConfiguration {
          * <p>
          * The Realm file will be saved in the provided folder, and it might require additional permissions.
          *
+         * @param context an Android context.
          * @param folder the folder to save Realm file in. Folder must be writable.
          * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
          */

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -389,6 +389,22 @@ public final class RealmConfiguration {
             initializeBuilder(context.getFilesDir());
         }
 
+        /**
+         * Creates an instance of the Builder for the RealmConfiguration.
+         * <p>
+         * The Realm file will be saved in the provided folder, and it might require additional permissions.
+         *
+         * @param folder the folder to save Realm file in. Folder must be writable.
+         * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
+         */
+        public Builder(Context context, File folder) {
+            if (context == null) {
+                throw new IllegalArgumentException("A non-null Context must be provided");
+            }
+            RealmCore.loadLibrary(context);
+            initializeBuilder(folder);
+        }
+
         // Setup builder in its initial state
         private void initializeBuilder(File folder) {
             if (folder == null || !folder.isDirectory()) {

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -381,7 +381,7 @@ public final class RealmConfiguration {
          * additional permissions. The default location is {@code /data/data/<packagename>/files}, but can
          * change depending on vendor implementations of Android.
          *
-         * @param context an Android context.
+         * @param context the Android application context.
          */
         public Builder(Context context) {
             if (context == null) {
@@ -396,7 +396,7 @@ public final class RealmConfiguration {
          * <p>
          * The Realm file will be saved in the provided folder, and it might require additional permissions.
          *
-         * @param context the Android context.
+         * @param context the Android application context.
          * @param folder the folder to save Realm file in. Folder must be writable.
          * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
          */

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -367,6 +367,7 @@ public final class RealmConfiguration {
          * @param folder the folder to save Realm file in. Folder must be writable.
          * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
          */
+        @Deprecated
         public Builder(File folder) {
             RealmCore.loadLibrary();
             initializeBuilder(folder);


### PR DESCRIPTION
`RealmConfiguration.Build(context, dirPath)` constructor invokes ReLinker which provides protections on broken android installs/updates with custom directory path.

Closes #2900.