### PR TITLE
insert(): Correctly detect multiple objects with the same primary key 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed a crash when an empty `Collection` is passed to `insert()`/`insertOrUpdate()` (#3103).
 * Fixed a concurrency allocation bug in storage engine which might lead to some random crashes.
 * Bulk insertion now throws if it is not called in a transaction (#3173).
+* `insert()` now correctly throws an exception if two different objects have the same primary key.
 
 ### Internal
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -784,8 +784,11 @@ public class RealmProxyClassGenerator {
         writer.emitStatement("long tableNativePtr = table.getNativeTablePointer()");
         writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
-        writer.emitStatement("long rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
-        writer.emitStatement("cache.put(object, rowIndex)");
+
+        if (metadata.hasPrimaryKey()) {
+            writer.emitStatement("long pkColumnIndex = table.getPrimaryKey()");
+        }
+        addPrimaryKeyCheckIfNeeeded(metadata, true, writer);
 
         for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
@@ -826,7 +829,9 @@ public class RealmProxyClassGenerator {
                         .emitEmptyLine();
 
             } else {
-                setTableValues(writer, fieldType, fieldName, interfaceName, getter, false);
+                if (metadata.getPrimaryKey() != field) {
+                    setTableValues(writer, fieldType, fieldName, interfaceName, getter, false);
+                }
             }
         }
 
@@ -847,14 +852,16 @@ public class RealmProxyClassGenerator {
         writer.emitStatement("long tableNativePtr = table.getNativeTablePointer()");
         writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
+        if (metadata.hasPrimaryKey()) {
+            writer.emitStatement("long pkColumnIndex = table.getPrimaryKey()");
+        }
         writer.emitStatement("%s object = null", qualifiedClassName);
 
         writer.beginControlFlow("while (objects.hasNext())");
         writer.emitStatement("object = (%s) objects.next()", qualifiedClassName);
         writer.beginControlFlow("if(!cache.containsKey(object))");
 
-        writer.emitStatement("long rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
-        writer.emitStatement("cache.put(object, rowIndex)");
+        addPrimaryKeyCheckIfNeeeded(metadata, true, writer);
 
         for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
@@ -895,14 +902,78 @@ public class RealmProxyClassGenerator {
                         .emitEmptyLine();
 
             } else {
-                setTableValues(writer, fieldType, fieldName, interfaceName, getter, false);
+                if (metadata.getPrimaryKey() != field) {
+                    setTableValues(writer, fieldType, fieldName, interfaceName, getter, false);
+                }
             }
         }
 
-            writer.endControlFlow();
+        writer.endControlFlow();
         writer.endControlFlow();
         writer.endMethod();
         writer.emitEmptyLine();
+    }
+
+    private void addPrimaryKeyCheckIfNeeeded(ClassMetaData metadata, boolean throwIfPrimaryKeyDuplicate, JavaWriter writer) throws IOException {
+        if (metadata.hasPrimaryKey()) {
+            String primaryKeyGetter = metadata.getPrimaryKeyGetter();
+            VariableElement primaryKeyElement = metadata.getPrimaryKey();
+            if (metadata.isNullable(primaryKeyElement)) {
+                if (Utils.isString(primaryKeyElement)) {
+                    writer
+                        .emitStatement("String primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
+                        .emitStatement("long rowIndex = TableOrView.NO_MATCH")
+                        .beginControlFlow("if (primaryKeyValue == null)")
+                            .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
+                        .nextControlFlow("else")
+                            .emitStatement("rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue)")
+                        .endControlFlow();
+                } else {
+                    writer
+                        .emitStatement("Object primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
+                        .emitStatement("long rowIndex = TableOrView.NO_MATCH")
+                        .beginControlFlow("if (primaryKeyValue == null)")
+                            .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
+                        .nextControlFlow("else")
+                            .emitStatement("rowIndex = Table.nativeFindFirstInt(tableNativePtr, pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter)
+                        .endControlFlow();
+                }
+            } else {
+                writer.emitStatement("long rowIndex = TableOrView.NO_MATCH");
+                writer.emitStatement("Object primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter);
+                writer.beginControlFlow("if (primaryKeyValue != null)");
+
+                if (Utils.isString(metadata.getPrimaryKey())) {
+                    writer.emitStatement("rowIndex = table.findFirstString(pkColumnIndex, (String)primaryKeyValue)");
+                } else {
+                    writer.emitStatement("rowIndex = table.findFirstLong(pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
+                }
+                writer.endControlFlow();
+            }
+
+            writer.beginControlFlow("if (rowIndex == TableOrView.NO_MATCH)");
+            writer.emitStatement("rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
+            if (Utils.isString(metadata.getPrimaryKey())) {
+                writer.beginControlFlow("if (primaryKeyValue != null)");
+                writer.emitStatement("Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, (String)primaryKeyValue)");
+                writer.endControlFlow();
+            } else {
+                writer.beginControlFlow("if (primaryKeyValue != null)");
+                writer.emitStatement("Table.nativeSetLong(tableNativePtr, pkColumnIndex, rowIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
+                writer.endControlFlow();
+            }
+
+            if (throwIfPrimaryKeyDuplicate) {
+                writer.nextControlFlow("else");
+                writer.emitStatement("table.throwDuplicatePrimaryKeyException(primaryKeyValue)");
+            }
+
+            writer.endControlFlow();
+            writer.emitStatement("cache.put(object, rowIndex)");
+        } else {
+            writer.emitStatement("long rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
+            writer.emitStatement("cache.put(object, rowIndex)");
+        }
     }
 
     private void emitInsertOrUpdateMethod(JavaWriter writer) throws IOException {
@@ -917,63 +988,11 @@ public class RealmProxyClassGenerator {
         writer.emitStatement("long tableNativePtr = table.getNativeTablePointer()");
         writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
+
         if (metadata.hasPrimaryKey()) {
             writer.emitStatement("long pkColumnIndex = table.getPrimaryKey()");
-
-            String primaryKeyGetter = metadata.getPrimaryKeyGetter();
-            VariableElement primaryKeyElement = metadata.getPrimaryKey();
-            if (metadata.isNullable(primaryKeyElement)) {
-                if (Utils.isString(primaryKeyElement)) {
-                    writer
-                            .emitStatement("String primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
-                            .emitStatement("long rowIndex = TableOrView.NO_MATCH")
-                            .beginControlFlow("if (primaryKeyValue == null)")
-                                .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
-                            .nextControlFlow("else")
-                                .emitStatement("rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue)")
-                            .endControlFlow();
-                } else {
-                    writer
-                            .emitStatement("Object primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
-                            .emitStatement("long rowIndex = TableOrView.NO_MATCH")
-                            .beginControlFlow("if (primaryKeyValue == null)")
-                                .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
-                            .nextControlFlow("else")
-                                .emitStatement("rowIndex = Table.nativeFindFirstInt(tableNativePtr, pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter)
-                            .endControlFlow();
-                }
-            } else {
-                writer.emitStatement("long rowIndex = TableOrView.NO_MATCH");
-                writer.emitStatement("Object primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
-                        .beginControlFlow("if (primaryKeyValue != null)");
-
-                if (Utils.isString(metadata.getPrimaryKey())) {
-                    writer.emitStatement("rowIndex = table.findFirstString(pkColumnIndex, (String)primaryKeyValue)");
-                } else {
-                    writer.emitStatement("rowIndex = table.findFirstLong(pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
-                }
-                writer.endControlFlow();
-            }
-
-            writer
-                    .beginControlFlow("if (rowIndex == TableOrView.NO_MATCH)")
-                    .emitStatement("rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
-            if (Utils.isString(metadata.getPrimaryKey())) {
-                writer.beginControlFlow("if (primaryKeyValue != null)");
-                    writer.emitStatement("Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, (String)primaryKeyValue)");
-                writer.endControlFlow();
-            } else {
-                writer.beginControlFlow("if (primaryKeyValue != null)");
-                    writer.emitStatement("Table.nativeSetLong(tableNativePtr, pkColumnIndex, rowIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
-                writer.endControlFlow();
-            }
-
-            writer.endControlFlow();
-            writer.emitStatement("cache.put(object, rowIndex)");
-        } else {
-            writer.emitStatement("long rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
-            writer.emitStatement("cache.put(object, rowIndex)");
         }
+        addPrimaryKeyCheckIfNeeeded(metadata, false, writer);
 
         for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
@@ -1017,7 +1036,9 @@ public class RealmProxyClassGenerator {
                         .emitEmptyLine();
 
             } else {
-                setTableValues(writer, fieldType, fieldName, interfaceName, getter, true);
+                if (metadata.getPrimaryKey() != field) {
+                    setTableValues(writer, fieldType, fieldName, interfaceName, getter, true);
+                }
             }
         }
 
@@ -1035,12 +1056,11 @@ public class RealmProxyClassGenerator {
                 "Realm", "realm", "Iterator<? extends RealmModel>", "objects", "Map<RealmModel,Long>", "cache" // Argument type & argument name
         );
 
-        boolean hasPrimaryKey = metadata.hasPrimaryKey();
         writer.emitStatement("Table table = realm.getTable(%s.class)", qualifiedClassName);
         writer.emitStatement("long tableNativePtr = table.getNativeTablePointer()");
         writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
-        if (hasPrimaryKey) {
+        if (metadata.hasPrimaryKey()) {
             writer.emitStatement("long pkColumnIndex = table.getPrimaryKey()");
         }
         writer.emitStatement("%s object = null", qualifiedClassName);
@@ -1049,61 +1069,7 @@ public class RealmProxyClassGenerator {
         writer.emitStatement("object = (%s) objects.next()", qualifiedClassName);
         writer.beginControlFlow("if(!cache.containsKey(object))");
 
-        if (hasPrimaryKey) {
-            String primaryKeyGetter = metadata.getPrimaryKeyGetter();
-            VariableElement primaryKeyElement = metadata.getPrimaryKey();
-            if (metadata.isNullable(primaryKeyElement)) {
-                if (Utils.isString(primaryKeyElement)) {
-                    writer
-                            .emitStatement("String primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
-                            .emitStatement("long rowIndex = TableOrView.NO_MATCH")
-                                .beginControlFlow("if (primaryKeyValue == null)")
-                            .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
-                            .nextControlFlow("else")
-                                .emitStatement("rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue)")
-                            .endControlFlow();
-                } else {
-                    writer
-                            .emitStatement("Object primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
-                            .emitStatement("long rowIndex = TableOrView.NO_MATCH")
-                            .beginControlFlow("if (primaryKeyValue == null)")
-                                .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
-                            .nextControlFlow("else")
-                                .emitStatement("rowIndex = Table.nativeFindFirstInt(tableNativePtr, pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter)
-                            .endControlFlow();
-                }
-            } else {
-                writer.emitStatement("long rowIndex = TableOrView.NO_MATCH");
-                writer.emitStatement("Object primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
-                        .beginControlFlow("if (primaryKeyValue != null)");
-                if (Utils.isString(metadata.getPrimaryKey())) {
-                    writer.emitStatement("rowIndex = table.findFirstString(pkColumnIndex, (String)primaryKeyValue)");
-                } else {
-                    writer.emitStatement("rowIndex = table.findFirstLong(pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
-                }
-                writer.endControlFlow();
-            }
-
-            writer
-                    .beginControlFlow("if (rowIndex == TableOrView.NO_MATCH)")
-                    .emitStatement("rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
-            if (Utils.isString(metadata.getPrimaryKey())) {
-                writer.beginControlFlow("if (primaryKeyValue != null)");
-                    writer.emitStatement("Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
-                writer.endControlFlow();
-            } else {
-                writer.beginControlFlow("if (primaryKeyValue != null)");
-                    writer.emitStatement("Table.nativeSetLong(tableNativePtr, pkColumnIndex, rowIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
-                writer.endControlFlow();
-            }
-            writer.endControlFlow();
-
-            writer.emitStatement("cache.put(object, rowIndex)");
-
-        } else {
-            writer.emitStatement("long rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1)");
-            writer.emitStatement("cache.put(object, rowIndex)");
-        }
+        addPrimaryKeyCheckIfNeeeded(metadata, false, writer);
 
         for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
@@ -1147,7 +1113,9 @@ public class RealmProxyClassGenerator {
                         .emitEmptyLine();
 
             } else {
-                setTableValues(writer, fieldType, fieldName, interfaceName, getter, true);
+                if (metadata.getPrimaryKey() != field) {
+                    setTableValues(writer, fieldType, fieldName, interfaceName, getter, true);
+                }
             }
         }
             writer.endControlFlow();

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -965,7 +965,7 @@ public class RealmProxyClassGenerator {
 
             if (throwIfPrimaryKeyDuplicate) {
                 writer.nextControlFlow("else");
-                writer.emitStatement("table.throwDuplicatePrimaryKeyException(primaryKeyValue)");
+                writer.emitStatement("Table.throwDuplicatePrimaryKeyException(primaryKeyValue)");
             }
 
             writer.endControlFlow();

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -924,7 +924,7 @@ public class RealmProxyClassGenerator {
                         .emitStatement("String primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
                         .emitStatement("long rowIndex = TableOrView.NO_MATCH")
                         .beginControlFlow("if (primaryKeyValue == null)")
-                            .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
+                            .emitStatement("rowIndex = Table.nativeFindFirstNull(tableNativePtr, pkColumnIndex)")
                         .nextControlFlow("else")
                             .emitStatement("rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue)")
                         .endControlFlow();
@@ -933,7 +933,7 @@ public class RealmProxyClassGenerator {
                         .emitStatement("Object primaryKeyValue = ((%s) object).%s()", interfaceName, primaryKeyGetter)
                         .emitStatement("long rowIndex = TableOrView.NO_MATCH")
                         .beginControlFlow("if (primaryKeyValue == null)")
-                            .emitStatement("rowIndex = table.findFirstNull(pkColumnIndex)")
+                            .emitStatement("rowIndex = Table.nativeFindFirstNull(tableNativePtr, pkColumnIndex)")
                         .nextControlFlow("else")
                             .emitStatement("rowIndex = Table.nativeFindFirstInt(tableNativePtr, pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter)
                         .endControlFlow();
@@ -944,9 +944,9 @@ public class RealmProxyClassGenerator {
                 writer.beginControlFlow("if (primaryKeyValue != null)");
 
                 if (Utils.isString(metadata.getPrimaryKey())) {
-                    writer.emitStatement("rowIndex = table.findFirstString(pkColumnIndex, (String)primaryKeyValue)");
+                    writer.emitStatement("rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, (String)primaryKeyValue)");
                 } else {
-                    writer.emitStatement("rowIndex = table.findFirstLong(pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
+                    writer.emitStatement("rowIndex = Table.nativeFindFirstInt(tableNativePtr, pkColumnIndex, ((%s) object).%s())", interfaceName, primaryKeyGetter);
                 }
                 writer.endControlFlow();
             }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -672,7 +672,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
         long rowIndex = TableOrView.NO_MATCH;
         if (primaryKeyValue == null) {
-            rowIndex = table.findFirstNull(pkColumnIndex);
+            rowIndex = Table.nativeFindFirstNull(tableNativePtr, pkColumnIndex);
         } else {
             rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue);
         }
@@ -735,7 +735,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
                 long rowIndex = TableOrView.NO_MATCH;
                 if (primaryKeyValue == null) {
-                    rowIndex = table.findFirstNull(pkColumnIndex);
+                    rowIndex = Table.nativeFindFirstNull(tableNativePtr, pkColumnIndex);
                 } else {
                     rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue);
                 }
@@ -795,7 +795,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
         long rowIndex = TableOrView.NO_MATCH;
         if (primaryKeyValue == null) {
-            rowIndex = table.findFirstNull(pkColumnIndex);
+            rowIndex = Table.nativeFindFirstNull(tableNativePtr, pkColumnIndex);
         } else {
             rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue);
         }
@@ -863,7 +863,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
                 long rowIndex = TableOrView.NO_MATCH;
                 if (primaryKeyValue == null) {
-                    rowIndex = table.findFirstNull(pkColumnIndex);
+                    rowIndex = Table.nativeFindFirstNull(tableNativePtr, pkColumnIndex);
                 } else {
                     rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue);
                 }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -682,7 +682,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, (String)primaryKeyValue);
             }
         } else {
-            table.throwDuplicatePrimaryKeyException(primaryKeyValue);
+            Table.throwDuplicatePrimaryKeyException(primaryKeyValue);
         }
         cache.put(object, rowIndex);
         Table.nativeSetLong(tableNativePtr, columnInfo.columnLongIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnLong());
@@ -745,7 +745,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                         Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, (String)primaryKeyValue);
                     }
                 } else {
-                    table.throwDuplicatePrimaryKeyException(primaryKeyValue);
+                    Table.throwDuplicatePrimaryKeyException(primaryKeyValue);
                 }
                 cache.put(object, rowIndex);
                 Table.nativeSetLong(tableNativePtr, columnInfo.columnLongIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnLong());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -668,12 +668,23 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         Table table = realm.getTable(some.test.AllTypes.class);
         long tableNativePtr = table.getNativeTablePointer();
         AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.schema.getColumnInfo(some.test.AllTypes.class);
-        long rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1);
-        cache.put(object, rowIndex);
-        String realmGet$columnString = ((AllTypesRealmProxyInterface)object).realmGet$columnString();
-        if (realmGet$columnString != null) {
-            Table.nativeSetString(tableNativePtr, columnInfo.columnStringIndex, rowIndex, realmGet$columnString);
+        long pkColumnIndex = table.getPrimaryKey();
+        String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
+        long rowIndex = TableOrView.NO_MATCH;
+        if (primaryKeyValue == null) {
+            rowIndex = table.findFirstNull(pkColumnIndex);
+        } else {
+            rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue);
         }
+        if (rowIndex == TableOrView.NO_MATCH) {
+            rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1);
+            if (primaryKeyValue != null) {
+                Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, (String)primaryKeyValue);
+            }
+        } else {
+            table.throwDuplicatePrimaryKeyException(primaryKeyValue);
+        }
+        cache.put(object, rowIndex);
         Table.nativeSetLong(tableNativePtr, columnInfo.columnLongIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnLong());
         Table.nativeSetFloat(tableNativePtr, columnInfo.columnFloatIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnFloat());
         Table.nativeSetDouble(tableNativePtr, columnInfo.columnDoubleIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnDouble());
@@ -716,16 +727,27 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         Table table = realm.getTable(some.test.AllTypes.class);
         long tableNativePtr = table.getNativeTablePointer();
         AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.schema.getColumnInfo(some.test.AllTypes.class);
+        long pkColumnIndex = table.getPrimaryKey();
         some.test.AllTypes object = null;
         while (objects.hasNext()) {
             object = (some.test.AllTypes) objects.next();
             if(!cache.containsKey(object)) {
-                long rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1);
-                cache.put(object, rowIndex);
-                String realmGet$columnString = ((AllTypesRealmProxyInterface)object).realmGet$columnString();
-                if (realmGet$columnString != null) {
-                    Table.nativeSetString(tableNativePtr, columnInfo.columnStringIndex, rowIndex, realmGet$columnString);
+                String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
+                long rowIndex = TableOrView.NO_MATCH;
+                if (primaryKeyValue == null) {
+                    rowIndex = table.findFirstNull(pkColumnIndex);
+                } else {
+                    rowIndex = Table.nativeFindFirstString(tableNativePtr, pkColumnIndex, primaryKeyValue);
                 }
+                if (rowIndex == TableOrView.NO_MATCH) {
+                    rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1);
+                    if (primaryKeyValue != null) {
+                        Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, (String)primaryKeyValue);
+                    }
+                } else {
+                    table.throwDuplicatePrimaryKeyException(primaryKeyValue);
+                }
+                cache.put(object, rowIndex);
                 Table.nativeSetLong(tableNativePtr, columnInfo.columnLongIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnLong());
                 Table.nativeSetFloat(tableNativePtr, columnInfo.columnFloatIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnFloat());
                 Table.nativeSetDouble(tableNativePtr, columnInfo.columnDoubleIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnDouble());
@@ -784,12 +806,6 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             }
         }
         cache.put(object, rowIndex);
-        String realmGet$columnString = ((AllTypesRealmProxyInterface)object).realmGet$columnString();
-        if (realmGet$columnString != null) {
-            Table.nativeSetString(tableNativePtr, columnInfo.columnStringIndex, rowIndex, realmGet$columnString);
-        } else {
-            Table.nativeSetNull(tableNativePtr, columnInfo.columnStringIndex, rowIndex);
-        }
         Table.nativeSetLong(tableNativePtr, columnInfo.columnLongIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnLong());
         Table.nativeSetFloat(tableNativePtr, columnInfo.columnFloatIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnFloat());
         Table.nativeSetDouble(tableNativePtr, columnInfo.columnDoubleIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnDouble());
@@ -854,16 +870,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 if (rowIndex == TableOrView.NO_MATCH) {
                     rowIndex = Table.nativeAddEmptyRow(tableNativePtr, 1);
                     if (primaryKeyValue != null) {
-                        Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, ((AllTypesRealmProxyInterface) object).realmGet$columnString());
+                        Table.nativeSetString(tableNativePtr, pkColumnIndex, rowIndex, (String)primaryKeyValue);
                     }
                 }
                 cache.put(object, rowIndex);
-                String realmGet$columnString = ((AllTypesRealmProxyInterface)object).realmGet$columnString();
-                if (realmGet$columnString != null) {
-                    Table.nativeSetString(tableNativePtr, columnInfo.columnStringIndex, rowIndex, realmGet$columnString);
-                } else {
-                    Table.nativeSetNull(tableNativePtr, columnInfo.columnStringIndex, rowIndex);
-                }
                 Table.nativeSetLong(tableNativePtr, columnInfo.columnLongIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnLong());
                 Table.nativeSetFloat(tableNativePtr, columnInfo.columnFloatIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnFloat());
                 Table.nativeSetDouble(tableNativePtr, columnInfo.columnDoubleIndex, rowIndex, ((AllTypesRealmProxyInterface)object).realmGet$columnDouble());

--- a/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
@@ -320,27 +320,29 @@ public class BulkInsertTests {
 
     @Test
     public void insert_duplicatedPrimaryKeyFails() {
-        AllJavaTypes obj = new AllJavaTypes();
-        AllJavaTypes childObj = new AllJavaTypes(1);
-        obj.setFieldList(new RealmList<AllJavaTypes>(childObj, childObj));
 
+        // Single object with 2 references to two objects with the same ID
+        AllJavaTypes obj = new AllJavaTypes(2);
+        obj.setFieldList(new RealmList<AllJavaTypes>(new AllJavaTypes(1), new AllJavaTypes(1)));
         realm.beginTransaction();
-
-        // Single object with 2 references to the same object
         try {
             realm.insert(obj);
             fail();
         } catch (RealmPrimaryKeyConstraintException ignored) {
+        } finally {
+            realm.cancelTransaction();
         }
 
-        // Two objects with the same id in a list
+        // Two objects with the same ID in a list
+        realm.beginTransaction();
         try {
-            realm.insert(Arrays.asList(obj, obj));
+            realm.insert(Arrays.asList(new AllJavaTypes(1), new AllJavaTypes(1)));
             fail();
         } catch (RealmPrimaryKeyConstraintException ignored) {
+        } finally {
+            realm.cancelTransaction();
         }
     }
-
 
     @Test
     public void insertOrUpdate() {

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -711,7 +711,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
                     }
                     break;
                 default:
-                    // Since it is sufficient to check the existance of duplicated null values
+                    // Since it is sufficient to check the existence of duplicated null values
                     // on PrimaryKey in supported types only, this part is left empty.
             }
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -717,7 +717,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
         }
     }
 
-    private void throwDuplicatePrimaryKeyException(Object value) {
+    public void throwDuplicatePrimaryKeyException(Object value) {
         throw new RealmPrimaryKeyConstraintException("Value already exists: " + value);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -1494,7 +1494,7 @@ public class Table implements TableOrView, TableSchema, Closeable {
     private native long nativeFindFirstDouble(long nativePtr, long columnIndex, double value);
     private native long nativeFindFirstTimestamp(long nativeTablePtr, long columnIndex, long dateTimeValue);
     public static native long nativeFindFirstString(long nativeTablePtr, long columnIndex, String value);
-    private native long nativeFindFirstNull(long nativePtr, long columnIndex);
+    public static native long nativeFindFirstNull(long nativeTablePtr, long columnIndex);
     private native long nativeFindAllInt(long nativePtr, long columnIndex, long value);
     private native long nativeFindAllBool(long nativePtr, long columnIndex, boolean value);
     private native long nativeFindAllFloat(long nativePtr, long columnIndex, float value);

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -717,7 +717,13 @@ public class Table implements TableOrView, TableSchema, Closeable {
         }
     }
 
-    public void throwDuplicatePrimaryKeyException(Object value) {
+    /**
+     * Throws a properly formatted exception when multiple objects with the same primary key
+     * value is detected.
+     *
+     * @param value the primary key value.
+     */
+    public static void throwDuplicatePrimaryKeyException(Object value) {
         throw new RealmPrimaryKeyConstraintException("Value already exists: " + value);
     }
 


### PR DESCRIPTION
Fixes #3212 

This PR fixes a bug which happened when using `insert()` with two java instances with the same primary key. This now correctly throws a `RealmPrimaryKeyConstraintBrokenException`.

@realm/java 