### PR TITLE
Remove deprecated constructor + add directory()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - `IncompatibleLockFileException` has been removed and replaced by `RealmFileException` with kind `INCOMPATIBLE_LOCK_FILE`.
   - `RealmIOExcpetion` has been removed and replaced by `RealmFileException`.
 * Removed `RealmConfiguration.Builder(Context, File)` and `RealmConfiguration.Builder(File)` constructors.
-* `RealmConfiguration.Builder.assetFile(Context, String)` have been renamed to `RealmConfiguration.Builder.assetFile(String)`.
+* `RealmConfiguration.Builder.assetFile(Context, String)` has been renamed to `RealmConfiguration.Builder.assetFile(String)`.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added new `RealmFileException`.
   - `IncompatibleLockFileException` has been removed and replaced by `RealmFileException` with kind `INCOMPATIBLE_LOCK_FILE`.
   - `RealmIOExcpetion` has been removed and replaced by `RealmFileException`.
-* Removed `RealmConfiguration.Builder(Context, File)` constructor.
+* Removed `RealmConfiguration.Builder(Context, File)` and `RealmConfiguration.Builder(File)` constructors.
 * `RealmConfiguration.Builder.assetFile(Context, String)` have been renamed to `RealmConfiguration.Builder.assetFile(String)`.
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@
 * Added new `RealmFileException`.
   - `IncompatibleLockFileException` has been removed and replaced by `RealmFileException` with kind `INCOMPATIBLE_LOCK_FILE`.
   - `RealmIOExcpetion` has been removed and replaced by `RealmFileException`.
