### PR TITLE
Remove redundant calls to std::move

### DIFF
--- a/realm/realm-jni/src/io_realm_internal_LinkView.cpp
+++ b/realm/realm-jni/src/io_realm_internal_LinkView.cpp
@@ -177,7 +177,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeWhere
     try {
         LinkViewRef *lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
-        Query *queryPtr = new Query(std::move(lvr->get_target_table().where(LinkViewRef(lvr))));
+        Query *queryPtr = new Query(lvr->get_target_table().where(LinkViewRef(lvr)));
         return reinterpret_cast<jlong>(queryPtr);
     } CATCH_STD()
     return 0;

--- a/realm/realm-jni/src/io_realm_internal_Table.cpp
+++ b/realm/realm-jni/src/io_realm_internal_Table.cpp
@@ -1065,7 +1065,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeWhere(
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return 0;
     try {
-        Query *queryPtr = new Query(std::move(TBL(nativeTablePtr)->where()));
+        Query *queryPtr = new Query(TBL(nativeTablePtr)->where());
         return reinterpret_cast<jlong>(queryPtr);
     } CATCH_STD()
     return 0;

--- a/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-jni/src/io_realm_internal_TableQuery.cpp
@@ -1135,12 +1135,12 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
         std::vector<std::unique_ptr<Query>> queries(number_of_queries);
 
         // import the first query
-        queries[0] = std::move(sg->import_from_handover(std::move(handoverQuery)));
+        queries[0] = sg->import_from_handover(std::move(handoverQuery));
 
         // import the rest of the queries
         for (size_t i = 1; i < number_of_queries; ++i) {
             std::unique_ptr<SharedGroup::Handover<Query>> handoverQuery(HO(Query, handover_queries_pointer_array[i]));
-            queries[i] = std::move(sg->import_from_handover(std::move(handoverQuery)));
+            queries[i] = sg->import_from_handover(std::move(handoverQuery));
         }
 
         // Step2: Bring the queries into the latest shared group version

--- a/realm/realm-jni/src/io_realm_internal_TableView.cpp
+++ b/realm/realm-jni/src/io_realm_internal_TableView.cpp
@@ -999,7 +999,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeWhere(
         if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
             return 0;
 
-        Query *queryPtr = new Query(std::move(TV(nativeViewPtr)->get_parent().where(TV(nativeViewPtr))));
+        Query *queryPtr = new Query(TV(nativeViewPtr)->get_parent().where(TV(nativeViewPtr)));
         return reinterpret_cast<jlong>(queryPtr);
     } CATCH_STD()
     return 0;


### PR DESCRIPTION
`std::move` casts an lvalue to an rvalue. It's redundant to call it with an rvalue as its argument.

/cc @beeender 
