### PR TITLE
Annotation processor no longer consume annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.1.1
 
+### Enhancements
+
+* The Realm Annotation processor no longer consumes the Realm annotations. Allowing other annotation processors to also run.
+
 ### Bug fixes
 
 * Fixed a wrong JNI method declaration which might cause "method not found" crash on some devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-* The Realm Annotation processor no longer consumes the Realm annotations. Allowing other annotation processors to also run.
+* The Realm Annotation processor no longer consumes the Realm annotations. Allowing other annotation processors to run.
 
 ### Bug fixes
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import javax.annotation.processing.AbstractProcessor;
-import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
@@ -102,6 +101,9 @@ import io.realm.annotations.RealmClass;
 })
 public class RealmProcessor extends AbstractProcessor {
 
+    // Don't consume annotations. This allows 3rd party annotation processors to also run.
+    public static final boolean CONSUME_ANNOTATIONS = false;
+
     Set<ClassMetaData> classesToValidate = new HashSet<ClassMetaData>();
     private boolean hasProcessedModules = false;
 
@@ -111,8 +113,9 @@ public class RealmProcessor extends AbstractProcessor {
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        // Don't run this processor in subsequent runs. We created everything in the first one.
         if (hasProcessedModules) {
-            return true;
+            return CONSUME_ANNOTATIONS;
         }
         RealmVersionChecker updateChecker = RealmVersionChecker.getInstance(processingEnv);
         updateChecker.executeRealmVersionUpdate();
@@ -165,7 +168,9 @@ public class RealmProcessor extends AbstractProcessor {
         }
 
         hasProcessedModules = true;
-        return processModules(roundEnv);
+        processModules(roundEnv);
+
+        return CONSUME_ANNOTATIONS;
     }
 
     // Returns true if modules was processed successfully, false otherwise

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -102,7 +102,7 @@ import io.realm.annotations.RealmClass;
 public class RealmProcessor extends AbstractProcessor {
 
     // Don't consume annotations. This allows 3rd party annotation processors to also run.
-    public static final boolean CONSUME_ANNOTATIONS = false;
+    private static final boolean CONSUME_ANNOTATIONS = false;
 
     Set<ClassMetaData> classesToValidate = new HashSet<ClassMetaData>();
     private boolean hasProcessedModules = false;

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -101,7 +101,7 @@ import io.realm.annotations.RealmClass;
 })
 public class RealmProcessor extends AbstractProcessor {
 
-    // Don't consume annotations. This allows 3rd party annotation processors to also run.
+    // Don't consume annotations. This allows 3rd party annotation processors to run.
     private static final boolean CONSUME_ANNOTATIONS = false;
 
     Set<ClassMetaData> classesToValidate = new HashSet<ClassMetaData>();


### PR DESCRIPTION
This PR changes the Realm annotation processor so it no longer consumes the annotations. The only effect this has is that it is now possible to write multiple annotation processors for the same annotation. 

It is not possible to specify the order of annotation processors from two different libraries, so if one of the processors consumed the annotation it would be random if both ran or only one of them.

I ran into this problem while working on a small side-project that involved creating a new annotation processor that also wanted to generate files based on the Realm model classes. So opening up for this will also allow others to write similar processors.

@realm/java 