### PR TITLE
Add section about examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ This means that `./gradlew clean` and `./gradlew cleanExamples` will fail if `as
 Note that IntelliJ [does not support multiple projects in the same window](https://youtrack.jetbrains.com/issue/IDEABKL-6118#)
 so each sub-project must be opened in its own window.
 
+## Examples
+
+The `./examples` folder contain a number of example projects showing how Realm can be used. If this is the first time you checkout this repository to try the examples, you must call `./gradlew assemble` from the top-level directory first. Otherwise the examples will not compile as they depend on all Realm artifacts being installed in `mavenLocal()`.
+
+A standalone version of the examples [downloaded from our website](https://realm.io/docs/java/latest/#getting-started).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details!

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ so each sub-project must be opened in its own window.
 
 ## Examples
 
-The `./examples` folder contain a number of example projects showing how Realm can be used. If this is the first time you checkout this repository to try the examples, you must call `./gradlew assemble` from the top-level directory first. Otherwise the examples will not compile as they depend on all Realm artifacts being installed in `mavenLocal()`.
+The `./examples` folder contain a number of example projects showing how Realm can be used. If this is the first time you checkout or pull a new version of this repository to try the examples, you must call `./gradlew installRealmJava` from the top-level directory first. Otherwise the examples will not compile as they depend on all Realm artifacts being installed in `mavenLocal()`.
 
 A standalone version of the examples [downloaded from our website](https://realm.io/docs/java/latest/#getting-started).
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ so each sub-project must be opened in its own window.
 
 The `./examples` folder contain a number of example projects showing how Realm can be used. If this is the first time you checkout or pull a new version of this repository to try the examples, you must call `./gradlew installRealmJava` from the top-level directory first. Otherwise the examples will not compile as they depend on all Realm artifacts being installed in `mavenLocal()`.
 
-A standalone version of the examples [downloaded from our website](https://realm.io/docs/java/latest/#getting-started).
+Standalone examples can be [downloaded from website](https://realm.io/docs/java/latest/#getting-started).
 
 ## Contributing
 


### PR DESCRIPTION
From time to time we have people that clone the repo to run the examples, and then get support questions on it since you need to assemble everything from the top-level directory first. Latest example: http://stackoverflow.com/questions/38772301/realm-gradle-examples-project-refresh-failed

This isn't entirely intuitive, but a consequence of our need to have multiple independent gradle projects. 

I added a small section to address this.

@realm/java 
