### PR TITLE
Save LogCat file in case of test failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,15 +93,14 @@
 }
 
 def startLogCatCollector() {
-    sh '''rm -f logcat.txt
-    adb logcat -c
+    sh '''adb logcat -c
     adb logcat > "logcat.txt" &
     '''
 }
 
 def stopLogCatCollector(boolean archiveLog) {
     sh '''jobs
-       kill %1'
+       kill %1
        '''
     if (archiveLog) {
         zip([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ def stopLogCatCollector(String backgroundPid, boolean archiveLog) {
         zip([
             'zipFile': 'logcat.zip',
             'archive': true,
-            'glob' : 'logcat.txt'
+            'glob' : 'realm/logcat.txt'
         ])
     }
     sh 'rm logcat.txt '

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ def String startLogCatCollector() {
 }
 
 def stopLogCatCollector(String backgroundPid, boolean archiveLog) {
-    sh 'kill $backgroundPid'
+    sh "kill ${backgroundPid}"
     if (archiveLog) {
         zip([
             'zipFile': 'logcat.zip',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ def stopLogCatCollector(String backgroundPid, boolean archiveLog) {
         zip([
             'zipFile': 'logcat.zip',
             'archive': true,
-            'glob' : 'realm/logcat.txt'
+            'glob' : '**/logcat.txt'
         ])
     }
     sh 'rm logcat.txt '

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,9 @@
 
                 stage 'Run instrumented tests'
                 try {
+                    sh 'cd realm'
                     startLogCatCollector()
-                    sh 'realm && ./gradlew connectedUnitTests --stacktrace'
+                    sh './gradlew connectedUnitTests --stacktrace'
                     stopLogCatCollector(backgroundPid, false)
                 } catch (Exception ) {
                     stopLogCatCollector(backgroundPid, true)
@@ -92,12 +93,10 @@
 }
 
 def startLogCatCollector() {
-    dir('realm/realm-library') {
-        sh '''rm -f logcat.txt
-        adb logcat -c
-        adb logcat > "logcat.txt" &
-        '''
-    }
+    sh '''rm -f logcat.txt
+    adb logcat -c
+    adb logcat > "logcat.txt" &
+    '''
 }
 
 def stopLogCatCollector(String pid, boolean archiveLog) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@
                     startLogCatCollector()
                     sh './gradlew connectedUnitTests --stacktrace'
                     stopLogCatCollector(backgroundPid, false)
-                } catch (Exception ) {
+                } catch (Exception e) {
                     stopLogCatCollector(backgroundPid, true)
                 } finally {
                     storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/TEST-*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,10 +93,10 @@
 
 def startLogCatCollector() {
     dir('realm/realm-library') {
-        sh 'rm -f logcat.txt'
-        sh 'adb logcat -c'
-        sh 'adb logcat > "logcat.txt" &'
-        return pid
+        sh '''rm -f logcat.txt
+        adb logcat -c
+        adb logcat > "logcat.txt" &
+        '''
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,9 +56,8 @@
                 }
 
                 stage 'Run instrumented tests'
-                String backgroundPid
                 try {
-                    backgroundPid = startLogCatCollector()
+                    startLogCatCollector()
                     sh 'realm && ./gradlew connectedUnitTests --stacktrace'
                     stopLogCatCollector(backgroundPid, false)
                 } catch (Exception ) {
@@ -92,20 +91,19 @@
     }
 }
 
-def String startLogCatCollector() {
+def startLogCatCollector() {
     dir('realm/realm-library') {
         sh 'rm -f logcat.txt'
         sh 'adb logcat -c'
-        sh '''adb logcat > "logcat.txt" &
-            echo $! > backgroundjob'''
-        String pid = readFile("backgroundjob").trim()
-        sh 'rm backgroundjob'
+        sh 'adb logcat > "logcat.txt" &'
         return pid
     }
 }
 
 def stopLogCatCollector(String pid, boolean archiveLog) {
-    sh 'kill $pid'
+    sh '''jobs
+       kill %1'
+       '''
     if (archiveLog) {
         zip([
             'zipFile': 'logcat.zip',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@
                     sh './gradlew connectedUnitTests --stacktrace'
                     archiveLog = false;
                 } finally {
-                    stopLogCatCollector(backgroundPid, archiveLog)
+                    stopLogCatCollector(archiveLog)
                     storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/TEST-*.xml'
                 }
 
@@ -99,7 +99,7 @@ def startLogCatCollector() {
     '''
 }
 
