### PR TITLE
Optimistic opening of a Realm file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Updated ProGuard configuration in order not to depend on Android's default configuration (#2972).
 * Fixed a race condition between Realms notifications and other UI events. This could e.g. cause ListView to crash (#2990).
 * Fixed a bug that allowed both `RealmConfiguration.Builder.assetFile()`/`deleteRealmIfMigrationNeeded()` to be configured at the same time, which leads to the asset file accidentally being deleted in migrations (#2933).
-* In case of two processes opening the same Realm file, Realm will now optimistically retry opening for 1 second before throwing an Error. Previously it crashed outright (#2459).
+* Realm crashed outright when the same Realm file was opened in two processes. Realm will now optimistically retry opening for 1 second before throwing an Error (#2459).
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Updated ProGuard configuration in order not to depend on Android's default configuration (#2972).
 * Fixed a race condition between Realms notifications and other UI events. This could e.g. cause ListView to crash (#2990).
 * Fixed a bug that allowed both `RealmConfiguration.Builder.assetFile()`/`deleteRealmIfMigrationNeeded()` to be configured at the same time, which leads to the asset file accidentally being deleted in migrations (#2933).
+* In case of two processes opening the same Realm file, Realm will now optimistically retry opening for 1 second before throwing an Error. Previously it crashed outright (#2459).
 
 ### Enhancements
 

--- a/realm/config/findbugs/findbugs-filter.xml
+++ b/realm/config/findbugs/findbugs-filter.xml
@@ -42,6 +42,16 @@
         <Field name="minDepth" />
         <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
     </Match>
+    <Match>
+        <Class name="io.realm.internal.SharedGroup" />
+        <Field name="INCREMENTAL_BACKOFF_MS" />
+        <Bug pattern="MS_FINAL_PKGPROTECT" />
+    </Match>
+    <Match>
+        <Class name="io.realm.internal.SharedGroup" />
+        <Field name="INCREMENTAL_BACKOFF_LIMIT_MS" />
+        <Bug pattern="MS_SHOULD_BE_FINAL" />
+    </Match>
 
     <!-- Unit tests -->
     <Match>

--- a/realm/realm-jni/src/io_realm_internal_Util.cpp
+++ b/realm/realm-jni/src/io_realm_internal_Util.cpp
@@ -173,6 +173,12 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeTestcase(
             if (dotest)
                 ThrowException(env, BadVersion, "parm1", "parm2");
             break;
+        case LockFileError:
+            expect = "io.realm.exceptions.IncompatibleLockFileException: parm1";
+            if (dotest)
+                ThrowException(env, LockFileError, "parm1", "parm2");
+            break;
+
 
     }
     if (dotest) {

--- a/realm/realm-jni/src/util.cpp
+++ b/realm/realm-jni/src/util.cpp
@@ -160,6 +160,12 @@ void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& cla
             jExceptionClass = env->FindClass("io/realm/internal/async/BadVersionException");
             message = classStr;
             break;
+
+        case LockFileError:
+            jExceptionClass = env->FindClass("io/realm/exceptions/IncompatibleLockFileException");
+            message = classStr;
+            break;
+
     }
     if (jExceptionClass != NULL) {
         env->ThrowNew(jExceptionClass, message.c_str());

--- a/realm/realm-jni/src/util.hpp
+++ b/realm/realm-jni/src/util.hpp
@@ -74,8 +74,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved);
                 std::string(e.what()) + " path: " + e.get_path()); \
     } \
     catch (realm::IncompatibleLockFile& e) { \
-        ThrowException(env, LockFileError, string(fileName), \
-                std::string(e.what())); \
+        ThrowException(env, LockFileError, std::string(e.what())); \
     } \
 
 

--- a/realm/realm-jni/src/util.hpp
+++ b/realm/realm-jni/src/util.hpp
@@ -72,7 +72,13 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved);
     catch (util::File::AccessError& e) { \
         ThrowException(env, FileAccessError, string(fileName), \
                 std::string(e.what()) + " path: " + e.get_path()); \
-    }
+    } \
+    catch (realm::IncompatibleLockFile& e) { \
+        ThrowException(env, LockFileError, string(fileName), \
+                std::string(e.what())); \
+    } \
+
+
 
 #define CATCH_STD() \
     catch (...) { \
@@ -125,7 +131,8 @@ enum ExceptionKind {
     RuntimeError = 12,
     RowInvalid = 13,
     CrossTableLink = 15,
-    BadVersion = 16
+    BadVersion = 16,
+    LockFileError = 17
 // NOTE!!!!: Please also add test cases to Util.java when introducing a new exception kind.
 };
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1186,7 +1186,7 @@ public class RealmObjectTests {
     public void getter_afterDeleteFromOtherThreadThrows() {
         final CountDownLatch bgRealmDone = new CountDownLatch(1);
         realm.beginTransaction();
-        final AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        final AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();
 
         new Thread(new Runnable() {
@@ -1194,7 +1194,7 @@ public class RealmObjectTests {
             public void run() {
                 Realm bgRealm = Realm.getInstance(realm.getConfiguration());
                 bgRealm.beginTransaction();
-                bgRealm.delete(AllJavaTypes.class);
+                bgRealm.delete(AllTypes.class);
                 bgRealm.commitTransaction();
                 bgRealm.close();
                 bgRealmDone.countDown();
@@ -1206,7 +1206,7 @@ public class RealmObjectTests {
         // Object should no longer be available
         assertFalse(obj.isValid());
         try {
-            obj.getFieldDate();
+            obj.getColumnLong();
             fail();
         } catch (IllegalStateException ignored) {
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.ConflictingFieldName;
@@ -1185,7 +1186,7 @@ public class RealmObjectTests {
     public void getter_afterDeleteFromOtherThreadThrows() {
         final CountDownLatch bgRealmDone = new CountDownLatch(1);
         realm.beginTransaction();
-        final AllTypes obj = realm.createObject(AllTypes.class);
+        final AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
         realm.commitTransaction();
 
         new Thread(new Runnable() {
@@ -1193,7 +1194,7 @@ public class RealmObjectTests {
             public void run() {
                 Realm bgRealm = Realm.getInstance(realm.getConfiguration());
                 bgRealm.beginTransaction();
-                bgRealm.delete(AllTypes.class);
+                bgRealm.delete(AllJavaTypes.class);
                 bgRealm.commitTransaction();
                 bgRealm.close();
                 bgRealmDone.countDown();
@@ -1205,7 +1206,7 @@ public class RealmObjectTests {
         // Object should no longer be available
         assertFalse(obj.isValid());
         try {
-            obj.getColumnLong();
+            obj.getFieldDate();
             fail();
         } catch (IllegalStateException ignored) {
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -40,7 +40,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.ConflictingFieldName;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -85,7 +85,7 @@ import io.realm.entities.PrimaryKeyRequiredAsBoxedLong;
 import io.realm.entities.PrimaryKeyRequiredAsBoxedShort;
 import io.realm.entities.PrimaryKeyRequiredAsString;
 import io.realm.entities.StringOnly;
-import io.realm.exceptions.IncompatibleLockFileException;
+import io.realm.exceptions.RealmError;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmIOException;
 import io.realm.exceptions.RealmPrimaryKeyConstraintException;
@@ -3345,12 +3345,12 @@ public class RealmTests {
         fooStream.close();
 
         try {
-            DynamicRealm.getInstance(realmConfig);
+            // This will try to open a second SharedGroup which should fail when the .lock file is corrupt
+            DynamicRealm.getInstance(realm.getConfiguration());
             fail();
-        } catch (IncompatibleLockFileException ignored) {
-
+        } catch (RealmError e) {
+            assertTrue(e.getMessage().contains("Info size doesn't match"));
         } finally {
-            realm.close();
             lockFile.delete();
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3348,8 +3348,8 @@ public class RealmTests {
             // This will try to open a second SharedGroup which should fail when the .lock file is corrupt
             DynamicRealm.getInstance(realm.getConfiguration());
             fail();
-        } catch (RealmError e) {
-            assertTrue(e.getMessage().contains("Info size doesn't match"));
+        } catch (RealmError expected) {
+            assertTrue(expected.getMessage().contains("Info size doesn't match"));
         } finally {
             lockFile.delete();
         }

--- a/realm/realm-library/src/main/java/io/realm/exceptions/IncompatibleLockFileException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/IncompatibleLockFileException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Realm Inc.
+ * Copyright 2016 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,24 +19,17 @@ package io.realm.exceptions;
 import io.realm.internal.Keep;
 
 /**
- * Class for reporting problems with Realm files.
+ * Triggered from the JNI level when there was something wrong with the lock file.
+ * This can happen if two different versions of Realm tries to access the same file concurrently.
  */
 @Keep
-public class RealmIOException extends RuntimeException {
+public class IncompatibleLockFileException extends RealmIOException {
 
-    public RealmIOException(Throwable cause) {
-        super(cause);
+    public IncompatibleLockFileException(String detailMessage) {
+        super(detailMessage);
     }
 
-    public RealmIOException() {
+    public IncompatibleLockFileException(String detailMessage, Throwable exception) {
+        super(detailMessage, exception);
     }
-
-    public RealmIOException(String message) {
-        super(message);
-    }
-
-    public RealmIOException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedGroup.java
@@ -114,7 +114,7 @@ public class SharedGroup implements Closeable {
     }
 
     // Returns the time to sleep before retrying opening the SharedGroup.
-    private long getSleepTime(int tries) {
+    private static long getSleepTime(int tries) {
         if (INCREMENTAL_BACKOFF_MS == null) {
             return 0;
         } else {

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedGroup.java
@@ -88,7 +88,7 @@ public class SharedGroup implements Closeable {
         // happens we assume the overlap is really small so instead of failing outright we retry using incremental
         // backoff.
         int i = 0;
-        long start = System.nanoTime();
+        final long start = System.nanoTime();
         RuntimeException lastError = null;
         while (TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) < INCREMENTAL_BACKOFF_LIMIT_MS) {
             try {
@@ -97,7 +97,6 @@ public class SharedGroup implements Closeable {
                     RealmLog.w("IncompatibleLockFile was detected. Error was resolved after " + i + " retries");
                 }
                 return nativePtr;
-
             } catch (IncompatibleLockFileException e) {
                 i++;
                 lastError = e;

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedGroup.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedGroup.java
@@ -30,8 +30,8 @@ public class SharedGroup implements Closeable {
 
     // Keep these public so we can ask users to experiment with these values if needed.
     // Should be locked down as soon as possible.
-    public static long[] INCREMENTAL_BACKOFF_MS = new long[] {1, 3, 10, 20}; // Will keep re-using last value until LIMIT is hit
-    public static long INCREMENTAL_BACKOFF_LIMIT_MS = 1000;
+    public static long[] INCREMENTAL_BACKOFF_MS = new long[] {1, 10, 20, 50, 100, 200, 400}; // Will keep re-using last value until LIMIT is hit
+    public static long INCREMENTAL_BACKOFF_LIMIT_MS = 3000;
 
     public static final boolean IMPLICIT_TRANSACTION = true;
     public static final boolean EXPLICIT_TRANSACTION = false;

--- a/realm/realm-library/src/main/java/io/realm/internal/Util.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Util.java
@@ -67,7 +67,8 @@ public class Util {
         Exception_RowInvalid(13),
         Exception_EncryptionNotSupported(14),
         Exception_CrossTableLink(15),
-        Exception_BadVersion(16);
+        Exception_BadVersion(16),
+        Exception_IncompatibleLockFile(17);
 
         private final int nativeTestcase;
         Testcase(int nativeValue) {


### PR DESCRIPTION
This PR is the result of investigating https://github.com/realm/realm-java/issues/2459

We have anecdotal evidence that multiple processes might be open for the same app. We have not been able to verify this, but the result matches the "IncompatibleLockFile" errors reported in #2459. This happens if the two processes have two versions of Realm (e.g. during app upgrades).

This PR is based on our assumption that such an overlap is not intentional and only happens because one process is started before the previous was completely shut down.

So this PR introduces an optimistic opening scheme where we retry for 1 second before crashing as before.

I also added logging so users can log if they run into this issue.
The settings for this are currently public in SharedGroup, which will allow users to modify the timeout and retry-policy without us needing to release a new version of Realm Java. 

@realm/java 
