### PR TITLE
Disable change listeners on IntentService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed a bug that `Error` in the background async thread is not forwared to the caller thread.
 * Fixed a crash when an empty `Collection` is passed to `insert()`/`insertOrUpdate()` (#3103).
 * Fixed a concurrency allocation bug in storage engine which might lead to some random crashes.
+* Throw a proper `IllegalStateException` if a `RealmChangeListener` is used inside an IntentService.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.1.1
 
+### Enhancements
+
+* The Realm Annotation processor no longer consumes the Realm annotations. Allowing other annotation processors to run.
+
 ### Bug fixes
 
 * Fixed a wrong JNI method declaration which might cause "method not found" crash on some devices.

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import javax.annotation.processing.AbstractProcessor;
-import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
@@ -102,6 +101,9 @@ import io.realm.annotations.RealmClass;
 })
 public class RealmProcessor extends AbstractProcessor {
 
+    // Don't consume annotations. This allows 3rd party annotation processors to run.
+    private static final boolean CONSUME_ANNOTATIONS = false;
+
     Set<ClassMetaData> classesToValidate = new HashSet<ClassMetaData>();
     private boolean hasProcessedModules = false;
 
@@ -111,8 +113,9 @@ public class RealmProcessor extends AbstractProcessor {
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        // Don't run this processor in subsequent runs. We created everything in the first one.
         if (hasProcessedModules) {
-            return true;
+            return CONSUME_ANNOTATIONS;
         }
         RealmVersionChecker updateChecker = RealmVersionChecker.getInstance(processingEnv);
         updateChecker.executeRealmVersionUpdate();
@@ -165,7 +168,9 @@ public class RealmProcessor extends AbstractProcessor {
         }
 
         hasProcessedModules = true;
-        return processModules(roundEnv);
+        processModules(roundEnv);
+
+        return CONSUME_ANNOTATIONS;
     }
 
     // Returns true if modules was processed successfully, false otherwise

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -54,7 +54,7 @@ import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -54,7 +54,7 @@ import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;
 
-import static org.junit.Assert.assertEquals;
+import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -1065,7 +1065,7 @@ public class NotificationsTest {
     }
 
     @Test
-    @RunTestInLooperThread(PopulateOneAllTypes.class)
+    @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void realmListener_realmResultShouldBeSynced() {
         final Realm realm = looperThread.realm;
         final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
@@ -1178,7 +1178,7 @@ public class NotificationsTest {
     //                            |Posted Runnable|                      |REALM_CHANGED/LOCAL_COMMIT|
     // Step 4: Posted runnable called.
     @Test
-    @RunTestInLooperThread(/*step1*/PopulateOneAllTypes.class)
+    @RunTestInLooperThread(/*step1*/ before = PopulateOneAllTypes.class)
     public void realmListener_localChangeShouldBeSendAtFrontOfTheQueue() {
         final Realm realm = looperThread.realm;
         final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
@@ -1219,7 +1219,7 @@ public class NotificationsTest {
     //                            |Posted Runnable|                      |REALM_CHANGED/LOCAL_COMMIT|
     // Step 5: Posted runnable called.
     @Test
-    @RunTestInLooperThread(/*step1*/PopulateOneAllTypes.class)
+    @RunTestInLooperThread(/*step1*/before = PopulateOneAllTypes.class)
     public void realmListener_localChangeShouldBeSendAtFrontOfTheQueueWithLoadedAsync() {
         final AtomicBoolean changedFirstTime = new AtomicBoolean(false);
         final Realm realm = looperThread.realm;
@@ -1273,7 +1273,7 @@ public class NotificationsTest {
     // Step 5: Posted runnable called.
     //
     @Test
-    @RunTestInLooperThread(/*step1*/PopulateOneAllTypes.class)
+    @RunTestInLooperThread(/*step1*/before = PopulateOneAllTypes.class)
     public void realmListener_localChangeShouldBeSendAtFrontOfTheQueueWithPausedAsync() {
         final Realm realm = looperThread.realm;
 
@@ -1400,4 +1400,96 @@ public class NotificationsTest {
         realm.commitTransaction();
     }
 
+    @Test
+    @RunTestInLooperThread(threadName = "IntentService[1]")
+    public void listenersNotAllowedOnIntentServiceThreads() {
+        final Realm realm = looperThread.realm;
+        realm.beginTransaction();
+        AllTypes obj = realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
+
+        // Global listener
+        try {
+            realm.addChangeListener(new RealmChangeListener<Realm>() {
+                @Override
+                public void onChange(Realm element) {
+
+                }
+            });
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+
+        // RealmResults listener
+        try {
+            results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
+                @Override
+                public void onChange(RealmResults<AllTypes> element) {
+
+                }
+            });
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+
+        // Object listener
+        try {
+            obj.addChangeListener(new RealmChangeListener<RealmModel>() {
+                @Override
+                public void onChange(RealmModel element) {
+
+                }
+            });
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+
+        looperThread.testComplete();
+    }
+
+    @Test
+    public void listenersNotAllowedOnNonLooperThreads() {
+        realm = Realm.getInstance(realmConfig);
+        realm.beginTransaction();
+        AllTypes obj = realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
+
+        // Global listener
+        try {
+            realm.addChangeListener(new RealmChangeListener<Realm>() {
+                @Override
+                public void onChange(Realm element) {
+
+                }
+            });
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+
+        // RealmResults listener
+        try {
+            results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
+                @Override
+                public void onChange(RealmResults<AllTypes> element) {
+
+                }
+            });
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+
+        // Object listener
+        try {
+            obj.addChangeListener(new RealmChangeListener<RealmModel>() {
+                @Override
+                public void onChange(RealmModel element) {
+
+                }
+            });
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
@@ -86,7 +87,8 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
             @Override
             public void evaluate() throws Throwable {
                 before();
-                Class<? extends RunnableBefore> runnableBefore = annotation.value();
+                final String threadName = annotation.threadName();
+                Class<? extends RunnableBefore> runnableBefore = annotation.before();
                 if (!runnableBefore.isInterface()) {
                     runnableBefore.newInstance().run(realmConfiguration);
                 }
@@ -94,7 +96,12 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
                     final CountDownLatch signalClosedRealm = new CountDownLatch(1);
                     final Throwable[] threadAssertionError = new Throwable[1];
                     final Looper[] backgroundLooper = new Looper[1];
-                    final ExecutorService executorService = Executors.newSingleThreadExecutor();
+                    final ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactory() {
+                        @Override
+                        public Thread newThread(Runnable runnable) {
+                            return new Thread(runnable, threadName);
+                        }
+                    });
                     executorService.submit(new Runnable() {
                         @Override
                         public void run() {

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunTestInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunTestInLooperThread.java
@@ -28,7 +28,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Annotation param {@link io.realm.rule.RunInLooperThread.RunnableBefore} can be supplied which will run before the
  * looper thread.
  */
-@Target(METHOD) @Retention(RUNTIME)
+@Target(METHOD)
+@Retention(RUNTIME)
 public @interface RunTestInLooperThread {
-    Class<? extends RunInLooperThread.RunnableBefore> value() default RunInLooperThread.RunnableBefore.class;
+        String threadName() default "RunTestInLooperThread";
+        Class<?extends RunInLooperThread.RunnableBefore> before() default RunInLooperThread.RunnableBefore.class;
 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -75,18 +75,15 @@ abstract class BaseRealm implements Closeable {
         RealmLog.add(BuildConfig.DEBUG ? new DebugAndroidLogger() : new ReleaseAndroidLogger());
     }
 
-    protected BaseRealm(RealmConfiguration configuration, boolean autoRefresh) {
+    protected BaseRealm(RealmConfiguration configuration) {
         this.threadId = Thread.currentThread().getId();
         this.configuration = configuration;
         this.sharedGroupManager = new SharedGroupManager(configuration);
         this.schema = new RealmSchema(this, sharedGroupManager.getTransaction());
         this.handlerController = new HandlerController(this);
-        if (Looper.myLooper() == null) {
-            if (autoRefresh) {
-                throw new IllegalStateException("Cannot set auto-refresh in a Thread without a Looper");
-            }
-        } else {
-            setAutoRefresh(autoRefresh);
+
+        if (handlerController.isAutoRefreshAvailable()) {
+            setAutoRefresh(true);
         }
     }
 
@@ -103,10 +100,7 @@ abstract class BaseRealm implements Closeable {
      */
     public void setAutoRefresh(boolean autoRefresh) {
         checkIfValid();
-        if (Looper.myLooper() == null) {
-            throw new IllegalStateException("Cannot set auto-refresh in a Thread without a Looper");
-        }
-
+        handlerController.checkCanBeAutoRefreshed();
         if (autoRefresh && !handlerController.isAutoRefreshEnabled()) { // Switch it on
             handler = new Handler(handlerController);
             handlers.put(handler, configuration.getPath());
@@ -141,7 +135,7 @@ abstract class BaseRealm implements Closeable {
         }
         checkIfValid();
         if (!handlerController.isAutoRefreshEnabled()) {
-            throw new IllegalStateException("You can't register a listener from a non-Looper thread ");
+            throw new IllegalStateException("You can't register a listener from a non-Looper or IntentService thread.");
         }
         handlerController.addChangeListener(listener);
     }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -16,7 +16,7 @@
 
 package io.realm;
 
-import android.os.Looper;
+import android.app.IntentService;
 
 import io.realm.annotations.internal.OptionalAPI;
 import io.realm.exceptions.RealmException;
@@ -47,8 +47,8 @@ import rx.Observable;
  */
 public final class DynamicRealm extends BaseRealm {
 
-    private DynamicRealm(RealmConfiguration configuration, boolean autoRefresh) {
-        super(configuration, autoRefresh);
+    private DynamicRealm(RealmConfiguration configuration) {
+        super(configuration);
     }
 
     /**
@@ -129,7 +129,7 @@ public final class DynamicRealm extends BaseRealm {
      *
      * @param listener the change listener.
      * @throws IllegalArgumentException if the change listener is {@code null}.
-     * @throws IllegalStateException if you try to register a listener from a non-Looper Thread.
+     * @throws IllegalStateException if you try to register a listener from a non-Looper or {@link IntentService} thread.
      * @see io.realm.RealmChangeListener
      * @see #removeChangeListener(RealmChangeListener)
      * @see #removeAllChangeListeners()
@@ -181,8 +181,7 @@ public final class DynamicRealm extends BaseRealm {
      * @return a {@link DynamicRealm} instance.
      */
     static DynamicRealm createInstance(RealmConfiguration configuration) {
-        boolean autoRefresh = Looper.myLooper() != null;
-        return new DynamicRealm(configuration, autoRefresh);
+        return new DynamicRealm(configuration);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -782,7 +782,7 @@ final class HandlerController implements Handler.Callback {
     }
 
     /**
-     * Validate that the current thread can enable auto refresh. An {@link IllegalStateException} will be thrown if that
+     * Validates that the current thread can enable auto refresh. An {@link IllegalStateException} will be thrown if that
      * is not the case.
      */
     public void checkCanBeAutoRefreshed() {

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -807,8 +807,8 @@ final class HandlerController implements Handler.Callback {
     }
 
     private static boolean isIntentServiceThread() {
-        // Tries to determine if a thread is an IntentService thread. No public API can detect this use the
-        // thread name as a heuristic:
+        // Tries to determine if a thread is an IntentService thread. No public API can detect this,
+        // so use the thread name as a heuristic:
         // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/app/IntentService.java#108
         String threadName = Thread.currentThread().getName();
         return threadName != null && threadName.startsWith("IntentService[");

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -17,6 +17,7 @@
 package io.realm;
 
 import android.annotation.TargetApi;
+import android.app.IntentService;
 import android.os.Build;
 import android.os.Looper;
 import android.os.Message;
@@ -43,6 +44,8 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import io.realm.RealmObject;
+import io.realm.RealmQuery;
 import io.realm.annotations.internal.OptionalAPI;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmIOException;
@@ -133,11 +136,10 @@ public final class Realm extends BaseRealm {
      * The constructor is private to enforce the use of the static one.
      *
      * @param configuration the {@link RealmConfiguration} used to open the Realm.
-     * @param autoRefresh {@code true} if Realm should auto-refresh. {@code false} otherwise.
      * @throws IllegalArgumentException if trying to open an encrypted Realm with the wrong key.
      */
-    Realm(RealmConfiguration configuration, boolean autoRefresh) {
-        super(configuration, autoRefresh);
+    Realm(RealmConfiguration configuration) {
+        super(configuration);
     }
 
     /**
@@ -236,8 +238,7 @@ public final class Realm extends BaseRealm {
     }
 
     static Realm createAndValidate(RealmConfiguration configuration, ColumnIndices columnIndices) {
-        boolean autoRefresh = Looper.myLooper() != null;
-        Realm realm = new Realm(configuration, autoRefresh);
+        Realm realm = new Realm(configuration);
         long currentVersion = realm.getVersion();
         long requiredVersion = configuration.getSchemaVersion();
         if (currentVersion != UNVERSIONED && currentVersion < requiredVersion && columnIndices == null) {
@@ -1044,7 +1045,7 @@ public final class Realm extends BaseRealm {
      *
      * @param listener the change listener.
      * @throws IllegalArgumentException if the change listener is {@code null}.
-     * @throws IllegalStateException if you try to register a listener from a non-Looper Thread.
+     * @throws IllegalStateException if you try to register a listener from a non-Looper or {@link IntentService} thread.
      * @see io.realm.RealmChangeListener
      * @see #removeChangeListener(RealmChangeListener)
      * @see #removeAllChangeListeners()

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import android.app.IntentService;
+
 import java.util.List;
 
 import io.realm.annotations.RealmClass;
@@ -219,6 +221,7 @@ public abstract class RealmObject implements RealmModel {
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null} or the object is an unmanaged object.
      * @throws IllegalArgumentException if object is an unmanaged RealmObject.
+     * @throws IllegalStateException if you try to add a listener from a non-Looper or {@link IntentService} thread.
      */
     public final <E extends RealmModel> void addChangeListener(RealmChangeListener<E> listener) {
         RealmObject.addChangeListener((E) this, listener);
@@ -231,7 +234,7 @@ public abstract class RealmObject implements RealmModel {
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the {@code object} or the change listener is {@code null}.
      * @throws IllegalArgumentException if object is an unmanaged RealmObject.
-     * @throws IllegalStateException if you try to add a listener from a non-Looper Thread.
+     * @throws IllegalStateException if you try to add a listener from a non-Looper or {@link IntentService} thread.
      */
     public static <E extends RealmModel> void addChangeListener(E object, RealmChangeListener<E> listener) {
         if (object == null) {
@@ -244,8 +247,8 @@ public abstract class RealmObject implements RealmModel {
             RealmObjectProxy proxy = (RealmObjectProxy) object;
             BaseRealm realm = proxy.realmGet$proxyState().getRealm$realm();
             realm.checkIfValid();
-            if (realm.handler == null) {
-                throw new IllegalStateException("You can't register a listener from a non-Looper thread ");
+            if (!realm.handlerController.isAutoRefreshEnabled()) {
+                throw new IllegalStateException("You can't register a listener from a non-Looper thread or IntentService thread.");
             }
             List<RealmChangeListener> listeners = proxy.realmGet$proxyState().getListeners$realm();
             if (!listeners.contains(listener)) {

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -17,6 +17,8 @@
 package io.realm;
 
 
+import android.app.IntentService;
+
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.Collections;
@@ -917,15 +919,15 @@ public final class RealmResults<E extends RealmModel> extends AbstractList<E> im
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null}.
-     * @throws IllegalStateException if you try to add a listener from a non-Looper Thread.
+     * @throws IllegalStateException if you try to add a listener from a non-Looper or {@link IntentService} thread.
      */
     public void addChangeListener(RealmChangeListener<RealmResults<E>> listener) {
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }
         realm.checkIfValid();
-        if (realm.handler == null) {
-            throw new IllegalStateException("You can't register a listener from a non-Looper thread ");
+        if (!realm.handlerController.isAutoRefreshEnabled()) {
+            throw new IllegalStateException("You can't register a listener from a non-Looper thread or IntentService thread. ");
         }
         if (!listeners.contains(listener)) {
             listeners.add(listener);


### PR DESCRIPTION
Fixes #2875 

With this change, using any form of ChangeListener will now throw on an IntentService thread.

IntentService has always been a bastard child in the sense that it is a  Looper thread, but is not meant to be used as such, since the looping is just used to process the queue of jobs.

- All logic around the auto-refresh feature has also been moved to the HandlerController instead of being scattered all over the place.

- `RunTestInLooperThread` have been extended so it is now possible to define the name of the worker thread.