### PR TITLE
Don't rely on dir() in docker containers in the Jenkinsfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV PATH ${PATH}:${NDK_HOME}
 RUN DEBIAN_FRONTEND=noninteractive dpkg --add-architecture i386 \
     && apt-get update -qq \
     && apt-get install -y file git curl wget zip unzip \
+                       bsdmainutils \
                        build-essential \
                        openjdk-8-jdk-headless \
                        libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386 \
@@ -31,7 +32,7 @@ RUN cd /opt && rm -f android-sdk.tgz
 
 # Grab what's needed in the SDK
 # ↓ updates tools to at least 25.1.7, but that prints 'Nothing was installed' (so I don't check the outputs).
-RUN echo y | android update sdk --no-ui --all --filter tools > /dev/null 
+RUN echo y | android update sdk --no-ui --all --filter tools > /dev/null
 RUN echo y | android update sdk --no-ui --all --filter platform-tools | grep 'package installed'
 RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.0 | grep 'package installed'
 RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository | grep 'package installed'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,23 +129,22 @@ def storeJunitResults(String path) {
 }
 
 def collectAarMetrics() {
-  dir('realm/realm-library/build/outputs/aar') {
-    sh '''set -xe
-    unzip realm-android-library-release.aar -d unzipped
-    find $ANDROID_HOME -name dx | sort -r | head -n 1 > dx
-    $(cat dx) --dex --output=temp.dex unzipped/classes.jar
-    cat temp.dex | head -c 92 | tail -c 4 | hexdump -e '1/4 "%d"' > methods
-    '''
-    sendMetrics('methods', readFile('methods'))
+  sh '''set -xe
+  cd realm/realm-library/build/outputs/aar
+  unzip realm-android-library-release.aar -d unzipped
+  find $ANDROID_HOME -name dx | sort -r | head -n 1 > dx
+  $(cat dx) --dex --output=temp.dex unzipped/classes.jar
+  cat temp.dex | head -c 92 | tail -c 4 | hexdump -e '1/4 "%d"' > methods
+  '''
+  sendMetrics('methods', readFile('realm/realm-library/build/outputs/aar/methods'))
 
-    sendMetrics('aar_size', new File('realm-android-library-release.aar').length())
+  sendMetrics('aar_size', new File('realm/realm-library/build/outputs/aar/realm-android-library-release.aar').length())
 
-    def rootFolder = new File('unzipped/jni')
-    rootFolder.traverse (type: DIRECTORIES) { folder ->
-      def abiName = folder.name()
-      def libSize = new File(folder, 'librealm-jni.so').size() as String
-      sendTaggedMetric('abi_size', libSize, 'type', abiName)
-    }
+  def rootFolder = new File('realm/realm-library/build/outputs/aar/unzipped/jni')
+  rootFolder.traverse (type: DIRECTORIES) { folder ->
+    def abiName = folder.name()
+    def libSize = new File(folder, 'librealm-jni.so').size() as String
+    sendTaggedMetric('abi_size', libSize, 'type', abiName)
   }
 }
 


### PR DESCRIPTION
Also, we need to install `hexdump` on our docker images in order to perform the method count.