### PR TITLE
DynamicRealmObject typed getters no longer seg faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* `DynamicRealmObject.getX(fieldName)` now throw a proper exception instead of a native crash when called with a field name of the wrong type (#3294).
+* `DynamicRealmObject.getX(fieldName)` now throws a proper exception instead of a native crash when called with a field name of the wrong type (#3294).
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.2
+
+### Bug fixes
+
+* `DynamicRealmObject.getX(fieldName)` now throw a proper exception instead of a native crash when called with a field name of the wrong type (#3294).
+
 ## 1.1.1
 
 ### Enhancements

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -143,6 +143,7 @@ public class DynamicRealmObjectTests {
             }
         }
     }
+
     @Test
     public void typedGetter_wrongUnderlyingTypeThrows() {
         for (SupportedType type : SupportedType.values()) {

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -149,12 +149,12 @@ public class DynamicRealmObjectTests {
         for (SupportedType type : SupportedType.values()) {
             try {
                 // Make sure we hit the wrong underlying type for all types.
-                if (type == SupportedType.STRING) {
-                    callGetter(type, Arrays.asList(AllJavaTypes.FIELD_BOOLEAN));
-                } else {
+                if (type == SupportedType.DOUBLE) {
                     callGetter(type, Arrays.asList(AllJavaTypes.FIELD_STRING));
+                } else {
+                    callGetter(type, Arrays.asList(AllJavaTypes.FIELD_DOUBLE));
                 }
-                fail();
+                fail(type + " failed to throw.");
             } catch (IllegalArgumentException ignored) {
             }
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -143,6 +143,21 @@ public class DynamicRealmObjectTests {
             }
         }
     }
+    @Test
+    public void typedGetter_wrongUnderlyingTypeThrows() {
+        for (SupportedType type : SupportedType.values()) {
+            try {
+                // Make sure we hit the wrong underlying type for all types.
+                if (type == SupportedType.STRING) {
+                    callGetter(type, Arrays.asList(AllJavaTypes.FIELD_BOOLEAN));
+                } else {
+                    callGetter(type, Arrays.asList(AllJavaTypes.FIELD_STRING));
+                }
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
 
     // Helper method for calling getters with different field names
     private void callGetter(SupportedType type, List<String> fieldNames) {
@@ -182,6 +197,25 @@ public class DynamicRealmObjectTests {
                 callSetter(type, args);
                 fail();
             } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void typedSetter_wrongUnderlyingTypeThrows() {
+        for (SupportedType type : SupportedType.values()) {
+            realm.beginTransaction();
+            try {
+                // Make sure we hit the wrong underlying type for all types.
+                if (type == SupportedType.STRING) {
+                    callSetter(type, Arrays.asList(AllJavaTypes.FIELD_BOOLEAN));
+                } else {
+                    callSetter(type, Arrays.asList(AllJavaTypes.FIELD_STRING));
+                }
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            } finally {
+                realm.cancelTransaction();
             }
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -115,7 +115,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.BOOLEAN) {
-            throw new IllegalArgumentException(fieldName + " is not a boolean, but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.BOOLEAN + "', but a " + columnType);
         }
         return proxyState.getRow$realm().getBoolean(columnIndex);
     }
@@ -165,7 +165,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.INTEGER) {
-            throw new IllegalArgumentException(fieldName + " is not an integer (short, int, long, byte), but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.INTEGER + "', but a " + columnType);
         }
         return proxyState.getRow$realm().getLong(columnIndex);
     }
@@ -201,7 +201,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.FLOAT) {
-            throw new IllegalArgumentException(fieldName + " is not a float, but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.FLOAT + "', but a '" + columnType + "'");
         }
         return proxyState.getRow$realm().getFloat(columnIndex);
     }
@@ -221,7 +221,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.DOUBLE) {
-            throw new IllegalArgumentException(fieldName + " is not a double, but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.DOUBLE + "', but a '" + columnType + "'");
         }
         return proxyState.getRow$realm().getDouble(columnIndex);
     }
@@ -237,7 +237,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.BINARY) {
-            throw new IllegalArgumentException(fieldName + " is not a binary field, but a " + columnType);
+            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.BINARY+ "', but a '" + columnType + "'");
         }
         return proxyState.getRow$realm().getBinaryByteArray(columnIndex);
     }
@@ -253,7 +253,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.STRING) {
-            throw new IllegalArgumentException(fieldName + " is not a string, but a " + columnType);
+            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.STRING + "', but a '" + columnType + "'");
         }
         return proxyState.getRow$realm().getString(columnIndex);
     }
