### PR TITLE
DeleteLocalRef when the ref is created in loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 * Fixed a lint error in proxy classes when the 'minSdkVersion' of user's project is smaller than 11 (#3356).
+* Fixed a potential crash when there were lots of async queries waiting in the queue.
 
 ## 1.2.0
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -2121,8 +2121,8 @@ public class RealmAsyncQueryTests {
     @RunTestInLooperThread
     public void batchUpdate_localRefIsDeletedInLoopOfNativeBatchUpdateQueries() {
         final Realm realm = looperThread.realm;
-        // For Android, the size of local ref map is 512
-        final int TEST_COUNT = 512;
+        // For Android, the size of local ref map is 512. Use 1024 for more pressure.
+        final int TEST_COUNT = 1024;
         final AtomicBoolean updatesTriggered = new AtomicBoolean(false);
         // The first time onChange gets called for every results.
         final AtomicInteger firstOnChangeCounter = new AtomicInteger(0);

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -1212,7 +1212,10 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
 
         // Step3: Run & export the queries against the latest shared group
         for (size_t i = 0; i < number_of_queries; ++i) {
-            JniLongArray query_param_array(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
+            // Delete the local ref since we might have a long loop
+            JniLocalRef<jlongArray> local_ref(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
+            JniLongArray query_param_array(env, local_ref);
+
             switch (query_param_array[0]) { // 0, index of the type of query, the next indicies are parameters
                 case QUERY_TYPE_FIND_ALL: {// nativeFindAllWithHandover
                     exported_handover_tableview_array[i] =

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -697,10 +697,10 @@ private:
     jint                m_releaseMode;
 };
 
-// Wrap jobject and call the DeleteLocalRef when destruction.
-// DeleteLocalRef is not necessary to be called in most cases since all local references will be cleaned up when program
-// returns to Java from native. But if the LocaRef is created in a loop, consider to use this class to wrap it because
-// the size of local reference table is relative small (512 on Android).
+// Wraps jobject and automatically calls DeleteLocalRef when this object is destroyed.
+// DeleteLocalRef is not necessary to be called in most cases since all local references will be cleaned up when the
+// program returns to Java from native. But if the LocaRef is created in a loop, consider to use this class to wrap it
+// because the size of local reference table is relative small (512 on Android).
 template <typename T>
 class JniLocalRef {
 public:

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -551,8 +551,9 @@ public:
     }
 
     ~KeyBuffer() {
-        if (m_ptr)
+        if (m_ptr) {
             m_env->ReleaseByteArrayElements(m_array, m_ptr, JNI_ABORT);
+        }
     }
 
 private:
@@ -694,6 +695,29 @@ private:
     jsize         const m_arrayLength;
     jboolean*     const m_array;
     jint                m_releaseMode;
+};
+
+// Wrap jobject and call the DeleteLocalRef when destruction.
+// DeleteLocalRef is not necessary to be called in most cases since all local references will be cleaned up when program
+// returns to Java from native. But if the LocaRef is created in a loop, consider to use this class to wrap it because
+// the size of local reference table is relative small (512 on Android).
+template <typename T>
+class JniLocalRef {
+public:
+    JniLocalRef(JNIEnv* env, T obj) : m_jobject(obj), m_env(env) {};
+    ~JniLocalRef()
+    {
+        m_env->DeleteLocalRef(m_jobject);
+    }
+
+    inline operator T() const noexcept
+    {
+            return m_jobject;
+    }
+
+private:
+    T m_jobject;
+    JNIEnv* m_env;
 };
 
 extern jclass java_lang_long;


### PR DESCRIPTION
Add wrapper class for JNI local reference to delete the local ref after
using it.

This is reported by user on helpscout:
https://secure.helpscout.net/conversation/244053233/6163/?folderId=366141

And some useful explanation can be found:
http://stackoverflow.com/questions/24289724/jni-deletelocalref-clarification

Normally the local ref doesn't have to be deleted since they will be
cleaned up when program returns to Java from native code. Using it in a
loop is obvious a corner case: the size of local ref table is relatively
small (512 on Android). To avoid it, the local ref should be deleted
when using it in a loop.