### PR TITLE
Migrate RealmLinkTests.java to JUnit4 style.

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
@@ -100,7 +100,6 @@ public class RealmLinkTests {
         if (testRealm != null) {
             testRealm.close();
         }
-        Realm.deleteRealm(realmConfig);
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
@@ -16,7 +16,13 @@
 
 package io.realm;
 
-import android.test.AndroidTestCase;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Date;
 
@@ -24,16 +30,29 @@ import io.realm.entities.AllTypes;
 import io.realm.entities.Cat;
 import io.realm.entities.Dog;
 import io.realm.entities.Owner;
+import io.realm.rule.TestRealmConfigurationFactory;
 
-public class RealmLinkTests extends AndroidTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-    protected Realm testRealm;
+@RunWith(AndroidJUnit4.class)
+public class RealmLinkTests {
 
-    protected void setUp() {
-        RealmConfiguration realmConfig = TestHelper.createConfiguration(getContext());
-        Realm.deleteRealm(realmConfig);
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+
+    private Realm testRealm;
+    private RealmConfiguration realmConfig;
+
+    @Before
+    public void setUp() {
+        realmConfig = configFactory.createConfiguration();
         testRealm = Realm.getInstance(realmConfig);
 
+        populate();
+    }
+
+    private void populate() {
         testRealm.beginTransaction();
         testRealm.delete(Dog.class);
         testRealm.delete(Cat.class);
@@ -76,12 +95,16 @@ public class RealmLinkTests extends AndroidTestCase {
         testRealm.commitTransaction();
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        testRealm.close();
+    @After
+    public void tearDown() {
+        if (testRealm != null) {
+            testRealm.close();
+        }
+        Realm.deleteRealm(realmConfig);
     }
 
-    public void testObjects() {
+    @Test
+    public void objects() {
         RealmResults<Owner> owners = testRealm.where(Owner.class).findAll();
         assertEquals(1, owners.size());
         assertEquals(2, owners.first().getDogs().size());
@@ -102,7 +125,8 @@ public class RealmLinkTests extends AndroidTestCase {
     }
 
 
-    public void testReamListQuery() {
+    @Test
+    public void reamListQuery() {
         RealmResults<Owner> owners = testRealm.where(Owner.class).findAll();
         RealmResults<Dog> dogs = owners.get(0).getDogs().where().contains("name", "o").findAll();
         assertEquals(2, dogs.size());
@@ -110,7 +134,8 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals("Fido", dogs.get(1).getName());
     }
 
-    public void testQuerySingleRelationBoolean() {
+    @Test
+    public void querySingleRelationBoolean() {
         RealmResults<Owner> owners = testRealm.where(Owner.class).equalTo("cat.hasTail", true).findAll();
         assertEquals(1, owners.size());
         assertEquals(12, owners.first().getCat().getAge());
@@ -119,7 +144,8 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(0, none.size());
     }
 
-    public void testQuerySingleRelationInteger() {
+    @Test
+    public void querySingleRelationInteger() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).equalTo("cat.age", 12).findAll();
         assertEquals(1, owners1.size());
         assertEquals(12, owners1.first().getCat().getAge());
@@ -157,7 +183,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-    public void testQuerySingleRelationDate() {
+    @Test
+    public void querySingleRelationDate() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).equalTo("cat.birthday", new Date(6000)).findAll();
         assertEquals(1, owners1.size());
         assertEquals(12, owners1.first().getCat().getAge());
@@ -196,7 +223,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-    public void testQuerySingleRelationFloat() {
+    @Test
+    public void querySingleRelationFloat() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).greaterThanOrEqualTo("cat.height", 0.2f).findAll();
         assertEquals(1, owners1.size());
         assertEquals(12, owners1.first().getCat().getAge());
@@ -227,7 +255,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-    public void testQuerySingleRelationDouble() {
+    @Test
+    public void querySingleRelationDouble() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).greaterThanOrEqualTo("cat.weight", 0.2).findAll();
         assertEquals(1, owners1.size());
         assertEquals(12, owners1.first().getCat().getAge());
@@ -259,8 +288,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-
-    public void testQuerySingleRelationString() {
+    @Test
+    public void querySingleRelationString() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).equalTo("cat.name", "Blackie").findAll();
         assertEquals(1, owners1.size());
 
@@ -286,7 +315,8 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(1, owners6.size());
     }
 
-    public void testQueryMultipleRelationsBoolean() {
+    @Test
+    public void queryMultipleRelationsBoolean() {
         RealmResults<Owner> owners = testRealm.where(Owner.class).equalTo("dogs.hasTail", true).findAll();
         assertEquals(1, owners.size());
 
@@ -294,7 +324,8 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(0, none.size());
     }
 
-    public void testQueryMultipleRelationsInteger() {
+    @Test
+    public void queryMultipleRelationsInteger() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).equalTo("dogs.age", 10).findAll();
         assertEquals(1, owners1.size());
 
@@ -326,7 +357,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-    public void testQueryMultipleRelationsDate() {
+    @Test
+    public void queryMultipleRelationsDate() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).equalTo("dogs.birthday", new Date(2000)).findAll();
         assertEquals(1, owners1.size());
 
@@ -359,7 +391,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-    public void testQueryMultipleRelationsFloat() {
+    @Test
+    public void queryMultipleRelationsFloat() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).greaterThanOrEqualTo("dogs.height", 0.2f).findAll();
         assertEquals(1, owners1.size());
         assertEquals(12, owners1.first().getCat().getAge());
@@ -391,7 +424,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-    public void testQueryMultipleRelationsDouble() {
+    @Test
+    public void queryMultipleRelationsDouble() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).greaterThanOrEqualTo("dogs.weight", 0.2).findAll();
         assertEquals(1, owners1.size());
         assertEquals(12, owners1.first().getCat().getAge());
@@ -423,8 +457,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-
-    public void testQueryMultipleRelationsString() {
+    @Test
+    public void queryMultipleRelationsString() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).equalTo("dogs.name", "Pluto").findAll();
         assertEquals(1, owners1.size());
 
@@ -447,7 +481,8 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(0, owners5.size());
     }
 
-    public void testQueryShouldFail() {
+    @Test
+    public void queryShouldFail() {
         try {
             RealmResults<Owner> owners = testRealm.where(Owner.class).equalTo("cat..hasTail", true).findAll();
             fail("Should throw Exception");
@@ -470,7 +505,8 @@ public class RealmLinkTests extends AndroidTestCase {
         }
     }
 
-    public void testWhere() throws Exception {
+    @Test
+    public void where() throws Exception {
         RealmResults<Owner> owners = testRealm.where(Owner.class).findAll();
         RealmResults<Dog> dogs = owners.first().getDogs().where().equalTo("name", "Pluto").findAll();
         assertEquals(1, dogs.size());
@@ -481,13 +517,15 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(0, none.size());
     }
 
-    public void testSubquery() {
+    @Test
+    public void subquery() {
         RealmResults<Owner> owners = testRealm.where(Owner.class).equalTo("dogs.name", "Pluto").findAll();
         RealmResults<Owner> subOwners = owners.where().equalTo("cat.name", "Blackie").findAll();
         assertEquals(1, subOwners.size());
     }
 
-    public void testLinkIsNull() {
+    @Test
+    public void linkIsNull() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).isNull("cat").findAll();
         assertEquals(0, owners1.size());
 
@@ -499,7 +537,8 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(1, owners2.size());
     }
 
-    public void testLinkIsNotNull() {
+    @Test
+    public void linkIsNotNull() {
         RealmResults<Owner> owners1 = testRealm.where(Owner.class).isNotNull("cat").findAll();
         assertEquals(1, owners1.size());
 
@@ -511,7 +550,8 @@ public class RealmLinkTests extends AndroidTestCase {
         assertEquals(0, owners2.size());
     }
 
-    public void testIsNullWrongType() {
+    @Test
+    public void isNullWrongType() {
         try {
             // AllTypes.columnFloat is not nullable
             testRealm.where(AllTypes.class).isNull("columnFloat").findAll();


### PR DESCRIPTION
`RealmLinkTest` is the last user of the deprecated `TestHelper.createConfiguration()` method.
I'll clean up `TestHelper.createConfiguration()`s in other PR.

@realm/java 