@@ -269,7 +269,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.DATE) {
-            throw new IllegalArgumentException(fieldName + " is not a date, but a " + columnType);
+            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.DATE + "', but a '" + columnType + "'");
         }
         if (proxyState.getRow$realm().isNull(columnIndex)) {
             return null;
@@ -289,7 +289,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.OBJECT) {
-            throw new IllegalArgumentException(fieldName + " is not an object reference, but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.OBJECT + "', but a '" + columnType + "'");
         }
         if (proxyState.getRow$realm().isNullLink(columnIndex)) {
             return null;
@@ -311,7 +311,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.LIST) {
-            throw new IllegalArgumentException(fieldName + " is not an list, but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.LIST + "', but a '" + columnType + "'");
         }
         LinkView linkView = proxyState.getRow$realm().getLinkList(columnIndex);
         String className = RealmSchema.getSchemaForTable(linkView.getTargetTable());

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -193,7 +193,6 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public float getFloat(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         checkFieldType(fieldName, columnIndex, RealmFieldType.FLOAT);
         return proxyState.getRow$realm().getFloat(columnIndex);
     }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -666,7 +666,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
                 indefiniteVowel = "n";
             }
             throw new IllegalArgumentException(String.format("'%s' is not a%s '%s', but a%s '%s'.",
-                    fieldName, indefiniteWowel, expectedType, indefiniteVowel, columnType));
+                    fieldName, indefiniteVowel, expectedType, indefiniteVowel, columnType));
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -178,8 +178,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      * @throws io.realm.exceptions.RealmException if the return value would be {@code null}.
      */
     public byte getByte(String fieldName) {
-        long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        return (byte) proxyState.getRow$realm().getLong(columnIndex);
+        return (byte) getLong(fieldName);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -113,6 +113,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public boolean getBoolean(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.BOOLEAN) {
+            throw new IllegalArgumentException(fieldName + " is not a boolean, but a " + columnType);
+        }
         return proxyState.getRow$realm().getBoolean(columnIndex);
     }
 
@@ -159,6 +163,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public long getLong(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.INTEGER) {
+            throw new IllegalArgumentException(fieldName + " is not an integer (short, int, long, byte), but a " + columnType);
+        }
         return proxyState.getRow$realm().getLong(columnIndex);
     }
 
@@ -191,6 +199,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public float getFloat(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.FLOAT) {
+            throw new IllegalArgumentException(fieldName + " is not a float, but a " + columnType);
+        }
         return proxyState.getRow$realm().getFloat(columnIndex);
     }
 
@@ -207,6 +219,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public double getDouble(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.DOUBLE) {
+            throw new IllegalArgumentException(fieldName + " is not a double, but a " + columnType);
+        }
         return proxyState.getRow$realm().getDouble(columnIndex);
     }
 
@@ -219,6 +235,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public byte[] getBlob(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.BINARY) {
+            throw new IllegalArgumentException(fieldName + " is not a binary field, but a " + columnType);
+        }
         return proxyState.getRow$realm().getBinaryByteArray(columnIndex);
     }
 
@@ -231,6 +251,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public String getString(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.STRING) {
+            throw new IllegalArgumentException(fieldName + " is not a string, but a " + columnType);
+        }
         return proxyState.getRow$realm().getString(columnIndex);
     }
 
