### PR TITLE
Remove improper incompatibleLockFile test

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3428,24 +3428,4 @@ public class RealmTests {
         TestHelper.awaitOrFail(bgRealmFished);
         assertFalse(bgRealmChangeResult.get());
     }
-
-    @Test
-    public void incompatibleLockFile() throws IOException {
-        // Replace .lock file with a corrupted one
-        File lockFile = new File(realmConfig.getPath() + ".lock");
-        assertTrue(lockFile.exists());
-        FileOutputStream fooStream = new FileOutputStream(lockFile, false);
-        fooStream.write("Boom".getBytes());
-        fooStream.close();
-
-        try {
-            // This will try to open a second SharedGroup which should fail when the .lock file is corrupt
-            DynamicRealm.getInstance(realm.getConfiguration());
-            fail();
-        } catch (RealmError expected) {
-            assertTrue(expected.getMessage().contains("Info size doesn't match"));
-        } finally {
-            lockFile.delete();
-        }
-    }
 }


### PR DESCRIPTION
This test is not constructed properly. It tries to modify the lock file
while the Realm is still opened. This would cause some undefined
behaviour in core. Especially when we are using the generic
external_commit_helper which is based on SharedGroup::wait_for_change()
the helper thread will freeze because of polling hangs forever.

Just remove the test, core should ensure the proper exception thrown and
we have other tests to ensure the exception conversion right.