### PR TITLE
Make findXxxWithHandover static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug fixes
 
+* Async query might block caller thread for disposing resources.
 * Fixed a wrong JNI method declaration which might cause "method not found" crash on some devices.
 
 ## 1.1.0

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1174,9 +1174,8 @@ public final class RealmQuery<E extends RealmModel> {
                                 realmConfiguration.getDurability(),
                                 realmConfiguration.getEncryptionKey());
 
-                        long handoverTableViewPointer = query.
+                        long handoverTableViewPointer = TableQuery.
                                 findDistinctWithHandover(sharedGroup.getNativePointer(),
-                                        sharedGroup.getNativeReplicationPointer(),
                                         handoverQueryPointer,
                                         columnIndex);
 
@@ -1485,7 +1484,8 @@ public final class RealmQuery<E extends RealmModel> {
                         // Run the query & handover the table view for the caller thread
                         // Note: the handoverQueryPointer contains the versionID needed by the SG in order
                         // to import it.
-                        long handoverTableViewPointer = query.findAllWithHandover(sharedGroup.getNativePointer(), sharedGroup.getNativeReplicationPointer(), handoverQueryPointer);
+                        long handoverTableViewPointer = TableQuery.findAllWithHandover(sharedGroup.getNativePointer(),
+                                handoverQueryPointer);
 
                         QueryUpdateTask.Result result = QueryUpdateTask.Result.newRealmResultsResponse();
                         result.updatedTableViews.put(weakRealmResults, handoverTableViewPointer);
@@ -1603,8 +1603,8 @@ public final class RealmQuery<E extends RealmModel> {
                         long columnIndex = getColumnIndexForSort(fieldName);
 
                         // run the query & handover the table view for the caller thread
-                        long handoverTableViewPointer = query.findAllSortedWithHandover(sharedGroup.getNativePointer(),
-                                sharedGroup.getNativeReplicationPointer(), handoverQueryPointer, columnIndex, sortOrder);
+                        long handoverTableViewPointer = TableQuery.findAllSortedWithHandover(sharedGroup.getNativePointer(),
+                                handoverQueryPointer, columnIndex, sortOrder);
 
                         QueryUpdateTask.Result result = QueryUpdateTask.Result.newRealmResultsResponse();
                         result.updatedTableViews.put(weakRealmResults, handoverTableViewPointer);
@@ -1776,8 +1776,8 @@ public final class RealmQuery<E extends RealmModel> {
                                     realmConfiguration.getEncryptionKey());
 
                             // run the query & handover the table view for the caller thread
-                            long handoverTableViewPointer = query.findAllMultiSortedWithHandover(sharedGroup.getNativePointer(),
-                                    sharedGroup.getNativeReplicationPointer(), handoverQueryPointer, indices, sortOrders);
+                            long handoverTableViewPointer = TableQuery.findAllMultiSortedWithHandover(sharedGroup.getNativePointer(),
+                                    handoverQueryPointer, indices, sortOrders);
 
                             QueryUpdateTask.Result result = QueryUpdateTask.Result.newRealmResultsResponse();
                             result.updatedTableViews.put(weakRealmResults, handoverTableViewPointer);
@@ -1915,8 +1915,7 @@ public final class RealmQuery<E extends RealmModel> {
                                 realmConfiguration.getDurability(),
                                 realmConfiguration.getEncryptionKey());
 
-                        long handoverRowPointer = query.findWithHandover(sharedGroup.getNativePointer(),
-                                sharedGroup.getNativeReplicationPointer(), handoverQueryPointer);
+                        long handoverRowPointer = TableQuery.findWithHandover(sharedGroup.getNativePointer(), handoverQueryPointer);
                         if (handoverRowPointer == 0) { // empty row
                             realm.handlerController.addToEmptyAsyncRealmObject(realmObjectWeakReference, RealmQuery.this);
                             realm.handlerController.removeFromAsyncRealmObject(realmObjectWeakReference);

--- a/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
@@ -420,14 +420,10 @@ public class TableQuery implements Closeable {
      * Performs a find query then handover the resulted Row (ready to be imported by another thread/shared_group).
      *
      * @param bgSharedGroupPtr current shared_group from which to operate the query.
-     * @param nativeReplicationPtr replication pointer associated with the shared_group.
      * @param ptrQuery query to run the the find against.
      * @return pointer to the handover result (table_view).
      */
-    public long findWithHandover(long bgSharedGroupPtr, long nativeReplicationPtr, long ptrQuery) {
-        validateQuery();
-        // Execute the disposal of abandoned realm objects each time a new realm object is created
-        context.executeDelayedDisposal();
+    public static long findWithHandover(long bgSharedGroupPtr, long ptrQuery) {
         return nativeFindWithHandover(bgSharedGroupPtr, ptrQuery, 0);
     }
 
@@ -462,31 +458,19 @@ public class TableQuery implements Closeable {
     // handover find* methods
     // this will use a background SharedGroup to import the query (using the handover object)
     // run the query, and return the table view to the caller SharedGroup using the handover object.
-    public long findAllWithHandover(long bgSharedGroupPtr, long nativeReplicationPtr,  long ptrQuery) throws BadVersionException {
-        validateQuery();
-        // Execute the disposal of abandoned realm objects each time a new realm object is created
-        context.executeDelayedDisposal();
+    public static long findAllWithHandover(long bgSharedGroupPtr, long ptrQuery) throws BadVersionException {
         return nativeFindAllWithHandover(bgSharedGroupPtr, ptrQuery, 0, Table.INFINITE, Table.INFINITE);
     }
 
-    public long findDistinctWithHandover(long bgSharedGroupPtr, long nativeReplicationPtr,  long ptrQuery, long columnIndex) throws BadVersionException {
-        validateQuery();
-        // Execute the disposal of abandoned realm objects each time a new realm object is created
-        context.executeDelayedDisposal();
+    public static long findDistinctWithHandover(long bgSharedGroupPtr, long ptrQuery, long columnIndex) throws BadVersionException {
         return nativeGetDistinctViewWithHandover(bgSharedGroupPtr, ptrQuery, columnIndex);
     }
 
-    public long findAllSortedWithHandover(long bgSharedGroupPtr, long nativeReplicationPtr, long ptrQuery, long columnIndex, Sort sortOrder) throws BadVersionException {
-        validateQuery();
-        // Execute the disposal of abandoned realm objects each time a new realm object is created
-        context.executeDelayedDisposal();
+    public static long findAllSortedWithHandover(long bgSharedGroupPtr, long ptrQuery, long columnIndex, Sort sortOrder) throws BadVersionException {
         return nativeFindAllSortedWithHandover(bgSharedGroupPtr, ptrQuery, 0, Table.INFINITE, Table.INFINITE, columnIndex, sortOrder.getValue());
     }
 
-    public long findAllMultiSortedWithHandover(long bgSharedGroupPtr, long nativeReplicationPtr, long ptrQuery, long[] columnIndices, Sort[] sortOrders) throws BadVersionException {
-        validateQuery();
-        // Execute the disposal of abandoned realm objects each time a new realm object is created
-        context.executeDelayedDisposal();
+    public static long findAllMultiSortedWithHandover(long bgSharedGroupPtr, long ptrQuery, long[] columnIndices, Sort[] sortOrders) throws BadVersionException {
         boolean[] ascendings = getNativeSortOrderValues(sortOrders);
         return nativeFindAllMultiSortedWithHandover(bgSharedGroupPtr, ptrQuery, 0, Table.INFINITE, Table.INFINITE, columnIndices, ascendings);
     }


### PR DESCRIPTION
I am not quite sure why they are like those at the first place. But
They don't seem to be necessary at all.

Those methods don't have to be member fuctions. Especially lock to
dispose resources might block caller thread.
