### PR TITLE
fix Javadoc documentation about encryption key length (64 bit -> 64 bytes)

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -443,7 +443,7 @@ public final class RealmConfiguration {
         }
 
         /**
-         * Sets the 64 bit key used to encrypt and decrypt the Realm file.
+         * Sets the {@value io.realm.RealmConfiguration#KEY_LENGTH} bytes key used to encrypt and decrypt the Realm file.
          */
         public Builder encryptionKey(byte[] key) {
             if (key == null) {


### PR DESCRIPTION
fixes #3389