### PR TITLE
improve `Table` and schema cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 * Throw a proper exception when operating on a non-existing field with the dynamic API (#3292).
 * `DynamicRealmObject.setList` should only accept `RealmList<DynamicRealmObject>` (#3280).
 * `DynamicRealmObject.getX(fieldName)` now throws a proper exception instead of a native crash when called with a field name of the wrong type (#3294).
-* Fixed a problem that `Table` and schema cache never hits against proxy classes (#3315).
+
+### Enhancements
+
+* Optimized internal caching of schema classes (#3315).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Throw a proper exception when operating on a non-existing field with the dynamic API (#3292).
 * `DynamicRealmObject.setList` should only accept `RealmList<DynamicRealmObject>` (#3280).
 * `DynamicRealmObject.getX(fieldName)` now throws a proper exception instead of a native crash when called with a field name of the wrong type (#3294).
+* Fixed a problem that `Table` and schema cache never hits against proxy classes (#3315).
 
 ### Internal
 

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -51,7 +51,6 @@ import io.realm.internal.ColumnInfo;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.RealmProxyMediator;
 import io.realm.internal.Table;
-import io.realm.internal.Util;
 import io.realm.internal.log.RealmLog;
 import rx.Observable;
 
@@ -121,10 +120,6 @@ import rx.Observable;
 public final class Realm extends BaseRealm {
 
     public static final String DEFAULT_REALM_NAME = RealmConfiguration.DEFAULT_REALM_NAME;
-
-    // Caches Class objects (both model classes and proxy classes) to Realm Tables
-    private final Map<Class<? extends RealmModel>, Table> classToTable =
-            new HashMap<Class<? extends RealmModel>, Table>();
 
     private static RealmConfiguration defaultConfiguration;
 
@@ -604,7 +599,7 @@ public final class Realm extends BaseRealm {
             return null;
         }
         E realmObject;
-        Table table = getTable(clazz);
+        Table table = schema.getTable(clazz);
         if (table.hasPrimaryKey()) {
             // As we need the primary key value we have to first parse the entire input stream as in the general
             // case that value might be the last property :(
@@ -683,7 +678,7 @@ public final class Realm extends BaseRealm {
      */
     public <E extends RealmModel> E createObject(Class<E> clazz) {
         checkIfValid();
-        Table table = getTable(clazz);
+        Table table = schema.getTable(clazz);
         long rowIndex = table.addEmptyRow();
         return get(clazz, rowIndex);
     }
@@ -703,7 +698,7 @@ public final class Realm extends BaseRealm {
      *                                  expected value.
      */
     public <E extends RealmModel> E createObject(Class<E> clazz, Object primaryKeyValue) {
-        Table table = getTable(clazz);
+        Table table = schema.getTable(clazz);
         long rowIndex = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
         return get(clazz, rowIndex);
     }
@@ -1292,7 +1287,7 @@ public final class Realm extends BaseRealm {
      */
     public void delete(Class<? extends RealmModel> clazz) {
         checkIfValid();
-        getTable(clazz).clear();
+        schema.getTable(clazz).clear();
     }
 
 
@@ -1314,7 +1309,7 @@ public final class Realm extends BaseRealm {
     }
 
     private void checkHasPrimaryKey(Class<? extends RealmModel> clazz) {
-        if (!getTable(clazz).hasPrimaryKey()) {
+        if (!schema.getTable(clazz).hasPrimaryKey()) {
             throw new IllegalArgumentException("A RealmObject with no @PrimaryKey cannot be updated: " + clazz.toString());
         }
     }
@@ -1404,13 +1399,7 @@ public final class Realm extends BaseRealm {
     }
 
     Table getTable(Class<? extends RealmModel> clazz) {
-        Table table = classToTable.get(clazz);
-        if (table == null) {
-            clazz = Util.getOriginalModelClass(clazz);
-            table = sharedGroupManager.getTable(configuration.getSchemaMediator().getTableName(clazz));
-            classToTable.put(clazz, table);
-        }
-        return table;
+        return schema.getTable(clazz);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -225,16 +225,13 @@ public final class RealmSchema {
             if (originalClass != clazz) {
                 table = classToTable.get(originalClass);
             }
-            if (table != null) {
-                // table was not cached against proxy class. Add cache entry.
-                classToTable.put(clazz, table);
-            } else {
+            if (table == null) {
                 table = transaction.getTable(realm.configuration.getSchemaMediator().getTableName(originalClass));
                 classToTable.put(originalClass, table);
-                if (originalClass != clazz) {
-                    // 'clazz' is the proxy class for 'originalClass'
-                    classToTable.put(clazz, table);
-                }
+            }
+            if (originalClass != clazz) {
+                // 'clazz' is the proxy class for 'originalClass'
+                classToTable.put(clazz, table);
             }
         }
         return table;
@@ -247,17 +244,14 @@ public final class RealmSchema {
             if (originalClass != clazz) {
                 classSchema = classToSchema.get(originalClass);
             }
-            if (classSchema != null) {
-                // classSchema was not cached against proxy class. Add cache entry.
-                classToSchema.put(clazz, classSchema);
-            } else {
+            if (classSchema == null) {
                 Table table = getTable(clazz);
                 classSchema = new RealmObjectSchema(realm, table, columnIndices.getColumnInfo(originalClass).getIndicesMap());
                 classToSchema.put(originalClass, classSchema);
-                if (originalClass != clazz) {
-                    // 'clazz' is the proxy class for 'originalClass'
-                    classToSchema.put(clazz, classSchema);
-                }
+            }
+            if (originalClass != clazz) {
+                // 'clazz' is the proxy class for 'originalClass'
+                classToSchema.put(clazz, classSchema);
             }
         }
         return classSchema;

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -232,7 +232,7 @@ public final class RealmSchema {
                 table = transaction.getTable(realm.configuration.getSchemaMediator().getTableName(originalClass));
                 classToTable.put(originalClass, table);
                 if (originalClass != clazz) {
-                    // Add cache entry for proxy class
+                    // 'clazz' is the proxy class for 'originalClass'
                     classToTable.put(clazz, table);
                 }
             }
@@ -255,7 +255,7 @@ public final class RealmSchema {
                 classSchema = new RealmObjectSchema(realm, table, columnIndices.getColumnInfo(originalClass).getIndicesMap());
                 classToSchema.put(originalClass, classSchema);
                 if (originalClass != clazz) {
-                    // Add cache entry for proxy class
+                    // 'clazz' is the proxy class for 'originalClass'
                     classToSchema.put(clazz, classSchema);
                 }
             }

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -222,14 +222,15 @@ public final class RealmSchema {
         Table table = classToTable.get(clazz);
         if (table == null) {
             Class<? extends RealmModel> originalClass = Util.getOriginalModelClass(clazz);
-            if (originalClass != clazz) {
+            if (isProxyClass(originalClass, clazz)) {
+                // if passed 'clazz' is the proxy, try again with model class
                 table = classToTable.get(originalClass);
             }
             if (table == null) {
                 table = transaction.getTable(realm.configuration.getSchemaMediator().getTableName(originalClass));
                 classToTable.put(originalClass, table);
             }
-            if (originalClass != clazz) {
+            if (isProxyClass(originalClass, clazz)) {
                 // 'clazz' is the proxy class for 'originalClass'
                 classToTable.put(clazz, table);
             }
@@ -241,7 +242,8 @@ public final class RealmSchema {
         RealmObjectSchema classSchema = classToSchema.get(clazz);
         if (classSchema == null) {
             Class<? extends RealmModel> originalClass = Util.getOriginalModelClass(clazz);
-            if (originalClass != clazz) {
+            if (isProxyClass(originalClass, clazz)) {
+                // if passed 'clazz' is the proxy, try again with model class
                 classSchema = classToSchema.get(originalClass);
             }
             if (classSchema == null) {
@@ -249,12 +251,17 @@ public final class RealmSchema {
                 classSchema = new RealmObjectSchema(realm, table, columnIndices.getColumnInfo(originalClass).getIndicesMap());
                 classToSchema.put(originalClass, classSchema);
             }
-            if (originalClass != clazz) {
+            if (isProxyClass(originalClass, clazz)) {
                 // 'clazz' is the proxy class for 'originalClass'
                 classToSchema.put(clazz, classSchema);
             }
         }
         return classSchema;
+    }
+
+    private static boolean isProxyClass(Class<? extends RealmModel> modelClass,
+                                        Class<? extends RealmModel> testee) {
+        return modelClass != testee;
     }
 
     RealmObjectSchema getSchemaForClass(String className) {


### PR DESCRIPTION
This PR solves following problems.

* There are two `Class to Table` caches. One is in `Realm` class and another is in `RealmSchema` class.`
* The cache never hits against proxy classes.