### PR TITLE
Forward all throwables but not only excpetions - Fix the CI timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fixed a wrong JNI method declaration which might cause "method not found" crash on some devices.
+* Fixed a bug that `Error` in the background async thread is not forwared to the caller thread.
 
 ## 1.1.0
 

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -39,6 +39,7 @@ import io.realm.entities.PrimaryKeyAsBoxedInteger;
 import io.realm.entities.PrimaryKeyAsBoxedLong;
 import io.realm.entities.PrimaryKeyAsBoxedShort;
 import io.realm.entities.PrimaryKeyAsString;
+import io.realm.internal.HandlerControllerConstants;
 import io.realm.internal.log.RealmLog;
 import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
@@ -521,7 +522,7 @@ public class DynamicRealmTests {
             @Override
             public boolean onInterceptInMessage(int what) {
                 switch (what) {
-                    case HandlerController.COMPLETED_ASYNC_REALM_OBJECT: {
+                    case HandlerControllerConstants.COMPLETED_ASYNC_REALM_OBJECT: {
                         post(new Runnable() {
                             @Override
                             public void run() {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -42,6 +42,7 @@ import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
 import io.realm.instrumentation.MockActivityManager;
+import io.realm.internal.HandlerControllerConstants;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.async.RealmThreadPoolExecutor;
 import io.realm.internal.log.RealmLog;
@@ -488,7 +489,7 @@ public class RealmAsyncQueryTests {
                 switch (what) {
                     // 5. Intercept all messages from other threads. On the first complete, we advance the tread
                     // which will cause the async query to rerun instead of triggering the change listener.
-                    case HandlerController.COMPLETED_ASYNC_REALM_RESULTS:
+                    case HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS:
                         if (intercepts == 1) {
                             // We advance the Realm so we can simulate a retry
                             realm.beginTransaction();
@@ -545,7 +546,7 @@ public class RealmAsyncQueryTests {
             @Override
             public boolean onInterceptInMessage(int what) {
                 int intercepts = numberOfIntercept.getAndIncrement();
-                if (what == HandlerController.COMPLETED_ASYNC_REALM_RESULTS && intercepts == 1) {
+                if (what == HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS && intercepts == 1) {
                     // 4. The first time the async queries complete we start an update from
                     // another background thread. This will cause queries to rerun when the
                     // background thread notifies this thread.
@@ -652,7 +653,7 @@ public class RealmAsyncQueryTests {
                 // Intercepts in order [QueryCompleted, RealmChanged, QueryUpdated]
                 int intercepts = numberOfIntercept.incrementAndGet();
                 switch (what) {
-                    case HandlerController.COMPLETED_ASYNC_REALM_RESULTS: {
+                    case HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS: {
                         // we advance the Realm so we can simulate a retry
                         if (intercepts == 1) {
                             realm.beginTransaction();
@@ -710,7 +711,7 @@ public class RealmAsyncQueryTests {
             @Override
             public boolean onInterceptInMessage(int what) {
                 switch (what) {
-                    case HandlerController.REALM_CHANGED: {
+                    case HandlerControllerConstants.REALM_CHANGED: {
                         // should only intercept the first REALM_CHANGED coming from the
                         // background update thread
 
@@ -720,11 +721,11 @@ public class RealmAsyncQueryTests {
                         // upcoming REALM_CHANGED to batch update all async queries
                         return numberOfInterceptedChangeMessage.getAndIncrement() == 0;
                     }
-                    case HandlerController.COMPLETED_ASYNC_REALM_RESULTS: {
+                    case HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS: {
                         if (numberOfCompletedAsyncQuery.incrementAndGet() == 2) {
                             // both queries have completed now (& their results should be ignored)
                             // now send the REALM_CHANGED event that should batch update all queries
-                            sendEmptyMessage(HandlerController.REALM_CHANGED);
+                            sendEmptyMessage(HandlerControllerConstants.REALM_CHANGED);
                         }
                     }
                 }
@@ -944,7 +945,7 @@ public class RealmAsyncQueryTests {
             public boolean onInterceptInMessage(int what) {
                 int intercepts = numberOfIntercept.incrementAndGet();
                 switch (what) {
-                    case HandlerController.COMPLETED_ASYNC_REALM_OBJECT: {
+                    case HandlerControllerConstants.COMPLETED_ASYNC_REALM_OBJECT: {
                         if (intercepts == 1) {
                             // we advance the Realm so we can simulate a retry
                             realm.beginTransaction();
@@ -1040,7 +1041,7 @@ public class RealmAsyncQueryTests {
                 // In order [QueryCompleted, RealmChanged, QueryUpdated]
                 int intercepts = numberOfIntercept.incrementAndGet();
                 switch (what) {
-                    case HandlerController.COMPLETED_ASYNC_REALM_RESULTS: {
+                    case HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS: {
                         if (intercepts == 1) {
                             // We advance the Realm so we can simulate a retry before listeners are
                             // called.
@@ -1103,7 +1104,7 @@ public class RealmAsyncQueryTests {
             @Override
             public boolean onInterceptInMessage(int what) {
                 switch (what) {
-                    case HandlerController.COMPLETED_ASYNC_REALM_RESULTS: {
+                    case HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS: {
                         if (numberOfIntercept.incrementAndGet() == 1) {
                             // 6. The first time the async queries complete we start an update from
                             // another background thread. This will cause queries to rerun when the
@@ -1240,7 +1241,7 @@ public class RealmAsyncQueryTests {
             @Override
             public boolean onInterceptInMessage(int what) {
                 int intercepts = numberOfIntercept.incrementAndGet();
-                if (what == HandlerController.COMPLETED_ASYNC_REALM_RESULTS && intercepts == 1) {
+                if (what == HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS && intercepts == 1) {
                     // 6. The first time the async queries complete we start an update from
                     // another background thread. This will cause queries to rerun when the
                     // background thread notifies this thread.

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -117,9 +117,7 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
                                     }
                                     unitTestFailed = true;
                                 }
-                                if (signalTestCompleted.getCount() > 0) {
-                                    signalTestCompleted.countDown();
-                                }
+                                signalTestCompleted.countDown();
                                 if (realm != null) {
                                     realm.close();
                                 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.realm.annotations.internal.OptionalAPI;
 import io.realm.exceptions.RealmMigrationNeededException;
+import io.realm.internal.HandlerControllerConstants;
 import io.realm.internal.InvalidRow;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.SharedGroupManager;
@@ -411,14 +412,14 @@ abstract class BaseRealm implements Closeable {
                     // that behaviour indicate a user bug. Previously this would be hidden as the UI would still
                     // be responsive.
                     Message msg = Message.obtain();
-                    msg.what = HandlerController.LOCAL_COMMIT;
-                    if (!handler.hasMessages(HandlerController.LOCAL_COMMIT)) {
-                        handler.removeMessages(HandlerController.REALM_CHANGED);
+                    msg.what = HandlerControllerConstants.LOCAL_COMMIT;
+                    if (!handler.hasMessages(HandlerControllerConstants.LOCAL_COMMIT)) {
+                        handler.removeMessages(HandlerControllerConstants.REALM_CHANGED);
                         messageHandled = handler.sendMessageAtFrontOfQueue(msg);
                     }
                 } else {
-                    if (!handler.hasMessages(HandlerController.REALM_CHANGED)) {
-                        messageHandled = handler.sendEmptyMessage(HandlerController.REALM_CHANGED);
+                    if (!handler.hasMessages(HandlerControllerConstants.REALM_CHANGED)) {
+                        messageHandled = handler.sendEmptyMessage(HandlerControllerConstants.REALM_CHANGED);
                     }
                 }
                 if (!messageHandled) {

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -44,13 +44,15 @@ import io.realm.internal.log.RealmLog;
 /**
  * Centralises all Handler callbacks, including updating async queries and refreshing the Realm.
  */
-final class HandlerController implements Handler.Callback {
+public final class HandlerController implements Handler.Callback {
 
     static final int REALM_CHANGED = 14930352; // Hopefully it won't clash with other message IDs.
     static final int COMPLETED_UPDATE_ASYNC_QUERIES = 24157817;
     static final int COMPLETED_ASYNC_REALM_RESULTS = 39088169;
     static final int COMPLETED_ASYNC_REALM_OBJECT = 63245986;
-    static final int REALM_ASYNC_BACKGROUND_EXCEPTION = 102334155;
+    // TODO: public (and the public HandlerController) because of QueryUpdateTask. This needs some refactor, one idea is
+    // catching and forwarding throwable in BgPriorityRunnable for all background tasks.
+    public static final int REALM_ASYNC_BACKGROUND_EXCEPTION = 102334155;
     static final int LOCAL_COMMIT = 165580141;
 
     private final static Boolean NO_REALM_QUERY = Boolean.TRUE;

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1187,7 +1187,7 @@ public final class RealmQuery<E extends RealmModel> {
                                 weakHandler, HandlerController.COMPLETED_ASYNC_REALM_RESULTS, result);
 
                         return handoverTableViewPointer;
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         RealmLog.e(e.getMessage(), e);
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
                                 weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
@@ -1500,7 +1500,7 @@ public final class RealmQuery<E extends RealmModel> {
                         RealmLog.d("findAllAsync handover could not complete due to a BadVersionException. " +
                                 "Retry is scheduled by a REALM_CHANGED event.");
 
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         RealmLog.e(e.getMessage(), e);
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
                                 weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
@@ -1618,7 +1618,7 @@ public final class RealmQuery<E extends RealmModel> {
                         RealmLog.d("findAllSortedAsync handover could not complete due to a BadVersionException. " +
                                 "Retry is scheduled by a REALM_CHANGED event.");
 
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         RealmLog.e(e.getMessage(), e);
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
                                 weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
@@ -1791,7 +1791,7 @@ public final class RealmQuery<E extends RealmModel> {
                             RealmLog.d("findAllSortedAsync handover could not complete due to a BadVersionException. " +
                                     "Retry is scheduled by a REALM_CHANGED event.");
 
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
                             RealmLog.e(e.getMessage(), e);
                             closeSharedGroupAndSendMessageToHandler(sharedGroup,
                                     weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
@@ -1930,7 +1930,7 @@ public final class RealmQuery<E extends RealmModel> {
 
                         return handoverRowPointer;
 
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         RealmLog.e(e.getMessage(), e);
                         // handler can't throw a checked exception need to wrap it into unchecked Exception
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 import io.realm.annotations.Required;
+import io.realm.internal.HandlerControllerConstants;
 import io.realm.internal.LinkView;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.Row;
@@ -1184,13 +1185,13 @@ public final class RealmQuery<E extends RealmModel> {
                         result.updatedTableViews.put(weakRealmResults, handoverTableViewPointer);
                         result.versionID = sharedGroup.getVersion();
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.COMPLETED_ASYNC_REALM_RESULTS, result);
+                                weakHandler, HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS, result);
 
                         return handoverTableViewPointer;
                     } catch (Throwable e) {
                         RealmLog.e(e.getMessage(), e);
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
+                                weakHandler, HandlerControllerConstants.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
 
                     } finally {
                         if (sharedGroup != null && !sharedGroup.isClosed()) {
@@ -1491,7 +1492,7 @@ public final class RealmQuery<E extends RealmModel> {
                         result.updatedTableViews.put(weakRealmResults, handoverTableViewPointer);
                         result.versionID = sharedGroup.getVersion();
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.COMPLETED_ASYNC_REALM_RESULTS, result);
+                                weakHandler, HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS, result);
 
                         return handoverTableViewPointer;
 
@@ -1503,7 +1504,7 @@ public final class RealmQuery<E extends RealmModel> {
                     } catch (Throwable e) {
                         RealmLog.e(e.getMessage(), e);
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
+                                weakHandler, HandlerControllerConstants.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
 
                     } finally {
                         if (sharedGroup != null && !sharedGroup.isClosed()) {
@@ -1610,7 +1611,7 @@ public final class RealmQuery<E extends RealmModel> {
                         result.updatedTableViews.put(weakRealmResults, handoverTableViewPointer);
                         result.versionID = sharedGroup.getVersion();
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.COMPLETED_ASYNC_REALM_RESULTS, result);
+                                weakHandler, HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS, result);
 
                         return handoverTableViewPointer;
                     } catch (BadVersionException e) {
@@ -1621,7 +1622,7 @@ public final class RealmQuery<E extends RealmModel> {
                     } catch (Throwable e) {
                         RealmLog.e(e.getMessage(), e);
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
+                                weakHandler, HandlerControllerConstants.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
 
                     } finally {
                         if (sharedGroup != null && !sharedGroup.isClosed()) {
@@ -1783,7 +1784,7 @@ public final class RealmQuery<E extends RealmModel> {
                             result.updatedTableViews.put(weakRealmResults, handoverTableViewPointer);
                             result.versionID = sharedGroup.getVersion();
                             closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                    weakHandler, HandlerController.COMPLETED_ASYNC_REALM_RESULTS, result);
+                                    weakHandler, HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS, result);
 
                             return handoverTableViewPointer;
                         } catch (BadVersionException e) {
@@ -1794,7 +1795,7 @@ public final class RealmQuery<E extends RealmModel> {
                         } catch (Throwable e) {
                             RealmLog.e(e.getMessage(), e);
                             closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                    weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
+                                    weakHandler, HandlerControllerConstants.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
 
                         } finally {
                             if (sharedGroup != null && !sharedGroup.isClosed()) {
@@ -1926,7 +1927,7 @@ public final class RealmQuery<E extends RealmModel> {
                         result.updatedRow.put(realmObjectWeakReference, handoverRowPointer);
                         result.versionID = sharedGroup.getVersion();
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.COMPLETED_ASYNC_REALM_OBJECT, result);
+                                weakHandler, HandlerControllerConstants.COMPLETED_ASYNC_REALM_OBJECT, result);
 
                         return handoverRowPointer;
 
@@ -1934,7 +1935,7 @@ public final class RealmQuery<E extends RealmModel> {
                         RealmLog.e(e.getMessage(), e);
                         // handler can't throw a checked exception need to wrap it into unchecked Exception
                         closeSharedGroupAndSendMessageToHandler(sharedGroup,
-                                weakHandler, HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
+                                weakHandler, HandlerControllerConstants.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e));
 
                     } finally {
                         if (sharedGroup != null && !sharedGroup.isClosed()) {

--- a/realm/realm-library/src/main/java/io/realm/internal/HandlerControllerConstants.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/HandlerControllerConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Realm Inc.
+ * Copyright 2016 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/realm/realm-library/src/main/java/io/realm/internal/HandlerControllerConstants.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/HandlerControllerConstants.java
@@ -16,6 +16,10 @@
 
 package io.realm.internal;
 
+/**
+ * This class is to share some Android handler related constants between package {@link io.realm} and
+ * {@link io.realm.internal.async}.
+ */
 public final class HandlerControllerConstants {
     public static final int REALM_CHANGED = 14930352; // Hopefully it won't clash with other message IDs.
     public static final int COMPLETED_UPDATE_ASYNC_QUERIES = 24157817;

--- a/realm/realm-library/src/main/java/io/realm/internal/HandlerControllerConstants.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/HandlerControllerConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal;
+
+public final class HandlerControllerConstants {
+    public static final int REALM_CHANGED = 14930352; // Hopefully it won't clash with other message IDs.
+    public static final int COMPLETED_UPDATE_ASYNC_QUERIES = 24157817;
+    public static final int COMPLETED_ASYNC_REALM_RESULTS = 39088169;
+    public static final int COMPLETED_ASYNC_REALM_OBJECT = 63245986;
+    public static final int REALM_ASYNC_BACKGROUND_EXCEPTION = 102334155;
+    public static final int LOCAL_COMMIT = 165580141;
+}

--- a/realm/realm-library/src/main/java/io/realm/internal/async/QueryUpdateTask.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/async/QueryUpdateTask.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 
+import io.realm.HandlerController;
 import io.realm.RealmConfiguration;
 import io.realm.RealmModel;
 import io.realm.RealmResults;
@@ -100,8 +101,12 @@ public class QueryUpdateTask implements Runnable {
                 handler.obtainMessage(message, result).sendToTarget();
             }
 
-        } catch (Exception e) {
+        } catch (Throwable e) {
             RealmLog.e(e.getMessage(), e);
+            Handler handler = callerHandler.get();
+            if (handler != null && handler.getLooper().getThread().isAlive()) {
+                handler.obtainMessage(HandlerController.REALM_ASYNC_BACKGROUND_EXCEPTION, new Error(e)).sendToTarget();
+            }
 
         } finally {
             if (sharedGroup != null) {


### PR DESCRIPTION
For example the UnsatisfiedLinkError should cause the process terminated.
This is the reason of all the time out issues we found for CI.