@@ -243,6 +267,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public Date getDate(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.DATE) {
+            throw new IllegalArgumentException(fieldName + " is not a date, but a " + columnType);
+        }
         if (proxyState.getRow$realm().isNull(columnIndex)) {
             return null;
         } else {
@@ -259,6 +287,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public DynamicRealmObject getObject(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.OBJECT) {
+            throw new IllegalArgumentException(fieldName + " is not an object reference, but a " + columnType);
+        }
         if (proxyState.getRow$realm().isNullLink(columnIndex)) {
             return null;
         } else {
@@ -277,6 +309,10 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public RealmList<DynamicRealmObject> getList(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.LIST) {
+            throw new IllegalArgumentException(fieldName + " is not an list, but a " + columnType);
+        }
         LinkView linkView = proxyState.getRow$realm().getLinkList(columnIndex);
         String className = RealmSchema.getSchemaForTable(linkView.getTargetTable());
         return new RealmList<DynamicRealmObject>(className, linkView, proxyState.getRealm$realm());

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -661,12 +661,12 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
     private void checkFieldType(String fieldName, long columnIndex, RealmFieldType expectedType) {
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != expectedType) {
-            String indefiniteWowel = "";
+            String indefiniteVowel = "";
             if (expectedType == RealmFieldType.INTEGER || expectedType == RealmFieldType.LIST) {
-                indefiniteWowel = "n";
+                indefiniteVowel = "n";
             }
             throw new IllegalArgumentException(String.format("'%s' is not a%s '%s', but a%s '%s'.",
-                    fieldName, indefiniteWowel, expectedType, indefiniteWowel, columnType));
+                    fieldName, indefiniteWowel, expectedType, indefiniteVowel, columnType));
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -115,7 +115,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.BOOLEAN) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.BOOLEAN + "', but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.BOOLEAN + "', but a '" + columnType + "'.");
         }
         return proxyState.getRow$realm().getBoolean(columnIndex);
     }
@@ -165,7 +165,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.INTEGER) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.INTEGER + "', but a " + columnType);
+            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.INTEGER + "', but a '" + columnType + "'.");
         }
         return proxyState.getRow$realm().getLong(columnIndex);
     }
@@ -201,7 +201,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.FLOAT) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.FLOAT + "', but a '" + columnType + "'");
+            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.FLOAT + "', but a '" + columnType + "'.");
         }
         return proxyState.getRow$realm().getFloat(columnIndex);
     }
@@ -221,7 +221,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.DOUBLE) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.DOUBLE + "', but a '" + columnType + "'");
+            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.DOUBLE + "', but a '" + columnType + "'.");
         }
         return proxyState.getRow$realm().getDouble(columnIndex);
     }
@@ -237,7 +237,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.BINARY) {
-            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.BINARY+ "', but a '" + columnType + "'");
+            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.BINARY+ "', but a '" + columnType + "'.");
         }
         return proxyState.getRow$realm().getBinaryByteArray(columnIndex);
     }
@@ -253,7 +253,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.STRING) {
-            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.STRING + "', but a '" + columnType + "'");
+            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.STRING + "', but a '" + columnType + "'.");
         }
         return proxyState.getRow$realm().getString(columnIndex);
     }
@@ -269,7 +269,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.DATE) {
-            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.DATE + "', but a '" + columnType + "'");
+            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.DATE + "', but a '" + columnType + "'.");
         }
         if (proxyState.getRow$realm().isNull(columnIndex)) {
             return null;
@@ -289,7 +289,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.OBJECT) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.OBJECT + "', but a '" + columnType + "'");
+            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.OBJECT + "', but a '" + columnType + "'.");
         }
         if (proxyState.getRow$realm().isNullLink(columnIndex)) {
             return null;
@@ -311,7 +311,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
         if (columnType != RealmFieldType.LIST) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.LIST + "', but a '" + columnType + "'");
