### PR TITLE
Fix a lint error in proxy classes when the 'minSdkVersion' is smaller than 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Move JNI build to CMake.
 
+### Bug fixes
+
+* Fixed a lint error in proxy classes when the 'minSdkVersion' of user's project is smaller than 11 (#3356).
+
 ## 1.2.0
 
 ### Bug fixes

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -62,6 +62,8 @@ public class RealmProxyClassGenerator {
                 .emitEmptyLine();
 
         ArrayList<String> imports = new ArrayList<String>();
+        imports.add("android.annotation.TargetApi");
+        imports.add("android.os.Build");
         imports.add("android.util.JsonReader");
         imports.add("android.util.JsonToken");
         imports.add("io.realm.RealmFieldType");
@@ -1553,6 +1555,7 @@ public class RealmProxyClassGenerator {
 
     private void emitCreateUsingJsonStream(JavaWriter writer) throws IOException {
         writer.emitAnnotation("SuppressWarnings", "\"cast\"");
+        writer.emitAnnotation("TargetApi", "Build.VERSION_CODES.HONEYCOMB");
         writer.beginMethod(
                 qualifiedClassName,
                 "createUsingJsonStream",

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -1,6 +1,8 @@
 package io.realm;
 
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.util.JsonReader;
 import android.util.JsonToken;
 import io.realm.RealmFieldType;
@@ -490,6 +492,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     }
 
     @SuppressWarnings("cast")
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static some.test.AllTypes createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         some.test.AllTypes obj = realm.createObject(some.test.AllTypes.class);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -1,6 +1,8 @@
 package io.realm;
 
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.util.JsonReader;
 import android.util.JsonToken;
 import io.realm.RealmFieldType;
@@ -225,6 +227,7 @@ public class BooleansRealmProxy extends some.test.Booleans
     }
 
     @SuppressWarnings("cast")
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static some.test.Booleans createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         some.test.Booleans obj = realm.createObject(some.test.Booleans.class);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1,6 +1,8 @@
 package io.realm;
 
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.util.JsonReader;
 import android.util.JsonToken;
 import io.realm.RealmFieldType;
@@ -910,6 +912,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     @SuppressWarnings("cast")
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static some.test.NullTypes createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         some.test.NullTypes obj = realm.createObject(some.test.NullTypes.class);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -1,6 +1,8 @@
 package io.realm;
 
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.util.JsonReader;
 import android.util.JsonToken;
 import io.realm.RealmFieldType;
@@ -163,6 +165,7 @@ public class SimpleRealmProxy extends some.test.Simple
     }
 
     @SuppressWarnings("cast")
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static some.test.Simple createUsingJsonStream(Realm realm, JsonReader reader)
             throws IOException {
         some.test.Simple obj = realm.createObject(some.test.Simple.class);


### PR DESCRIPTION
fixes #3356

@realm/java 