-def stopLogCatCollector(String pid, boolean archiveLog) {
+def stopLogCatCollector(boolean archiveLog) {
     sh '''jobs
        kill %1'
        '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,14 +56,14 @@
                 }
 
                 stage 'Run instrumented tests'
+                boolean archiveLog = true;
                 try {
                     sh 'cd realm'
                     startLogCatCollector()
                     sh './gradlew connectedUnitTests --stacktrace'
-                    stopLogCatCollector(backgroundPid, false)
-                } catch (Exception e) {
-                    stopLogCatCollector(backgroundPid, true)
+                    archiveLog = false;
                 } finally {
+                    stopLogCatCollector(backgroundPid, archiveLog)
                     storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/TEST-*.xml'
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@
                 }
 
                 stage 'Run instrumented tests'
-                var backgroundPid
+                String backgroundPid
                 try {
                     backgroundPid = startLogCatCollector()
                     sh 'realm && ./gradlew connectedUnitTests --stacktrace'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,9 +59,8 @@
                 boolean archiveLog = true
                 String backgroundPid
                 try {
-                    sh 'cd realm'
                     backgroundPid = startLogCatCollector()
-                    sh './gradlew connectedUnitTests --stacktrace'
+                    sh 'cd realm && ./gradlew connectedUnitTests --stacktrace'
                     archiveLog = false;
                 } finally {
                     stopLogCatCollector(backgroundPid, archiveLog)
@@ -107,7 +106,7 @@ def stopLogCatCollector(String backgroundPid, boolean archiveLog) {
         zip([
             'zipFile': 'logcat.zip',
             'archive': true,
-            'glob' : '**/logcat.txt'
+            'glob' : 'logcat.txt'
         ])
     }
     sh 'rm logcat.txt '

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,8 @@
 
 def String startLogCatCollector() {
     sh '''adb logcat -c
-    `adb logcat > "logcat.txt" &` & echo $1 > pid
+    adb logcat > "logcat.txt" &
+    echo $! > pid
     '''
     return readFile("pid").trim()
 }

--- a/integration-tests/optionalAPIExists/build.gradle
+++ b/integration-tests/optionalAPIExists/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'realm-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.0"
 
     defaultConfig {
         applicationId "io.realm.tests.optionalapiexists"

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3354,9 +3354,4 @@ public class RealmTests {
             lockFile.delete();
         }
     }
-
-    @Test
-    public void testFailureLog() {
-        fail();
-    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3354,4 +3354,9 @@ public class RealmTests {
             lockFile.delete();
         }
     }
+
+    @Test
+    public void testFailureLog() {
+        fail();
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIMixedSubtableTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIMixedSubtableTest.java
@@ -25,7 +25,6 @@ import io.realm.RealmFieldType;
 public class JNIMixedSubtableTest extends TestCase {
 
     public void testGetSubtableFromMixedColumnTest() {
-        Util.setDebugLevel(2);
         Table table = new Table();
 
         table.addColumn(RealmFieldType.INTEGER, "num");


### PR DESCRIPTION
Move from https://github.com/realm/realm-java/pull/3049

If unit tests crashes with native exceptions we currently have no way of knowing why.

With this PR we now save the LogCat file in case there is a test failure. For green builds nothing is saved.

A local test on my phone indicates that a full logcat file is ~8MB in size and 400Kb when zipped.

The CI log seems to be much smaller (~4Mb compressed to 130k) 
An example is here: https://ci.realm.io/job/android-pr-jenkinsfile/630/

We need to enable logging before starting tests as Android only have a 256Kb buffer for log entries and rotates between multiple files. This means that dumping the log afterwards are missing _a lot_ of entries.

@realm/java 
@emanuelez 
