### PR TITLE
Wait all async tasks done before next test

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -1884,7 +1884,7 @@ public class RealmAsyncQueryTests {
     @Test
     @UiThreadTest
     public void badVersion_findAll() throws NoSuchFieldException, IllegalAccessException {
-        TestHelper.replaceRealmThreadExectutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
+        TestHelper.replaceRealmThreadExecutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
         RealmConfiguration config = configFactory.createConfiguration();
         Realm realm = Realm.getInstance(config);
         realm.executeTransactionAsync(new Realm.Transaction() {
@@ -1911,6 +1911,7 @@ public class RealmAsyncQueryTests {
         } finally {
             realm.close();
         }
+        TestHelper.resetRealmThreadExecutor();
     }
 
     // Test case for https://github.com/realm/realm-java/issues/2417
@@ -1918,7 +1919,7 @@ public class RealmAsyncQueryTests {
     @Test
     @UiThreadTest
     public void badVersion_findAllSortedAsync() throws NoSuchFieldException, IllegalAccessException {
-        TestHelper.replaceRealmThreadExectutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
+        TestHelper.replaceRealmThreadExecutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
         RealmConfiguration config = configFactory.createConfiguration();
         Realm realm = Realm.getInstance(config);
         realm.executeTransactionAsync(new Realm.Transaction() {
@@ -1943,6 +1944,7 @@ public class RealmAsyncQueryTests {
                 .findAllSortedAsync(AllTypes.FIELD_STRING, Sort.ASCENDING, AllTypes.FIELD_LONG, Sort.DESCENDING)
                 .load();
         realm.close();
+        TestHelper.resetRealmThreadExecutor();
     }
 
     // Test case for https://github.com/realm/realm-java/issues/2417
@@ -1950,7 +1952,7 @@ public class RealmAsyncQueryTests {
     @Test
     @UiThreadTest
     public void badVersion_distinct() throws NoSuchFieldException, IllegalAccessException {
-        TestHelper.replaceRealmThreadExectutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
+        TestHelper.replaceRealmThreadExecutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
         RealmConfiguration config = configFactory.createConfiguration();
         Realm realm = Realm.getInstance(config);
         realm.executeTransactionAsync(new Realm.Transaction() {
@@ -1976,6 +1978,7 @@ public class RealmAsyncQueryTests {
                 .load();
 
         realm.close();
+        TestHelper.resetRealmThreadExecutor();
     }
 
     // Test case for https://github.com/realm/realm-java/issues/2417
@@ -1983,7 +1986,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void badVersion_syncTransaction() throws NoSuchFieldException, IllegalAccessException {
-        TestHelper.replaceRealmThreadExectutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
+        TestHelper.replaceRealmThreadExecutor(RealmThreadPoolExecutor.newSingleThreadExecutor());
         Realm realm = looperThread.realm;
 
         // 1. Make sure that async query is not started
@@ -2009,6 +2012,7 @@ public class RealmAsyncQueryTests {
 
         // 3. The async query should now (hopefully) fail with a BadVersion
         result.load();
+        TestHelper.resetRealmThreadExecutor();
     }
 
     // handlerController#emptyAsyncRealmObject is accessed from different threads

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -883,8 +883,6 @@ public class TestHelper {
             // used. Any exception in the `after()` code will mask the original error.
             TestHelper.awaitOrFail(signalTestFinished);
         } finally {
-            // close the executor
-            executorService.shutdownNow();
             if (looper[0] != null) {
                 // failing to quit the looper will not execute the finally block responsible
                 // of closing the Realm
@@ -893,6 +891,9 @@ public class TestHelper {
 
             // wait for the finally block to execute & close the Realm
             TestHelper.awaitOrFail(signalClosedRealm);
+            // Close the executor.
+            // This needs to be called after waiting since it might interrupt waitRealmThreadExecutorFinish().
+            executorService.shutdownNow();
 
             if (throwable[0] != null) {
                 // throw any assertion errors happened in the background thread
@@ -947,15 +948,48 @@ public class TestHelper {
     /**
      * Replaces the current thread executor with a another one for testing.
      * WARNING: This method should only be called before any async tasks have been started.
+     *          Call {@link #resetRealmThreadExecutor()} before test return to reset the excutor to default.
      *
      * @param executor {@link RealmThreadPoolExecutor} that should replace the current one
      */
-    public static RealmThreadPoolExecutor replaceRealmThreadExectutor(RealmThreadPoolExecutor executor) throws NoSuchFieldException, IllegalAccessException {
+    public static RealmThreadPoolExecutor replaceRealmThreadExecutor(RealmThreadPoolExecutor executor)
+            throws NoSuchFieldException, IllegalAccessException {
         Field field = BaseRealm.class.getDeclaredField("asyncTaskExecutor");
         field.setAccessible(true);
         RealmThreadPoolExecutor oldExecutor = (RealmThreadPoolExecutor) field.get(null);
         field.set(field, executor);
         return oldExecutor;
+    }
+
+    /**
+     * This will first wait for finishing all tasks in BaseRealm.asyncTaskExecutor, throws if time out.
+     * Then reset the BaseRealm.asyncTaskExecutor to the default value.
+     *
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     */
+    public static void resetRealmThreadExecutor() throws NoSuchFieldException, IllegalAccessException {
+        waitRealmThreadExecutorFinish();
+        replaceRealmThreadExecutor(RealmThreadPoolExecutor.newDefaultExecutor());
+    }
+
+    /**
+     * Wait and check if all tasks in BaseRealm.asyncTaskExecutor can be finished in 5 seconds, otherwise fail the test.
+     */
+    public static void waitRealmThreadExecutorFinish() {
+        int counter = 50;
+        while (counter > 0) {
+            if (BaseRealm.asyncTaskExecutor.getActiveCount() == 0) {
+                return;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                fail(e.getMessage());
+            }
+            counter--;
+        }
+        fail("'BaseRealm.asyncTaskExecutor' is not finished in " + counter/10 + " seconds");
     }
 
     /**

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
+import io.realm.TestHelper;
 
 import static org.junit.Assert.assertTrue;
 
@@ -73,6 +74,10 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
 
     @Override
     protected void after() {
+        // Wait all async tasks done to ensure successful deleteRealm call.
+        // This will throw when timeout. And the reason of timeout needs to be solved properly.
+        TestHelper.waitRealmThreadExecutorFinish();
+
         try {
             for (RealmConfiguration configuration : configurations) {
                 Realm.deleteRealm(configuration);

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -352,15 +352,15 @@ abstract class BaseRealm implements Closeable {
      * changes from this commit.
      */
     public void commitTransaction() {
-        commitTransaction(true, true, null);
+        commitTransaction(true, true);
     }
 
     /**
      * Commits an async transaction. This will not trigger any REALM_CHANGED events. Caller is responsible for handling
      * that.
      */
-    void commitAsyncTransaction(Runnable runAfterCommit) {
-        commitTransaction(false, false, runAfterCommit);
+    void commitAsyncTransaction() {
+        commitTransaction(false, false);
     }
 
     /**
@@ -369,15 +369,10 @@ abstract class BaseRealm implements Closeable {
      * other threads see the changes to majoyly avoid the flaky tests.
      *
      * @param notifyLocalThread set to {@code false} to prevent this commit from triggering thread local change listeners.
-     * @param runAfterCommit runnable will run after transaction committed but before notification sent.
      */
-    void commitTransaction(boolean notifyLocalThread, boolean notifyOtherThreads, Runnable runAfterCommit) {
+    void commitTransaction(boolean notifyLocalThread, boolean notifyOtherThreads) {
         checkIfValid();
         sharedGroupManager.commitAndContinueAsRead();
-
-        if (runAfterCommit != null)  {
-            runAfterCommit.run();
-        }
 
         for (Map.Entry<Handler, String> handlerIntegerEntry : handlers.entrySet()) {
             Handler handler = handlerIntegerEntry.getKey();

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1189,8 +1189,9 @@ public final class Realm extends BaseRealm {
 
                     if (!Thread.currentThread().isInterrupted()) {
                         bgRealm.commitAsyncTransaction();
-                        // The bgRealm needs to be closed before post event to caller's handler to avoid concurrency
-                        // problem. This is currently guaranteed by posting handleAsyncTransactionCompleted below.
+                        // The bgRealm needs to be closed before posting the REALM_CHANGED event to the caller's handler
+                        // to avoid currency problems. This is currently guaranteed by posting
+                        // handleAsyncTransactionCompleted below.
                         bgRealm.close();
                         transactionCommitted = true;
                     }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -290,7 +290,7 @@ public final class Realm extends BaseRealm {
             }
         } finally {
             if (commitNeeded) {
-                realm.commitTransaction(false, true, null);
+                realm.commitTransaction(false, true);
             } else {
                 realm.cancelTransaction();
             }
@@ -1188,15 +1188,10 @@ public final class Realm extends BaseRealm {
                     transaction.execute(bgRealm);
 
                     if (!Thread.currentThread().isInterrupted()) {
-                        bgRealm.commitAsyncTransaction(new Runnable() {
-                            @Override
-                            public void run() {
-                                // The bgRealm needs to be closed before post event to caller's handler to avoid
-                                // concurrency problem. eg.: User wants to delete Realm in the callbacks.
-                                // This will close Realm before sending REALM_CHANGED.
-                                bgRealm.close();
-                            }
-                        });
+                        bgRealm.commitAsyncTransaction();
+                        // The bgRealm needs to be closed before post event to caller's handler to avoid concurrency
+                        // problem. This is currently guaranteed by posting handleAsyncTransactionCompleted below.
+                        bgRealm.close();
                         transactionCommitted = true;
                     }
                 } catch (final Throwable e) {


### PR DESCRIPTION
This is highly related with #1900.
Below things are still guaranteed by this change after commit async
transaction:
* When callback function called (onSuccess/onError), the background
  Realm is closed.
* When any change listeners called, the background Realm is closed.

What is true now but it is not guaranteed in the future:
* Background Realm might not be closed before REALM_CHANGED sent (not
  received).

Due to this, to avoid the flaky tests, we have to ensure all async tasks
quit peacefully before start the next test. This is implemented by wait
and check in the TestRealmConfigurationFactory.

NOTE: Any test, if the async tasks cannot be finished peacefully in a
certain time, it has to be considered as a problem and fixed.

This would be needed by OS notifications since Java won't have a precise
control of sending REALM_CHANGED anymore.