+* Removed `RealmConfiguration.Builder(Context, File)` constructor.
+* `RealmConfiguration.Builder.assetFile(Context, String)` have been renamed to `RealmConfiguration.Builder.assetFile(String)`.
 
 ### Enhancements
 
 * Added `realmObject.isManaged()`, `RealmObject.isManaged(obj)` and `RealmCollection.isManaged()` (#3101).
-
-## 1.2.1
+* Added `RealmConfiguration.Builder.directory(File)`.
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
@@ -182,7 +182,7 @@ public class RealmCacheTests {
 
         // 1. Write a copy of the encrypted Realm to a new file
         Realm testRealm = Realm.getInstance(config);
-        File copiedRealm = new File(config.getRealmFolder(), "encrypted-copy.realm");
+        File copiedRealm = new File(config.getRealmDirectory(), "encrypted-copy.realm");
         if (copiedRealm.exists()) {
             assertTrue(copiedRealm.delete());
         }
@@ -193,7 +193,7 @@ public class RealmCacheTests {
         Realm.deleteRealm(config);
 
         // 3. Rename the new file to the old file name.
-        assertTrue(copiedRealm.renameTo(new File(config.getRealmFolder(), REALM_NAME)));
+        assertTrue(copiedRealm.renameTo(new File(config.getRealmDirectory(), REALM_NAME)));
 
         // 4. Try to open the file again with the new password
         // If the configuration cache wasn't cleared this would fail as we would detect two

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -523,7 +523,7 @@ public class RealmObjectTests {
             realm_differentName.close();
         }
 
-        // Check the hash code of the object from a Realm in different folder.
+        // Check the hash code of the object from a Realm in different directory.
         RealmConfiguration realmConfig_differentPath = configFactory.createConfiguration(
                 "anotherDir", realmConfig.getRealmFileName());
         Realm realm_differentPath = Realm.getInstance(realmConfig_differentPath);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -174,30 +174,6 @@ public class RealmTests {
         populateTestRealm(realm, TEST_DATA_SIZE);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void getInstance_nullDir() {
-        Realm.getInstance(new RealmConfiguration.Builder((File) null).build());
-    }
-
-    @Test
-    public void getInstance_writeProtectedDir() {
-        File folder = new File("/");
-        thrown.expect(IllegalArgumentException.class);
-        Realm.getInstance(new RealmConfiguration.Builder(folder).build());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void getInstance_nullContextWithCustomDirThrows() {
-        Realm.getInstance(new RealmConfiguration.Builder((Context) null, configFactory.getRoot()).build());
-    }
-
-    @Test
-    public void getInstance_writeProtectedDirWithContext() {
-        File folder = new File("/");
-        thrown.expect(IllegalArgumentException.class);
-        Realm.getInstance(new RealmConfiguration.Builder(context, folder).build());
-    }
-
     @Test
     public void getInstance_writeProtectedFile() throws IOException {
         String REALM_FILE = "readonly.realm";
@@ -208,7 +184,10 @@ public class RealmTests {
         assertTrue(realmFile.setWritable(false));
 
         try {
-            Realm.getInstance(new RealmConfiguration.Builder(folder).name(REALM_FILE).build());
+            Realm.getInstance(new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext())
+                    .directory(folder)
+                    .name(REALM_FILE)
+                    .build());
         } catch (RealmFileException expected) {
             assertEquals(expected.getKind(), RealmFileException.Kind.PERMISSION_DENIED);
         }
@@ -224,7 +203,7 @@ public class RealmTests {
         assertTrue(realmFile.setWritable(false));
 
         try {
-            Realm.getInstance(new RealmConfiguration.Builder(context, folder).name(REALM_FILE).build());
+            Realm.getInstance(new RealmConfiguration.Builder(context).directory(folder).name(REALM_FILE).build());
         } catch (RealmFileException expected) {
             assertEquals(expected.getKind(), RealmFileException.Kind.PERMISSION_DENIED);
         }
@@ -1980,7 +1959,9 @@ public class RealmTests {
         File tempDirRenamed = new File(configFactory.getRoot(), "delete_test_dir_2");
         assertTrue(tempDir.mkdir());
 
-        final RealmConfiguration configuration = new RealmConfiguration.Builder(tempDir).build();
+        final RealmConfiguration configuration = new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext())
+                .directory(tempDir)
+                .build();
 
         final CountDownLatch bgThreadReadyLatch = new CountDownLatch(1);
         final CountDownLatch readyToCloseLatch = new CountDownLatch(1);

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -19,6 +19,7 @@ package io.realm;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.os.Looper;
+import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 
 import org.junit.Assert;
@@ -382,7 +383,9 @@ public class TestHelper {
      */
     @Deprecated
     public static RealmConfiguration createConfiguration(File dir, String name, byte[] key) {
-        RealmConfiguration.Builder config = new RealmConfiguration.Builder(dir).name(name);
+        RealmConfiguration.Builder config = new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext())
+                .directory(dir)
+                .name(name);
         if (key != null) {
             config.encryptionKey(key);
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
@@ -88,7 +88,7 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
                 throw e;
             }
         } finally {
-            // This will delete the temp folder.
+            // This will delete the temp directory.
             super.after();
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
@@ -18,6 +18,7 @@ package io.realm.rule;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.support.test.InstrumentationRegistry;
 
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
@@ -94,7 +95,8 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
     }
 
     public RealmConfiguration createConfiguration() {
-        RealmConfiguration configuration = new RealmConfiguration.Builder(getRoot())
+        RealmConfiguration configuration = new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext())
+                .directory(getRoot())
                 .build();
 
         configurations.add(configuration);
@@ -104,7 +106,8 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
     public RealmConfiguration createConfiguration(String subDir, String name) {
         final File folder = new File(getRoot(), subDir);
         assertTrue(folder.mkdirs());
-        RealmConfiguration configuration = new RealmConfiguration.Builder(folder)
+        RealmConfiguration configuration = new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext())
+                .directory(folder)
                 .name(name)
                 .build();
 
@@ -113,7 +116,8 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
     }
 
     public RealmConfiguration createConfiguration(String name) {
-        RealmConfiguration configuration = new RealmConfiguration.Builder(getRoot())
+        RealmConfiguration configuration = new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext())
+                .directory(getRoot())
                 .name(name)
                 .build();
 
@@ -122,7 +126,8 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
     }
 
     public RealmConfiguration createConfiguration(String name, byte[] key) {
-        RealmConfiguration configuration = new RealmConfiguration.Builder(getRoot())
+        RealmConfiguration configuration = new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext())
+                .directory(getRoot())
                 .name(name)
                 .encryptionKey(key)
                 .build();
@@ -132,14 +137,15 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
     }
 
     public RealmConfiguration.Builder createConfigurationBuilder() {
-        return new RealmConfiguration.Builder(getRoot());
+        return new RealmConfiguration.Builder(InstrumentationRegistry.getTargetContext()).directory(getRoot());
     }
 
     // Copies a Realm file from assets to temp dir
     public void copyRealmFromAssets(Context context, String realmPath, String newName)
             throws IOException {
         // Delete the existing file before copy
-        RealmConfiguration configToDelete = new RealmConfiguration.Builder(getRoot())
+        RealmConfiguration configToDelete = new RealmConfiguration.Builder(context)
+                .directory(getRoot())
                 .name(newName)
                 .build();
         Realm.deleteRealm(configToDelete);

--- a/realm/realm-library/src/benchmarks/java/io/realm/benchmarks/config/BenchmarkConfig.java
+++ b/realm/realm-library/src/benchmarks/java/io/realm/benchmarks/config/BenchmarkConfig.java
@@ -31,13 +31,13 @@ import dk.ilios.spanner.output.ResultProcessor;
 public class BenchmarkConfig {
 
     public static SpannerConfig getConfiguration(String className) {
-        // Document folder is located at: /sdcard/realm-benchmarks
+        // Document directory is located at: /sdcard/realm-benchmarks
         // Benchmarks results should be saved in <documentFolder>/results/<className>.json
         // Baseline data should be found in <documentFolder>/baselines/<className>.json
         // Custom CSV files should be found in <documentFolder>/csv/<className>.csv
         File externalDocuments = new File(Environment.getExternalStorageDirectory(), "realm-benchmarks");
         if (!externalDocuments.exists() && !externalDocuments.mkdir()) {
-            throw new RuntimeException("Could not create benchmark folder: " + externalDocuments);
+            throw new RuntimeException("Could not create benchmark directory: " + externalDocuments);
         }
         File resultsDir = new File(externalDocuments, "results");
         File baselineDir = new File(externalDocuments, "baselines");

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -665,12 +665,12 @@ abstract class BaseRealm implements Closeable {
                 }
 
                 String canonicalPath = configuration.getPath();
-                File realmFolder = configuration.getRealmFolder();
+                File realmFolder = configuration.getRealmDirectory();
                 String realmFileName = configuration.getRealmFileName();
                 File managementFolder = new File(realmFolder, realmFileName + management);
 
-                // delete files in management folder and the folder
-                // there is no subfolders in the management folder
+                // delete files in management directory and the directory
+                // there is no subfolders in the management directory
                 File[] files = managementFolder.listFiles();
                 if (files != null) {
                     for (File file : files) {
@@ -679,7 +679,7 @@ abstract class BaseRealm implements Closeable {
                 }
                 realmDeleted.set(realmDeleted.get() && managementFolder.delete());
 
-                // delete specific files in root folder
+                // delete specific files in root directory
                 realmDeleted.set(realmDeleted.get() && deletes(canonicalPath, realmFolder, realmFileName));
             }
         });

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -293,7 +293,7 @@ final class RealmCache {
     private static void copyAssetFileIfNeeded(RealmConfiguration configuration) {
         IOException exceptionWhenClose = null;
         if (configuration.hasAssetFile()) {
-            File realmFile = new File(configuration.getRealmFolder(), configuration.getRealmFileName());
+            File realmFile = new File(configuration.getRealmDirectory(), configuration.getRealmFileName());
             if (realmFile.exists()) {
                 return;
             }

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -419,10 +419,8 @@ public final class RealmConfiguration {
             if (directory.isFile()) {
                 throw new IllegalArgumentException("'dir' is a file, not a directory: " + directory.getAbsolutePath() + ".");
             }
-            if (!directory.exists()) {
-                if (directory.mkdirs()) {
-                    throw new IllegalArgumentException("Could not create the specified directory: " + directory.getAbsolutePath() + ".");
-                }
+            if (!directory.exists() && !directory.mkdirs()) {
+                throw new IllegalArgumentException("Could not create the specified directory: " + directory.getAbsolutePath() + ".");
             }
             if (!directory.canWrite()) {
                 throw new IllegalArgumentException("Realm directory is not writable: " + directory.getAbsolutePath() + ".");

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -421,11 +421,11 @@ public final class RealmConfiguration {
             }
             if (!dir.exists()) {
                 if (dir.mkdirs()) {
-                    throw new RuntimeException("Could not create the specified directory: " + dir.getAbsolutePath());
+                    throw new IllegalArgumentException("Could not create the specified directory: " + dir.getAbsolutePath());
                 }
             }
-            if (dir.canWrite()) {
-                throw new RuntimeException("Realm directory is not writable: " + dir.getAbsolutePath());
+            if (!dir.canWrite()) {
+                throw new IllegalArgumentException("Realm directory is not writable: " + dir.getAbsolutePath());
             }
             this.directory = dir;
             return this;

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -407,9 +407,9 @@ public final class RealmConfiguration {
 
         /**
          * Specify the directory where the Realm file will be saved. The default value is {@code context.getFiles()}.
-         * If the directory does not exists. It will be created.
+         * If the directory does not exist, it will be created.
          *
-         * @param directory the directory to save the Realm file in. Folder must be writable.
+         * @param directory the directory to save the Realm file in. Directory must be writable.
          * @throws IllegalArgumentException if {@code directory} is null, not writable or a file.
          */
         public Builder directory(File directory) {

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -406,28 +406,28 @@ public final class RealmConfiguration {
         }
 
         /**
-         * Specify the dir where the Realm file will be saved. The default value is {@code context.getFiles()}.
+         * Specify the directory where the Realm file will be saved. The default value is {@code context.getFiles()}.
          * If the directory does not exists. It will be created.
          *
-         * @param dir the directory to save the Realm file in. Folder must be writable.
-         * @throws IllegalArgumentException if {@code dir} is null, not writable or a file.
+         * @param directory the directory to save the Realm file in. Folder must be writable.
+         * @throws IllegalArgumentException if {@code directory} is null, not writable or a file.
          */
-        public Builder directory(File dir) {
-            if (dir == null) {
-                throw new IllegalArgumentException("Non-null 'dir' required");
+        public Builder directory(File directory) {
+            if (directory == null) {
+                throw new IllegalArgumentException("Non-null 'dir' required.");
             }
-            if (dir.isFile()) {
-                throw new IllegalArgumentException("'dir' is a file, not a directory: " + dir.getAbsolutePath());
+            if (directory.isFile()) {
+                throw new IllegalArgumentException("'dir' is a file, not a directory: " + directory.getAbsolutePath() + ".");
             }
-            if (!dir.exists()) {
-                if (dir.mkdirs()) {
-                    throw new IllegalArgumentException("Could not create the specified directory: " + dir.getAbsolutePath());
+            if (!directory.exists()) {
+                if (directory.mkdirs()) {
+                    throw new IllegalArgumentException("Could not create the specified directory: " + directory.getAbsolutePath() + ".");
                 }
             }
-            if (!dir.canWrite()) {
-                throw new IllegalArgumentException("Realm directory is not writable: " + dir.getAbsolutePath());
+            if (!directory.canWrite()) {
+                throw new IllegalArgumentException("Realm directory is not writable: " + directory.getAbsolutePath() + ".");
             }
-            this.directory = dir;
+            this.directory = directory;
             return this;
         }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.realm.annotations.PrimaryKey;
 import io.realm.annotations.RealmModule;
 import io.realm.exceptions.RealmException;
 import io.realm.internal.RealmCore;
@@ -84,7 +85,7 @@ public final class RealmConfiguration {
         }
     }
 
-    private final File realmFolder;
+    private final File realmDirectory;
     private final String realmFileName;
     private final String canonicalPath;
     private final String assetFilePath;
@@ -99,9 +100,9 @@ public final class RealmConfiguration {
     private final WeakReference<Context> contextWeakRef;
 
     private RealmConfiguration(Builder builder) {
-        this.realmFolder = builder.folder;
+        this.realmDirectory = builder.directory;
         this.realmFileName = builder.fileName;
-        this.canonicalPath = Realm.getCanonicalPath(new File(realmFolder, realmFileName));
+        this.canonicalPath = Realm.getCanonicalPath(new File(realmDirectory, realmFileName));
         this.assetFilePath = builder.assetFilePath;
         this.key = builder.key;
         this.schemaVersion = builder.schemaVersion;
@@ -114,8 +115,8 @@ public final class RealmConfiguration {
         this.contextWeakRef = builder.contextWeakRef;
     }
 
-    public File getRealmFolder() {
-        return realmFolder;
+    public File getRealmDirectory() {
+        return realmDirectory;
     }
 
     public String getRealmFileName() {
@@ -222,7 +223,7 @@ public final class RealmConfiguration {
 
         if (schemaVersion != that.schemaVersion) return false;
         if (deleteRealmIfMigrationNeeded != that.deleteRealmIfMigrationNeeded) return false;
-        if (!realmFolder.equals(that.realmFolder)) return false;
+        if (!realmDirectory.equals(that.realmDirectory)) return false;
         if (!realmFileName.equals(that.realmFileName)) return false;
         if (!canonicalPath.equals(that.canonicalPath)) return false;
         if (!Arrays.equals(key, that.key)) return false;
@@ -236,7 +237,7 @@ public final class RealmConfiguration {
 
     @Override
     public int hashCode() {
-        int result = realmFolder.hashCode();
+        int result = realmDirectory.hashCode();
         result = 31 * result + realmFileName.hashCode();
         result = 31 * result + canonicalPath.hashCode();
         result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
@@ -304,7 +305,7 @@ public final class RealmConfiguration {
     public String toString() {
         //noinspection StringBufferReplaceableByString
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("realmFolder: ").append(realmFolder.toString());
+        stringBuilder.append("realmDirectory: ").append(realmDirectory.toString());
         stringBuilder.append("\n");
         stringBuilder.append("realmFileName : ").append(realmFileName);
         stringBuilder.append("\n");
@@ -346,7 +347,7 @@ public final class RealmConfiguration {
      * RealmConfiguration.Builder used to construct instances of a RealmConfiguration in a fluent manner.
      */
     public static final class Builder {
-        private File folder;
+        private File directory;
         private String fileName;
         private String assetFilePath;
         private byte[] key;
@@ -362,20 +363,6 @@ public final class RealmConfiguration {
 
         /**
          * Creates an instance of the Builder for the RealmConfiguration.
-         * The Realm file will be saved in the provided folder.
-         *
-         * @param folder the folder to save Realm file in. Folder must be writable.
-         * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
-         * @deprecated Please use {@link #Builder(Context, File)} instead.
-         */
-        @Deprecated
-        public Builder(File folder) {
-            RealmCore.loadLibrary();
-            initializeBuilder(folder);
-        }
-
-        /**
-         * Creates an instance of the Builder for the RealmConfiguration.
          * <p>
          * This will use the app's own internal directory for storing the Realm file. This does not require any
          * additional permissions. The default location is {@code /data/data/<packagename>/files}, but can
@@ -388,37 +375,13 @@ public final class RealmConfiguration {
                 throw new IllegalArgumentException("A non-null Context must be provided");
             }
             RealmCore.loadLibrary(context);
-            initializeBuilder(context.getFilesDir());
-        }
-
-        /**
-         * Creates an instance of the Builder for the RealmConfiguration.
-         * <p>
-         * The Realm file will be saved in the provided folder, and it might require additional permissions.
-         *
-         * @param context the Android application context.
-         * @param folder the folder to save Realm file in. Folder must be writable.
-         * @throws IllegalArgumentException if folder doesn't exist or isn't writable.
-         */
-        public Builder(Context context, File folder) {
-            if (context == null) {
-                throw new IllegalArgumentException("A non-null Context must be provided");
-            }
-            RealmCore.loadLibrary(context);
-            initializeBuilder(folder);
+            initializeBuilder(context);
         }
 
         // Setup builder in its initial state
-        private void initializeBuilder(File folder) {
-            if (folder == null || !folder.isDirectory()) {
-                throw new IllegalArgumentException(("An existing folder must be provided. " +
-                        "Yours was " + (folder != null ? folder.getAbsolutePath() : "null")));
-            }
-            if (!folder.canWrite()) {
-                throw new IllegalArgumentException("Folder is not writable: " + folder.getAbsolutePath());
-            }
-
-            this.folder = folder;
+        private void initializeBuilder(Context context) {
+            this.contextWeakRef = new WeakReference<Context>(context);
+            this.directory = context.getFilesDir();
             this.fileName = Realm.DEFAULT_REALM_NAME;
             this.key = null;
             this.schemaVersion = 0;
@@ -431,7 +394,7 @@ public final class RealmConfiguration {
         }
 
         /**
-         * Sets the filename for the Realm.
+         * Sets the filename for the Realm file.
          */
         public Builder name(String filename) {
             if (filename == null || filename.isEmpty()) {
@@ -439,6 +402,32 @@ public final class RealmConfiguration {
             }
 
             this.fileName = filename;
+            return this;
+        }
+
+        /**
+         * Specify the dir where the Realm file will be saved. The default value is {@code context.getFiles()}.
+         * If the directory does not exists. It will be created.
+         *
+         * @param dir the directory to save the Realm file in. Folder must be writable.
+         * @throws IllegalArgumentException if {@code dir} is null, not writable or a file.
+         */
+        public Builder directory(File dir) {
+            if (dir == null) {
+                throw new IllegalArgumentException("Non-null 'dir' required");
+            }
+            if (dir.isFile()) {
+                throw new IllegalArgumentException("'dir' is a file, not a directory: " + dir.getAbsolutePath());
+            }
+            if (!dir.exists()) {
+                if (dir.mkdirs()) {
+                    throw new RuntimeException("Could not create the specified directory: " + dir.getAbsolutePath());
+                }
+            }
+            if (dir.canWrite()) {
+                throw new RuntimeException("Realm directory is not writable: " + dir.getAbsolutePath());
+            }
+            this.directory = dir;
             return this;
         }
 
@@ -493,11 +482,11 @@ public final class RealmConfiguration {
          * with the new Realm schema.
          *
          * <p>This cannot be configured to have an asset file at the same time by calling
-         * {@link #assetFile(Context, String)} as the provided asset file will be deleted in migrations.
+         * {@link #assetFile(String)} as the provided asset file will be deleted in migrations.
          *
          * <p><b>WARNING!</b> This will result in loss of data.
          *
-         * @throws IllegalStateException if configured to use an asset file by calling {@link #assetFile(Context, String)} previously.
+         * @throws IllegalStateException if configured to use an asset file by calling {@link #assetFile(String)} previously.
          */
         public Builder deleteRealmIfMigrationNeeded() {
             if (this.assetFilePath != null && this.assetFilePath.length() != 0) {
@@ -587,14 +576,10 @@ public final class RealmConfiguration {
          * <p>
          * WARNING: This could potentially be a lengthy operation and should ideally be done on a background thread.
          *
-         * @param context Android application context.
          * @param assetFile path to the asset database file.
          * @throws IllegalStateException if this is configured to clear its schema by calling {@link #deleteRealmIfMigrationNeeded()}.
          */
-        public Builder assetFile(Context context, final String assetFile) {
-            if (context == null) {
-                throw new IllegalArgumentException("A non-null Context must be provided");
-            }
+        public Builder assetFile(final String assetFile) {
             if (TextUtils.isEmpty(assetFile)) {
                 throw new IllegalArgumentException("A non-empty asset file path must be provided");
             }
@@ -605,7 +590,6 @@ public final class RealmConfiguration {
                 throw new IllegalStateException("Realm cannot use an asset file when previously configured to clear its schema in migration by calling deleteRealmIfMigrationNeeded().");
             }
 
-            this.contextWeakRef = new WeakReference<>(context);
             this.assetFilePath = assetFile;
 
             return this;


### PR DESCRIPTION
This PR removes previously deprecated constructor + adds a new `directory(File)` option to the RealmConfiguration builder.

This means that we now always have a Context reference, so `assetFile(context, string)` could be simplified to `assetFile(string)` as well.

Most of the changes in this PR is in the unit tests. The interesting code change is in `RealmConfiguration`

@realm/java 