### PR TITLE
DynamicRealmObject typed getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Throw a proper exception when operating on a non-existing field with the dynamic API (#3292).
 * `DynamicRealmObject.setList` should only accept `RealmList<DynamicRealmObject>` (#3280).
+* `DynamicRealmObject.getX(fieldName)` now throws a proper exception instead of a native crash when called with a field name of the wrong type (#3294).
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -144,6 +144,22 @@ public class DynamicRealmObjectTests {
         }
     }
 
+    @Test
+    public void typedGetter_wrongUnderlyingTypeThrows() {
+        for (SupportedType type : SupportedType.values()) {
+            try {
+                // Make sure we hit the wrong underlying type for all types.
+                if (type == SupportedType.DOUBLE) {
+                    callGetter(type, Arrays.asList(AllJavaTypes.FIELD_STRING));
+                } else {
+                    callGetter(type, Arrays.asList(AllJavaTypes.FIELD_DOUBLE));
+                }
+                fail(type + " failed to throw.");
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
     // Helper method for calling getters with different field names
     private void callGetter(SupportedType type, List<String> fieldNames) {
         for (String fieldName : fieldNames) {
@@ -182,6 +198,25 @@ public class DynamicRealmObjectTests {
                 callSetter(type, args);
                 fail();
             } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void typedSetter_wrongUnderlyingTypeThrows() {
+        for (SupportedType type : SupportedType.values()) {
+            realm.beginTransaction();
+            try {
+                // Make sure we hit the wrong underlying type for all types.
+                if (type == SupportedType.STRING) {
+                    callSetter(type, Arrays.asList(AllJavaTypes.FIELD_BOOLEAN));
+                } else {
+                    callSetter(type, Arrays.asList(AllJavaTypes.FIELD_STRING));
+                }
+                fail();
+            } catch (IllegalArgumentException ignored) {
+            } finally {
+                realm.cancelTransaction();
             }
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -115,6 +115,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public boolean getBoolean(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.BOOLEAN);
         return proxyState.getRow$realm().getBoolean(columnIndex);
     }
 
@@ -161,6 +162,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public long getLong(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.INTEGER);
         return proxyState.getRow$realm().getLong(columnIndex);
     }
 
@@ -176,8 +178,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      * @throws io.realm.exceptions.RealmException if the return value would be {@code null}.
      */
     public byte getByte(String fieldName) {
-        long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
-        return (byte) proxyState.getRow$realm().getLong(columnIndex);
+        return (byte) getLong(fieldName);
     }
 
     /**
@@ -193,6 +194,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public float getFloat(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.FLOAT);
         return proxyState.getRow$realm().getFloat(columnIndex);
     }
 
@@ -209,6 +211,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public double getDouble(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.DOUBLE);
         return proxyState.getRow$realm().getDouble(columnIndex);
     }
 
@@ -221,6 +224,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public byte[] getBlob(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.BINARY);
         return proxyState.getRow$realm().getBinaryByteArray(columnIndex);
     }
 
@@ -233,6 +237,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public String getString(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.STRING);
         return proxyState.getRow$realm().getString(columnIndex);
     }
 
@@ -245,6 +250,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public Date getDate(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.DATE);
         if (proxyState.getRow$realm().isNull(columnIndex)) {
             return null;
         } else {
@@ -261,6 +267,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public DynamicRealmObject getObject(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.OBJECT);
         if (proxyState.getRow$realm().isNullLink(columnIndex)) {
             return null;
         } else {
@@ -279,6 +286,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
      */
     public RealmList<DynamicRealmObject> getList(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
+        checkFieldType(fieldName, columnIndex, RealmFieldType.LIST);
         LinkView linkView = proxyState.getRow$realm().getLinkList(columnIndex);
         String className = RealmSchema.getSchemaForTable(linkView.getTargetTable());
         return new RealmList<DynamicRealmObject>(className, linkView, proxyState.getRealm$realm());
@@ -648,6 +656,22 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
     public RealmFieldType getFieldType(String fieldName) {
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         return proxyState.getRow$realm().getColumnType(columnIndex);
+    }
+
+    private void checkFieldType(String fieldName, long columnIndex, RealmFieldType expectedType) {
+        RealmFieldType columnType = proxyState.getRow$realm().getColumnType(columnIndex);
+        if (columnType != expectedType) {
+            String expectedIndefiniteVowel = "";
+            if (expectedType == RealmFieldType.INTEGER || expectedType == RealmFieldType.OBJECT) {
+                expectedIndefiniteVowel = "n";
+            }
+            String columnTypeIndefiniteVowel = "";
+            if (expectedType == RealmFieldType.INTEGER || expectedType == RealmFieldType.OBJECT) {
+                columnTypeIndefiniteVowel = "n";
+            }
+            throw new IllegalArgumentException(String.format("'%s' is not a%s '%s', but a%s '%s'.",
+                    fieldName, expectedIndefiniteVowel, expectedType, columnTypeIndefiniteVowel, columnType));
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #3294

DynamicRealmObject typed getters didn't check if the field name being retrieved was the correct type, which caused a seg fault if you called dynamicObj.getString(integerField). A proper IllegalArgumentException is now being throw instead.