### PR TITLE
Upgrading to Gradle 2.2.0-alpha6

### DIFF
--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha6'
         classpath 'de.undercouch:gradle-download-task:2.0.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -113,7 +113,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 preBuild.dependsOn ':realm-jni:buildAndroidJni'
 
 task findbugs(type: FindBugs) {
-    dependsOn assembleDebug
+    dependsOn "assembleDebug"
     group = 'Verification'
 
     ignoreFailures = false


### PR DESCRIPTION
Upgrading to Android Studio 2.2 preview 6 also pulls in Gradle 2.2.0 alpha 6.