### PR TITLE
Verify SharedGroup in handleAsyncTransactionCompleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Throw a proper exception when operating on a non-existing field with the dynamic API (#3292).
 * `DynamicRealmObject.setList` should only accept `RealmList<DynamicRealmObject>` (#3280).
+* Fixed a concurrency crash which might happen when `Realm.executeTransactionAsync()` called with a `OnSuccess` and Realm closed before `OnSuccess` called.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Throw a proper exception when operating on a non-existing field with the dynamic API (#3292).
 * `DynamicRealmObject.setList` should only accept `RealmList<DynamicRealmObject>` (#3280).
-* Fixed a concurrency crash which might happen when `Realm.executeTransactionAsync()` called with a `OnSuccess` and Realm closed before `OnSuccess` called.
+* Fixed a concurrency crash which might happen when `Realm.executeTransactionAsync()` tried to call `onSucess` after the Realm was closed.
 
 ### Internal
 

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -156,10 +156,13 @@ final class HandlerController implements Handler.Callback {
      * @param onSuccess onSuccess callback to run for the async transaction that completed.
      */
     public void handleAsyncTransactionCompleted(Runnable onSuccess) {
-        if (onSuccess != null) {
-            pendingOnSuccessAsyncTransactionCallbacks.add(onSuccess);
+        // Same reason with handleMessage
+        if (realm.sharedGroupManager != null) {
+            if (onSuccess != null) {
+                pendingOnSuccessAsyncTransactionCallbacks.add(onSuccess);
+            }
+            realmChanged(false);
         }
-        realmChanged(false);
     }
 
     void addChangeListener(RealmChangeListener<? extends BaseRealm> listener) {

--- a/realm/realm-library/src/main/java/io/realm/HandlerController.java
+++ b/realm/realm-library/src/main/java/io/realm/HandlerController.java
@@ -156,7 +156,7 @@ final class HandlerController implements Handler.Callback {
      * @param onSuccess onSuccess callback to run for the async transaction that completed.
      */
     public void handleAsyncTransactionCompleted(Runnable onSuccess) {
-        // Same reason with handleMessage
+        // Same reason as handleMessage()
         if (realm.sharedGroupManager != null) {
             if (onSuccess != null) {
                 pendingOnSuccessAsyncTransactionCallbacks.add(onSuccess);


### PR DESCRIPTION
In a rare case, if handleAsyncTransactionCompleted posted before set
handler to null, the handleAsyncTransactionCompleted will be called with
a closed Realm.


It is very difficult to construct a test case for this.