+            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.LIST + "', but a '" + columnType + "'.");
         }
         LinkView linkView = proxyState.getRow$realm().getLinkList(columnIndex);
         String className = RealmSchema.getSchemaForTable(linkView.getTargetTable());

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -113,10 +113,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public boolean getBoolean(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.BOOLEAN) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.BOOLEAN + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.BOOLEAN);
         return proxyState.getRow$realm().getBoolean(columnIndex);
     }
 
@@ -163,10 +160,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public long getLong(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.INTEGER) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.INTEGER + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.INTEGER);
         return proxyState.getRow$realm().getLong(columnIndex);
     }
 
@@ -200,9 +194,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
     public float getFloat(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.FLOAT) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.FLOAT + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.FLOAT);
         return proxyState.getRow$realm().getFloat(columnIndex);
     }
 
@@ -219,10 +211,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public double getDouble(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.DOUBLE) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not a '" + RealmFieldType.DOUBLE + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.DOUBLE);
         return proxyState.getRow$realm().getDouble(columnIndex);
     }
 
@@ -235,10 +224,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public byte[] getBlob(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.BINARY) {
-            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.BINARY+ "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.BINARY);
         return proxyState.getRow$realm().getBinaryByteArray(columnIndex);
     }
 
@@ -251,10 +237,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public String getString(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.STRING) {
-            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.STRING + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.STRING);
         return proxyState.getRow$realm().getString(columnIndex);
     }
 
@@ -267,10 +250,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public Date getDate(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.DATE) {
-            throw new IllegalArgumentException(fieldName + " is not a '" + RealmFieldType.DATE + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.DATE);
         if (proxyState.getRow$realm().isNull(columnIndex)) {
             return null;
         } else {
@@ -287,10 +267,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public DynamicRealmObject getObject(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.OBJECT) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.OBJECT + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.OBJECT);
         if (proxyState.getRow$realm().isNullLink(columnIndex)) {
             return null;
         } else {
@@ -309,10 +286,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public RealmList<DynamicRealmObject> getList(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.LIST) {
-            throw new IllegalArgumentException("'" + fieldName + "' is not an '" + RealmFieldType.LIST + "', but a '" + columnType + "'.");
-        }
+        checkFieldType(fieldName, columnIndex, RealmFieldType.LIST);
         LinkView linkView = proxyState.getRow$realm().getLinkList(columnIndex);
         String className = RealmSchema.getSchemaForTable(linkView.getTargetTable());
         return new RealmList<DynamicRealmObject>(className, linkView, proxyState.getRealm$realm());
@@ -682,6 +656,18 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
     public RealmFieldType getFieldType(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         return proxyState.getRow$realm().getColumnType(columnIndex);
+    }
+
+    private void checkFieldType(String fieldName, long columnIndex, RealmFieldType expectedType) {
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != RealmFieldType.BOOLEAN) {
+            String indefiniteWowel = "";
+            if (expectedType == RealmFieldType.INTEGER || expectedType == RealmFieldType.LIST) {
+                indefiniteWowel = "n";
+            }
+            throw new IllegalArgumentException(String.format("'%s' is not a%s '%s', but a%s '%s'.",
+                    fieldName, indefiniteWowel, expectedType, indefiniteWowel, columnType));
+        }
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -659,7 +659,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
 
     private void checkFieldType(String fieldName, long columnIndex, RealmFieldType expectedType) {
         RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
-        if (columnType != RealmFieldType.BOOLEAN) {
+        if (columnType != expectedType) {
             String indefiniteWowel = "";
             if (expectedType == RealmFieldType.INTEGER || expectedType == RealmFieldType.LIST) {
                 indefiniteWowel = "n";


### PR DESCRIPTION
Closes #3294 

DynamicRealmObject typed getters didn't check if the field name being retrieved was the correct type, which caused a seg fault if you called `dynamicObj.getString(integerField)`. A proper `IllegalArgumentException` is now being throw instead.

@realm/java 