### PR TITLE
Disable optional api transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2
+
+### Bug fixes
+
+* Disabled the optional API transformer since it has problems with DexGuard (3022).
+
 ## 1.0.1
 
 ### Bug fixes

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -49,9 +49,7 @@ class Realm implements Plugin<Project> {
         }
 
         project.android.registerTransform(new RealmTransformer(project))
-        if (!isAndroidLib) {
-            project.android.registerTransform(new RealmOptionalAPITransformer())
-        }
+
         project.repositories.add(project.getRepositories().jcenter())
         project.dependencies.add("compile", "io.realm:realm-android-library:${Version.VERSION}")
         project.dependencies.add("compile", "io.realm:realm-annotations:${Version.VERSION}")

--- a/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
+++ b/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
@@ -32,6 +32,7 @@ import org.junit.Before
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 import static org.junit.Assert.fail
 
@@ -69,7 +70,8 @@ class PluginTest {
         assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-annotations', currentVersion))
 
         assertTrue(containsTransform(project.android.transforms, RealmTransformer.class))
-        assertTrue(containsTransform(project.android.transforms, RealmOptionalAPITransformer.class))
+        // Disabled because of https://github.com/realm/realm-java/issues/3022
+        assertFalse(containsTransform(project.android.transforms, RealmOptionalAPITransformer.class))
     }
 
     @Test


### PR DESCRIPTION
Because of #3022, this transformer doesn't play well with DexGuard.
The idea way is we can supply an option to disable it by users. But
unfortunately it seems to be difficult:

* The realm gradle options block is evaluated after calling
android.registerTransformer()
* We can pass a closure to transformer later, but the problem
Transformer.getScope() cannot return null or an empty set, otherwise
an exception will be thrown.

Just disable it until we find a proper way.