### PR TITLE
Classes are not properly transformed during androidTests

### DIFF
--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
@@ -115,7 +115,7 @@ public class ExampleActivity extends Activity {
             public void execute(Realm realm) {
                 // Add a person
                 Person person = realm.createObject(Person.class);
-                person.setId(1);
+                person.id = 1;
                 person.setName("John Young");
                 person.setAge(14);
             }

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/model/Person.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/model/Person.java
@@ -38,7 +38,7 @@ public class Person extends RealmObject {
     @Ignore
     private int tempReference;
 
-    private long id;
+    public long id;
 
     // The standard getters and setters your IDE generates are fine.
     // Realm will overload them and code inside them is ignored.
@@ -82,13 +82,5 @@ public class Person extends RealmObject {
 
     public void setTempReference(int tempReference) {
         this.tempReference = tempReference;
-    }
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
     }
 }


### PR DESCRIPTION
Reproduces #2936 

Observations so far:
- All unit tests seems to work fine when run from inside the `realm-library` folder.
- Log says that all files should be transformed. 
- Decompiled .class files have not been transformed (which is also why the androidTest transformer crashes)
- Can only be reproduced if run from inside a proper app project (I modified unitTestExamples)