### PR TITLE
Use createObject(class, primaryKey) in test

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
@@ -833,8 +833,8 @@ public class BulkInsertTests {
     @Test
     public void insertOrUpdate_collectionOfManagedObjects() {
         realm.beginTransaction();
-        AllTypesPrimaryKey allTypes = realm.createObject(AllTypesPrimaryKey.class);
-        allTypes.getColumnRealmList().add(realm.createObject(DogPrimaryKey.class));
+        AllTypesPrimaryKey allTypes = realm.createObject(AllTypesPrimaryKey.class, 0);
+        allTypes.getColumnRealmList().add(realm.createObject(DogPrimaryKey.class, 0));
         realm.commitTransaction();
         assertEquals(1, allTypes.getColumnRealmList().size());
 
@@ -856,8 +856,8 @@ public class BulkInsertTests {
     @Test
     public void insertOrUpdate_shouldNotClearRealmList() {
         realm.beginTransaction();
-        AllTypesPrimaryKey allTypes = realm.createObject(AllTypesPrimaryKey.class);
-        allTypes.getColumnRealmList().add(realm.createObject(DogPrimaryKey.class));
+        AllTypesPrimaryKey allTypes = realm.createObject(AllTypesPrimaryKey.class, 0);
+        allTypes.getColumnRealmList().add(realm.createObject(DogPrimaryKey.class, 0));
         realm.commitTransaction();
         assertEquals(1, allTypes.getColumnRealmList().size());
 

--- a/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
@@ -200,7 +200,7 @@ public abstract class CollectionTests {
                 return realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_STRING);
 
             case MANAGED_REALMLIST:
-                AllJavaTypes first = realm.createObject(AllJavaTypes.class);
+                AllJavaTypes first = realm.createObject(AllJavaTypes.class, 0);
                 first.setFieldString(args[0]);
                 first.getFieldList().add(first);
                 for (int i = 1; i < args.length; i++) {

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -68,7 +68,7 @@ public class DynamicRealmObjectTests {
         RealmConfiguration realmConfig = configFactory.createConfiguration();
         realm = Realm.getInstance(realmConfig);
         realm.beginTransaction();
-        typedObj = realm.createObject(AllJavaTypes.class);
+        typedObj = realm.createObject(AllJavaTypes.class, 0);
         typedObj.setFieldString("str");
         typedObj.setFieldShort((short) 1);
         typedObj.setFieldInt(1);
@@ -247,7 +247,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void typedGettersAndSetters() {
         realm.beginTransaction();
-        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 0);
         DynamicRealmObject dObj = new DynamicRealmObject(obj);
         try {
             for (SupportedType type : SupportedType.values()) {
@@ -311,7 +311,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void setter_null() {
         realm.beginTransaction();
-        NullTypes obj = realm.createObject(NullTypes.class);
+        NullTypes obj = realm.createObject(NullTypes.class, 0);
         DynamicRealmObject dObj = new DynamicRealmObject(obj);
         try {
             for (SupportedType type : SupportedType.values()) {
@@ -384,7 +384,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void setter_nullOnRequiredFieldsThrows() {
         realm.beginTransaction();
-        NullTypes obj = realm.createObject(NullTypes.class);
+        NullTypes obj = realm.createObject(NullTypes.class, 0);
         DynamicRealmObject dObj = new DynamicRealmObject(obj);
         try {
             for (SupportedType type : SupportedType.values()) {
@@ -418,7 +418,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void typedSetter_null() {
         realm.beginTransaction();
-        NullTypes obj = realm.createObject(NullTypes.class);
+        NullTypes obj = realm.createObject(NullTypes.class, 0);
         DynamicRealmObject dObj = new DynamicRealmObject(obj);
         try {
             for (SupportedType type : SupportedType.values()) {
@@ -478,7 +478,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void setObject_wrongTypeThrows() {
         realm.beginTransaction();
-        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 0);
         Dog otherObj = realm.createObject(Dog.class);
         DynamicRealmObject dynamicObj = new DynamicRealmObject(obj);
         DynamicRealmObject dynamicWrongType = new DynamicRealmObject(otherObj);
@@ -611,8 +611,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void untypedSetter_listMixedTypesThrows() {
         realm.beginTransaction();
-        AllJavaTypes obj1 = realm.createObject(AllJavaTypes.class);
-        obj1.setFieldLong(2);
+        AllJavaTypes obj1 = realm.createObject(AllJavaTypes.class, 2);
         CyclicType obj2 = realm.createObject(CyclicType.class);
 
         RealmList<DynamicRealmObject> list = new RealmList<DynamicRealmObject>();
@@ -644,7 +643,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void untypedGetterSetter() {
         realm.beginTransaction();
-        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 0);
         DynamicRealmObject dObj = new DynamicRealmObject(obj);
         try {
             for (SupportedType type : SupportedType.values()) {
@@ -713,7 +712,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void untypedSetter_usingStringConversion() {
         realm.beginTransaction();
-        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 0);
         DynamicRealmObject dObj = new DynamicRealmObject(obj);
         try {
             for (SupportedType type : SupportedType.values()) {
@@ -767,7 +766,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void untypedSetter_illegalImplicitConversionThrows() {
         realm.beginTransaction();
-        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 0);
         DynamicRealmObject dObj = new DynamicRealmObject(obj);
         try {
             for (SupportedType type : SupportedType.values()) {
@@ -827,7 +826,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void isNull_true() {
         realm.beginTransaction();
-        AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 0);
         realm.commitTransaction();
 
         assertTrue(new DynamicRealmObject(obj).isNull(AllJavaTypes.FIELD_OBJECT));
@@ -913,7 +912,7 @@ public class DynamicRealmObjectTests {
     @Test
     public void toString_nullValues() {
         dynamicRealm.beginTransaction();
-        final DynamicRealmObject obj = dynamicRealm.createObject(NullTypes.CLASS_NAME);
+        final DynamicRealmObject obj = dynamicRealm.createObject(NullTypes.CLASS_NAME, 0);
         dynamicRealm.commitTransaction();
 
         String str = obj.toString();

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedOrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedOrderedRealmCollectionTests.java
@@ -170,7 +170,7 @@ public class ManagedOrderedRealmCollectionTests extends CollectionTests {
         switch (collectionClass) {
             case MANAGED_REALMLIST:
                 realm.beginTransaction();
-                NullTypes obj = realm.createObject(NullTypes.class);
+                NullTypes obj = realm.createObject(NullTypes.class, 0);
                 realm.commitTransaction();
                 return obj.getFieldListNull();
 

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
@@ -139,7 +139,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
         switch (collectionClass) {
             case MANAGED_REALMLIST:
                 realm.beginTransaction();
-                NullTypes obj = realm.createObject(NullTypes.class);
+                NullTypes obj = realm.createObject(NullTypes.class, 0);
                 realm.commitTransaction();
                 return obj.getFieldListNull();
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
@@ -50,7 +50,7 @@ public class RealmAnnotationTests {
         RealmConfiguration realmConfig = configFactory.createConfiguration();
         realm = Realm.getInstance(realmConfig);
         realm.beginTransaction();
-        AnnotationTypes object = realm.createObject(AnnotationTypes.class);
+        AnnotationTypes object = realm.createObject(AnnotationTypes.class, 0);
         object.setNotIndexString("String 1");
         object.setIndexString("String 2");
         object.setIgnoreString("String 3");
@@ -102,9 +102,8 @@ public class RealmAnnotationTests {
     public void primaryKey_migration_long() {
         realm.beginTransaction();
         for (int i = 1; i <= 2; i++) {
-            PrimaryKeyAsString obj = realm.createObject(PrimaryKeyAsString.class);
+            PrimaryKeyAsString obj = realm.createObject(PrimaryKeyAsString.class, "String" + i);
             obj.setId(i);
-            obj.setName("String" + i);
         }
 
         Table table = realm.getTable(PrimaryKeyAsString.class);
@@ -118,9 +117,8 @@ public class RealmAnnotationTests {
     public void primaryKey_migration_longDuplicateValues() {
         realm.beginTransaction();
         for (int i = 1; i <= 2; i++) {
-            PrimaryKeyAsString obj = realm.createObject(PrimaryKeyAsString.class);
+            PrimaryKeyAsString obj = realm.createObject(PrimaryKeyAsString.class, "String" + i);
             obj.setId(1); // Create duplicate values
-            obj.setName("String" + i);
         }
 
         Table table = realm.getTable(PrimaryKeyAsString.class);
@@ -139,8 +137,7 @@ public class RealmAnnotationTests {
     public void primaryKey_migration_string() {
         realm.beginTransaction();
         for (int i = 1; i <= 2; i++) {
-            PrimaryKeyAsLong obj = realm.createObject(PrimaryKeyAsLong.class);
-            obj.setId(i);
+            PrimaryKeyAsLong obj = realm.createObject(PrimaryKeyAsLong.class, i);
             obj.setName("String" + i);
         }
 
@@ -155,8 +152,7 @@ public class RealmAnnotationTests {
     public void primaryKey_migration_stringDuplicateValues() {
         realm.beginTransaction();
         for (int i = 1; i <= 2; i++) {
-            PrimaryKeyAsLong obj = realm.createObject(PrimaryKeyAsLong.class);
-            obj.setId(i);
+            PrimaryKeyAsLong obj = realm.createObject(PrimaryKeyAsLong.class, i);
             obj.setName("String"); // Create duplicate values
         }
 
@@ -175,7 +171,7 @@ public class RealmAnnotationTests {
     public void primaryKey_checkPrimaryKeyOnCreate() {
         realm.beginTransaction();
         try {
-            realm.createObject(AnnotationTypes.class);
+            realm.createObject(AnnotationTypes.class, 0);
             fail("Two empty objects cannot be created on the same table if a primary key is defined");
         } catch (RealmPrimaryKeyConstraintException ignored) {
         } finally {
@@ -187,8 +183,7 @@ public class RealmAnnotationTests {
     @Test
     public void primaryKey_defaultStringValue() {
         realm.beginTransaction();
-        PrimaryKeyAsString str = realm.createObject(PrimaryKeyAsString.class);
-        str.setName("");
+        realm.createObject(PrimaryKeyAsString.class, "");
         realm.commitTransaction();
     }
 
@@ -196,7 +191,7 @@ public class RealmAnnotationTests {
     @Test
     public void primaryKey_defaultLongValue() {
         realm.beginTransaction();
-        PrimaryKeyAsLong str = realm.createObject(PrimaryKeyAsLong.class);
+        PrimaryKeyAsLong str = realm.createObject(PrimaryKeyAsLong.class, 0);
         str.setId(0);
         realm.commitTransaction();
     }
@@ -205,10 +200,8 @@ public class RealmAnnotationTests {
     public void primaryKey_errorOnInsertingSameObject() {
         try {
             realm.beginTransaction();
-            AnnotationTypes obj1 = realm.createObject(AnnotationTypes.class);
-            obj1.setId(1);
-            AnnotationTypes obj2 = realm.createObject(AnnotationTypes.class);
-            obj2.setId(1);
+            realm.createObject(AnnotationTypes.class, 1);
+            realm.createObject(AnnotationTypes.class, 1);
             fail("Inserting two objects with same primary key should fail");
         } catch (RealmPrimaryKeyConstraintException ignored) {
         } finally {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmChangeListenerTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmChangeListenerTests.java
@@ -127,7 +127,7 @@ public class RealmChangeListenerTests {
         });
 
         realm.beginTransaction();
-        AllTypesRealmModel model = realm.createObject(AllTypesRealmModel.class);
+        AllTypesRealmModel model = realm.createObject(AllTypesRealmModel.class, 0);
         model.columnString = "data 1";
         realm.commitTransaction();
     }
@@ -160,7 +160,7 @@ public class RealmChangeListenerTests {
     public void returnedRealmModelIsNotNull() {
         Realm realm = looperThread.realm;
         realm.beginTransaction();
-        AllTypesRealmModel model = realm.createObject(AllTypesRealmModel.class);
+        AllTypesRealmModel model = realm.createObject(AllTypesRealmModel.class, 0);
         realm.commitTransaction();
 
         looperThread.keepStrongReference.add(model);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
@@ -137,7 +137,7 @@ public class RealmCollectionTests extends CollectionTests {
         switch (collectionClass) {
             case MANAGED_REALMLIST:
                 realm.beginTransaction();
-                NullTypes obj = realm.createObject(NullTypes.class);
+                NullTypes obj = realm.createObject(NullTypes.class, 0);
                 realm.commitTransaction();
                 return obj.getFieldListNull();
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -515,9 +515,9 @@ public class RealmMigrationTests {
             realm.executeTransaction(new DynamicRealm.Transaction() {
                 @Override
                 public void execute(DynamicRealm realm) {
-                    realm.createObject(className).setString(MigrationPrimaryKey.FIELD_PRIMARY, "12");
+                    realm.createObject(className, "12");
                     if (insertNullValue) {
-                        realm.createObject(className).setString(MigrationPrimaryKey.FIELD_PRIMARY, null);
+                        realm.createObject(className, null);
                     }
                 }
             });

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -971,7 +971,7 @@ public class RealmObjectTests {
     @Test
     public void set_get_nullOnNullableFields() {
         realm.beginTransaction();
-        NullTypes nullTypes = realm.createObject(NullTypes.class);
+        NullTypes nullTypes = realm.createObject(NullTypes.class, 0);
         // 1 String
         nullTypes.setFieldStringNull(null);
         // 2 Bytes
@@ -1024,7 +1024,7 @@ public class RealmObjectTests {
         final byte[] testBytes = new byte[] {42};
         final Date testDate = newDate(2000, 1, 1);
         realm.beginTransaction();
-        NullTypes nullTypes = realm.createObject(NullTypes.class);
+        NullTypes nullTypes = realm.createObject(NullTypes.class, 0);
         // 1 String
         nullTypes.setFieldStringNull(testString);
         // 2 Bytes
@@ -1075,7 +1075,7 @@ public class RealmObjectTests {
     public void set_nullValuesToNonNullableFields() {
         try {
             realm.beginTransaction();
-            NullTypes nullTypes = realm.createObject(NullTypes.class);
+            NullTypes nullTypes = realm.createObject(NullTypes.class, 0);
             // 1 String
             try {
                 nullTypes.setFieldStringNotNull(null);
@@ -1144,7 +1144,7 @@ public class RealmObjectTests {
     @Test
     public void defaultValuesForNewObject() {
         realm.beginTransaction();
-        NullTypes nullTypes = realm.createObject(NullTypes.class);
+        NullTypes nullTypes = realm.createObject(NullTypes.class, 0);
         realm.commitTransaction();
 
         assertNotNull(nullTypes);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -2547,8 +2547,7 @@ public class RealmQueryTests {
                 // Crash with i == 1000, 500, 100, 89, 85, 84
                 // Doesn't crash for i == 10, 50, 75, 82, 83
                 for (int i = 0; i < 84; i++) {
-                    AllJavaTypes obj = realm.createObject(AllJavaTypes.class);
-                    obj.setFieldLong(i + 1);
+                    AllJavaTypes obj = realm.createObject(AllJavaTypes.class, i + 1);
                     obj.setFieldBoolean(i % 2 == 0);
                     obj.setFieldObject(obj);
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -1243,7 +1243,7 @@ public class RealmTests {
     @Test
     public void copyToRealm_primaryKeyIsSetDirectly() {
         realm.beginTransaction();
-        realm.createObject(OwnerPrimaryKey.class);
+        realm.createObject(OwnerPrimaryKey.class, 0);
         realm.copyToRealm(new OwnerPrimaryKey(1, "Foo"));
         realm.commitTransaction();
         assertEquals(2, realm.where(OwnerPrimaryKey.class).count());
@@ -1323,9 +1323,8 @@ public class RealmTests {
         realm.beginTransaction();
 
         // Child object is managed by Realm
-        CyclicTypePrimaryKey childObj = realm.createObject(CyclicTypePrimaryKey.class);
+        CyclicTypePrimaryKey childObj = realm.createObject(CyclicTypePrimaryKey.class, 1);
         childObj.setName("Child");
-        childObj.setId(1);
 
         // Parent object is an unmanaged object
         CyclicTypePrimaryKey parentObj = new CyclicTypePrimaryKey(2);
@@ -1737,7 +1736,7 @@ public class RealmTests {
         final CountDownLatch bgThreadDoneLatch = new CountDownLatch(1);
 
         realm.beginTransaction();
-        final OwnerPrimaryKey ownerPrimaryKey = realm.createObject(OwnerPrimaryKey.class);
+        final OwnerPrimaryKey ownerPrimaryKey = realm.createObject(OwnerPrimaryKey.class, 0);
         realm.commitTransaction();
 
         new Thread(new Runnable() {
@@ -1949,8 +1948,7 @@ public class RealmTests {
         realm.beginTransaction();
 
         // Create an owner with two dogs
-        OwnerPrimaryKey owner = realm.createObject(OwnerPrimaryKey.class);
-        owner.setId(1);
+        OwnerPrimaryKey owner = realm.createObject(OwnerPrimaryKey.class, 1);
         owner.setName("Jack");
         Dog rex = realm.createObject(Dog.class);
         rex.setName("Rex");


### PR DESCRIPTION
Since Realm.createObject(class) will be deprecated on master for Classes
with primary key defined, fix the test cases which use it first to avoid
more conflicts when merging.