### PR TITLE
Allow to specify default value of the field in model's constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Importing from JSON without the primary key field defined in the JSON object now throws `IllegalArgumentException`.
 * Now `Realm.beginTransaction()`, `Realm.executeTransaction()` and `Realm.waitForChange()` throw `RealmMigrationNeededException` if a remote process introduces incompatible schema changes (#3409).
 * The primary key value of an object can no longer be changed after the object was created. Instead a new object must be created and all fields copied over.
-* Now `Realm.createObject(Class)` and `Realm.createObject(Class,Object)` take the values from the model's fields and default constructor (#777).
+* Now `Realm.createObject(Class)` and `Realm.createObject(Class,Object)` take the values from the model's fields and default constructor. `DynamicRealm` does not take these default values (#777).
 * When `Realm.create*FromJson()`s create a new `RealmObject`, now they take the default values defined by the field itself and its default constructor for those fields that are not defined in the JSON object.
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 2.0.0
 
-### Known issues
-
-* When creating a `RealmObject` from a JSON stream, it will take the default values defined by its default constructor for those fields that are not defined in the JSON object. This behaviour is different from other APIs when creating `RealmObject`s.
-
 ### Breaking Changes
 
 * `isValid()` now always returns `true` instead of `false` for unmanaged `RealmObject` and `RealmList`. This puts it in line with the behaviour of the Cocoa and .NET API's (#3101).
@@ -17,6 +13,8 @@
 * Importing from JSON without the primary key field defined in the JSON object now throws `IllegalArgumentException`.
 * Now `Realm.beginTransaction()`, `Realm.executeTransaction()` and `Realm.waitForChange()` throw `RealmMigrationNeededException` if a remote process introduces incompatible schema changes (#3409).
 * The primary key value of an object can no longer be changed after the object was created. Instead a new object must be created and all fields copied over.
+* Now `Realm.createObject(Class)` and `Realm.createObject(Class,Object)` take the values from the model's constructor (#777).
+* When `Realm.create*FromJson()`s create a new `RealmObject`, now they take the default values defined by its default constructor for those fields that are not defined in the JSON object.
 
 ### Enhancements
 
@@ -30,6 +28,7 @@
 * Fixed a lint error in proxy classes when the 'minSdkVersion' of user's project is smaller than 11 (#3356).
 * Fixed a potential crash when there were lots of async queries waiting in the queue.
 * Fixed a bug causing the Realm Transformer to not transform field access in the model's constructors (#3361).
+* Fixed a bug causing the `NullPointerException` when calling getters/setters in the model's constructors (#2536).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 * Importing from JSON without the primary key field defined in the JSON object now throws `IllegalArgumentException`.
 * Now `Realm.beginTransaction()`, `Realm.executeTransaction()` and `Realm.waitForChange()` throw `RealmMigrationNeededException` if a remote process introduces incompatible schema changes (#3409).
 * The primary key value of an object can no longer be changed after the object was created. Instead a new object must be created and all fields copied over.
-* Now `Realm.createObject(Class)` and `Realm.createObject(Class,Object)` take the values from the model's constructor (#777).
-* When `Realm.create*FromJson()`s create a new `RealmObject`, now they take the default values defined by its default constructor for those fields that are not defined in the JSON object.
+* Now `Realm.createObject(Class)` and `Realm.createObject(Class,Object)` take the values from the model's fields and default constructor (#777).
+* When `Realm.create*FromJson()`s create a new `RealmObject`, now they take the default values defined by the field itself and its default constructor for those fields that are not defined in the JSON object.
 
 ### Enhancements
 

--- a/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
@@ -93,8 +93,6 @@ class BytecodeModifier {
         final List<CtField> managedFields
         final CtClass ctClass
         final CtBehavior behavior
-        final boolean isModelClass
-        final boolean isInConstructor
 
         FieldAccessToAccessorConverter(List<CtField> managedFields,
                                        CtClass ctClass,
@@ -103,8 +101,6 @@ class BytecodeModifier {
             this.managedFields = managedFields
             this.ctClass = ctClass
             this.behavior = behavior
-            this.isModelClass = isModelClass
-            this.isInConstructor = behavior instanceof CtConstructor
         }
 
         @Override
@@ -118,23 +114,9 @@ class BytecodeModifier {
                 logger.info "        Methods: ${ctClass.declaredMethods}"
                 def fieldName = fieldAccess.fieldName
                 if (fieldAccess.isReader()) {
-                    if (isInConstructor && isModelClass) {
-                        // work around https://github.com/realm/realm-java/issues/2536
-                        // '$0' is the object that owns target field.
-                        // 'this' is the instance where the constructor belongs.
-                        fieldAccess.replace('$_ = ($0 == this) ? $0.' + fieldName + ' : $0.realmGet$' + fieldName + '();')
-                    } else {
-                        fieldAccess.replace('$_ = $0.realmGet$' + fieldName + '();')
-                    }
+                    fieldAccess.replace('$_ = $0.realmGet$' + fieldName + '();')
                 } else if (fieldAccess.isWriter()) {
-                    if (isInConstructor && isModelClass) {
-                        // work around https://github.com/realm/realm-java/issues/2536
-                        // '$0' is the object that owns target field.
-                        // 'this' is the instance where the constructor belongs.
-                        fieldAccess.replace('if ($0 == this) {$0.' + fieldName + ' = $1;} else { $0.realmSet$' + fieldName + '($1);}')
-                    } else {
-                        fieldAccess.replace('$0.realmSet$' + fieldName + '($1);')
-                    }
+                    fieldAccess.replace('$0.realmSet$' + fieldName + '($1);')
                 }
             }
         }

--- a/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
@@ -57,7 +57,7 @@ class BytecodeModifier {
      * @param clazz The CtClass to modify
      * @param managedFields List of fields whose access should be replaced
      */
-    public static void useRealmAccessors(CtClass clazz, List<CtField> managedFields, List<CtClass> modelClasses) {
+    public static void useRealmAccessors(CtClass clazz, List<CtField> managedFields) {
         clazz.getDeclaredBehaviors().each { behavior ->
             logger.info "    Behavior: ${behavior.name}"
             if (
@@ -69,7 +69,7 @@ class BytecodeModifier {
                     behavior instanceof CtConstructor
                 )
             ) {
-                behavior.instrument(new FieldAccessToAccessorConverter(managedFields, clazz, behavior, modelClasses.contains(clazz)))
+                behavior.instrument(new FieldAccessToAccessorConverter(managedFields, clazz, behavior))
             }
         }
     }
@@ -96,8 +96,7 @@ class BytecodeModifier {
 
         FieldAccessToAccessorConverter(List<CtField> managedFields,
                                        CtClass ctClass,
-                                       CtBehavior behavior,
-                                       boolean isModelClass) {
+                                       CtBehavior behavior) {
             this.managedFields = managedFields
             this.ctClass = ctClass
             this.behavior = behavior

--- a/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
@@ -137,7 +137,7 @@ class RealmTransformer extends Transform {
         inputClassNames.each {
             logger.info "  Modifying class ${it}"
             def ctClass = classPool.getCtClass(it)
-            BytecodeModifier.useRealmAccessors(ctClass, allManagedFields, allModelClasses)
+            BytecodeModifier.useRealmAccessors(ctClass, allManagedFields)
             ctClass.writeFile(getOutputFile(outputProvider).canonicalPath)
         }
 

--- a/realm-transformer/src/test/groovy/io/realm/transformer/BytecodeModifierTest.groovy
+++ b/realm-transformer/src/test/groovy/io/realm/transformer/BytecodeModifierTest.groovy
@@ -126,10 +126,9 @@ class BytecodeModifierTest extends Specification {
         when: 'the field use is replaced by the accessor'
         BytecodeModifier.useRealmAccessors(ctClass, [ctField], [ctClass])
 
-        then: 'the field is still used and also getter is called in the constructor'
-        // to work around https://github.com/realm/realm-java/issues/2536 , field access is not removed
-        isFieldRead(ctDefaultConstructor) && hasMethodCall(ctDefaultConstructor) &&
-                isFieldRead(ctNonDefaultConstructor) && hasMethodCall(ctNonDefaultConstructor)
+        then: 'the field is not used in the method anymore'
+        !isFieldRead(ctDefaultConstructor) && hasMethodCall(ctDefaultConstructor) &&
+                !isFieldRead(ctNonDefaultConstructor) && hasMethodCall(ctNonDefaultConstructor)
     }
 
     def "UseRealmAccessors_fieldAccessInNonModelConstructorIsTransformed"() {

--- a/realm-transformer/src/test/groovy/io/realm/transformer/BytecodeModifierTest.groovy
+++ b/realm-transformer/src/test/groovy/io/realm/transformer/BytecodeModifierTest.groovy
@@ -93,13 +93,13 @@ class BytecodeModifierTest extends Specification {
         BytecodeModifier.addRealmAccessors(ctClass)
 
         when: 'the field use is replaced by the accessor'
-        BytecodeModifier.useRealmAccessors(ctClass, [ctField], [])
+        BytecodeModifier.useRealmAccessors(ctClass, [ctField])
 
         then: 'the field is not used and getter is called in the method '
         !isFieldRead(ctMethod) && hasMethodCall(ctMethod)
     }
 
-    def "UseRealmAccessors_fieldAccessInModelConstructorIsTransformed"() {
+    def "UseRealmAccessors_fieldAccessConstructorIsTransformed"() {
         setup: 'generate an empty class'
         def classPool = ClassPool.getDefault()
         def ctClass = classPool.makeClass('TestClass')
@@ -124,39 +124,7 @@ class BytecodeModifierTest extends Specification {
         BytecodeModifier.addRealmAccessors(ctClass)
 
         when: 'the field use is replaced by the accessor'
-        BytecodeModifier.useRealmAccessors(ctClass, [ctField], [ctClass])
-
-        then: 'the field is not used in the method anymore'
-        !isFieldRead(ctDefaultConstructor) && hasMethodCall(ctDefaultConstructor) &&
-                !isFieldRead(ctNonDefaultConstructor) && hasMethodCall(ctNonDefaultConstructor)
-    }
-
-    def "UseRealmAccessors_fieldAccessInNonModelConstructorIsTransformed"() {
-        setup: 'generate an empty class'
-        def classPool = ClassPool.getDefault()
-        def ctClass = classPool.makeClass('TestClass')
-
-        and: 'add a field'
-        def ctField = new CtField(CtClass.intType, 'age', ctClass)
-        ctClass.addField(ctField)
-
-        and: 'add a method that sets such field'
-        def ctMethod = CtNewMethod.make('private void setupAge(int age) { this.age = age; }', ctClass)
-        ctClass.addMethod(ctMethod)
-
-        and: 'add a default constructor that uses the method'
-        def ctDefaultConstructor = CtNewConstructor.make('public TestClass() { int myAge = this.age; }', ctClass)
-        ctClass.addConstructor(ctDefaultConstructor)
-
-        and: 'add a non-default constructor that uses the method'
-        def ctNonDefaultConstructor = CtNewConstructor.make('public TestClass(TestClass other) { int otherAge = other.age; }', ctClass)
-        ctClass.addConstructor(ctNonDefaultConstructor)
-
-        and: 'realm accessors are added'
-        BytecodeModifier.addRealmAccessors(ctClass)
-
-        when: 'the field use is replaced by the accessor'
-        BytecodeModifier.useRealmAccessors(ctClass, [ctField], [/* no ctClass in model class list*/])
+        BytecodeModifier.useRealmAccessors(ctClass, [ctField])
 
         then: 'the field is not used in the method anymore'
         !isFieldRead(ctDefaultConstructor) && hasMethodCall(ctDefaultConstructor) &&

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -360,10 +360,6 @@ public class ClassMetaData {
         return primaryKey;
     }
 
-    public boolean isPrimaryKey(VariableElement field) {
-        return primaryKey == field;
-    }
-
     public String getPrimaryKeyGetter() {
         return getGetter(primaryKey.getSimpleName().toString());
     }
@@ -375,6 +371,19 @@ public class ClassMetaData {
      */
     public boolean isNullable(VariableElement variableElement) {
         return nullableFields.contains(variableElement);
+    }
+
+    /**
+     * Checks if a VariableElement is a primary key.
+     *
+     * @param variableElement the element/field
+     * @return {@code true} if a VariableElement is primary key, {@code false} otherwise.
+     */
+    public boolean isPrimaryKey(VariableElement variableElement) {
+        if (primaryKey == null) {
+            return false;
+        }
+        return primaryKey.equals(variableElement);
     }
 
     private boolean isValidPrimaryKeyType(TypeMirror type) {

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -360,6 +360,10 @@ public class ClassMetaData {
         return primaryKey;
     }
 
+    public boolean isPrimaryKey(VariableElement field) {
+        return primaryKey == field;
+    }
+
     public String getPrimaryKeyGetter() {
         return getGetter(primaryKey.getSimpleName().toString());
     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
@@ -301,10 +301,10 @@ public class RealmJsonTypeHelper {
             writer
                 .beginControlFlow("if (json.has(\"%s\"))", fieldName)
                     .beginControlFlow("if (json.isNull(\"%s\"))", fieldName)
-                        .emitStatement("obj = (%1$s) realm.createObjectWithoutThreadCheck(%2$s.class, null, true, excludeFields)",
+                        .emitStatement("obj = (%1$s) realm.createObjectInternal(%2$s.class, null, true, excludeFields)",
                                 qualifiedRealmObjectProxyClass, qualifiedRealmObjectClass)
                     .nextControlFlow("else")
-                        .emitStatement("obj = (%1$s) realm.createObjectWithoutThreadCheck(%2$s.class, json.get%3$s(\"%4$s\"), true, excludeFields)",
+                        .emitStatement("obj = (%1$s) realm.createObjectInternal(%2$s.class, json.get%3$s(\"%4$s\"), true, excludeFields)",
                                 qualifiedRealmObjectProxyClass, qualifiedRealmObjectClass, jsonType, fieldName)
                     .endControlFlow()
                 .nextControlFlow("else")

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
@@ -301,10 +301,10 @@ public class RealmJsonTypeHelper {
             writer
                 .beginControlFlow("if (json.has(\"%s\"))", fieldName)
                     .beginControlFlow("if (json.isNull(\"%s\"))", fieldName)
-                        .emitStatement("obj = (%1$s) realm.createObject(%2$s.class, null)",
+                        .emitStatement("obj = (%1$s) realm.createObjectWithoutThreadCheck(%2$s.class, null, true, excludeFields)",
                                 qualifiedRealmObjectProxyClass, qualifiedRealmObjectClass)
                     .nextControlFlow("else")
-                        .emitStatement("obj = (%1$s) realm.createObject(%2$s.class, json.get%3$s(\"%4$s\"))",
+                        .emitStatement("obj = (%1$s) realm.createObjectWithoutThreadCheck(%2$s.class, json.get%3$s(\"%4$s\"), true, excludeFields)",
                                 qualifiedRealmObjectProxyClass, qualifiedRealmObjectClass, jsonType, fieldName)
                     .endControlFlow()
                 .nextControlFlow("else")

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -90,6 +90,28 @@ import io.realm.annotations.RealmClass;
  *  <li>Each time a static helper method is needed, Realm can now delegate these method calls to the appropriate
  *    Mediator which in turn will delegate the method call to the appropriate RealmObjectProxy class.</li>
  * </ol>
+ *
+ * <h1>CREATING A MANAGED RealmObject</h1>
+ *
+ * To allow to specify default values by model's constructor or direct field assignment,
+ * the flow of creating the proxy object is a bit complicated. This section illustrates
+ * how proxy object should be created.
+ *
+ * <ol>
+ *  <li>Get the thread local {@code io.realm.BaseRealm.RealmObjectContext} instance by {@code BaseRealm.objectContext.get()} </li>
+ *  <li>Set the object context information to the {@code RealmObjectContext} those should be set to the creating proxy object.</li>
+ *  <li>Create proxy object ({@code new io.realm.FooRealmProxy()}).</li>
+ *  <li>Set the object context information to the created proxy when the first access of its accessors (or in its constructor if accessors are not used in the model's constructor).</li>
+ *  <li>Clear the object context information in the thread local {@code io.realm.BaseRealm.RealmObjectContext} instance by calling {@code
+ *  #clear()} method.</li>
+ * </ol>
+ *
+ * The reason of this complicated step is that we can't pass these context information
+ * via the constructor of the proxy. It's because the constructor of the proxy is executed
+ * <b>after</b> the constructor of the model class. The access to the fields in the model's
+ * constructor happens before the assignment of the context information to the 'proxyState'.
+ * This will cause the {@link NullPointerException} if getters/setter is accessed in the model's
+ * constructor (see https://github.com/realm/realm-java/issues/2536 ).
  */
 @SupportedAnnotationTypes({
         "io.realm.annotations.RealmClass",

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -725,7 +725,7 @@ public class RealmProxyClassGenerator {
                 .emitStatement("return object")
             .endControlFlow();
 
-        writer.emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();");
+        writer.emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get()");
 
         writer.emitStatement("RealmObjectProxy cachedRealmObject = cache.get(object)");
         writer.beginControlFlow("if (cachedRealmObject != null)")
@@ -777,7 +777,7 @@ public class RealmProxyClassGenerator {
                             .emitStatement("realmObject = new %s()", qualifiedGeneratedClassName)
                             .emitStatement("cache.put(object, (RealmObjectProxy) realmObject)")
                         .nextControlFlow("finally")
-                            .emitStatement("objectContext.clear();")
+                            .emitStatement("objectContext.clear()")
                         .endControlFlow()
 
                     .nextControlFlow("else")
@@ -1579,7 +1579,7 @@ public class RealmProxyClassGenerator {
         writer.emitEmptyLine();
         writer.emitStatement("String path = proxyState.getRealm$realm().getPath()");
         writer.emitStatement("String otherPath = %s.proxyState.getRealm$realm().getPath()", otherObjectVarName);
-        writer.emitStatement("if (path != null ? !path.equals(otherPath) : otherPath != null) return false;");
+        writer.emitStatement("if (path != null ? !path.equals(otherPath) : otherPath != null) return false");
         writer.emitEmptyLine();
         writer.emitStatement("String tableName = proxyState.getRow$realm().getTable().getName()");
         writer.emitStatement("String otherTableName = %s.proxyState.getRow$realm().getTable().getName()", otherObjectVarName);
@@ -1629,12 +1629,12 @@ public class RealmProxyClassGenerator {
             }
             writer
                     .beginControlFlow("if (rowIndex != TableOrView.NO_MATCH)")
-                        .emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();")
+                        .emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get()")
                         .beginControlFlow("try")
                             .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class), false)", qualifiedClassName)
                             .emitStatement("obj = new %s()", qualifiedGeneratedClassName)
                         .nextControlFlow("finally")
-                            .emitStatement("objectContext.clear();")
+                            .emitStatement("objectContext.clear()")
                         .endControlFlow()
                     .endControlFlow()
                 .endControlFlow();

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -276,7 +276,7 @@ public class RealmProxyClassGenerator {
                 writer.emitStatement("proxyState.getRealm$realm().checkIfValid()");
                 // Although setting null value for String and bytes[] can be handled by the JNI code, we still generate the same code here.
                 // Compared with getter, null value won't trigger more native calls in setter which is relatively cheaper.
-                if (field.equals(metadata.getPrimaryKey())) {
+                if (metadata.isPrimaryKey(field)) {
                     // Primary key is not allowed to be changed after object created.
                     writer.emitStatement(Constants.STATEMENT_EXCEPTION_PRIMARY_KEY_CANNOT_BE_CHANGED, fieldName);
                 } else {
@@ -577,7 +577,7 @@ public class RealmProxyClassGenerator {
                 if (metadata.isNullable(field)) {
                     writer.beginControlFlow("if (!table.isColumnNullable(%s))", fieldIndexVariableReference(field));
                     // Check if the existing PrimaryKey does support null value for String, Byte, Short, Integer, & Long
-                    if (field.equals(metadata.getPrimaryKey())) {
+                    if (metadata.isPrimaryKey(field)) {
                         writer.emitStatement("throw new RealmMigrationNeededException(sharedRealm.getPath()," +
                                 "\"@PrimaryKey field '%s' does not support null values in the existing Realm file. " +
                                 "Migrate using RealmObjectSchema.setNullable(), or mark the field as @Required.\")",
@@ -598,7 +598,7 @@ public class RealmProxyClassGenerator {
                     writer.endControlFlow();
                 } else {
                     // check before migrating a nullable field containing null value to not-nullable PrimaryKey field for Realm version 0.89+
-                    if (field.equals(metadata.getPrimaryKey())) {
+                    if (metadata.isPrimaryKey(field)) {
                         writer
                             .beginControlFlow("if (table.isColumnNullable(%s) && table.findFirstNull(%s) != TableOrView.NO_MATCH)",
                                     fieldIndexVariableReference(field), fieldIndexVariableReference(field))
@@ -624,7 +624,7 @@ public class RealmProxyClassGenerator {
                 }
 
                 // Validate @PrimaryKey
-                if (field.equals(metadata.getPrimaryKey())) {
+                if (metadata.isPrimaryKey(field)) {
                     writer.beginControlFlow("if (table.getPrimaryKey() != table.getColumnIndex(\"%s\"))", fieldName);
                     writer.emitStatement("throw new RealmMigrationNeededException(sharedRealm.getPath(), \"Primary key not defined for field '%s' in existing Realm file. Add @PrimaryKey.\")", fieldName);
                     writer.endControlFlow();
@@ -1296,7 +1296,7 @@ public class RealmProxyClassGenerator {
                 String setter = metadata.getSetter(fieldName);
                 String getter = metadata.getGetter(fieldName);
 
-                if (field.equals(metadata.getPrimaryKey())) {
+                if (metadata.isPrimaryKey(field)) {
                     // PK has been set when creating object.
                     continue;
                 }
@@ -1647,7 +1647,7 @@ public class RealmProxyClassGenerator {
         for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             String qualifiedFieldType = field.asType().toString();
-            if (field.equals(metadata.getPrimaryKey())) {
+            if (metadata.isPrimaryKey(field)) {
                 // Primary key has already been set when adding new row or finding the existing row.
                 continue;
             }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -401,6 +401,20 @@ public class RealmProxyClassGenerator {
                     writer.beginControlFlow("if (value != null && !RealmObject.isManaged(value))")
                             .emitStatement("value = ((Realm) proxyState.getRealm$realm()).copyToRealm(value)")
                             .endControlFlow();
+                } else if (Utils.isRealmList(field)) {
+                    final String modelFqcn = Utils.getGenericTypeQualifiedName(field);
+                    writer.beginControlFlow("if (value != null && !value.isManaged())")
+                            .emitStatement("final Realm realm = (Realm) proxyState.getRealm$realm()")
+                            .emitStatement("final RealmList<%1$s> original = value", modelFqcn)
+                            .emitStatement("value = new RealmList<%1$s>()", modelFqcn)
+                            .beginControlFlow("for (%1$s item : original)", modelFqcn)
+                                .beginControlFlow("if (item == null || RealmObject.isManaged(item))")
+                                    .emitStatement("value.add(item)")
+                                .nextControlFlow("else")
+                                    .emitStatement("value.add(realm.copyToRealm(item))")
+                                .endControlFlow()
+                            .endControlFlow()
+                        .endControlFlow();
                 }
             }
             writer.endControlFlow()

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -1298,10 +1298,10 @@ public class RealmProxyClassGenerator {
 
             writer.emitSingleLineComment("rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.");
             if (metadata.hasPrimaryKey()) {
-                writer.emitStatement("%s realmObject = realm.createObjectWithoutThreadCheck(%s.class, ((%s) newObject).%s(), false, Collections.<String>emptyList())",
+                writer.emitStatement("%s realmObject = realm.createObjectInternal(%s.class, ((%s) newObject).%s(), false, Collections.<String>emptyList())",
                         qualifiedClassName, qualifiedClassName, interfaceName, metadata.getPrimaryKeyGetter());
             } else {
-                writer.emitStatement("%s realmObject = realm.createObjectWithoutThreadCheck(%s.class, false, Collections.<String>emptyList())",
+                writer.emitStatement("%s realmObject = realm.createObjectInternal(%s.class, false, Collections.<String>emptyList())",
                         qualifiedClassName, qualifiedClassName);
             }
             writer.emitStatement("cache.put(newObject, (RealmObjectProxy) realmObject)");
@@ -1623,7 +1623,7 @@ public class RealmProxyClassGenerator {
         }
         if (!metadata.hasPrimaryKey()) {
             buildExcludeFieldsList(writer, metadata.getFields());
-            writer.emitStatement("%s obj = realm.createObjectWithoutThreadCheck(%s.class, true, excludeFields)",
+            writer.emitStatement("%s obj = realm.createObjectInternal(%s.class, true, excludeFields)",
                     qualifiedClassName, qualifiedClassName);
         } else {
             String pkType = Utils.isString(metadata.getPrimaryKey()) ? "String" : "Long";

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -391,8 +391,7 @@ public class RealmProxyClassGenerator {
         writer.emitEmptyLine();
 
         if (isSetter) {
-            writer.beginControlFlow(
-                    "if (proxyState.isUnderConstruction())");
+            writer.beginControlFlow("if (proxyState.isUnderConstruction())");
             {
                 if (isPrimaryKey) {
                     writer.emitSingleLineComment("default value of the primary key is always ignored.");
@@ -1725,8 +1724,8 @@ public class RealmProxyClassGenerator {
         }
     }
 
-    // Since we need to check the PK in stream before create an object, this is now using copyToRealm instead of
-    // createObject() to avoid parse the stream twice.
+    // Since we need to check the PK in stream before creating the object, this is now using copyToRealm
+    // instead of createObject() to avoid parsing the stream twice.
     private void emitCreateUsingJsonStream(JavaWriter writer) throws IOException {
         writer.emitAnnotation("SuppressWarnings", "\"cast\"");
         writer.emitAnnotation("TargetApi", "Build.VERSION_CODES.HONEYCOMB");

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -200,7 +200,6 @@ public class RealmProxyClassGenerator {
     }
 
     private void emitClassFields(JavaWriter writer) throws IOException {
-        writer.emitField("boolean", "acceptDefaultValue", EnumSet.of(Modifier.PRIVATE));
         writer.emitField(columnInfoClassName(), "columnInfo", EnumSet.of(Modifier.PRIVATE));
         writer.emitField("ProxyState", "proxyState", EnumSet.of(Modifier.PRIVATE));
 
@@ -224,8 +223,7 @@ public class RealmProxyClassGenerator {
 
     private void emitConstructor(JavaWriter writer) throws IOException {
         // FooRealmProxy(ColumnInfo)
-        writer.beginConstructor(EnumSet.noneOf(Modifier.class), "boolean", "acceptDefaultValue");
-        writer.emitStatement("this.acceptDefaultValue = acceptDefaultValue");
+        writer.beginConstructor(EnumSet.noneOf(Modifier.class));
         writer.beginControlFlow("if (proxyState == null)")
                 .emitStatement("injectObjectContext()")
                 .endControlFlow();
@@ -394,7 +392,7 @@ public class RealmProxyClassGenerator {
 
         if (isSetter) {
             writer.beginControlFlow(
-                    "if (proxyState.isUnderConstruction() && !this.acceptDefaultValue)")
+                    "if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm())")
                         .emitStatement("return")
                         .endControlFlow()
                         .emitEmptyLine();
@@ -411,9 +409,9 @@ public class RealmProxyClassGenerator {
         writer.emitStatement("final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get()");
         writer.emitStatement("this.columnInfo = (%1$s) context.getColumnInfo()", columnInfoClassName());
         writer.emitStatement("this.proxyState = new ProxyState(%1$s.class, this)", qualifiedClassName);
-        writer.emitEmptyLine();
         writer.emitStatement("proxyState.setRealm$realm(context.getRealm())");
         writer.emitStatement("proxyState.setRow$realm(context.getRow())");
+        writer.emitStatement("proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue())");
 
         writer.endMethod();
         writer.emitEmptyLine();
@@ -747,8 +745,8 @@ public class RealmProxyClassGenerator {
                 writer
                     .beginControlFlow("if (rowIndex != TableOrView.NO_MATCH)")
                         .beginControlFlow("try")
-                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class))", qualifiedClassName)
-                            .emitStatement("realmObject = new %s(true)", qualifiedGeneratedClassName)
+                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class), true)", qualifiedClassName)
+                            .emitStatement("realmObject = new %s()", qualifiedGeneratedClassName)
                             .emitStatement("cache.put(object, (RealmObjectProxy) realmObject)")
                         .nextControlFlow("finally")
                             .emitStatement("objectContext.clear();")
@@ -1603,8 +1601,8 @@ public class RealmProxyClassGenerator {
                     .beginControlFlow("if (rowIndex != TableOrView.NO_MATCH)")
                         .emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();")
                         .beginControlFlow("try")
-                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class))", qualifiedClassName)
-                            .emitStatement("obj = new %s(true)", qualifiedGeneratedClassName)
+                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class), true)", qualifiedClassName)
+                            .emitStatement("obj = new %s()", qualifiedGeneratedClassName)
                         .nextControlFlow("finally")
                             .emitStatement("objectContext.clear();")
                         .endControlFlow()

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -309,7 +309,7 @@ public class RealmProxyClassGenerator {
                 writer.beginControlFlow("if (proxyState.getRow$realm().isNullLink(%s))", fieldIndexVariableReference(field));
                         writer.emitStatement("return null");
                         writer.endControlFlow();
-                writer.emitStatement("return proxyState.getRealm$realm().get(%s.class, proxyState.getRow$realm().getLink(%s))",
+                writer.emitStatement("return proxyState.getRealm$realm().get(%s.class, proxyState.getRow$realm().getLink(%s), false)",
                         fieldTypeCanonicalName, fieldIndexVariableReference(field));
                 writer.endMethod();
                 writer.emitEmptyLine();
@@ -745,7 +745,7 @@ public class RealmProxyClassGenerator {
                 writer
                     .beginControlFlow("if (rowIndex != TableOrView.NO_MATCH)")
                         .beginControlFlow("try")
-                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class), true)", qualifiedClassName)
+                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class), false)", qualifiedClassName)
                             .emitStatement("realmObject = new %s()", qualifiedGeneratedClassName)
                             .emitStatement("cache.put(object, (RealmObjectProxy) realmObject)")
                         .nextControlFlow("finally")
@@ -1601,7 +1601,7 @@ public class RealmProxyClassGenerator {
                     .beginControlFlow("if (rowIndex != TableOrView.NO_MATCH)")
                         .emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();")
                         .beginControlFlow("try")
-                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class), true)", qualifiedClassName)
+                            .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(%s.class), false)", qualifiedClassName)
                             .emitStatement("obj = new %s()", qualifiedGeneratedClassName)
                         .nextControlFlow("finally")
                             .emitStatement("objectContext.clear();")

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -77,6 +77,7 @@ public class RealmProxyMediatorGenerator {
                 "io.realm.internal.SharedRealm",
                 "io.realm.internal.RealmObjectProxy",
                 "io.realm.internal.RealmProxyMediator",
+                "io.realm.internal.Row",
                 "io.realm.internal.Table",
                 "org.json.JSONException",
                 "org.json.JSONObject"
@@ -204,14 +205,24 @@ public class RealmProxyMediatorGenerator {
                 "<E extends RealmModel> E",
                 "newInstance",
                 EnumSet.of(Modifier.PUBLIC),
-                "Class<E>", "clazz"
+                "Class<E>", "clazz",
+                "Object", "baseRealm",
+                "Row", "row",
+                "ColumnInfo", "columnInfo",
+                "boolean", "acceptDefaultValue"
         );
+        writer.emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get()");
+        writer.beginControlFlow("try")
+                .emitStatement("objectContext.set((BaseRealm) baseRealm, row, columnInfo)");
         emitMediatorSwitch(new ProxySwitchStatement() {
             @Override
             public void emitStatement(int i, JavaWriter writer) throws IOException {
-                writer.emitStatement("return clazz.cast(new %s())", qualifiedProxyClasses.get(i));
+                writer.emitStatement("return clazz.cast(new %s(acceptDefaultValue))", qualifiedProxyClasses.get(i));
             }
         }, writer);
+        writer.nextControlFlow("finally")
+                .emitStatement("objectContext.clear()")
+                .endControlFlow();
         writer.endMethod();
         writer.emitEmptyLine();
     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -204,12 +204,12 @@ public class RealmProxyMediatorGenerator {
                 "<E extends RealmModel> E",
                 "newInstance",
                 EnumSet.of(Modifier.PUBLIC),
-                "Class<E>", "clazz", "ColumnInfo", "columnInfo"
+                "Class<E>", "clazz"
         );
         emitMediatorSwitch(new ProxySwitchStatement() {
             @Override
             public void emitStatement(int i, JavaWriter writer) throws IOException {
-                writer.emitStatement("return clazz.cast(new %s(columnInfo))", qualifiedProxyClasses.get(i));
+                writer.emitStatement("return clazz.cast(new %s())", qualifiedProxyClasses.get(i));
             }
         }, writer);
         writer.endMethod();

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -209,11 +209,12 @@ public class RealmProxyMediatorGenerator {
                 "Object", "baseRealm",
                 "Row", "row",
                 "ColumnInfo", "columnInfo",
-                "boolean", "acceptDefaultValue"
+                "boolean", "acceptDefaultValue",
+                "List<String>", "excludeFields"
         );
         writer.emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get()");
         writer.beginControlFlow("try")
-                .emitStatement("objectContext.set((BaseRealm) baseRealm, row, columnInfo, acceptDefaultValue)");
+                .emitStatement("objectContext.set((BaseRealm) baseRealm, row, columnInfo, acceptDefaultValue, excludeFields)");
         emitMediatorSwitch(new ProxySwitchStatement() {
             @Override
             public void emitStatement(int i, JavaWriter writer) throws IOException {

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -213,11 +213,11 @@ public class RealmProxyMediatorGenerator {
         );
         writer.emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get()");
         writer.beginControlFlow("try")
-                .emitStatement("objectContext.set((BaseRealm) baseRealm, row, columnInfo)");
+                .emitStatement("objectContext.set((BaseRealm) baseRealm, row, columnInfo, acceptDefaultValue)");
         emitMediatorSwitch(new ProxySwitchStatement() {
             @Override
             public void emitStatement(int i, JavaWriter writer) throws IOException {
-                writer.emitStatement("return clazz.cast(new %s(acceptDefaultValue))", qualifiedProxyClasses.get(i));
+                writer.emitStatement("return clazz.cast(new %s())", qualifiedProxyClasses.get(i));
             }
         }, writer);
         writer.nextControlFlow("finally")

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -139,8 +139,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -164,8 +166,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -189,8 +193,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -214,8 +220,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -239,8 +247,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -264,8 +274,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -292,8 +304,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -322,8 +336,13 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
+            if (value != null && !RealmObject.isManaged(value)) {
+                value = ((Realm) proxyState.getRealm$realm()).copyToRealm(value);
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -364,8 +383,10 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         LinkView links = proxyState.getRow$realm().getLinkList(columnInfo.columnRealmListIndex);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -140,9 +140,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         }
 
         if (proxyState.isUnderConstruction()) {
-            if (!proxyState.getAcceptDefaultValue$realm()) {
-                return;
-            }
+            // default value of the primary key is always ignored.
+            return;
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -386,6 +385,18 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
                 return;
+            }
+            if (value != null && !value.isManaged()) {
+                final Realm realm = (Realm) proxyState.getRealm$realm();
+                final RealmList<some.test.AllTypes> original = value;
+                value = new RealmList<some.test.AllTypes>();
+                for (some.test.AllTypes item : original) {
+                    if (item == null || RealmObject.isManaged(item)) {
+                        value.add(item);
+                    } else {
+                        value.add(realm.copyToRealm(item));
+                    }
+                }
             }
         }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -120,6 +120,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
         proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
+        proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
     @SuppressWarnings("cast")
@@ -326,7 +327,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         if (proxyState.getRow$realm().isNullLink(columnInfo.columnObjectIndex)) {
             return null;
         }
-        return proxyState.getRealm$realm().get(some.test.AllTypes.class, proxyState.getRow$realm().getLink(columnInfo.columnObjectIndex), false);
+        return proxyState.getRealm$realm().get(some.test.AllTypes.class, proxyState.getRow$realm().getLink(columnInfo.columnObjectIndex), false, Collections.<String>emptyList());
     }
 
     public void realmSet$columnObject(some.test.AllTypes value) {
@@ -337,6 +338,9 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
+            if (proxyState.getExcludeFields$realm().contains("columnObject")) {
                 return;
             }
             if (value != null && !RealmObject.isManaged(value)) {
@@ -384,6 +388,9 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
+            if (proxyState.getExcludeFields$realm().contains("columnRealmList")) {
                 return;
             }
             if (value != null && !value.isManaged()) {
@@ -574,6 +581,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     @SuppressWarnings("cast")
     public static some.test.AllTypes createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
+        final List<String> excludeFields = new ArrayList<String>(2);
         some.test.AllTypes obj = null;
         if (update) {
             Table table = realm.getTable(some.test.AllTypes.class);
@@ -587,7 +595,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             if (rowIndex != TableOrView.NO_MATCH) {
                 final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
                 try {
-                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false);
+                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false, Collections.<String> emptyList());
                     obj = new io.realm.AllTypesRealmProxy();
                 } finally {
                     objectContext.clear();
@@ -595,11 +603,17 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             }
         }
         if (obj == null) {
+            if (json.has("columnObject")) {
+                excludeFields.add("columnObject");
+            }
+            if (json.has("columnRealmList")) {
+                excludeFields.add("columnRealmList");
+            }
             if (json.has("columnString")) {
                 if (json.isNull("columnString")) {
-                    obj = (io.realm.AllTypesRealmProxy) realm.createObject(some.test.AllTypes.class, null);
+                    obj = (io.realm.AllTypesRealmProxy) realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, null, true, excludeFields);
                 } else {
-                    obj = (io.realm.AllTypesRealmProxy) realm.createObject(some.test.AllTypes.class, json.getString("columnString"));
+                    obj = (io.realm.AllTypesRealmProxy) realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, json.getString("columnString"), true, excludeFields);
                 }
             } else {
                 throw new IllegalArgumentException("JSON object doesn't have the primary key field 'columnString'.");
@@ -798,7 +812,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 }
                 if (rowIndex != TableOrView.NO_MATCH) {
                     try {
-                        objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false);
+                        objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false, Collections.<String> emptyList());
                         realmObject = new io.realm.AllTypesRealmProxy();
                         cache.put(object, (RealmObjectProxy) realmObject);
                     } finally {
@@ -823,7 +837,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             return (some.test.AllTypes) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.AllTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, ((AllTypesRealmProxyInterface) newObject).realmGet$columnString(), false);
+            some.test.AllTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, ((AllTypesRealmProxyInterface) newObject).realmGet$columnString(), false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnLong(((AllTypesRealmProxyInterface) newObject).realmGet$columnLong());
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnFloat(((AllTypesRealmProxyInterface) newObject).realmGet$columnFloat());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -88,6 +88,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         }
 
     }
+    private boolean acceptDefaultValue;
     private AllTypesColumnInfo columnInfo;
     private ProxyState proxyState;
     private RealmList<some.test.AllTypes> columnRealmListRealmList;
@@ -106,7 +107,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    AllTypesRealmProxy() {
+    AllTypesRealmProxy(boolean acceptDefaultValue) {
+        this.acceptDefaultValue = acceptDefaultValue;
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -139,7 +141,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -164,7 +166,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -189,7 +191,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -214,7 +216,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -239,7 +241,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -264,7 +266,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -292,7 +294,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -322,7 +324,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -364,7 +366,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -556,7 +558,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
                 try {
                     objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class));
-                    obj = new io.realm.AllTypesRealmProxy();
+                    obj = new io.realm.AllTypesRealmProxy(true);
                 } finally {
                     objectContext.clear();;
                 }
@@ -767,7 +769,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 if (rowIndex != TableOrView.NO_MATCH) {
                     try {
                         objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class));
-                        realmObject = new io.realm.AllTypesRealmProxy();
+                        realmObject = new io.realm.AllTypesRealmProxy(true);
                         cache.put(object, (RealmObjectProxy) realmObject);
                     } finally {
                         objectContext.clear();;

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -88,8 +88,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         }
 
     }
-    private final AllTypesColumnInfo columnInfo;
-    private final ProxyState proxyState;
+    private AllTypesColumnInfo columnInfo;
+    private ProxyState proxyState;
     private RealmList<some.test.AllTypes> columnRealmListRealmList;
     private static final List<String> FIELD_NAMES;
     static {
@@ -106,73 +106,168 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    AllTypesRealmProxy(ColumnInfo columnInfo) {
-        this.columnInfo = (AllTypesColumnInfo) columnInfo;
+    AllTypesRealmProxy() {
+        if (proxyState == null) {
+            injectObjectContext();
+        }
+        proxyState.setConstructionFinished();
+    }
+
+    private void injectObjectContext() {
+        final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
+        this.columnInfo = (AllTypesColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.AllTypes.class, this);
+
+        proxyState.setRealm$realm(context.getRealm());
+        proxyState.setRow$realm(context.getRow());
     }
 
     @SuppressWarnings("cast")
     public String realmGet$columnString() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.columnStringIndex);
     }
 
     public void realmSet$columnString(String value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         throw new io.realm.exceptions.RealmException("Primary key field 'columnString' cannot be changed after object was created.");
     }
 
     @SuppressWarnings("cast")
     public long realmGet$columnLong() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (long) proxyState.getRow$realm().getLong(columnInfo.columnLongIndex);
     }
 
     public void realmSet$columnLong(long value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setLong(columnInfo.columnLongIndex, value);
     }
 
     @SuppressWarnings("cast")
     public float realmGet$columnFloat() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (float) proxyState.getRow$realm().getFloat(columnInfo.columnFloatIndex);
     }
 
     public void realmSet$columnFloat(float value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setFloat(columnInfo.columnFloatIndex, value);
     }
 
     @SuppressWarnings("cast")
     public double realmGet$columnDouble() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (double) proxyState.getRow$realm().getDouble(columnInfo.columnDoubleIndex);
     }
 
     public void realmSet$columnDouble(double value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setDouble(columnInfo.columnDoubleIndex, value);
     }
 
     @SuppressWarnings("cast")
     public boolean realmGet$columnBoolean() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.columnBooleanIndex);
     }
 
     public void realmSet$columnBoolean(boolean value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setBoolean(columnInfo.columnBooleanIndex, value);
     }
 
     @SuppressWarnings("cast")
     public Date realmGet$columnDate() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (java.util.Date) proxyState.getRow$realm().getDate(columnInfo.columnDateIndex);
     }
 
     public void realmSet$columnDate(Date value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'columnDate' to null.");
@@ -182,11 +277,25 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
     @SuppressWarnings("cast")
     public byte[] realmGet$columnBinary() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (byte[]) proxyState.getRow$realm().getBinaryByteArray(columnInfo.columnBinaryIndex);
     }
 
     public void realmSet$columnBinary(byte[] value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'columnBinary' to null.");
@@ -195,6 +304,11 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     }
 
     public some.test.AllTypes realmGet$columnObject() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNullLink(columnInfo.columnObjectIndex)) {
             return null;
@@ -203,6 +317,15 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     }
 
     public void realmSet$columnObject(some.test.AllTypes value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().nullifyLink(columnInfo.columnObjectIndex);
@@ -218,6 +341,11 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     }
 
     public RealmList<some.test.AllTypes> realmGet$columnRealmList() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         // use the cached value if available
         if (columnRealmListRealmList != null) {
@@ -231,6 +359,15 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
     public void realmSet$columnRealmList(RealmList<some.test.AllTypes> value) {
         proxyState.getRealm$realm().checkIfValid();
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         LinkView links = proxyState.getRow$realm().getLinkList(columnInfo.columnRealmListIndex);
         links.clear();
         if (value == null) {
@@ -416,9 +553,13 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 rowIndex = table.findFirstString(pkColumnIndex, json.getString("columnString"));
             }
             if (rowIndex != TableOrView.NO_MATCH) {
-                obj = new io.realm.AllTypesRealmProxy(realm.schema.getColumnInfo(some.test.AllTypes.class));
-                ((RealmObjectProxy)obj).realmGet$proxyState().setRealm$realm(realm);
-                ((RealmObjectProxy)obj).realmGet$proxyState().setRow$realm(table.getUncheckedRow(rowIndex));
+                final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
+                try {
+                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class));
+                    obj = new io.realm.AllTypesRealmProxy();
+                } finally {
+                    objectContext.clear();;
+                }
             }
         }
         if (obj == null) {
@@ -606,6 +747,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.AllTypes) cachedRealmObject;
@@ -623,10 +765,13 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                     rowIndex = table.findFirstString(pkColumnIndex, value);
                 }
                 if (rowIndex != TableOrView.NO_MATCH) {
-                    realmObject = new io.realm.AllTypesRealmProxy(realm.schema.getColumnInfo(some.test.AllTypes.class));
-                    ((RealmObjectProxy)realmObject).realmGet$proxyState().setRealm$realm(realm);
-                    ((RealmObjectProxy)realmObject).realmGet$proxyState().setRow$realm(table.getUncheckedRow(rowIndex));
-                    cache.put(object, (RealmObjectProxy) realmObject);
+                    try {
+                        objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class));
+                        realmObject = new io.realm.AllTypesRealmProxy();
+                        cache.put(object, (RealmObjectProxy) realmObject);
+                    } finally {
+                        objectContext.clear();;
+                    }
                 } else {
                     canUpdate = false;
                 }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -313,7 +313,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         if (proxyState.getRow$realm().isNullLink(columnInfo.columnObjectIndex)) {
             return null;
         }
-        return proxyState.getRealm$realm().get(some.test.AllTypes.class, proxyState.getRow$realm().getLink(columnInfo.columnObjectIndex));
+        return proxyState.getRealm$realm().get(some.test.AllTypes.class, proxyState.getRow$realm().getLink(columnInfo.columnObjectIndex), false);
     }
 
     public void realmSet$columnObject(some.test.AllTypes value) {
@@ -555,7 +555,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             if (rowIndex != TableOrView.NO_MATCH) {
                 final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
                 try {
-                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), true);
+                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false);
                     obj = new io.realm.AllTypesRealmProxy();
                 } finally {
                     objectContext.clear();;
@@ -766,7 +766,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 }
                 if (rowIndex != TableOrView.NO_MATCH) {
                     try {
-                        objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), true);
+                        objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false);
                         realmObject = new io.realm.AllTypesRealmProxy();
                         cache.put(object, (RealmObjectProxy) realmObject);
                     } finally {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -822,7 +822,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         if (cachedRealmObject != null) {
             return (some.test.AllTypes) cachedRealmObject;
         } else {
-            some.test.AllTypes realmObject = realm.createObject(some.test.AllTypes.class, ((AllTypesRealmProxyInterface) newObject).realmGet$columnString());
+            // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
+            some.test.AllTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, ((AllTypesRealmProxyInterface) newObject).realmGet$columnString(), false);
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnLong(((AllTypesRealmProxyInterface) newObject).realmGet$columnLong());
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnFloat(((AllTypesRealmProxyInterface) newObject).realmGet$columnFloat());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -88,7 +88,6 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         }
 
     }
-    private boolean acceptDefaultValue;
     private AllTypesColumnInfo columnInfo;
     private ProxyState proxyState;
     private RealmList<some.test.AllTypes> columnRealmListRealmList;
@@ -107,8 +106,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    AllTypesRealmProxy(boolean acceptDefaultValue) {
-        this.acceptDefaultValue = acceptDefaultValue;
+    AllTypesRealmProxy() {
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -119,9 +117,9 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (AllTypesColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.AllTypes.class, this);
-
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
+        proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
     }
 
     @SuppressWarnings("cast")
@@ -141,7 +139,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -166,7 +164,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -191,7 +189,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -216,7 +214,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -241,7 +239,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -266,7 +264,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -294,7 +292,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -324,7 +322,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -366,7 +364,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -557,8 +555,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             if (rowIndex != TableOrView.NO_MATCH) {
                 final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
                 try {
-                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class));
-                    obj = new io.realm.AllTypesRealmProxy(true);
+                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), true);
+                    obj = new io.realm.AllTypesRealmProxy();
                 } finally {
                     objectContext.clear();;
                 }
@@ -768,8 +766,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 }
                 if (rowIndex != TableOrView.NO_MATCH) {
                     try {
-                        objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class));
-                        realmObject = new io.realm.AllTypesRealmProxy(true);
+                        objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), true);
+                        realmObject = new io.realm.AllTypesRealmProxy();
                         cache.put(object, (RealmObjectProxy) realmObject);
                     } finally {
                         objectContext.clear();;

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -611,9 +611,9 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             }
             if (json.has("columnString")) {
                 if (json.isNull("columnString")) {
-                    obj = (io.realm.AllTypesRealmProxy) realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, null, true, excludeFields);
+                    obj = (io.realm.AllTypesRealmProxy) realm.createObjectInternal(some.test.AllTypes.class, null, true, excludeFields);
                 } else {
-                    obj = (io.realm.AllTypesRealmProxy) realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, json.getString("columnString"), true, excludeFields);
+                    obj = (io.realm.AllTypesRealmProxy) realm.createObjectInternal(some.test.AllTypes.class, json.getString("columnString"), true, excludeFields);
                 }
             } else {
                 throw new IllegalArgumentException("JSON object doesn't have the primary key field 'columnString'.");
@@ -837,7 +837,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             return (some.test.AllTypes) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.AllTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.AllTypes.class, ((AllTypesRealmProxyInterface) newObject).realmGet$columnString(), false, Collections.<String>emptyList());
+            some.test.AllTypes realmObject = realm.createObjectInternal(some.test.AllTypes.class, ((AllTypesRealmProxyInterface) newObject).realmGet$columnString(), false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnLong(((AllTypesRealmProxyInterface) newObject).realmGet$columnLong());
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnFloat(((AllTypesRealmProxyInterface) newObject).realmGet$columnFloat());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -585,12 +585,12 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 rowIndex = table.findFirstString(pkColumnIndex, json.getString("columnString"));
             }
             if (rowIndex != TableOrView.NO_MATCH) {
-                final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
+                final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
                 try {
                     objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false);
                     obj = new io.realm.AllTypesRealmProxy();
                 } finally {
-                    objectContext.clear();;
+                    objectContext.clear();
                 }
             }
         }
@@ -779,7 +779,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
-        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.AllTypes) cachedRealmObject;
@@ -802,7 +802,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                         realmObject = new io.realm.AllTypesRealmProxy();
                         cache.put(object, (RealmObjectProxy) realmObject);
                     } finally {
-                        objectContext.clear();;
+                        objectContext.clear();
                     }
                 } else {
                     canUpdate = false;
@@ -1272,7 +1272,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
         String path = proxyState.getRealm$realm().getPath();
         String otherPath = aAllTypes.proxyState.getRealm$realm().getPath();
-        if (path != null ? !path.equals(otherPath) : otherPath != null) return false;;
+        if (path != null ? !path.equals(otherPath) : otherPath != null) return false;
 
         String tableName = proxyState.getRow$realm().getTable().getName();
         String otherTableName = aAllTypes.proxyState.getRow$realm().getTable().getName();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -68,7 +68,6 @@ public class BooleansRealmProxy extends some.test.Booleans
         }
 
     }
-    private boolean acceptDefaultValue;
     private BooleansColumnInfo columnInfo;
     private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
@@ -81,8 +80,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    BooleansRealmProxy(boolean acceptDefaultValue) {
-        this.acceptDefaultValue = acceptDefaultValue;
+    BooleansRealmProxy() {
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -93,9 +91,9 @@ public class BooleansRealmProxy extends some.test.Booleans
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (BooleansColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.Booleans.class, this);
-
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
+        proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
     }
 
     @SuppressWarnings("cast")
@@ -115,7 +113,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -140,7 +138,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -165,7 +163,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -190,7 +188,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -293,7 +293,7 @@ public class BooleansRealmProxy extends some.test.Booleans
     public static some.test.Booleans createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
         final List<String> excludeFields = Collections.<String> emptyList();
-        some.test.Booleans obj = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, true, excludeFields);
+        some.test.Booleans obj = realm.createObjectInternal(some.test.Booleans.class, true, excludeFields);
         if (json.has("done")) {
             if (json.isNull("done")) {
                 throw new IllegalArgumentException("Trying to set non-nullable field 'done' to null.");
@@ -392,7 +392,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             return (some.test.Booleans) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.Booleans realmObject = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, false, Collections.<String>emptyList());
+            some.test.Booleans realmObject = realm.createObjectInternal(some.test.Booleans.class, false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((BooleansRealmProxyInterface) realmObject).realmSet$done(((BooleansRealmProxyInterface) newObject).realmGet$done());
             ((BooleansRealmProxyInterface) realmObject).realmSet$isReady(((BooleansRealmProxyInterface) newObject).realmGet$isReady());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -291,7 +291,7 @@ public class BooleansRealmProxy extends some.test.Booleans
     @SuppressWarnings("cast")
     public static some.test.Booleans createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
-        some.test.Booleans obj = realm.createObject(some.test.Booleans.class);
+        some.test.Booleans obj = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, true);
         if (json.has("done")) {
             if (json.isNull("done")) {
                 throw new IllegalArgumentException("Trying to set non-nullable field 'done' to null.");
@@ -389,7 +389,8 @@ public class BooleansRealmProxy extends some.test.Booleans
         if (cachedRealmObject != null) {
             return (some.test.Booleans) cachedRealmObject;
         } else {
-            some.test.Booleans realmObject = realm.createObject(some.test.Booleans.class);
+            // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
+            some.test.Booleans realmObject = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, false);
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((BooleansRealmProxyInterface) realmObject).realmSet$done(((BooleansRealmProxyInterface) newObject).realmGet$done());
             ((BooleansRealmProxyInterface) realmObject).realmSet$isReady(((BooleansRealmProxyInterface) newObject).realmGet$isReady());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -68,6 +68,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         }
 
     }
+    private boolean acceptDefaultValue;
     private BooleansColumnInfo columnInfo;
     private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
@@ -80,7 +81,8 @@ public class BooleansRealmProxy extends some.test.Booleans
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    BooleansRealmProxy() {
+    BooleansRealmProxy(boolean acceptDefaultValue) {
+        this.acceptDefaultValue = acceptDefaultValue;
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -113,7 +115,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -138,7 +140,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -163,7 +165,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -188,7 +190,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -113,8 +113,10 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -138,8 +140,10 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -163,8 +167,10 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -188,8 +194,10 @@ public class BooleansRealmProxy extends some.test.Booleans
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -94,6 +94,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
         proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
+        proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
     @SuppressWarnings("cast")
@@ -291,7 +292,8 @@ public class BooleansRealmProxy extends some.test.Booleans
     @SuppressWarnings("cast")
     public static some.test.Booleans createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
-        some.test.Booleans obj = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, true);
+        final List<String> excludeFields = Collections.<String> emptyList();
+        some.test.Booleans obj = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, true, excludeFields);
         if (json.has("done")) {
             if (json.isNull("done")) {
                 throw new IllegalArgumentException("Trying to set non-nullable field 'done' to null.");
@@ -390,7 +392,7 @@ public class BooleansRealmProxy extends some.test.Booleans
             return (some.test.Booleans) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.Booleans realmObject = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, false);
+            some.test.Booleans realmObject = realm.createObjectWithoutThreadCheck(some.test.Booleans.class, false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((BooleansRealmProxyInterface) realmObject).realmSet$done(((BooleansRealmProxyInterface) newObject).realmGet$done());
             ((BooleansRealmProxyInterface) realmObject).realmSet$isReady(((BooleansRealmProxyInterface) newObject).realmGet$isReady());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -68,8 +68,8 @@ public class BooleansRealmProxy extends some.test.Booleans
         }
 
     }
-    private final BooleansColumnInfo columnInfo;
-    private final ProxyState proxyState;
+    private BooleansColumnInfo columnInfo;
+    private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
     static {
         List<String> fieldNames = new ArrayList<String>();
@@ -80,51 +80,118 @@ public class BooleansRealmProxy extends some.test.Booleans
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    BooleansRealmProxy(ColumnInfo columnInfo) {
-        this.columnInfo = (BooleansColumnInfo) columnInfo;
+    BooleansRealmProxy() {
+        if (proxyState == null) {
+            injectObjectContext();
+        }
+        proxyState.setConstructionFinished();
+    }
+
+    private void injectObjectContext() {
+        final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
+        this.columnInfo = (BooleansColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.Booleans.class, this);
+
+        proxyState.setRealm$realm(context.getRealm());
+        proxyState.setRow$realm(context.getRow());
     }
 
     @SuppressWarnings("cast")
     public boolean realmGet$done() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.doneIndex);
     }
 
     public void realmSet$done(boolean value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setBoolean(columnInfo.doneIndex, value);
     }
 
     @SuppressWarnings("cast")
     public boolean realmGet$isReady() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.isReadyIndex);
     }
 
     public void realmSet$isReady(boolean value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setBoolean(columnInfo.isReadyIndex, value);
     }
 
     @SuppressWarnings("cast")
     public boolean realmGet$mCompleted() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.mCompletedIndex);
     }
 
     public void realmSet$mCompleted(boolean value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setBoolean(columnInfo.mCompletedIndex, value);
     }
 
     @SuppressWarnings("cast")
     public boolean realmGet$anotherBoolean() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.anotherBooleanIndex);
     }
 
     public void realmSet$anotherBoolean(boolean value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setBoolean(columnInfo.anotherBooleanIndex, value);
     }
@@ -300,6 +367,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.Booleans) cachedRealmObject;

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -375,7 +375,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
-        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.Booleans) cachedRealmObject;
@@ -552,7 +552,7 @@ public class BooleansRealmProxy extends some.test.Booleans
 
         String path = proxyState.getRealm$realm().getPath();
         String otherPath = aBooleans.proxyState.getRealm$realm().getPath();
-        if (path != null ? !path.equals(otherPath) : otherPath != null) return false;;
+        if (path != null ? !path.equals(otherPath) : otherPath != null) return false;
 
         String tableName = proxyState.getRow$realm().getTable().getName();
         String otherTableName = aBooleans.proxyState.getRow$realm().getTable().getName();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -179,6 +179,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
         proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
+        proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
     @SuppressWarnings("cast")
@@ -825,7 +826,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         if (proxyState.getRow$realm().isNullLink(columnInfo.fieldObjectNullIndex)) {
             return null;
         }
-        return proxyState.getRealm$realm().get(some.test.NullTypes.class, proxyState.getRow$realm().getLink(columnInfo.fieldObjectNullIndex), false);
+        return proxyState.getRealm$realm().get(some.test.NullTypes.class, proxyState.getRow$realm().getLink(columnInfo.fieldObjectNullIndex), false, Collections.<String>emptyList());
     }
 
     public void realmSet$fieldObjectNull(some.test.NullTypes value) {
@@ -836,6 +837,9 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
+            if (proxyState.getExcludeFields$realm().contains("fieldObjectNull")) {
                 return;
             }
             if (value != null && !RealmObject.isManaged(value)) {
@@ -1121,7 +1125,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     @SuppressWarnings("cast")
     public static some.test.NullTypes createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
-        some.test.NullTypes obj = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, true);
+        final List<String> excludeFields = new ArrayList<String>(1);
+        if (json.has("fieldObjectNull")) {
+            excludeFields.add("fieldObjectNull");
+        }
+        some.test.NullTypes obj = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, true, excludeFields);
         if (json.has("fieldStringNotNull")) {
             if (json.isNull("fieldStringNotNull")) {
                 ((NullTypesRealmProxyInterface) obj).realmSet$fieldStringNotNull(null);
@@ -1480,7 +1488,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             return (some.test.NullTypes) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.NullTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, false);
+            some.test.NullTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((NullTypesRealmProxyInterface) realmObject).realmSet$fieldStringNotNull(((NullTypesRealmProxyInterface) newObject).realmGet$fieldStringNotNull());
             ((NullTypesRealmProxyInterface) realmObject).realmSet$fieldStringNull(((NullTypesRealmProxyInterface) newObject).realmGet$fieldStringNull());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1129,7 +1129,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         if (json.has("fieldObjectNull")) {
             excludeFields.add("fieldObjectNull");
         }
-        some.test.NullTypes obj = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, true, excludeFields);
+        some.test.NullTypes obj = realm.createObjectInternal(some.test.NullTypes.class, true, excludeFields);
         if (json.has("fieldStringNotNull")) {
             if (json.isNull("fieldStringNotNull")) {
                 ((NullTypesRealmProxyInterface) obj).realmSet$fieldStringNotNull(null);
@@ -1488,7 +1488,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             return (some.test.NullTypes) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.NullTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, false, Collections.<String>emptyList());
+            some.test.NullTypes realmObject = realm.createObjectInternal(some.test.NullTypes.class, false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((NullTypesRealmProxyInterface) realmObject).realmSet$fieldStringNotNull(((NullTypesRealmProxyInterface) newObject).realmGet$fieldStringNotNull());
             ((NullTypesRealmProxyInterface) realmObject).realmSet$fieldStringNull(((NullTypesRealmProxyInterface) newObject).realmGet$fieldStringNull());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -136,6 +136,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         }
 
     }
+    private boolean acceptDefaultValue;
     private NullTypesColumnInfo columnInfo;
     private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
@@ -165,7 +166,8 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    NullTypesRealmProxy() {
+    NullTypesRealmProxy(boolean acceptDefaultValue) {
+        this.acceptDefaultValue = acceptDefaultValue;
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -198,7 +200,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -226,7 +228,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -255,7 +257,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -286,7 +288,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -315,7 +317,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -343,7 +345,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -372,7 +374,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -403,7 +405,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -432,7 +434,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -463,7 +465,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -492,7 +494,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -523,7 +525,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -552,7 +554,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -583,7 +585,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -612,7 +614,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -643,7 +645,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -672,7 +674,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -703,7 +705,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -732,7 +734,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -763,7 +765,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -794,7 +796,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -785,7 +785,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         if (proxyState.getRow$realm().isNullLink(columnInfo.fieldObjectNullIndex)) {
             return null;
         }
-        return proxyState.getRealm$realm().get(some.test.NullTypes.class, proxyState.getRow$realm().getLink(columnInfo.fieldObjectNullIndex));
+        return proxyState.getRealm$realm().get(some.test.NullTypes.class, proxyState.getRow$realm().getLink(columnInfo.fieldObjectNullIndex), false);
     }
 
     public void realmSet$fieldObjectNull(some.test.NullTypes value) {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -136,7 +136,6 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         }
 
     }
-    private boolean acceptDefaultValue;
     private NullTypesColumnInfo columnInfo;
     private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
@@ -166,8 +165,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    NullTypesRealmProxy(boolean acceptDefaultValue) {
-        this.acceptDefaultValue = acceptDefaultValue;
+    NullTypesRealmProxy() {
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -178,9 +176,9 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (NullTypesColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.NullTypes.class, this);
-
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
+        proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
     }
 
     @SuppressWarnings("cast")
@@ -200,7 +198,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -228,7 +226,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -257,7 +255,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -288,7 +286,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -317,7 +315,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -345,7 +343,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -374,7 +372,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -405,7 +403,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -434,7 +432,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -465,7 +463,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -494,7 +492,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -525,7 +523,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -554,7 +552,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -585,7 +583,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -614,7 +612,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -645,7 +643,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -674,7 +672,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -705,7 +703,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -734,7 +732,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -765,7 +763,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -796,7 +794,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -136,8 +136,8 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         }
 
     }
-    private final NullTypesColumnInfo columnInfo;
-    private final ProxyState proxyState;
+    private NullTypesColumnInfo columnInfo;
+    private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
     static {
         List<String> fieldNames = new ArrayList<String>();
@@ -165,18 +165,43 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    NullTypesRealmProxy(ColumnInfo columnInfo) {
-        this.columnInfo = (NullTypesColumnInfo) columnInfo;
+    NullTypesRealmProxy() {
+        if (proxyState == null) {
+            injectObjectContext();
+        }
+        proxyState.setConstructionFinished();
+    }
+
+    private void injectObjectContext() {
+        final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
+        this.columnInfo = (NullTypesColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.NullTypes.class, this);
+
+        proxyState.setRealm$realm(context.getRealm());
+        proxyState.setRow$realm(context.getRow());
     }
 
     @SuppressWarnings("cast")
     public String realmGet$fieldStringNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.fieldStringNotNullIndex);
     }
 
     public void realmSet$fieldStringNotNull(String value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldStringNotNull' to null.");
@@ -186,11 +211,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public String realmGet$fieldStringNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.fieldStringNullIndex);
     }
 
     public void realmSet$fieldStringNull(String value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldStringNullIndex);
@@ -201,11 +240,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Boolean realmGet$fieldBooleanNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.fieldBooleanNotNullIndex);
     }
 
     public void realmSet$fieldBooleanNotNull(Boolean value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldBooleanNotNull' to null.");
@@ -215,6 +268,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Boolean realmGet$fieldBooleanNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldBooleanNullIndex)) {
             return null;
@@ -223,6 +281,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldBooleanNull(Boolean value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldBooleanNullIndex);
@@ -233,11 +300,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public byte[] realmGet$fieldBytesNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (byte[]) proxyState.getRow$realm().getBinaryByteArray(columnInfo.fieldBytesNotNullIndex);
     }
 
     public void realmSet$fieldBytesNotNull(byte[] value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldBytesNotNull' to null.");
@@ -247,11 +328,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public byte[] realmGet$fieldBytesNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (byte[]) proxyState.getRow$realm().getBinaryByteArray(columnInfo.fieldBytesNullIndex);
     }
 
     public void realmSet$fieldBytesNull(byte[] value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldBytesNullIndex);
@@ -262,11 +357,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Byte realmGet$fieldByteNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (byte) proxyState.getRow$realm().getLong(columnInfo.fieldByteNotNullIndex);
     }
 
     public void realmSet$fieldByteNotNull(Byte value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldByteNotNull' to null.");
@@ -276,6 +385,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Byte realmGet$fieldByteNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldByteNullIndex)) {
             return null;
@@ -284,6 +398,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldByteNull(Byte value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldByteNullIndex);
@@ -294,11 +417,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Short realmGet$fieldShortNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (short) proxyState.getRow$realm().getLong(columnInfo.fieldShortNotNullIndex);
     }
 
     public void realmSet$fieldShortNotNull(Short value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldShortNotNull' to null.");
@@ -308,6 +445,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Short realmGet$fieldShortNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldShortNullIndex)) {
             return null;
@@ -316,6 +458,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldShortNull(Short value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldShortNullIndex);
@@ -326,11 +477,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Integer realmGet$fieldIntegerNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (int) proxyState.getRow$realm().getLong(columnInfo.fieldIntegerNotNullIndex);
     }
 
     public void realmSet$fieldIntegerNotNull(Integer value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldIntegerNotNull' to null.");
@@ -340,6 +505,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Integer realmGet$fieldIntegerNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldIntegerNullIndex)) {
             return null;
@@ -348,6 +518,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldIntegerNull(Integer value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldIntegerNullIndex);
@@ -358,11 +537,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Long realmGet$fieldLongNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (long) proxyState.getRow$realm().getLong(columnInfo.fieldLongNotNullIndex);
     }
 
     public void realmSet$fieldLongNotNull(Long value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldLongNotNull' to null.");
@@ -372,6 +565,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Long realmGet$fieldLongNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldLongNullIndex)) {
             return null;
@@ -380,6 +578,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldLongNull(Long value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldLongNullIndex);
@@ -390,11 +597,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Float realmGet$fieldFloatNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (float) proxyState.getRow$realm().getFloat(columnInfo.fieldFloatNotNullIndex);
     }
 
     public void realmSet$fieldFloatNotNull(Float value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldFloatNotNull' to null.");
@@ -404,6 +625,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Float realmGet$fieldFloatNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldFloatNullIndex)) {
             return null;
@@ -412,6 +638,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldFloatNull(Float value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldFloatNullIndex);
@@ -422,11 +657,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Double realmGet$fieldDoubleNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (double) proxyState.getRow$realm().getDouble(columnInfo.fieldDoubleNotNullIndex);
     }
 
     public void realmSet$fieldDoubleNotNull(Double value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldDoubleNotNull' to null.");
@@ -436,6 +685,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Double realmGet$fieldDoubleNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldDoubleNullIndex)) {
             return null;
@@ -444,6 +698,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldDoubleNull(Double value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldDoubleNullIndex);
@@ -454,11 +717,25 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Date realmGet$fieldDateNotNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (java.util.Date) proxyState.getRow$realm().getDate(columnInfo.fieldDateNotNullIndex);
     }
 
     public void realmSet$fieldDateNotNull(Date value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             throw new IllegalArgumentException("Trying to set non-nullable field 'fieldDateNotNull' to null.");
@@ -468,6 +745,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @SuppressWarnings("cast")
     public Date realmGet$fieldDateNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNull(columnInfo.fieldDateNullIndex)) {
             return null;
@@ -476,6 +758,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldDateNull(Date value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.fieldDateNullIndex);
@@ -485,6 +776,11 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public some.test.NullTypes realmGet$fieldObjectNull() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNullLink(columnInfo.fieldObjectNullIndex)) {
             return null;
@@ -493,6 +789,15 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     public void realmSet$fieldObjectNull(some.test.NullTypes value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().nullifyLink(columnInfo.fieldObjectNullIndex);
@@ -1115,6 +1420,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.NullTypes) cachedRealmObject;

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1121,7 +1121,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     @SuppressWarnings("cast")
     public static some.test.NullTypes createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
-        some.test.NullTypes obj = realm.createObject(some.test.NullTypes.class);
+        some.test.NullTypes obj = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, true);
         if (json.has("fieldStringNotNull")) {
             if (json.isNull("fieldStringNotNull")) {
                 ((NullTypesRealmProxyInterface) obj).realmSet$fieldStringNotNull(null);
@@ -1479,7 +1479,8 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         if (cachedRealmObject != null) {
             return (some.test.NullTypes) cachedRealmObject;
         } else {
-            some.test.NullTypes realmObject = realm.createObject(some.test.NullTypes.class);
+            // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
+            some.test.NullTypes realmObject = realm.createObjectWithoutThreadCheck(some.test.NullTypes.class, false);
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((NullTypesRealmProxyInterface) realmObject).realmSet$fieldStringNotNull(((NullTypesRealmProxyInterface) newObject).realmGet$fieldStringNotNull());
             ((NullTypesRealmProxyInterface) realmObject).realmSet$fieldStringNull(((NullTypesRealmProxyInterface) newObject).realmGet$fieldStringNull());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -198,8 +198,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -226,8 +228,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -255,8 +259,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -286,8 +292,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -315,8 +323,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -343,8 +353,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -372,8 +384,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -403,8 +417,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -432,8 +448,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -463,8 +481,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -492,8 +512,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -523,8 +545,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -552,8 +576,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -583,8 +609,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -612,8 +640,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -643,8 +673,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -672,8 +704,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -703,8 +737,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -732,8 +768,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -763,8 +801,10 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -794,8 +834,13 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
+            if (value != null && !RealmObject.isManaged(value)) {
+                value = ((Realm) proxyState.getRealm$realm()).copyToRealm(value);
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1465,7 +1465,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
-        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.NullTypes) cachedRealmObject;
@@ -2181,7 +2181,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
         String path = proxyState.getRealm$realm().getPath();
         String otherPath = aNullTypes.proxyState.getRealm$realm().getPath();
-        if (path != null ? !path.equals(otherPath) : otherPath != null) return false;;
+        if (path != null ? !path.equals(otherPath) : otherPath != null) return false;
 
         String tableName = proxyState.getRow$realm().getTable().getName();
         String otherTableName = aNullTypes.proxyState.getRow$realm().getTable().getName();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -74,11 +74,11 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public <E extends RealmModel> E newInstance(Class<E> clazz, ColumnInfo columnInfo) {
+    public <E extends RealmModel> E newInstance(Class<E> clazz) {
         checkClass(clazz);
 
         if (clazz.equals(some.test.AllTypes.class)) {
-            return clazz.cast(new io.realm.AllTypesRealmProxy(columnInfo));
+            return clazz.cast(new io.realm.AllTypesRealmProxy());
         } else {
             throw getMissingProxyClassException(clazz);
         }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -5,6 +5,7 @@ import android.util.JsonReader;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.RealmProxyMediator;
+import io.realm.internal.Row;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
 import java.io.IOException;
@@ -74,13 +75,19 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public <E extends RealmModel> E newInstance(Class<E> clazz) {
-        checkClass(clazz);
+    public <E extends RealmModel> E newInstance(Class<E> clazz, Object baseRealm, Row row, ColumnInfo columnInfo, boolean acceptDefaultValue) {
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
+        try {
+            objectContext.set((BaseRealm) baseRealm, row, columnInfo);
+            checkClass(clazz);
 
-        if (clazz.equals(some.test.AllTypes.class)) {
-            return clazz.cast(new io.realm.AllTypesRealmProxy());
-        } else {
-            throw getMissingProxyClassException(clazz);
+            if (clazz.equals(some.test.AllTypes.class)) {
+                return clazz.cast(new io.realm.AllTypesRealmProxy(acceptDefaultValue));
+            } else {
+                throw getMissingProxyClassException(clazz);
+            }
+        } finally {
+            objectContext.clear();
         }
     }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -78,11 +78,11 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     public <E extends RealmModel> E newInstance(Class<E> clazz, Object baseRealm, Row row, ColumnInfo columnInfo, boolean acceptDefaultValue) {
         final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
         try {
-            objectContext.set((BaseRealm) baseRealm, row, columnInfo);
+            objectContext.set((BaseRealm) baseRealm, row, columnInfo, acceptDefaultValue);
             checkClass(clazz);
 
             if (clazz.equals(some.test.AllTypes.class)) {
-                return clazz.cast(new io.realm.AllTypesRealmProxy(acceptDefaultValue));
+                return clazz.cast(new io.realm.AllTypesRealmProxy());
             } else {
                 throw getMissingProxyClassException(clazz);
             }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -75,10 +75,10 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public <E extends RealmModel> E newInstance(Class<E> clazz, Object baseRealm, Row row, ColumnInfo columnInfo, boolean acceptDefaultValue) {
+    public <E extends RealmModel> E newInstance(Class<E> clazz, Object baseRealm, Row row, ColumnInfo columnInfo, boolean acceptDefaultValue, List<String> excludeFields) {
         final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
         try {
-            objectContext.set((BaseRealm) baseRealm, row, columnInfo, acceptDefaultValue);
+            objectContext.set((BaseRealm) baseRealm, row, columnInfo, acceptDefaultValue, excludeFields);
             checkClass(clazz);
 
             if (clazz.equals(some.test.AllTypes.class)) {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -60,8 +60,8 @@ public class SimpleRealmProxy extends some.test.Simple
         }
 
     }
-    private final SimpleColumnInfo columnInfo;
-    private final ProxyState proxyState;
+    private SimpleColumnInfo columnInfo;
+    private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
     static {
         List<String> fieldNames = new ArrayList<String>();
@@ -70,18 +70,43 @@ public class SimpleRealmProxy extends some.test.Simple
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    SimpleRealmProxy(ColumnInfo columnInfo) {
-        this.columnInfo = (SimpleColumnInfo) columnInfo;
+    SimpleRealmProxy() {
+        if (proxyState == null) {
+            injectObjectContext();
+        }
+        proxyState.setConstructionFinished();
+    }
+
+    private void injectObjectContext() {
+        final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
+        this.columnInfo = (SimpleColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.Simple.class, this);
+
+        proxyState.setRealm$realm(context.getRealm());
+        proxyState.setRow$realm(context.getRow());
     }
 
     @SuppressWarnings("cast")
     public String realmGet$name() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.nameIndex);
     }
 
     public void realmSet$name(String value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         if (value == null) {
             proxyState.getRow$realm().setNull(columnInfo.nameIndex);
@@ -92,11 +117,25 @@ public class SimpleRealmProxy extends some.test.Simple
 
     @SuppressWarnings("cast")
     public int realmGet$age() {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         return (int) proxyState.getRow$realm().getLong(columnInfo.ageIndex);
     }
 
     public void realmSet$age(int value) {
+        if (proxyState == null) {
+            // Called from model's constructor. Inject context.
+            injectObjectContext();
+        }
+
+        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+            return;
+        }
+
         proxyState.getRealm$realm().checkIfValid();
         proxyState.getRow$realm().setLong(columnInfo.ageIndex, value);
     }
@@ -224,6 +263,7 @@ public class SimpleRealmProxy extends some.test.Simple
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.Simple) cachedRealmObject;

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -213,7 +213,7 @@ public class SimpleRealmProxy extends some.test.Simple
     public static some.test.Simple createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
         final List<String> excludeFields = Collections.<String> emptyList();
-        some.test.Simple obj = realm.createObjectWithoutThreadCheck(some.test.Simple.class, true, excludeFields);
+        some.test.Simple obj = realm.createObjectInternal(some.test.Simple.class, true, excludeFields);
         if (json.has("name")) {
             if (json.isNull("name")) {
                 ((SimpleRealmProxyInterface) obj).realmSet$name(null);
@@ -284,7 +284,7 @@ public class SimpleRealmProxy extends some.test.Simple
             return (some.test.Simple) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.Simple realmObject = realm.createObjectWithoutThreadCheck(some.test.Simple.class, false, Collections.<String>emptyList());
+            some.test.Simple realmObject = realm.createObjectInternal(some.test.Simple.class, false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((SimpleRealmProxyInterface) realmObject).realmSet$name(((SimpleRealmProxyInterface) newObject).realmGet$name());
             ((SimpleRealmProxyInterface) realmObject).realmSet$age(((SimpleRealmProxyInterface) newObject).realmGet$age());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -267,7 +267,7 @@ public class SimpleRealmProxy extends some.test.Simple
         if (object instanceof RealmObjectProxy && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm() != null && ((RealmObjectProxy)object).realmGet$proxyState().getRealm$realm().getPath().equals(realm.getPath())) {
             return object;
         }
-        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();;
+        final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
         RealmObjectProxy cachedRealmObject = cache.get(object);
         if (cachedRealmObject != null) {
             return (some.test.Simple) cachedRealmObject;

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -211,7 +211,7 @@ public class SimpleRealmProxy extends some.test.Simple
     @SuppressWarnings("cast")
     public static some.test.Simple createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
-        some.test.Simple obj = realm.createObject(some.test.Simple.class);
+        some.test.Simple obj = realm.createObjectWithoutThreadCheck(some.test.Simple.class, true);
         if (json.has("name")) {
             if (json.isNull("name")) {
                 ((SimpleRealmProxyInterface) obj).realmSet$name(null);
@@ -281,7 +281,8 @@ public class SimpleRealmProxy extends some.test.Simple
         if (cachedRealmObject != null) {
             return (some.test.Simple) cachedRealmObject;
         } else {
-            some.test.Simple realmObject = realm.createObject(some.test.Simple.class);
+            // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
+            some.test.Simple realmObject = realm.createObjectWithoutThreadCheck(some.test.Simple.class, false);
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((SimpleRealmProxyInterface) realmObject).realmSet$name(((SimpleRealmProxyInterface) newObject).realmGet$name());
             ((SimpleRealmProxyInterface) realmObject).realmSet$age(((SimpleRealmProxyInterface) newObject).realmGet$age());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -103,8 +103,10 @@ public class SimpleRealmProxy extends some.test.Simple
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();
@@ -132,8 +134,10 @@ public class SimpleRealmProxy extends some.test.Simple
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
-            return;
+        if (proxyState.isUnderConstruction()) {
+            if (!proxyState.getAcceptDefaultValue$realm()) {
+                return;
+            }
         }
 
         proxyState.getRealm$realm().checkIfValid();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -60,7 +60,6 @@ public class SimpleRealmProxy extends some.test.Simple
         }
 
     }
-    private boolean acceptDefaultValue;
     private SimpleColumnInfo columnInfo;
     private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
@@ -71,8 +70,7 @@ public class SimpleRealmProxy extends some.test.Simple
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    SimpleRealmProxy(boolean acceptDefaultValue) {
-        this.acceptDefaultValue = acceptDefaultValue;
+    SimpleRealmProxy() {
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -83,9 +81,9 @@ public class SimpleRealmProxy extends some.test.Simple
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (SimpleColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState(some.test.Simple.class, this);
-
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
+        proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
     }
 
     @SuppressWarnings("cast")
@@ -105,7 +103,7 @@ public class SimpleRealmProxy extends some.test.Simple
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 
@@ -134,7 +132,7 @@ public class SimpleRealmProxy extends some.test.Simple
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
+        if (proxyState.isUnderConstruction() && !proxyState.getAcceptDefaultValue$realm()) {
             return;
         }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -60,6 +60,7 @@ public class SimpleRealmProxy extends some.test.Simple
         }
 
     }
+    private boolean acceptDefaultValue;
     private SimpleColumnInfo columnInfo;
     private ProxyState proxyState;
     private static final List<String> FIELD_NAMES;
@@ -70,7 +71,8 @@ public class SimpleRealmProxy extends some.test.Simple
         FIELD_NAMES = Collections.unmodifiableList(fieldNames);
     }
 
-    SimpleRealmProxy() {
+    SimpleRealmProxy(boolean acceptDefaultValue) {
+        this.acceptDefaultValue = acceptDefaultValue;
         if (proxyState == null) {
             injectObjectContext();
         }
@@ -103,7 +105,7 @@ public class SimpleRealmProxy extends some.test.Simple
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 
@@ -132,7 +134,7 @@ public class SimpleRealmProxy extends some.test.Simple
             injectObjectContext();
         }
 
-        if (proxyState.isUnderConstruction() && !proxyState.getRealm$realm().isInTransaction()) {
+        if (proxyState.isUnderConstruction() && !this.acceptDefaultValue) {
             return;
         }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -84,6 +84,7 @@ public class SimpleRealmProxy extends some.test.Simple
         proxyState.setRealm$realm(context.getRealm());
         proxyState.setRow$realm(context.getRow());
         proxyState.setAcceptDefaultValue$realm(context.getAcceptDefaultValue());
+        proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
     @SuppressWarnings("cast")
@@ -211,7 +212,8 @@ public class SimpleRealmProxy extends some.test.Simple
     @SuppressWarnings("cast")
     public static some.test.Simple createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {
-        some.test.Simple obj = realm.createObjectWithoutThreadCheck(some.test.Simple.class, true);
+        final List<String> excludeFields = Collections.<String> emptyList();
+        some.test.Simple obj = realm.createObjectWithoutThreadCheck(some.test.Simple.class, true, excludeFields);
         if (json.has("name")) {
             if (json.isNull("name")) {
                 ((SimpleRealmProxyInterface) obj).realmSet$name(null);
@@ -282,7 +284,7 @@ public class SimpleRealmProxy extends some.test.Simple
             return (some.test.Simple) cachedRealmObject;
         } else {
             // rejecting default values to avoid creating unexpected objects from RealmModel/RealmList fields.
-            some.test.Simple realmObject = realm.createObjectWithoutThreadCheck(some.test.Simple.class, false);
+            some.test.Simple realmObject = realm.createObjectWithoutThreadCheck(some.test.Simple.class, false, Collections.<String>emptyList());
             cache.put(newObject, (RealmObjectProxy) realmObject);
             ((SimpleRealmProxyInterface) realmObject).realmSet$name(((SimpleRealmProxyInterface) newObject).realmGet$name());
             ((SimpleRealmProxyInterface) realmObject).realmSet$age(((SimpleRealmProxyInterface) newObject).realmGet$age());

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -27,17 +27,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import dk.ilios.spanner.All;
 import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AnnotationIndexTypes;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
@@ -21,6 +21,8 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Base64;
 
+import com.google.gson.internal.bind.util.ISO8601Utils;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -42,10 +44,12 @@ import java.util.TimeZone;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.AnnotationTypes;
+import io.realm.entities.DefaultValueOfField;
 import io.realm.entities.Dog;
 import io.realm.entities.NoPrimaryKeyNullTypes;
 import io.realm.entities.NullTypes;
 import io.realm.entities.OwnerPrimaryKey;
+import io.realm.entities.RandomPrimaryKey;
 import io.realm.exceptions.RealmException;
 import io.realm.rule.TestRealmConfigurationFactory;
 
@@ -361,6 +365,220 @@ public class RealmJsonTests {
 
         assertEquals(3, realm.where(Dog.class).count());
         assertEquals(1, realm.where(Dog.class).equalTo("name", "Fido-3").findAll().size());
+    }
+
+    @Test
+    public void createFromJson_respectDefaultValues() throws JSONException {
+        final long fieldLongPrimaryKeyValue = DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE + 1;
+
+        // Step 1: Prepare almost empty JSON
+        final JSONObject json = new JSONObject();
+        json.put(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY, fieldLongPrimaryKeyValue);
+
+        // Step 2: Update with almost empty JSONObject
+        realm.beginTransaction();
+        final DefaultValueOfField managedObj = realm.createOrUpdateObjectFromJson(DefaultValueOfField.class, json);
+        realm.commitTransaction();
+
+        // Step 3: Check that default values are applied
+        assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE,
+                managedObj.getFieldIgnored());
+        assertEquals(DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE, managedObj.getFieldString());
+        assertEquals(DefaultValueOfField.lastRandomStringValue, managedObj.getFieldRandomString());
+        assertEquals(DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE, managedObj.getFieldShort());
+        assertEquals(DefaultValueOfField.FIELD_INT_DEFAULT_VALUE, managedObj.getFieldInt());
+        assertEquals(fieldLongPrimaryKeyValue, managedObj.getFieldLongPrimaryKey());
+        assertEquals(DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE, managedObj.getFieldLong());
+        assertEquals(DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE, managedObj.getFieldByte());
+        assertEquals(DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE, managedObj.getFieldFloat(), 0f);
+        assertEquals(DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE, managedObj.getFieldDouble(), 0d);
+        assertEquals(DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE, managedObj.isFieldBoolean());
+        assertEquals(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE, managedObj.getFieldDate());
+        assertTrue(Arrays.equals(DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE, managedObj.getFieldBinary()));
+        assertEquals(RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE, managedObj.getFieldObject().getFieldInt());
+        assertEquals(1, managedObj.getFieldList().size());
+        assertEquals(RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE, managedObj.getFieldList().first().getFieldInt());
+
+        // make sure that excess object by default value is not created.
+        assertEquals(2, realm.where(RandomPrimaryKey.class).count());
+    }
+
+    @Test
+    public void createFromJson_defaultValuesAreIgnored() throws JSONException {
+        final long fieldLongPrimaryKeyValue = DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE + 1;
+
+        // Step 1: Prepare JSON
+        final String fieldIgnoredValue = DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE + ".modified";
+        final String fieldStringValue = DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE + ".modified";
+        final String fieldRandomStringValue = "non-random";
+        final short fieldShortValue = (short) (DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE + 1);
+        final int fieldIntValue = DefaultValueOfField.FIELD_INT_DEFAULT_VALUE + 1;
+        final long fieldLongValue = DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE + 1;
+        final byte fieldByteValue = (byte) (DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE + 1);
+        final float fieldFloatValue = DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE + 1;
+        final double fieldDoubleValue = DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE + 1;
+        final boolean fieldBooleanValue = !DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE;
+        final Date fieldDateValue = new Date(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE.getTime() + 1);
+        final byte[] fieldBinaryValue = {(byte) (DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE[0] - 1)};
+        final int fieldObjectIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1;
+        final int fieldListIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 2;
+
+        final JSONObject json = new JSONObject();
+        json.put(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY, fieldLongPrimaryKeyValue);
+        json.put(DefaultValueOfField.FIELD_IGNORED, fieldIgnoredValue);
+        json.put(DefaultValueOfField.FIELD_STRING, fieldStringValue);
+        json.put(DefaultValueOfField.FIELD_RANDOM_STRING, fieldRandomStringValue);
+        json.put(DefaultValueOfField.FIELD_SHORT, fieldShortValue);
+        json.put(DefaultValueOfField.FIELD_INT, fieldIntValue);
+        json.put(DefaultValueOfField.FIELD_LONG, fieldLongValue);
+        json.put(DefaultValueOfField.FIELD_BYTE, fieldByteValue);
+        json.put(DefaultValueOfField.FIELD_FLOAT, fieldFloatValue);
+        json.put(DefaultValueOfField.FIELD_DOUBLE, fieldDoubleValue);
+        json.put(DefaultValueOfField.FIELD_BOOLEAN, fieldBooleanValue);
+        json.put(DefaultValueOfField.FIELD_DATE, ISO8601Utils.format(fieldDateValue, true));
+        json.put(DefaultValueOfField.FIELD_BINARY, Base64.encodeToString(fieldBinaryValue, Base64.DEFAULT));
+        // value for 'fieldObject'
+        final JSONObject fieldObjectJson = new JSONObject();
+        fieldObjectJson.put(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY, "pk of fieldObject");
+        fieldObjectJson.put(RandomPrimaryKey.FIELD_INT, fieldObjectIntValue);
+        json.put(DefaultValueOfField.FIELD_OBJECT, fieldObjectJson);
+        // value for 'fieldList'
+        final JSONArray fieldListArrayJson = new JSONArray();
+        final JSONObject fieldListItem0Json = new JSONObject();
+        fieldListItem0Json.put(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY, "pk1 of fieldList");
+        fieldListItem0Json.put(RandomPrimaryKey.FIELD_INT, fieldListIntValue);
+        fieldListArrayJson.put(fieldListItem0Json);
+        final JSONObject fieldListItem1Json = new JSONObject();
+        fieldListItem1Json.put(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY, "pk2 of fieldList");
+        fieldListItem1Json.put(RandomPrimaryKey.FIELD_INT, fieldListIntValue + 1);
+        fieldListArrayJson.put(fieldListItem1Json);
+        json.put(DefaultValueOfField.FIELD_LIST, fieldListArrayJson);
+
+        // Step 3: Update with JSONObject
+        realm.beginTransaction();
+        final DefaultValueOfField managedObj = realm.createOrUpdateObjectFromJson(DefaultValueOfField.class, json);
+        realm.commitTransaction();
+
+        // Step 4: Check that properly created
+        assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE/*not fieldIgnoredValue*/,
+                managedObj.getFieldIgnored());
+        assertEquals(fieldStringValue, managedObj.getFieldString());
+        assertEquals(fieldRandomStringValue, managedObj.getFieldRandomString());
+        assertEquals(fieldShortValue, managedObj.getFieldShort());
+        assertEquals(fieldIntValue, managedObj.getFieldInt());
+        assertEquals(fieldLongPrimaryKeyValue, managedObj.getFieldLongPrimaryKey());
+        assertEquals(fieldLongValue, managedObj.getFieldLong());
+        assertEquals(fieldByteValue, managedObj.getFieldByte());
+        assertEquals(fieldFloatValue, managedObj.getFieldFloat(), 0f);
+        assertEquals(fieldDoubleValue, managedObj.getFieldDouble(), 0d);
+        assertEquals(fieldBooleanValue, managedObj.isFieldBoolean());
+        assertEquals(fieldDateValue, managedObj.getFieldDate());
+        assertTrue(Arrays.equals(fieldBinaryValue, managedObj.getFieldBinary()));
+        assertEquals(fieldObjectJson.getString(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY),
+                managedObj.getFieldObject().getFieldRandomPrimaryKey());
+        assertEquals(fieldObjectIntValue, managedObj.getFieldObject().getFieldInt());
+        assertEquals(2, managedObj.getFieldList().size());
+        assertEquals(fieldListItem0Json.get(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY),
+                managedObj.getFieldList().get(0).getFieldRandomPrimaryKey());
+        assertEquals(fieldListIntValue, managedObj.getFieldList().get(0).getFieldInt());
+        assertEquals(fieldListItem1Json.get(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY),
+                managedObj.getFieldList().get(1).getFieldRandomPrimaryKey());
+        assertEquals(fieldListIntValue + 1, managedObj.getFieldList().get(1).getFieldInt());
+
+        // make sure that excess object by default value is not created.
+        assertEquals(3, realm.where(RandomPrimaryKey.class).count());
+    }
+
+    @Test
+    public void updateFromJson_defaultValuesAreIgnored() throws JSONException {
+        final long fieldLongPrimaryKeyValue = DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE + 1;
+
+        // Step 1: Create an object with default values
+        final DefaultValueOfField original;
+        realm.beginTransaction(); {
+            original = realm.createObject(DefaultValueOfField.class, fieldLongPrimaryKeyValue);
+        }
+        realm.commitTransaction();
+
+        // Step 2: Prepare JSON
+        final String fieldIgnoredValue = DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE + ".modified";
+        final String fieldStringValue = DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE + ".modified";
+        final String fieldRandomStringValue = "non-random";
+        final short fieldShortValue = (short) (DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE + 1);
+        final int fieldIntValue = DefaultValueOfField.FIELD_INT_DEFAULT_VALUE + 1;
+        final long fieldLongValue = DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE + 1;
+        final byte fieldByteValue = (byte) (DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE + 1);
+        final float fieldFloatValue = DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE + 1;
+        final double fieldDoubleValue = DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE + 1;
+        final boolean fieldBooleanValue = !DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE;
+        final Date fieldDateValue = new Date(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE.getTime() + 1);
+        final byte[] fieldBinaryValue = {(byte) (DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE[0] - 1)};
+        final int fieldObjectIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1;
+        final int fieldListIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 2;
+
+        final JSONObject json = new JSONObject();
+        json.put(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY, fieldLongPrimaryKeyValue);
+        json.put(DefaultValueOfField.FIELD_IGNORED, fieldIgnoredValue);
+        json.put(DefaultValueOfField.FIELD_STRING, fieldStringValue);
+        json.put(DefaultValueOfField.FIELD_RANDOM_STRING, fieldRandomStringValue);
+        json.put(DefaultValueOfField.FIELD_SHORT, fieldShortValue);
+        json.put(DefaultValueOfField.FIELD_INT, fieldIntValue);
+        json.put(DefaultValueOfField.FIELD_LONG, fieldLongValue);
+        json.put(DefaultValueOfField.FIELD_BYTE, fieldByteValue);
+        json.put(DefaultValueOfField.FIELD_FLOAT, fieldFloatValue);
+        json.put(DefaultValueOfField.FIELD_DOUBLE, fieldDoubleValue);
+        json.put(DefaultValueOfField.FIELD_BOOLEAN, fieldBooleanValue);
+        json.put(DefaultValueOfField.FIELD_DATE, ISO8601Utils.format(fieldDateValue, true));
+        json.put(DefaultValueOfField.FIELD_BINARY, Base64.encodeToString(fieldBinaryValue, Base64.DEFAULT));
+        // value for 'fieldObject'
+        final JSONObject fieldObjectJson = new JSONObject();
+        fieldObjectJson.put(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY,
+                original.getFieldObject().getFieldRandomPrimaryKey());
+        fieldObjectJson.put(RandomPrimaryKey.FIELD_INT, fieldObjectIntValue);
+        json.put(DefaultValueOfField.FIELD_OBJECT, fieldObjectJson);
+        // value for 'fieldList'
+        final JSONArray fieldListArrayJson = new JSONArray();
+        final JSONObject fieldListItem0Json = new JSONObject(); // to be added
+        fieldListItem0Json.put(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY,  "unique value");
+        fieldListItem0Json.put(RandomPrimaryKey.FIELD_INT, fieldListIntValue);
+        fieldListArrayJson.put(fieldListItem0Json);
+        final JSONObject fieldListItem1Json = new JSONObject(); // to be updated
+        fieldListItem1Json.put(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY,
+                original.getFieldList().first().getFieldRandomPrimaryKey());
+        fieldListItem1Json.put(RandomPrimaryKey.FIELD_INT, fieldListIntValue + 1);
+        fieldListArrayJson.put(fieldListItem1Json);
+        json.put(DefaultValueOfField.FIELD_LIST, fieldListArrayJson);
+
+        // Step 3: Update with JSONObject
+        realm.beginTransaction();
+        final DefaultValueOfField managedObj = realm.createOrUpdateObjectFromJson(DefaultValueOfField.class, json);
+        realm.commitTransaction();
+
+        // Step 4: Check that properly updated
+        assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE/*not fieldIgnoredValue*/,
+                managedObj.getFieldIgnored());
+        assertEquals(fieldStringValue, managedObj.getFieldString());
+        assertEquals(fieldRandomStringValue, managedObj.getFieldRandomString());
+        assertEquals(fieldShortValue, managedObj.getFieldShort());
+        assertEquals(fieldIntValue, managedObj.getFieldInt());
+        assertEquals(fieldLongPrimaryKeyValue, managedObj.getFieldLongPrimaryKey());
+        assertEquals(fieldLongValue, managedObj.getFieldLong());
+        assertEquals(fieldByteValue, managedObj.getFieldByte());
+        assertEquals(fieldFloatValue, managedObj.getFieldFloat(), 0f);
+        assertEquals(fieldDoubleValue, managedObj.getFieldDouble(), 0d);
+        assertEquals(fieldBooleanValue, managedObj.isFieldBoolean());
+        assertEquals(fieldDateValue, managedObj.getFieldDate());
+        assertTrue(Arrays.equals(fieldBinaryValue, managedObj.getFieldBinary()));
+        assertEquals(fieldObjectIntValue, managedObj.getFieldObject().getFieldInt());
+        assertEquals(2, managedObj.getFieldList().size());
+        assertEquals("unique value", managedObj.getFieldList().get(0).getFieldRandomPrimaryKey());
+        assertEquals(fieldListIntValue, managedObj.getFieldList().get(0).getFieldInt());
+        assertEquals(fieldListItem1Json.get(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY),
+                managedObj.getFieldList().get(1).getFieldRandomPrimaryKey());
+        assertEquals(fieldListIntValue + 1, managedObj.getFieldList().get(1).getFieldInt());
+
+        // make sure that excess object by default value is not created.
+        assertEquals(3/* 2 updated + 1 added*/, realm.where(RandomPrimaryKey.class).count());
     }
 
     // Test if Json object doesn't have the field, then the field should have default value.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
@@ -19,6 +19,7 @@ package io.realm;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.text.TextUtils;
 import android.util.Base64;
 
 import com.google.gson.internal.bind.util.ISO8601Utils;
@@ -384,7 +385,7 @@ public class RealmJsonTests {
         assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE,
                 managedObj.getFieldIgnored());
         assertEquals(DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE, managedObj.getFieldString());
-        assertEquals(DefaultValueOfField.lastRandomStringValue, managedObj.getFieldRandomString());
+        assertFalse(TextUtils.isEmpty(managedObj.getFieldRandomString()));
         assertEquals(DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE, managedObj.getFieldShort());
         assertEquals(DefaultValueOfField.FIELD_INT_DEFAULT_VALUE, managedObj.getFieldInt());
         assertEquals(fieldLongPrimaryKeyValue, managedObj.getFieldLongPrimaryKey());
@@ -614,6 +615,7 @@ public class RealmJsonTests {
         realm.beginTransaction();
         try {
             realm.createObjectFromJson(AllTypes.class, json);
+            fail();
         } catch (RealmException ignored) {
         } finally {
             realm.commitTransaction();
@@ -1359,7 +1361,7 @@ public class RealmJsonTests {
 
         RealmResults<NullTypes> nullTypesRealmResults = realm.where(NullTypes.class).findAll();
         assertEquals(2, nullTypesRealmResults.size());
-        checkNullableValuesAreNotNull(nullTypesRealmResults.first());
+        checkNullableValuesAreNotNull(nullTypesRealmResults.where().equalTo("id", 1).findFirst());
 
         // Update object with id 1, nullable fields should have null values
         JSONArray array = new JSONArray(json);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -41,6 +42,7 @@ import io.realm.entities.DefaultValueOfField;
 import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
+import io.realm.entities.RandomPrimaryKey;
 import io.realm.entities.StringOnly;
 import io.realm.internal.Table;
 import io.realm.rule.RunInLooperThread;
@@ -1040,17 +1042,77 @@ public class RealmResultsTests extends CollectionTests {
     }
 
     @Test
-    public void query_defaultValueFromModelField() {
+    public void syncQuery_defaultValuesAreIgnored() {
+        final String fieldIgnoredValue = DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE + ".modified";
+        final String fieldStringValue = DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE + ".modified";
+        final String fieldRandomStringValue = "non-random";
+        final short fieldShortValue = (short) (DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE + 1);
+        final int fieldIntValue = DefaultValueOfField.FIELD_INT_DEFAULT_VALUE + 1;
+        final long fieldLongPrimaryKeyValue = DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE + 1;
+        final long fieldLongValue = DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE + 1;
+        final byte fieldByteValue = (byte) (DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE + 1);
+        final float fieldFloatValue = DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE + 1;
+        final double fieldDoubleValue = DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE + 1;
+        final boolean fieldBooleanValue = !DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE;
+        final Date fieldDateValue = new Date(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE.getTime() + 1);
+        final byte[] fieldBinaryValue = {(byte) (DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE[0] - 1)};
+        final int fieldObjectIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1;
+        final int fieldListIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 2;
+
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
-                realm.createObject(DefaultValueOfField.class,
-                        DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+                final DefaultValueOfField obj = new DefaultValueOfField();
+                obj.setFieldIgnored(fieldIgnoredValue);
+                obj.setFieldString(fieldStringValue);
+                obj.setFieldRandomString(fieldRandomStringValue);
+                obj.setFieldShort(fieldShortValue);
+                obj.setFieldInt(fieldIntValue);
+                obj.setFieldLongPrimaryKey(fieldLongPrimaryKeyValue);
+                obj.setFieldLong(fieldLongValue);
+                obj.setFieldByte(fieldByteValue);
+                obj.setFieldFloat(fieldFloatValue);
+                obj.setFieldDouble(fieldDoubleValue);
+                obj.setFieldBoolean(fieldBooleanValue);
+                obj.setFieldDate(fieldDateValue);
+                obj.setFieldBinary(fieldBinaryValue);
+
+                final RandomPrimaryKey fieldObjectValue = new RandomPrimaryKey();
+                fieldObjectValue.setFieldInt(fieldObjectIntValue);
+                obj.setFieldObject(fieldObjectValue);
+
+                final RealmList<RandomPrimaryKey> list = new RealmList<>();
+                final RandomPrimaryKey listItem = new RandomPrimaryKey();
+                listItem.setFieldInt(fieldListIntValue);
+                list.add(listItem);
+                obj.setFieldList(list);
+
+                realm.copyToRealm(obj);
             }
         });
-        final String createdRandomString = DefaultValueOfField.lastRandomStringValue;
+
+        final RealmResults<DefaultValueOfField> result = realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY,
+                        fieldLongPrimaryKeyValue).findAll();
+
+        final DefaultValueOfField obj = result.first();
+
+        assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE/*not fieldIgnoredValue*/,
+                obj.getFieldIgnored());
+        assertEquals(fieldStringValue, obj.getFieldString());
+        assertEquals(fieldRandomStringValue, obj.getFieldRandomString());
+        assertEquals(fieldShortValue, obj.getFieldShort());
+        assertEquals(fieldIntValue, obj.getFieldInt());
+        assertEquals(fieldLongPrimaryKeyValue, obj.getFieldLongPrimaryKey());
+        assertEquals(fieldLongValue, obj.getFieldLong());
+        assertEquals(fieldByteValue, obj.getFieldByte());
+        assertEquals(fieldFloatValue, obj.getFieldFloat(), 0f);
+        assertEquals(fieldDoubleValue, obj.getFieldDouble(), 0d);
+        assertEquals(fieldBooleanValue, obj.isFieldBoolean());
+        assertEquals(fieldDateValue, obj.getFieldDate());
+        assertTrue(Arrays.equals(fieldBinaryValue, obj.getFieldBinary()));
+        assertEquals(fieldObjectIntValue, obj.getFieldObject().getFieldInt());
+        assertEquals(1, obj.getFieldList().size());
+        assertEquals(fieldListIntValue, obj.getFieldList().first().getFieldInt());
     }
-
-
-
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -37,6 +37,7 @@ import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AnnotationIndexTypes;
 import io.realm.entities.CyclicType;
+import io.realm.entities.DefaultValueOfField;
 import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.Owner;
@@ -1037,4 +1038,19 @@ public class RealmResultsTests extends CollectionTests {
 
         assertEquals(0, realm.where(StringOnly.class).findAll().size());
     }
+
+    @Test
+    public void query_defaultValueFromModelField() {
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createObject(DefaultValueOfField.class,
+                        DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+            }
+        });
+        final String createdRandomString = DefaultValueOfField.lastRandomStringValue;
+    }
+
+
+
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2271,6 +2271,7 @@ public class RealmTests {
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
+                // create a DefaultValueOfField with non-default primary key value
                 realm.createObject(DefaultValueOfField.class,
                         DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
             }
@@ -2330,6 +2331,7 @@ public class RealmTests {
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
+                // create a DefaultValueConstructor with non-default primary key value
                 realm.createObject(DefaultValueConstructor.class,
                         DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
             }
@@ -2389,6 +2391,7 @@ public class RealmTests {
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
+                // create a DefaultValueSetter with non-default primary key value
                 realm.createObject(DefaultValueSetter.class,
                         DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
             }
@@ -2445,6 +2448,86 @@ public class RealmTests {
                 .equalTo(DefaultValueSetter.FIELD_LIST+ "." + RandomPrimaryKey.FIELD_INT,
                         RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1)
                 .count());
+    }
+
+    @Test
+    public void copyToRealm_defaultValuesAreIgnored() {
+        final String fieldIgnoredValue = DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE + ".modified";
+        final String fieldStringValue = DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE + ".modified";
+        final String fieldRandomStringValue = "non-random";
+        final short fieldShortValue = (short) (DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE + 1);
+        final int fieldIntValue = DefaultValueOfField.FIELD_INT_DEFAULT_VALUE + 1;
+        final long fieldLongPrimaryKeyValue = DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE + 1;
+        final long fieldLongValue = DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE + 1;
+        final byte fieldByteValue = (byte) (DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE + 1);
+        final float fieldFloatValue = DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE + 1;
+        final double fieldDoubleValue = DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE + 1;
+        final boolean fieldBooleanValue = !DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE;
+        final Date fieldDateValue = new Date(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE.getTime() + 1);
+        final byte[] fieldBinaryValue = {(byte) (DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE[0] - 1)};
+        final int fieldObjectIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1;
+        final int fieldListIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 2;
+
+        final DefaultValueOfField managedObj;
+        realm.beginTransaction(); {
+            final DefaultValueOfField obj = new DefaultValueOfField();
+            obj.setFieldIgnored(fieldIgnoredValue);
+            obj.setFieldString(fieldStringValue);
+            obj.setFieldRandomString(fieldRandomStringValue);
+            obj.setFieldShort(fieldShortValue);
+            obj.setFieldInt(fieldIntValue);
+            obj.setFieldLongPrimaryKey(fieldLongPrimaryKeyValue);
+            obj.setFieldLong(fieldLongValue);
+            obj.setFieldByte(fieldByteValue);
+            obj.setFieldFloat(fieldFloatValue);
+            obj.setFieldDouble(fieldDoubleValue);
+            obj.setFieldBoolean(fieldBooleanValue);
+            obj.setFieldDate(fieldDateValue);
+            obj.setFieldBinary(fieldBinaryValue);
+
+            final RandomPrimaryKey fieldObjectValue = new RandomPrimaryKey();
+            fieldObjectValue.setFieldInt(fieldObjectIntValue);
+            obj.setFieldObject(fieldObjectValue);
+
+            final RealmList<RandomPrimaryKey> list = new RealmList<>();
+            final RandomPrimaryKey listItem = new RandomPrimaryKey();
+            listItem.setFieldInt(fieldListIntValue);
+            list.add(listItem);
+            obj.setFieldList(list);
+
+            managedObj = realm.copyToRealm(obj);
+        }
+        realm.commitTransaction();
+
+        assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE/*not fieldIgnoredValue*/,
+                managedObj.getFieldIgnored());
+        assertEquals(fieldStringValue,
+                managedObj.getFieldString());
+        assertEquals(fieldRandomStringValue,
+                managedObj.getFieldRandomString());
+        assertEquals(fieldShortValue,
+                managedObj.getFieldShort());
+        assertEquals(fieldIntValue,
+                managedObj.getFieldInt());
+        assertEquals(fieldLongPrimaryKeyValue,
+                managedObj.getFieldLongPrimaryKey());
+        assertEquals(fieldLongValue,
+                managedObj.getFieldLong());
+        assertEquals(fieldByteValue,
+                managedObj.getFieldByte());
+        assertEquals(fieldFloatValue,
+                managedObj.getFieldFloat(), 0f);
+        assertEquals(fieldDoubleValue,
+                managedObj.getFieldDouble(), 0d);
+        assertEquals(fieldBooleanValue,
+                managedObj.isFieldBoolean());
+        assertEquals(fieldDateValue,
+                managedObj.getFieldDate());
+        assertTrue(Arrays.equals(fieldBinaryValue, managedObj.getFieldBinary()));
+        assertEquals(fieldObjectIntValue,
+                managedObj.getFieldObject().getFieldInt());
+        assertEquals(fieldListIntValue,
+                managedObj.getFieldList().first().getFieldInt());
     }
 
     // Test close Realm in another thread different from where it is created.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2312,11 +2312,12 @@ public class RealmTests {
         assertEquals(1L, realm.where(DefaultValueOfField.class)
                 .equalTo(DefaultValueOfField.FIELD_BINARY, DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE)
                 .count());
-        // FIXME supprting default value of RealmObject and RealmList
-//        assertEquals(1L, realm.where(DefaultValueOfField.class)
-//                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT
-//                        , PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT_DEFAULT_VALUE)
-//                .count());
+
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT
+                        , PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT_DEFAULT_VALUE)
+                .count());
+        // FIXME supporting default value of  RealmList
 //        assertEquals(1L, realm.where(DefaultValueOfField.class)
 //                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT,
 //                        PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT_DEFAULT_VALUE)

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -100,6 +100,8 @@ import io.realm.rule.TestRealmConfigurationFactory;
 import io.realm.util.ExceptionHolder;
 import io.realm.util.RealmThread;
 
+import static io.realm.TestHelper.testNoObjectFound;
+import static io.realm.TestHelper.testOneObjectFound;
 import static io.realm.internal.test.ExtraTests.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2278,52 +2280,50 @@ public class RealmTests {
         });
         final String createdRandomString = DefaultValueOfField.lastRandomStringValue;
 
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_STRING, DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_RANDOM_STRING, createdRandomString)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_SHORT, DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_INT, DefaultValueOfField.FIELD_INT_DEFAULT_VALUE)
-                .count());
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_STRING,
+                DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_RANDOM_STRING, createdRandomString);
+        testOneObjectFound(realm, DefaultValueOfField.class,DefaultValueOfField.FIELD_SHORT,
+                DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_INT,
+                DefaultValueOfField.FIELD_INT_DEFAULT_VALUE);
         // default value for pk must be ignored
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY,
-                        DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_LONG, DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_BYTE, DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_FLOAT, DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_DOUBLE, DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_BOOLEAN, DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_DATE, DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_BINARY, DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
-                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
-                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
-                .count());
+        testNoObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_LONG_PRIMARY_KEY,
+                DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_LONG_PRIMARY_KEY,
+                DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_LONG,
+                DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_BYTE,
+                DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_FLOAT,
+                DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_DOUBLE,
+                DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_BOOLEAN,
+                DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_DATE,
+                DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_BINARY,
+                DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueOfField.class,
+                DefaultValueOfField.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
+                RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE);
     }
 
     @Test
@@ -2338,52 +2338,51 @@ public class RealmTests {
         });
         final String createdRandomString = DefaultValueConstructor.lastRandomStringValue;
 
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_STRING, DefaultValueConstructor.FIELD_STRING_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_RANDOM_STRING, createdRandomString)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_SHORT, DefaultValueConstructor.FIELD_SHORT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_INT, DefaultValueConstructor.FIELD_INT_DEFAULT_VALUE)
-                .count());
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_STRING,
+                DefaultValueConstructor.FIELD_STRING_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_RANDOM_STRING,
+                createdRandomString);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_SHORT,
+                DefaultValueConstructor.FIELD_SHORT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_INT,
+                DefaultValueConstructor.FIELD_INT_DEFAULT_VALUE);;
         // default value for pk must be ignored
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY,
-                        DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_LONG, DefaultValueConstructor.FIELD_LONG_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_BYTE, DefaultValueConstructor.FIELD_BYTE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_FLOAT, DefaultValueConstructor.FIELD_FLOAT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_DOUBLE, DefaultValueConstructor.FIELD_DOUBLE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_BOOLEAN, DefaultValueConstructor.FIELD_BOOLEAN_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_DATE, DefaultValueConstructor.FIELD_DATE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_BINARY, DefaultValueConstructor.FIELD_BINARY_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
-                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
-                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
-                .count());
+        testNoObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY,
+                        DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY,
+                        DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_LONG,
+                DefaultValueConstructor.FIELD_LONG_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_BYTE,
+                DefaultValueConstructor.FIELD_BYTE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_FLOAT,
+                DefaultValueConstructor.FIELD_FLOAT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_DOUBLE,
+                DefaultValueConstructor.FIELD_DOUBLE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_BOOLEAN,
+                DefaultValueConstructor.FIELD_BOOLEAN_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_DATE, DefaultValueConstructor.FIELD_DATE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_BINARY,
+                DefaultValueConstructor.FIELD_BINARY_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueConstructor.class,
+                DefaultValueConstructor.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE);
     }
 
     @Test
@@ -2398,56 +2397,55 @@ public class RealmTests {
         });
         final String createdRandomString = DefaultValueSetter.lastRandomStringValue;
 
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_STRING, DefaultValueSetter.FIELD_STRING_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_RANDOM_STRING, createdRandomString)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_SHORT, DefaultValueSetter.FIELD_SHORT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_INT, DefaultValueSetter.FIELD_INT_DEFAULT_VALUE)
-                .count());
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_STRING,
+                DefaultValueSetter.FIELD_STRING_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_RANDOM_STRING,
+                createdRandomString);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_SHORT,
+                DefaultValueSetter.FIELD_SHORT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_INT,
+                DefaultValueSetter.FIELD_INT_DEFAULT_VALUE);
         // default value for pk must be ignored
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_LONG_PRIMARY_KEY,
-                        DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_LONG, DefaultValueSetter.FIELD_LONG_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_BYTE, DefaultValueSetter.FIELD_BYTE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_FLOAT, DefaultValueSetter.FIELD_FLOAT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_DOUBLE, DefaultValueSetter.FIELD_DOUBLE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_BOOLEAN, DefaultValueSetter.FIELD_BOOLEAN_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_DATE, DefaultValueSetter.FIELD_DATE_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_BINARY, DefaultValueSetter.FIELD_BINARY_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
-                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
-                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
-                .count());
-        assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_LIST+ "." + RandomPrimaryKey.FIELD_INT,
-                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1)
-                .count());
+        testNoObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_LONG_PRIMARY_KEY,
+                        DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_LONG_PRIMARY_KEY,
+                        DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_LONG,
+                DefaultValueSetter.FIELD_LONG_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_BYTE,
+                DefaultValueSetter.FIELD_BYTE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_FLOAT,
+                DefaultValueSetter.FIELD_FLOAT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_DOUBLE,
+                DefaultValueSetter.FIELD_DOUBLE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_BOOLEAN,
+                DefaultValueSetter.FIELD_BOOLEAN_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_DATE,
+                DefaultValueSetter.FIELD_DATE_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_BINARY,
+                DefaultValueSetter.FIELD_BINARY_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE);
+        testOneObjectFound(realm, DefaultValueSetter.class,
+                DefaultValueSetter.FIELD_LIST+ "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1);
     }
 
     @Test
@@ -2501,33 +2499,20 @@ public class RealmTests {
 
         assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE/*not fieldIgnoredValue*/,
                 managedObj.getFieldIgnored());
-        assertEquals(fieldStringValue,
-                managedObj.getFieldString());
-        assertEquals(fieldRandomStringValue,
-                managedObj.getFieldRandomString());
-        assertEquals(fieldShortValue,
-                managedObj.getFieldShort());
-        assertEquals(fieldIntValue,
-                managedObj.getFieldInt());
-        assertEquals(fieldLongPrimaryKeyValue,
-                managedObj.getFieldLongPrimaryKey());
-        assertEquals(fieldLongValue,
-                managedObj.getFieldLong());
-        assertEquals(fieldByteValue,
-                managedObj.getFieldByte());
-        assertEquals(fieldFloatValue,
-                managedObj.getFieldFloat(), 0f);
-        assertEquals(fieldDoubleValue,
-                managedObj.getFieldDouble(), 0d);
-        assertEquals(fieldBooleanValue,
-                managedObj.isFieldBoolean());
-        assertEquals(fieldDateValue,
-                managedObj.getFieldDate());
+        assertEquals(fieldStringValue, managedObj.getFieldString());
+        assertEquals(fieldRandomStringValue, managedObj.getFieldRandomString());
+        assertEquals(fieldShortValue, managedObj.getFieldShort());
+        assertEquals(fieldIntValue, managedObj.getFieldInt());
+        assertEquals(fieldLongPrimaryKeyValue, managedObj.getFieldLongPrimaryKey());
+        assertEquals(fieldLongValue, managedObj.getFieldLong());
+        assertEquals(fieldByteValue, managedObj.getFieldByte());
+        assertEquals(fieldFloatValue, managedObj.getFieldFloat(), 0f);
+        assertEquals(fieldDoubleValue, managedObj.getFieldDouble(), 0d);
+        assertEquals(fieldBooleanValue, managedObj.isFieldBoolean());
+        assertEquals(fieldDateValue, managedObj.getFieldDate());
         assertTrue(Arrays.equals(fieldBinaryValue, managedObj.getFieldBinary()));
-        assertEquals(fieldObjectIntValue,
-                managedObj.getFieldObject().getFieldInt());
-        assertEquals(fieldListIntValue,
-                managedObj.getFieldList().first().getFieldInt());
+        assertEquals(fieldObjectIntValue, managedObj.getFieldObject().getFieldInt());
+        assertEquals(fieldListIntValue, managedObj.getFieldList().first().getFieldInt());
     }
 
     // Test close Realm in another thread different from where it is created.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2523,6 +2523,59 @@ public class RealmTests {
         assertEquals(2, realm.where(RandomPrimaryKey.class).count());
     }
 
+    @Test
+    public void copyFromRealm_defaultValuesAreIgnored() {
+        final DefaultValueOfField managedObj;
+        realm.beginTransaction(); {
+            final DefaultValueOfField obj = new DefaultValueOfField();
+            obj.setFieldIgnored(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE + ".modified");
+            obj.setFieldString(DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE + ".modified");
+            obj.setFieldRandomString("non-random");
+            obj.setFieldShort((short) (DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE + 1));
+            obj.setFieldInt(DefaultValueOfField.FIELD_INT_DEFAULT_VALUE + 1);
+            obj.setFieldLongPrimaryKey(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE + 1);
+            obj.setFieldLong(DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE + 1);
+            obj.setFieldByte((byte) (DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE + 1));
+            obj.setFieldFloat(DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE + 1);
+            obj.setFieldDouble(DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE + 1);
+            obj.setFieldBoolean(!DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE);
+            obj.setFieldDate(new Date(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE.getTime() + 1));
+            obj.setFieldBinary(new byte[] {(byte) (DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE[0] - 1)});
+
+            final RandomPrimaryKey fieldObjectValue = new RandomPrimaryKey();
+            fieldObjectValue.setFieldInt(RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1);
+            obj.setFieldObject(fieldObjectValue);
+
+            final RealmList<RandomPrimaryKey> list = new RealmList<>();
+            final RandomPrimaryKey listItem = new RandomPrimaryKey();
+            listItem.setFieldInt(RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 2);
+            list.add(listItem);
+            obj.setFieldList(list);
+
+            managedObj = realm.copyToRealm(obj);
+        }
+        realm.commitTransaction();
+
+        final DefaultValueOfField copy = realm.copyFromRealm(managedObj);
+
+        assertEquals(DefaultValueOfField.FIELD_IGNORED_DEFAULT_VALUE, copy.getFieldIgnored());
+        assertEquals(managedObj.getFieldString(), copy.getFieldString());
+        assertEquals(managedObj.getFieldRandomString(), copy.getFieldRandomString());
+        assertEquals(managedObj.getFieldShort(), copy.getFieldShort());
+        assertEquals(managedObj.getFieldInt(), copy.getFieldInt());
+        assertEquals(managedObj.getFieldLongPrimaryKey(), copy.getFieldLongPrimaryKey());
+        assertEquals(managedObj.getFieldLong(), copy.getFieldLong());
+        assertEquals(managedObj.getFieldByte(), copy.getFieldByte());
+        assertEquals(managedObj.getFieldFloat(), copy.getFieldFloat(), 0f);
+        assertEquals(managedObj.getFieldDouble(), copy.getFieldDouble(), 0d);
+        assertEquals(managedObj.isFieldBoolean(), copy.isFieldBoolean());
+        assertEquals(managedObj.getFieldDate(), copy.getFieldDate());
+        assertTrue(Arrays.equals(managedObj.getFieldBinary(), copy.getFieldBinary()));
+        assertEquals(managedObj.getFieldObject().getFieldInt(), copy.getFieldObject().getFieldInt());
+        assertEquals(1, copy.getFieldList().size());
+        assertEquals(managedObj.getFieldList().first().getFieldInt(), copy.getFieldList().first().getFieldInt());
+    }
+
     // Test close Realm in another thread different from where it is created.
     @Test
     public void close_differentThread() throws InterruptedException {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -63,6 +63,7 @@ import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.Cat;
 import io.realm.entities.CyclicType;
 import io.realm.entities.CyclicTypePrimaryKey;
+import io.realm.entities.DefaultValueOfField;
 import io.realm.entities.Dog;
 import io.realm.entities.DogPrimaryKey;
 import io.realm.entities.NoPrimaryKeyNullTypes;
@@ -82,6 +83,7 @@ import io.realm.entities.PrimaryKeyRequiredAsBoxedInteger;
 import io.realm.entities.PrimaryKeyRequiredAsBoxedLong;
 import io.realm.entities.PrimaryKeyRequiredAsBoxedShort;
 import io.realm.entities.PrimaryKeyRequiredAsString;
+import io.realm.entities.PrimaryKeyWithNoPrimaryKeyObjectRelation;
 import io.realm.entities.StringOnly;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
@@ -2260,6 +2262,65 @@ public class RealmTests {
         }
 
         realm.cancelTransaction();
+    }
+
+    @Test
+    public void createObject_defaultValueFromModelField() {
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createObject(DefaultValueOfField.class,
+                        DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+            }
+        });
+
+        final String createdRandomString = DefaultValueOfField.lastRandomStringValue;
+
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_STRING, DefaultValueOfField.FIELD_STRING_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_RANDOM_STRING, createdRandomString)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_SHORT, DefaultValueOfField.FIELD_SHORT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_INT, DefaultValueOfField.FIELD_INT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY, DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_LONG, DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_BYTE, DefaultValueOfField.FIELD_BYTE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_FLOAT, DefaultValueOfField.FIELD_FLOAT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_DOUBLE, DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_BOOLEAN, DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_DATE, DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_BINARY, DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE)
+                .count());
+        // FIXME supprting default value of RealmObject and RealmList
+//        assertEquals(1L, realm.where(DefaultValueOfField.class)
+//                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT
+//                        , PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT_DEFAULT_VALUE)
+//                .count());
+//        assertEquals(1L, realm.where(DefaultValueOfField.class)
+//                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT,
+//                        PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT_DEFAULT_VALUE)
+//                .count());
     }
 
     // Test close Realm in another thread different from where it is created.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -84,6 +84,7 @@ import io.realm.entities.PrimaryKeyRequiredAsBoxedLong;
 import io.realm.entities.PrimaryKeyRequiredAsBoxedShort;
 import io.realm.entities.PrimaryKeyRequiredAsString;
 import io.realm.entities.PrimaryKeyWithNoPrimaryKeyObjectRelation;
+import io.realm.entities.RandomPrimaryKey;
 import io.realm.entities.StringOnly;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
@@ -2273,7 +2274,6 @@ public class RealmTests {
                         DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
             }
         });
-
         final String createdRandomString = DefaultValueOfField.lastRandomStringValue;
 
         assertEquals(1L, realm.where(DefaultValueOfField.class)
@@ -2312,16 +2312,14 @@ public class RealmTests {
         assertEquals(1L, realm.where(DefaultValueOfField.class)
                 .equalTo(DefaultValueOfField.FIELD_BINARY, DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE)
                 .count());
-
         assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT
-                        , PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT_DEFAULT_VALUE)
+                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
                 .count());
-        // FIXME supporting default value of  RealmList
-//        assertEquals(1L, realm.where(DefaultValueOfField.class)
-//                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT,
-//                        PrimaryKeyWithNoPrimaryKeyObjectRelation.FIELD_COLUMN_INT_DEFAULT_VALUE)
-//                .count());
+        assertEquals(1L, realm.where(DefaultValueOfField.class)
+                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
+                .count());
     }
 
     // Test close Realm in another thread different from where it is created.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2289,8 +2289,10 @@ public class RealmTests {
         assertEquals(1L, realm.where(DefaultValueOfField.class)
                 .equalTo(DefaultValueOfField.FIELD_INT, DefaultValueOfField.FIELD_INT_DEFAULT_VALUE)
                 .count());
+        // default value for pk must be ignored
         assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY, DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE)
+                .equalTo(DefaultValueOfField.FIELD_LONG_PRIMARY_KEY,
+                        DefaultValueOfField.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3)
                 .count());
         assertEquals(1L, realm.where(DefaultValueOfField.class)
                 .equalTo(DefaultValueOfField.FIELD_LONG, DefaultValueOfField.FIELD_LONG_DEFAULT_VALUE)
@@ -2346,8 +2348,10 @@ public class RealmTests {
         assertEquals(1L, realm.where(DefaultValueConstructor.class)
                 .equalTo(DefaultValueConstructor.FIELD_INT, DefaultValueConstructor.FIELD_INT_DEFAULT_VALUE)
                 .count());
+        // default value for pk must be ignored
         assertEquals(1L, realm.where(DefaultValueConstructor.class)
-                .equalTo(DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY, DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE)
+                .equalTo(DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY,
+                        DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3)
                 .count());
         assertEquals(1L, realm.where(DefaultValueConstructor.class)
                 .equalTo(DefaultValueConstructor.FIELD_LONG, DefaultValueConstructor.FIELD_LONG_DEFAULT_VALUE)
@@ -2403,8 +2407,10 @@ public class RealmTests {
         assertEquals(1L, realm.where(DefaultValueSetter.class)
                 .equalTo(DefaultValueSetter.FIELD_INT, DefaultValueSetter.FIELD_INT_DEFAULT_VALUE)
                 .count());
+        // default value for pk must be ignored
         assertEquals(1L, realm.where(DefaultValueSetter.class)
-                .equalTo(DefaultValueSetter.FIELD_LONG_PRIMARY_KEY, DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE)
+                .equalTo(DefaultValueSetter.FIELD_LONG_PRIMARY_KEY,
+                        DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3)
                 .count());
         assertEquals(1L, realm.where(DefaultValueSetter.class)
                 .equalTo(DefaultValueSetter.FIELD_LONG, DefaultValueSetter.FIELD_LONG_DEFAULT_VALUE)

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -2512,7 +2512,11 @@ public class RealmTests {
         assertEquals(fieldDateValue, managedObj.getFieldDate());
         assertTrue(Arrays.equals(fieldBinaryValue, managedObj.getFieldBinary()));
         assertEquals(fieldObjectIntValue, managedObj.getFieldObject().getFieldInt());
+        assertEquals(1, managedObj.getFieldList().size());
         assertEquals(fieldListIntValue, managedObj.getFieldList().first().getFieldInt());
+
+        // make sure that excess object by default value is not created.
+        assertEquals(2, realm.where(RandomPrimaryKey.class).count());
     }
 
     // Test close Realm in another thread different from where it is created.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -63,7 +63,9 @@ import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.Cat;
 import io.realm.entities.CyclicType;
 import io.realm.entities.CyclicTypePrimaryKey;
+import io.realm.entities.DefaultValueConstructor;
 import io.realm.entities.DefaultValueOfField;
+import io.realm.entities.DefaultValueSetter;
 import io.realm.entities.Dog;
 import io.realm.entities.DogPrimaryKey;
 import io.realm.entities.NoPrimaryKeyNullTypes;
@@ -83,7 +85,6 @@ import io.realm.entities.PrimaryKeyRequiredAsBoxedInteger;
 import io.realm.entities.PrimaryKeyRequiredAsBoxedLong;
 import io.realm.entities.PrimaryKeyRequiredAsBoxedShort;
 import io.realm.entities.PrimaryKeyRequiredAsString;
-import io.realm.entities.PrimaryKeyWithNoPrimaryKeyObjectRelation;
 import io.realm.entities.RandomPrimaryKey;
 import io.realm.entities.StringOnly;
 import io.realm.exceptions.RealmException;
@@ -2317,8 +2318,126 @@ public class RealmTests {
                         RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
                 .count());
         assertEquals(1L, realm.where(DefaultValueOfField.class)
-                .equalTo(DefaultValueOfField.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                .equalTo(DefaultValueOfField.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
                         RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
+                .count());
+    }
+
+    @Test
+    public void createObject_defaultValueFromModelConstructor() {
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createObject(DefaultValueConstructor.class,
+                        DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+            }
+        });
+        final String createdRandomString = DefaultValueConstructor.lastRandomStringValue;
+
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_STRING, DefaultValueConstructor.FIELD_STRING_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_RANDOM_STRING, createdRandomString)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_SHORT, DefaultValueConstructor.FIELD_SHORT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_INT, DefaultValueConstructor.FIELD_INT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY, DefaultValueConstructor.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_LONG, DefaultValueConstructor.FIELD_LONG_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_BYTE, DefaultValueConstructor.FIELD_BYTE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_FLOAT, DefaultValueConstructor.FIELD_FLOAT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_DOUBLE, DefaultValueConstructor.FIELD_DOUBLE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_BOOLEAN, DefaultValueConstructor.FIELD_BOOLEAN_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_DATE, DefaultValueConstructor.FIELD_DATE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_BINARY, DefaultValueConstructor.FIELD_BINARY_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueConstructor.class)
+                .equalTo(DefaultValueConstructor.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
+                .count());
+    }
+
+    @Test
+    public void createObject_defaultValueSetterInConstructor() {
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                realm.createObject(DefaultValueSetter.class,
+                        DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE * 3);
+            }
+        });
+        final String createdRandomString = DefaultValueSetter.lastRandomStringValue;
+
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_STRING, DefaultValueSetter.FIELD_STRING_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_RANDOM_STRING, createdRandomString)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_SHORT, DefaultValueSetter.FIELD_SHORT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_INT, DefaultValueSetter.FIELD_INT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_LONG_PRIMARY_KEY, DefaultValueSetter.FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_LONG, DefaultValueSetter.FIELD_LONG_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_BYTE, DefaultValueSetter.FIELD_BYTE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_FLOAT, DefaultValueSetter.FIELD_FLOAT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_DOUBLE, DefaultValueSetter.FIELD_DOUBLE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_BOOLEAN, DefaultValueSetter.FIELD_BOOLEAN_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_DATE, DefaultValueSetter.FIELD_DATE_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_BINARY, DefaultValueSetter.FIELD_BINARY_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_OBJECT + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_LIST + "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE)
+                .count());
+        assertEquals(1L, realm.where(DefaultValueSetter.class)
+                .equalTo(DefaultValueSetter.FIELD_LIST+ "." + RandomPrimaryKey.FIELD_INT,
+                        RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1)
                 .count());
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -937,6 +937,64 @@ public class TestHelper {
         }
     }
 
+    public static void testNoObjectFound(
+            Realm realm,
+            Class<? extends RealmModel> clazz,
+            String fieldName, Object value) {
+        testObjectCount(realm, 0L, clazz, fieldName, value);
+    }
+
+    public static void testOneObjectFound(
+            Realm realm,
+            Class<? extends RealmModel> clazz,
+            String fieldName, Object value) {
+        testObjectCount(realm, 1L, clazz, fieldName, value);
+    }
+
+    public static void testObjectCount(
+            Realm realm,
+            long expectedCount,
+            Class<? extends RealmModel> clazz,
+            String fieldName, Object value) {
+        final RealmQuery<? extends RealmModel> query;
+        switch (value.getClass().getSimpleName()) {
+            case "String":
+                query = realm.where(clazz).equalTo(fieldName, (String) value);
+                break;
+            case "Byte":
+                query = realm.where(clazz).equalTo(fieldName, (Byte) value);
+                break;
+            case "Short":
+                query = realm.where(clazz).equalTo(fieldName, (Short) value);
+                break;
+            case "Integer":
+                query = realm.where(clazz).equalTo(fieldName, (Integer) value);
+                break;
+            case "Long":
+                query = realm.where(clazz).equalTo(fieldName, (Long) value);
+                break;
+            case "Float":
+                query = realm.where(clazz).equalTo(fieldName, (Float) value);
+                break;
+            case "Double":
+                query = realm.where(clazz).equalTo(fieldName, (Double) value);
+                break;
+            case "Boolean":
+                query = realm.where(clazz).equalTo(fieldName, (Boolean) value);
+                break;
+            case "Date":
+                query = realm.where(clazz).equalTo(fieldName, (Date) value);
+                break;
+            case "byte[]":
+                query = realm.where(clazz).equalTo(fieldName, (byte[]) value);
+                break;
+            default:
+                throw new AssertionError("unknown type: " + value.getClass().getSimpleName());
+        }
+
+        assertEquals(expectedCount, query.count());
+    }
+
     /**
      * Replaces the current thread executor with a another one for testing.
      * WARNING: This method should only be called before any async tasks have been started.

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueConstructor.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueConstructor.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import java.util.Date;
+import java.util.UUID;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.PrimaryKey;
+
+public class DefaultValueConstructor extends RealmObject {
+
+    public static final String CLASS_NAME = "DefaultValueOfField";
+    public static String FIELD_IGNORED = "fieldIgnored";
+    public static String FIELD_RANDOM_STRING = "fieldRandomString";
+    public static String FIELD_STRING = "fieldString";
+    public static String FIELD_SHORT = "fieldShort";
+    public static String FIELD_INT = "fieldInt";
+    public static String FIELD_LONG_PRIMARY_KEY = "fieldLongPrimaryKey";
+    public static String FIELD_LONG = "fieldLong";
+    public static String FIELD_BYTE = "fieldByte";
+    public static String FIELD_FLOAT = "fieldFloat";
+    public static String FIELD_DOUBLE = "fieldDouble";
+    public static String FIELD_BOOLEAN = "fieldBoolean";
+    public static String FIELD_DATE = "fieldDate";
+    public static String FIELD_BINARY = "fieldBinary";
+    public static String FIELD_OBJECT = "fieldObject";
+    public static String FIELD_LIST = "fieldList";
+
+
+    public static String FIELD_IGNORED_DEFAULT_VALUE = "ignored";
+    public static String FIELD_STRING_DEFAULT_VALUE = "defaultString";
+    public static short FIELD_SHORT_DEFAULT_VALUE = 1234;
+    public static int FIELD_INT_DEFAULT_VALUE = 123456;
+    public static long FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE = 2L * Integer.MAX_VALUE;
+    public static long FIELD_LONG_DEFAULT_VALUE = 3L * Integer.MAX_VALUE;
+    public static byte FIELD_BYTE_DEFAULT_VALUE = 100;
+    public static float FIELD_FLOAT_DEFAULT_VALUE = 0.5f;
+    public static double FIELD_DOUBLE_DEFAULT_VALUE = 0.25;
+    public static boolean FIELD_BOOLEAN_DEFAULT_VALUE = true;
+    public static Date FIELD_DATE_DEFAULT_VALUE = new Date(1473691826000L /*2016/9/12 23:56:26 JST*/);
+    public static byte[] FIELD_BINARY_DEFAULT_VALUE = new byte[] {123, -100, 0, 2};
+    public static RandomPrimaryKey FIELD_OBJECT_DEFAULT_VALUE;
+    public static RealmList<RandomPrimaryKey> FIELD_LIST_DEFAULT_VALUE;
+
+    static {
+        FIELD_OBJECT_DEFAULT_VALUE = new RandomPrimaryKey();
+        FIELD_LIST_DEFAULT_VALUE = new RealmList<RandomPrimaryKey>();
+        FIELD_LIST_DEFAULT_VALUE.add(new RandomPrimaryKey());
+    }
+
+    public static String lastRandomStringValue;
+
+    @Ignore private String fieldIgnored;
+    private String fieldString;
+    private String fieldRandomString;
+    private short fieldShort;
+    private int fieldInt;
+    @PrimaryKey private long fieldLongPrimaryKey;
+    private long fieldLong;
+    private byte fieldByte;
+    private float fieldFloat;
+    private double fieldDouble;
+    private boolean fieldBoolean;
+    private Date fieldDate;
+    private byte[] fieldBinary;
+    private RandomPrimaryKey fieldObject;
+    private RealmList<RandomPrimaryKey> fieldList;
+
+    public DefaultValueConstructor() {
+        fieldIgnored = FIELD_IGNORED_DEFAULT_VALUE;
+        fieldString = FIELD_STRING_DEFAULT_VALUE;
+        fieldRandomString = lastRandomStringValue = UUID.randomUUID().toString();
+        fieldShort = FIELD_SHORT_DEFAULT_VALUE;
+        fieldInt = FIELD_INT_DEFAULT_VALUE;
+        fieldLongPrimaryKey = FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE;
+        fieldLong = FIELD_LONG_DEFAULT_VALUE;
+        fieldByte = FIELD_BYTE_DEFAULT_VALUE;
+        fieldFloat = FIELD_FLOAT_DEFAULT_VALUE;
+        fieldDouble = FIELD_DOUBLE_DEFAULT_VALUE;
+        fieldBoolean = FIELD_BOOLEAN_DEFAULT_VALUE;
+        fieldDate = FIELD_DATE_DEFAULT_VALUE;
+        fieldBinary = FIELD_BINARY_DEFAULT_VALUE;
+        fieldObject = FIELD_OBJECT_DEFAULT_VALUE;
+        fieldList = FIELD_LIST_DEFAULT_VALUE;
+    }
+
+    public DefaultValueConstructor(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public String getFieldIgnored() {
+        return fieldIgnored;
+    }
+
+    public void setFieldIgnored(String fieldIgnored) {
+        this.fieldIgnored = fieldIgnored;
+    }
+
+    public String getFieldString() {
+        return fieldString;
+    }
+
+    public void setFieldString(String fieldString) {
+        this.fieldString = fieldString;
+    }
+
+    public String getFieldRandomString() {
+        return fieldRandomString;
+    }
+
+    public void setFieldRandomString(String fieldRandomString) {
+        this.fieldRandomString = fieldRandomString;
+    }
+
+    public short getFieldShort() {
+        return fieldShort;
+    }
+
+    public void setFieldShort(short fieldShort) {
+        this.fieldShort = fieldShort;
+    }
+
+    public int getFieldInt() {
+        return fieldInt;
+    }
+
+    public void setFieldInt(int fieldInt) {
+        this.fieldInt = fieldInt;
+    }
+
+    public long getFieldLongPrimaryKey() {
+        return fieldLongPrimaryKey;
+    }
+
+    public void setFieldLongPrimaryKey(long fieldLongPrimaryKey) {
+        this.fieldLongPrimaryKey = fieldLongPrimaryKey;
+    }
+
+    public long getFieldLong() {
+        return fieldLong;
+    }
+
+    public void setFieldLong(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public byte getFieldByte() {
+        return fieldByte;
+    }
+
+    public void setFieldByte(byte fieldByte) {
+        this.fieldByte = fieldByte;
+    }
+
+    public float getFieldFloat() {
+        return fieldFloat;
+    }
+
+    public void setFieldFloat(float fieldFloat) {
+        this.fieldFloat = fieldFloat;
+    }
+
+    public double getFieldDouble() {
+        return fieldDouble;
+    }
+
+    public void setFieldDouble(double fieldDouble) {
+        this.fieldDouble = fieldDouble;
+    }
+
+    public boolean isFieldBoolean() {
+        return fieldBoolean;
+    }
+
+    public void setFieldBoolean(boolean fieldBoolean) {
+        this.fieldBoolean = fieldBoolean;
+    }
+
+    public Date getFieldDate() {
+        return fieldDate;
+    }
+
+    public void setFieldDate(Date fieldDate) {
+        this.fieldDate = fieldDate;
+    }
+
+    public byte[] getFieldBinary() {
+        return fieldBinary;
+    }
+
+    public void setFieldBinary(byte[] fieldBinary) {
+        this.fieldBinary = fieldBinary;
+    }
+
+    public RandomPrimaryKey getFieldObject() {
+        return fieldObject;
+    }
+
+    public void setFieldObject(RandomPrimaryKey fieldObject) {
+        this.fieldObject = fieldObject;
+    }
+
+    public RealmList<RandomPrimaryKey> getFieldList() {
+        return fieldList;
+    }
+
+    public void setFieldList(RealmList<RandomPrimaryKey> fieldList) {
+        this.fieldList = fieldList;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
@@ -80,8 +80,8 @@ public class DefaultValueOfField extends RealmObject {
     private boolean fieldBoolean = FIELD_BOOLEAN_DEFAULT_VALUE;
     private Date fieldDate = FIELD_DATE_DEFAULT_VALUE;
     private byte[] fieldBinary = FIELD_BINARY_DEFAULT_VALUE;
+    private PrimaryKeyWithNoPrimaryKeyObjectRelation fieldObject = FIELD_OBJECT_DEFAULT_VALUE;
     // FIXME supports these default values
-    private PrimaryKeyWithNoPrimaryKeyObjectRelation fieldObject;// = FIELD_OBJECT_DEFAULT_VALUE;
     private RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> fieldList;// = FIELD_LIST_DEFAULT_VALUE;
 
     public DefaultValueOfField() {

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import java.util.Date;
+import java.util.UUID;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.PrimaryKey;
+
+public class DefaultValueOfField extends RealmObject {
+
+    public static final String CLASS_NAME = "DefaultValueOfField";
+    public static String FIELD_IGNORED = "fieldIgnored";
+    public static String FIELD_RANDOM_STRING = "fieldRandomString";
+    public static String FIELD_STRING = "fieldString";
+    public static String FIELD_SHORT = "fieldShort";
+    public static String FIELD_INT = "fieldInt";
+    public static String FIELD_LONG_PRIMARY_KEY = "fieldLongPrimaryKey";
+    public static String FIELD_LONG = "fieldLong";
+    public static String FIELD_BYTE = "fieldByte";
+    public static String FIELD_FLOAT = "fieldFloat";
+    public static String FIELD_DOUBLE = "fieldDouble";
+    public static String FIELD_BOOLEAN = "fieldBoolean";
+    public static String FIELD_DATE = "fieldDate";
+    public static String FIELD_BINARY = "fieldBinary";
+    public static String FIELD_OBJECT = "fieldObject";
+    public static String FIELD_LIST = "fieldList";
+
+
+    public static String FIELD_IGNORED_DEFAULT_VALUE = "ignored";
+    public static String FIELD_STRING_DEFAULT_VALUE = "defaultString";
+    public static short FIELD_SHORT_DEFAULT_VALUE = 1234;
+    public static int FIELD_INT_DEFAULT_VALUE = 123456;
+    public static long FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE = 2L * Integer.MAX_VALUE;
+    public static long FIELD_LONG_DEFAULT_VALUE = 3L * Integer.MAX_VALUE;
+    public static byte FIELD_BYTE_DEFAULT_VALUE = 100;
+    public static float FIELD_FLOAT_DEFAULT_VALUE = 0.5f;
+    public static double FIELD_DOUBLE_DEFAULT_VALUE = 0.25;
+    public static boolean FIELD_BOOLEAN_DEFAULT_VALUE = true;
+    public static Date FIELD_DATE_DEFAULT_VALUE = new Date(1473691826000L /*2016/9/12 23:56:26 JST*/);
+    public static byte[] FIELD_BINARY_DEFAULT_VALUE = new byte[] {123, -100, 0, 2};
+    public static PrimaryKeyWithNoPrimaryKeyObjectRelation FIELD_OBJECT_DEFAULT_VALUE;
+    public static RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> FIELD_LIST_DEFAULT_VALUE;
+
+    static {
+        FIELD_OBJECT_DEFAULT_VALUE = new PrimaryKeyWithNoPrimaryKeyObjectRelation();
+        FIELD_LIST_DEFAULT_VALUE = new RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation>();
+        FIELD_LIST_DEFAULT_VALUE.add(new PrimaryKeyWithNoPrimaryKeyObjectRelation());
+    }
+
+    public static String lastRandomStringValue;
+
+    @Ignore private String fieldIgnored = FIELD_IGNORED_DEFAULT_VALUE;
+    private String fieldString = FIELD_STRING_DEFAULT_VALUE;
+    private String fieldRandomString = lastRandomStringValue = UUID.randomUUID().toString();
+    private short fieldShort = FIELD_SHORT_DEFAULT_VALUE;
+    private int fieldInt = FIELD_INT_DEFAULT_VALUE;
+    @PrimaryKey private long fieldLongPrimaryKey = FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE;
+    private long fieldLong = FIELD_LONG_DEFAULT_VALUE;
+    private byte fieldByte = FIELD_BYTE_DEFAULT_VALUE;
+    private float fieldFloat = FIELD_FLOAT_DEFAULT_VALUE;
+    private double fieldDouble = FIELD_DOUBLE_DEFAULT_VALUE;
+    private boolean fieldBoolean = FIELD_BOOLEAN_DEFAULT_VALUE;
+    private Date fieldDate = FIELD_DATE_DEFAULT_VALUE;
+    private byte[] fieldBinary = FIELD_BINARY_DEFAULT_VALUE;
+    // FIXME supports these default values
+    private PrimaryKeyWithNoPrimaryKeyObjectRelation fieldObject;// = FIELD_OBJECT_DEFAULT_VALUE;
+    private RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> fieldList;// = FIELD_LIST_DEFAULT_VALUE;
+
+    public DefaultValueOfField() {
+
+    }
+
+    public DefaultValueOfField(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public String getFieldIgnored() {
+        return fieldIgnored;
+    }
+
+    public void setFieldIgnored(String fieldIgnored) {
+        this.fieldIgnored = fieldIgnored;
+    }
+
+    public String getFieldString() {
+        return fieldString;
+    }
+
+    public void setFieldString(String fieldString) {
+        this.fieldString = fieldString;
+    }
+
+    public String getFieldRandomString() {
+        return fieldRandomString;
+    }
+
+    public void setFieldRandomString(String fieldRandomString) {
+        this.fieldRandomString = fieldRandomString;
+    }
+
+    public short getFieldShort() {
+        return fieldShort;
+    }
+
+    public void setFieldShort(short fieldShort) {
+        this.fieldShort = fieldShort;
+    }
+
+    public int getFieldInt() {
+        return fieldInt;
+    }
+
+    public void setFieldInt(int fieldInt) {
+        this.fieldInt = fieldInt;
+    }
+
+    public long getFieldLongPrimaryKey() {
+        return fieldLongPrimaryKey;
+    }
+
+    public void setFieldLongPrimaryKey(long fieldLongPrimaryKey) {
+        this.fieldLongPrimaryKey = fieldLongPrimaryKey;
+    }
+
+    public long getFieldLong() {
+        return fieldLong;
+    }
+
+    public void setFieldLong(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public byte getFieldByte() {
+        return fieldByte;
+    }
+
+    public void setFieldByte(byte fieldByte) {
+        this.fieldByte = fieldByte;
+    }
+
+    public float getFieldFloat() {
+        return fieldFloat;
+    }
+
+    public void setFieldFloat(float fieldFloat) {
+        this.fieldFloat = fieldFloat;
+    }
+
+    public double getFieldDouble() {
+        return fieldDouble;
+    }
+
+    public void setFieldDouble(double fieldDouble) {
+        this.fieldDouble = fieldDouble;
+    }
+
+    public boolean isFieldBoolean() {
+        return fieldBoolean;
+    }
+
+    public void setFieldBoolean(boolean fieldBoolean) {
+        this.fieldBoolean = fieldBoolean;
+    }
+
+    public Date getFieldDate() {
+        return fieldDate;
+    }
+
+    public void setFieldDate(Date fieldDate) {
+        this.fieldDate = fieldDate;
+    }
+
+    public byte[] getFieldBinary() {
+        return fieldBinary;
+    }
+
+    public void setFieldBinary(byte[] fieldBinary) {
+        this.fieldBinary = fieldBinary;
+    }
+
+    public PrimaryKeyWithNoPrimaryKeyObjectRelation getFieldObject() {
+        return fieldObject;
+    }
+
+    public void setFieldObject(PrimaryKeyWithNoPrimaryKeyObjectRelation fieldObject) {
+        this.fieldObject = fieldObject;
+    }
+
+    public RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> getFieldList() {
+        return fieldList;
+    }
+
+    public void setFieldList(RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> fieldList) {
+        this.fieldList = fieldList;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
@@ -56,13 +56,13 @@ public class DefaultValueOfField extends RealmObject {
     public static boolean FIELD_BOOLEAN_DEFAULT_VALUE = true;
     public static Date FIELD_DATE_DEFAULT_VALUE = new Date(1473691826000L /*2016/9/12 23:56:26 JST*/);
     public static byte[] FIELD_BINARY_DEFAULT_VALUE = new byte[] {123, -100, 0, 2};
-    public static PrimaryKeyWithNoPrimaryKeyObjectRelation FIELD_OBJECT_DEFAULT_VALUE;
-    public static RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> FIELD_LIST_DEFAULT_VALUE;
+    public static RandomPrimaryKey FIELD_OBJECT_DEFAULT_VALUE;
+    public static RealmList<RandomPrimaryKey> FIELD_LIST_DEFAULT_VALUE;
 
     static {
-        FIELD_OBJECT_DEFAULT_VALUE = new PrimaryKeyWithNoPrimaryKeyObjectRelation();
-        FIELD_LIST_DEFAULT_VALUE = new RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation>();
-        FIELD_LIST_DEFAULT_VALUE.add(new PrimaryKeyWithNoPrimaryKeyObjectRelation());
+        FIELD_OBJECT_DEFAULT_VALUE = new RandomPrimaryKey();
+        FIELD_LIST_DEFAULT_VALUE = new RealmList<RandomPrimaryKey>();
+        FIELD_LIST_DEFAULT_VALUE.add(new RandomPrimaryKey());
     }
 
     public static String lastRandomStringValue;
@@ -80,9 +80,8 @@ public class DefaultValueOfField extends RealmObject {
     private boolean fieldBoolean = FIELD_BOOLEAN_DEFAULT_VALUE;
     private Date fieldDate = FIELD_DATE_DEFAULT_VALUE;
     private byte[] fieldBinary = FIELD_BINARY_DEFAULT_VALUE;
-    private PrimaryKeyWithNoPrimaryKeyObjectRelation fieldObject = FIELD_OBJECT_DEFAULT_VALUE;
-    // FIXME supports these default values
-    private RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> fieldList;// = FIELD_LIST_DEFAULT_VALUE;
+    private RandomPrimaryKey fieldObject = FIELD_OBJECT_DEFAULT_VALUE;
+    private RealmList<RandomPrimaryKey> fieldList = FIELD_LIST_DEFAULT_VALUE;
 
     public DefaultValueOfField() {
 
@@ -196,19 +195,19 @@ public class DefaultValueOfField extends RealmObject {
         this.fieldBinary = fieldBinary;
     }
 
-    public PrimaryKeyWithNoPrimaryKeyObjectRelation getFieldObject() {
+    public RandomPrimaryKey getFieldObject() {
         return fieldObject;
     }
 
-    public void setFieldObject(PrimaryKeyWithNoPrimaryKeyObjectRelation fieldObject) {
+    public void setFieldObject(RandomPrimaryKey fieldObject) {
         this.fieldObject = fieldObject;
     }
 
-    public RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> getFieldList() {
+    public RealmList<RandomPrimaryKey> getFieldList() {
         return fieldList;
     }
 
-    public void setFieldList(RealmList<PrimaryKeyWithNoPrimaryKeyObjectRelation> fieldList) {
+    public void setFieldList(RealmList<RandomPrimaryKey> fieldList) {
         this.fieldList = fieldList;
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueSetter.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueSetter.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import java.util.Date;
+import java.util.UUID;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.PrimaryKey;
+
+public class DefaultValueSetter extends RealmObject {
+
+    public static final String CLASS_NAME = "DefaultValueOfField";
+    public static String FIELD_IGNORED = "fieldIgnored";
+    public static String FIELD_RANDOM_STRING = "fieldRandomString";
+    public static String FIELD_STRING = "fieldString";
+    public static String FIELD_SHORT = "fieldShort";
+    public static String FIELD_INT = "fieldInt";
+    public static String FIELD_LONG_PRIMARY_KEY = "fieldLongPrimaryKey";
+    public static String FIELD_LONG = "fieldLong";
+    public static String FIELD_BYTE = "fieldByte";
+    public static String FIELD_FLOAT = "fieldFloat";
+    public static String FIELD_DOUBLE = "fieldDouble";
+    public static String FIELD_BOOLEAN = "fieldBoolean";
+    public static String FIELD_DATE = "fieldDate";
+    public static String FIELD_BINARY = "fieldBinary";
+    public static String FIELD_OBJECT = "fieldObject";
+    public static String FIELD_LIST = "fieldList";
+
+
+    public static String FIELD_IGNORED_DEFAULT_VALUE = "ignored";
+    public static String FIELD_STRING_DEFAULT_VALUE = "defaultString";
+    public static short FIELD_SHORT_DEFAULT_VALUE = 1234;
+    public static int FIELD_INT_DEFAULT_VALUE = 123456;
+    public static long FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE = 2L * Integer.MAX_VALUE;
+    public static long FIELD_LONG_DEFAULT_VALUE = 3L * Integer.MAX_VALUE;
+    public static byte FIELD_BYTE_DEFAULT_VALUE = 100;
+    public static float FIELD_FLOAT_DEFAULT_VALUE = 0.5f;
+    public static double FIELD_DOUBLE_DEFAULT_VALUE = 0.25;
+    public static boolean FIELD_BOOLEAN_DEFAULT_VALUE = true;
+    public static Date FIELD_DATE_DEFAULT_VALUE = new Date(1473691826000L /*2016/9/12 23:56:26 JST*/);
+    public static byte[] FIELD_BINARY_DEFAULT_VALUE = new byte[] {123, -100, 0, 2};
+    public static RandomPrimaryKey FIELD_OBJECT_DEFAULT_VALUE;
+    public static RealmList<RandomPrimaryKey> FIELD_LIST_DEFAULT_VALUE;
+
+    static {
+        FIELD_OBJECT_DEFAULT_VALUE = new RandomPrimaryKey();
+        FIELD_LIST_DEFAULT_VALUE = new RealmList<RandomPrimaryKey>();
+        FIELD_LIST_DEFAULT_VALUE.add(new RandomPrimaryKey());
+    }
+
+    public static String lastRandomStringValue;
+
+    @Ignore private String fieldIgnored;
+    private String fieldString;
+    private String fieldRandomString;
+    private short fieldShort;
+    private int fieldInt;
+    @PrimaryKey private long fieldLongPrimaryKey;
+    private long fieldLong;
+    private byte fieldByte;
+    private float fieldFloat;
+    private double fieldDouble;
+    private boolean fieldBoolean;
+    private Date fieldDate;
+    private byte[] fieldBinary;
+    private RandomPrimaryKey fieldObject;
+    private RealmList<RandomPrimaryKey> fieldList;
+
+    public DefaultValueSetter() {
+        setFieldIgnored(FIELD_IGNORED_DEFAULT_VALUE);
+        setFieldString(FIELD_STRING_DEFAULT_VALUE);
+        setFieldRandomString(lastRandomStringValue = UUID.randomUUID().toString());
+        setFieldShort(FIELD_SHORT_DEFAULT_VALUE);
+        setFieldInt(FIELD_INT_DEFAULT_VALUE);
+        setFieldLongPrimaryKey(FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE);
+        setFieldLong(FIELD_LONG_DEFAULT_VALUE);
+        setFieldByte(FIELD_BYTE_DEFAULT_VALUE);
+        setFieldFloat(FIELD_FLOAT_DEFAULT_VALUE);
+        setFieldDouble(FIELD_DOUBLE_DEFAULT_VALUE);
+        setFieldBoolean(FIELD_BOOLEAN_DEFAULT_VALUE);
+        setFieldDate(FIELD_DATE_DEFAULT_VALUE);
+        setFieldBinary(FIELD_BINARY_DEFAULT_VALUE);
+        setFieldObject(FIELD_OBJECT_DEFAULT_VALUE);
+        setFieldList(FIELD_LIST_DEFAULT_VALUE);
+
+        final RandomPrimaryKey listItem2 = new RandomPrimaryKey();
+        listItem2.setFieldInt(listItem2.getFieldInt() + 1);
+        getFieldList().add(listItem2);
+    }
+
+    public DefaultValueSetter(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public String getFieldIgnored() {
+        return fieldIgnored;
+    }
+
+    public void setFieldIgnored(String fieldIgnored) {
+        this.fieldIgnored = fieldIgnored;
+    }
+
+    public String getFieldString() {
+        return fieldString;
+    }
+
+    public void setFieldString(String fieldString) {
+        this.fieldString = fieldString;
+    }
+
+    public String getFieldRandomString() {
+        return fieldRandomString;
+    }
+
+    public void setFieldRandomString(String fieldRandomString) {
+        this.fieldRandomString = fieldRandomString;
+    }
+
+    public short getFieldShort() {
+        return fieldShort;
+    }
+
+    public void setFieldShort(short fieldShort) {
+        this.fieldShort = fieldShort;
+    }
+
+    public int getFieldInt() {
+        return fieldInt;
+    }
+
+    public void setFieldInt(int fieldInt) {
+        this.fieldInt = fieldInt;
+    }
+
+    public long getFieldLongPrimaryKey() {
+        return fieldLongPrimaryKey;
+    }
+
+    public void setFieldLongPrimaryKey(long fieldLongPrimaryKey) {
+        this.fieldLongPrimaryKey = fieldLongPrimaryKey;
+    }
+
+    public long getFieldLong() {
+        return fieldLong;
+    }
+
+    public void setFieldLong(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public byte getFieldByte() {
+        return fieldByte;
+    }
+
+    public void setFieldByte(byte fieldByte) {
+        this.fieldByte = fieldByte;
+    }
+
+    public float getFieldFloat() {
+        return fieldFloat;
+    }
+
+    public void setFieldFloat(float fieldFloat) {
+        this.fieldFloat = fieldFloat;
+    }
+
+    public double getFieldDouble() {
+        return fieldDouble;
+    }
+
+    public void setFieldDouble(double fieldDouble) {
+        this.fieldDouble = fieldDouble;
+    }
+
+    public boolean isFieldBoolean() {
+        return fieldBoolean;
+    }
+
+    public void setFieldBoolean(boolean fieldBoolean) {
+        this.fieldBoolean = fieldBoolean;
+    }
+
+    public Date getFieldDate() {
+        return fieldDate;
+    }
+
+    public void setFieldDate(Date fieldDate) {
+        this.fieldDate = fieldDate;
+    }
+
+    public byte[] getFieldBinary() {
+        return fieldBinary;
+    }
+
+    public void setFieldBinary(byte[] fieldBinary) {
+        this.fieldBinary = fieldBinary;
+    }
+
+    public RandomPrimaryKey getFieldObject() {
+        return fieldObject;
+    }
+
+    public void setFieldObject(RandomPrimaryKey fieldObject) {
+        this.fieldObject = fieldObject;
+    }
+
+    public RealmList<RandomPrimaryKey> getFieldList() {
+        return fieldList;
+    }
+
+    public void setFieldList(RealmList<RandomPrimaryKey> fieldList) {
+        this.fieldList = fieldList;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyWithNoPrimaryKeyObjectRelation.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyWithNoPrimaryKeyObjectRelation.java
@@ -20,12 +20,19 @@ import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 
 public class PrimaryKeyWithNoPrimaryKeyObjectRelation extends RealmObject {
+    public static final String CLASS_NAME = "PrimaryKeyWithNoPrimaryKeyObjectRelation";
+    public static final String FIELD_COLUMN_STRING = "columnString";
+    public static final String FIELD_COLUMN_REALM_OBJECT_NO_PK = "columnRealmObjectNoPK";
+    public static final String FIELD_COLUMN_INT = "columnInt";
+
+    public static final int FIELD_COLUMN_INT_DEFAULT_VALUE = 8;
+
     @PrimaryKey
     private String columnString;
 
     private AllTypes columnRealmObjectNoPK;
 
-    private int columnInt = 8;
+    private int columnInt = FIELD_COLUMN_INT_DEFAULT_VALUE;
 
     public String getColumnString() {
         return columnString;

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/RandomPrimaryKey.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/RandomPrimaryKey.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import java.util.UUID;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class RandomPrimaryKey extends RealmObject {
+
+    public static final String CLASS_NAME = "RandomPrimaryKey";
+    public static String FIELD_RANDOM_PRIMARY_KEY = "fieldRandomPrimaryKey";
+    public static String FIELD_INT = "fieldInt";
+
+
+    public static int FIELD_INT_DEFAULT_VALUE = 1357924;
+
+    @PrimaryKey private String fieldRandomPrimaryKey = UUID.randomUUID().toString();
+    private int fieldInt = FIELD_INT_DEFAULT_VALUE;
+
+    public RandomPrimaryKey() {
+    }
+
+    public String getFieldRandomPrimaryKey() {
+        return fieldRandomPrimaryKey;
+    }
+
+    public void setFieldRandomPrimaryKey(String fieldRandomPrimaryKey) {
+        this.fieldRandomPrimaryKey = fieldRandomPrimaryKey;
+    }
+
+    public int getFieldInt() {
+        return fieldInt;
+    }
+
+    public void setFieldInt(int fieldInt) {
+        this.fieldInt = fieldInt;
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -490,10 +490,10 @@ abstract class BaseRealm implements Closeable {
         return schema;
     }
 
-    <E extends RealmModel> E get(Class<E> clazz, long rowIndex) {
+    <E extends RealmModel> E get(Class<E> clazz, long rowIndex, boolean acceptDefaultValue) {
         Table table = schema.getTable(clazz);
         UncheckedRow row = table.getUncheckedRow(rowIndex);
-        E result = configuration.getSchemaMediator().newInstance(clazz, this, row, schema.getColumnInfo(clazz), true);
+        E result = configuration.getSchemaMediator().newInstance(clazz, this, row, schema.getColumnInfo(clazz), acceptDefaultValue);
         RealmObjectProxy proxy = (RealmObjectProxy) result;
         proxy.realmGet$proxyState().setTableVersion$realm();
         return result;

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -703,11 +703,13 @@ abstract class BaseRealm implements Closeable {
         private BaseRealm realm;
         private Row row;
         private ColumnInfo columnInfo;
+        private boolean acceptDefaultValue;
 
-        public void set(BaseRealm realm, Row row, ColumnInfo columnInfo) {
+        public void set(BaseRealm realm, Row row, ColumnInfo columnInfo, boolean acceptDefaultValue) {
             this.realm = realm;
             this.row = row;
             this.columnInfo = columnInfo;
+            this.acceptDefaultValue = acceptDefaultValue;
         }
 
         public BaseRealm getRealm() {
@@ -722,10 +724,19 @@ abstract class BaseRealm implements Closeable {
             return columnInfo;
         }
 
+        public boolean getAcceptDefaultValue() {
+            return acceptDefaultValue;
+        }
+
+        public void setAcceptDefaultValue(boolean acceptDefaultValue) {
+            this.acceptDefaultValue = acceptDefaultValue;
+        }
+
         public void clear() {
             realm = null;
             row = null;
             columnInfo = null;
+            acceptDefaultValue = false;
         }
     }
     static final class ThreadLocalRealmObjectContext extends ThreadLocal<RealmObjectContext> {

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -100,7 +100,7 @@ public final class DynamicRealm extends BaseRealm {
     public DynamicRealmObject createObject(String className, Object primaryKeyValue) {
         Table table = schema.getTable(className);
         long index = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
-        return new DynamicRealmObject(this, table.getCheckedRow(index));
+        return new DynamicRealmObject(this, table.getCheckedRow(index), false);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -64,20 +64,28 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         Row row = proxy.realmGet$proxyState().getRow$realm();
         proxyState.setRealm$realm(proxy.realmGet$proxyState().getRealm$realm());
         proxyState.setRow$realm(((UncheckedRow) row).convertToChecked());
+        proxyState.setConstructionFinished();
     }
 
-    // Create a dynamic object. Only used internally
-    DynamicRealmObject() {
-
-    }
-
-    DynamicRealmObject(BaseRealm realm, Row row) {
+    DynamicRealmObject(BaseRealm realm, Row row, boolean convertTocheckedRow) {
         proxyState.setRealm$realm(realm);
-        proxyState.setRow$realm((row instanceof CheckedRow) ? (CheckedRow) row : ((UncheckedRow) row).convertToChecked());
+        if (convertTocheckedRow) {
+            proxyState.setRow$realm((row instanceof CheckedRow) ? (CheckedRow) row : ((UncheckedRow) row).convertToChecked());
+        } else {
+            proxyState.setRow$realm(row);
+        }
+        proxyState.setConstructionFinished();
     }
 
-    DynamicRealmObject(String className) {
+    DynamicRealmObject(String className, BaseRealm realm, Row row, boolean convertTocheckedRow) {
         proxyState.setClassName(className);
+        proxyState.setRealm$realm(realm);
+        if (convertTocheckedRow) {
+            proxyState.setRow$realm((row instanceof CheckedRow) ? (CheckedRow) row : ((UncheckedRow) row).convertToChecked());
+        } else {
+            proxyState.setRow$realm(row);
+        }
+        proxyState.setConstructionFinished();
     }
 
     /**
@@ -279,7 +287,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         } else {
             long linkRowIndex = proxyState.getRow$realm().getLink(columnIndex);
             CheckedRow linkRow = proxyState.getRow$realm().getTable().getLinkTarget(columnIndex).getCheckedRow(linkRowIndex);
-            return new DynamicRealmObject(proxyState.getRealm$realm(), linkRow);
+            return new DynamicRealmObject(proxyState.getRealm$realm(), linkRow, false);
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/ProxyState.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyState.java
@@ -34,6 +34,8 @@ public final class ProxyState<E extends RealmModel> {
     private String className;
     private Class<? extends RealmModel> clazzName;
 
+    private boolean underConstruction = true;
+
     private Row row;
     private BaseRealm realm;
 
@@ -175,6 +177,14 @@ public final class ProxyState<E extends RealmModel> {
 
     public void setClassName(String className) {
         this.className = className;
+    }
+
+    public boolean isUnderConstruction() {
+        return underConstruction;
+    }
+
+    public void setConstructionFinished() {
+        underConstruction = false;
     }
 
     private Table getTable () {

--- a/realm/realm-library/src/main/java/io/realm/ProxyState.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyState.java
@@ -34,6 +34,7 @@ public final class ProxyState<E extends RealmModel> {
     private String className;
     private Class<? extends RealmModel> clazzName;
 
+    // true only while executing the constructor of the enclosing proxy object
     private boolean underConstruction = true;
 
     private Row row;

--- a/realm/realm-library/src/main/java/io/realm/ProxyState.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyState.java
@@ -40,6 +40,7 @@ public final class ProxyState<E extends RealmModel> {
     private Row row;
     private BaseRealm realm;
     private boolean acceptDefaultValue;
+    private List<String> excludeFields;
 
     private final List<RealmChangeListener<E>> listeners = new CopyOnWriteArrayList<RealmChangeListener<E>>();
     private Future<Long> pendingQuery;
@@ -96,6 +97,14 @@ public final class ProxyState<E extends RealmModel> {
 
     public void setAcceptDefaultValue$realm(boolean acceptDefaultValue) {
         this.acceptDefaultValue = acceptDefaultValue;
+    }
+
+    public List<String> getExcludeFields$realm() {
+        return excludeFields;
+    }
+
+    public void setExcludeFields$realm(List<String> excludeFields) {
+        this.excludeFields = excludeFields;
     }
 
     public Object getPendingQuery$realm() {
@@ -195,6 +204,8 @@ public final class ProxyState<E extends RealmModel> {
 
     public void setConstructionFinished() {
         underConstruction = false;
+        // only used while construction.
+        excludeFields = null;
     }
 
     private Table getTable () {

--- a/realm/realm-library/src/main/java/io/realm/ProxyState.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyState.java
@@ -39,6 +39,7 @@ public final class ProxyState<E extends RealmModel> {
 
     private Row row;
     private BaseRealm realm;
+    private boolean acceptDefaultValue;
 
     private final List<RealmChangeListener<E>> listeners = new CopyOnWriteArrayList<RealmChangeListener<E>>();
     private Future<Long> pendingQuery;
@@ -87,6 +88,14 @@ public final class ProxyState<E extends RealmModel> {
 
     public void setRow$realm(Row row) {
         this.row = row;
+    }
+
+    public boolean getAcceptDefaultValue$realm() {
+        return acceptDefaultValue;
+    }
+
+    public void setAcceptDefaultValue$realm(boolean acceptDefaultValue) {
+        this.acceptDefaultValue = acceptDefaultValue;
     }
 
     public Object getPendingQuery$realm() {

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -684,10 +684,16 @@ public final class Realm extends BaseRealm {
 
     /**
      * Instantiates and adds a new object to the Realm.
+     * <p>
+     * This method is only available for the model classes that have no primary key defined
+     * even though the class provides a default value for it.
+     * If you'd like to create an object that has primary key, please use {@link #createObject(Class, Object)}
+     * or {@link #copyToRealm(RealmModel)} instead.
      *
      * @param clazz the Class of the object to create.
      * @return the new object.
      * @throws RealmException if an object cannot be created.
+     * @see #createObject(Class, Object)
      */
     public <E extends RealmModel> E createObject(Class<E> clazz) {
         checkIfValid();
@@ -706,6 +712,7 @@ public final class Realm extends BaseRealm {
      * <p>
      * If the value violates the primary key constraint, no object will be added and a {@link RealmException} will be
      * thrown.
+     * The default value for primary key provided by the model class will be ignored.
      *
      * @param clazz the Class of the object to create.
      * @param primaryKeyValue value for the primary key field.

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -697,7 +697,7 @@ public final class Realm extends BaseRealm {
      */
     public <E extends RealmModel> E createObject(Class<E> clazz) {
         checkIfValid();
-        return createObjectWithoutThreadCheck(clazz, true, Collections.<String> emptyList());
+        return createObjectInternal(clazz, true, Collections.<String> emptyList());
     }
 
     /**
@@ -710,7 +710,7 @@ public final class Realm extends BaseRealm {
      * @throws RealmException if an object cannot be created.
      */
     // called from proxy classes
-    <E extends RealmModel> E createObjectWithoutThreadCheck(Class<E> clazz,
+    <E extends RealmModel> E createObjectInternal(Class<E> clazz,
                                                             boolean acceptDefaultValue,
                                                             List<String> excludeFields) {
         Table table = schema.getTable(clazz);
@@ -740,7 +740,7 @@ public final class Realm extends BaseRealm {
      */
     public <E extends RealmModel> E createObject(Class<E> clazz, Object primaryKeyValue) {
         checkIfValid();
-        return createObjectWithoutThreadCheck(clazz, primaryKeyValue, true, Collections.<String> emptyList());
+        return createObjectInternal(clazz, primaryKeyValue, true, Collections.<String> emptyList());
     }
 
     /**
@@ -756,7 +756,7 @@ public final class Realm extends BaseRealm {
      * @throws IllegalArgumentException if the {@code primaryKeyValue} doesn't have a value that can be converted to the
      */
     // called from proxy classes
-    <E extends RealmModel> E createObjectWithoutThreadCheck(Class<E> clazz, Object primaryKeyValue,
+    <E extends RealmModel> E createObjectInternal(Class<E> clazz, Object primaryKeyValue,
                                                             boolean acceptDefaultValue,
                                                             List<String> excludeFields) {
         Table table = schema.getTable(clazz);

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -696,7 +697,7 @@ public final class Realm extends BaseRealm {
      */
     public <E extends RealmModel> E createObject(Class<E> clazz) {
         checkIfValid();
-        return createObjectWithoutThreadCheck(clazz, true);
+        return createObjectWithoutThreadCheck(clazz, true, Collections.<String> emptyList());
     }
 
     /**
@@ -709,7 +710,9 @@ public final class Realm extends BaseRealm {
      * @throws RealmException if an object cannot be created.
      */
     // called from proxy classes
-    <E extends RealmModel> E createObjectWithoutThreadCheck(Class<E> clazz, boolean acceptDefaultValue) {
+    <E extends RealmModel> E createObjectWithoutThreadCheck(Class<E> clazz,
+                                                            boolean acceptDefaultValue,
+                                                            List<String> excludeFields) {
         Table table = schema.getTable(clazz);
         // Check and throw the exception earlier for a better exception message.
         if (table.hasPrimaryKey()) {
@@ -717,7 +720,7 @@ public final class Realm extends BaseRealm {
                     " 'createObject(Class<E>, Object)' instead.", Table.tableNameToClassName(table.getName())));
         }
         long rowIndex = table.addEmptyRow();
-        return get(clazz, rowIndex, acceptDefaultValue);
+        return get(clazz, rowIndex, acceptDefaultValue, excludeFields);
     }
 
     /**
@@ -737,7 +740,7 @@ public final class Realm extends BaseRealm {
      */
     public <E extends RealmModel> E createObject(Class<E> clazz, Object primaryKeyValue) {
         checkIfValid();
-        return createObjectWithoutThreadCheck(clazz, primaryKeyValue, true);
+        return createObjectWithoutThreadCheck(clazz, primaryKeyValue, true, Collections.<String> emptyList());
     }
 
     /**
@@ -754,10 +757,11 @@ public final class Realm extends BaseRealm {
      */
     // called from proxy classes
     <E extends RealmModel> E createObjectWithoutThreadCheck(Class<E> clazz, Object primaryKeyValue,
-                                                            boolean acceptDefaultValue) {
+                                                            boolean acceptDefaultValue,
+                                                            List<String> excludeFields) {
         Table table = schema.getTable(clazz);
         long rowIndex = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
-        return get(clazz, rowIndex, acceptDefaultValue);
+        return get(clazz, rowIndex, acceptDefaultValue, excludeFields);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -687,7 +687,7 @@ public final class Realm extends BaseRealm {
      * <p>
      * This method is only available for the model classes that have no primary key defined
      * even though the class provides a default value for it.
-     * If you'd like to create an object that has primary key, please use {@link #createObject(Class, Object)}
+     * In order to create an object that has primary key, please use {@link #createObject(Class, Object)}
      * or {@link #copyToRealm(RealmModel)} instead.
      *
      * @param clazz the Class of the object to create.

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -698,7 +698,7 @@ public final class Realm extends BaseRealm {
                     " 'createObject(Class<E>, Object)' instead.", Table.tableNameToClassName(table.getName())));
         }
         long rowIndex = table.addEmptyRow();
-        return get(clazz, rowIndex);
+        return get(clazz, rowIndex, true);
     }
 
     /**
@@ -718,7 +718,7 @@ public final class Realm extends BaseRealm {
     public <E extends RealmModel> E createObject(Class<E> clazz, Object primaryKeyValue) {
         Table table = schema.getTable(clazz);
         long rowIndex = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
-        return get(clazz, rowIndex);
+        return get(clazz, rowIndex, true);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -685,9 +685,8 @@ public final class Realm extends BaseRealm {
     /**
      * Instantiates and adds a new object to the Realm.
      * <p>
-     * This method is only available for the model classes that have no primary key defined
-     * even though the class provides a default value for it.
-     * In order to create an object that has primary key, please use {@link #createObject(Class, Object)}
+     * This method is only available for model classes with no @PrimaryKey annotation.
+     * If you like to create an object that has a primary key, use {@link #createObject(Class, Object)}
      * or {@link #copyToRealm(RealmModel)} instead.
      *
      * @param clazz the Class of the object to create.

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -692,7 +692,7 @@ public final class Realm extends BaseRealm {
      *
      * @param clazz the Class of the object to create.
      * @return the new object.
-     * @throws RealmException if an object cannot be created.
+     * @throws RealmException if the primary key is defined in the model class or an object cannot be created.
      * @see #createObject(Class, Object)
      */
     public <E extends RealmModel> E createObject(Class<E> clazz) {
@@ -707,7 +707,7 @@ public final class Realm extends BaseRealm {
      * @param acceptDefaultValue if {@code true}, default value of the object will be applied and
      *                           if {@code false}, it will be ignored.
      * @return the new object.
-     * @throws RealmException if an object cannot be created.
+     * @throws RealmException if the primary key is defined in the model class or an object cannot be created.
      */
     // called from proxy classes
     <E extends RealmModel> E createObjectInternal(Class<E> clazz,
@@ -734,7 +734,7 @@ public final class Realm extends BaseRealm {
      * @param primaryKeyValue value for the primary key field.
      * @return the new object.
      * @throws RealmException if object could not be created due to the primary key being invalid.
-     * @throws IllegalStateException if the model clazz does not have an primary key defined.
+     * @throws IllegalStateException if the model class does not have an primary key defined.
      * @throws IllegalArgumentException if the {@code primaryKeyValue} doesn't have a value that can be converted to the
      *                                  expected value.
      */
@@ -752,7 +752,7 @@ public final class Realm extends BaseRealm {
      *                           if {@code false}, it will be ignored.
      * @return the new object.
      * @throws RealmException if object could not be created due to the primary key being invalid.
-     * @throws IllegalStateException if the model clazz does not have an primary key defined.
+     * @throws IllegalStateException if the model class does not have an primary key defined.
      * @throws IllegalArgumentException if the {@code primaryKeyValue} doesn't have a value that can be converted to the
      */
     // called from proxy classes

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -696,6 +696,20 @@ public final class Realm extends BaseRealm {
      */
     public <E extends RealmModel> E createObject(Class<E> clazz) {
         checkIfValid();
+        return createObjectWithoutThreadCheck(clazz, true);
+    }
+
+    /**
+     * Same as {@link #createObject(Class)} but this does not check the thread.
+     *
+     * @param clazz the Class of the object to create.
+     * @param acceptDefaultValue if {@code true}, default value of the object will be applied and
+     *                           if {@code false}, it will be ignored.
+     * @return the new object.
+     * @throws RealmException if an object cannot be created.
+     */
+    // called from proxy classes
+    <E extends RealmModel> E createObjectWithoutThreadCheck(Class<E> clazz, boolean acceptDefaultValue) {
         Table table = schema.getTable(clazz);
         // Check and throw the exception earlier for a better exception message.
         if (table.hasPrimaryKey()) {
@@ -703,7 +717,7 @@ public final class Realm extends BaseRealm {
                     " 'createObject(Class<E>, Object)' instead.", Table.tableNameToClassName(table.getName())));
         }
         long rowIndex = table.addEmptyRow();
-        return get(clazz, rowIndex, true);
+        return get(clazz, rowIndex, acceptDefaultValue);
     }
 
     /**
@@ -722,9 +736,27 @@ public final class Realm extends BaseRealm {
      *                                  expected value.
      */
     public <E extends RealmModel> E createObject(Class<E> clazz, Object primaryKeyValue) {
+        return createObjectWithoutThreadCheck(clazz, primaryKeyValue, true);
+    }
+
+    /**
+     * Same as {@link #createObject(Class, Object)} but this does not check the thread.
+     *
+     * @param clazz the Class of the object to create.
+     * @param primaryKeyValue value for the primary key field.
+     * @param acceptDefaultValue if {@code true}, default value of the object will be applied and
+     *                           if {@code false}, it will be ignored.
+     * @return the new object.
+     * @throws RealmException if object could not be created due to the primary key being invalid.
+     * @throws IllegalStateException if the model clazz does not have an primary key defined.
+     * @throws IllegalArgumentException if the {@code primaryKeyValue} doesn't have a value that can be converted to the
+     */
+    // called from proxy classes
+    <E extends RealmModel> E createObjectWithoutThreadCheck(Class<E> clazz, Object primaryKeyValue,
+                                                            boolean acceptDefaultValue) {
         Table table = schema.getTable(clazz);
         long rowIndex = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
-        return get(clazz, rowIndex, true);
+        return get(clazz, rowIndex, acceptDefaultValue);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -492,7 +492,7 @@ public final class RealmObjectSchema {
         if (function != null) {
             long size = table.size();
             for (long i = 0; i < size; i++) {
-                function.apply(new DynamicRealmObject(realm, table.getCheckedRow(i)));
+                function.apply(new DynamicRealmObject(realm, table.getCheckedRow(i), false));
             }
         }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -19,6 +19,7 @@ package io.realm;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -2103,7 +2104,9 @@ public final class RealmQuery<E extends RealmModel> {
             //noinspection unchecked
             result = (E) new DynamicRealmObject(className, realm, Row.EMPTY_ROW, false);
         } else {
-            result = realm.getConfiguration().getSchemaMediator().newInstance(clazz, realm, Row.EMPTY_ROW, realm.getSchema().getColumnInfo(clazz), false);
+            result = realm.getConfiguration().getSchemaMediator().newInstance(
+                    clazz, realm, Row.EMPTY_ROW, realm.getSchema().getColumnInfo(clazz),
+                    false, Collections.<String>emptyList());
         }
 
         final RealmObjectProxy proxy = (RealmObjectProxy) result;

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -85,9 +85,14 @@ public abstract class RealmProxyMediator {
      * Creates a new instance of an {@link RealmObjectProxy} for the given RealmObject class.
      *
      * @param clazz the {@link RealmObject} to create {@link RealmObjectProxy} for.
+     * @param acceptDefaultValue {@code true} to accept the values set in the constructor, {@code false} otherwise.
      * @return created {@link RealmObjectProxy} object.
      */
-    public abstract <E extends RealmModel> E newInstance(Class<E> clazz);
+    public abstract <E extends RealmModel> E newInstance(Class<E> clazz,
+                                                         Object baseRealm,
+                                                         Row row,
+                                                         ColumnInfo columnInfo,
+                                                         boolean acceptDefaultValue);
 
     /**
      * Returns the list of RealmObject classes that can be saved in this Realm.

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -86,13 +86,18 @@ public abstract class RealmProxyMediator {
      *
      * @param clazz the {@link RealmObject} to create {@link RealmObjectProxy} for.
      * @param acceptDefaultValue {@code true} to accept the values set in the constructor, {@code false} otherwise.
+     * @param excludeFields the column names whose default value will be ignored if the {@code acceptDefaultValue}
+     *                       is {@code true}. Only {@link io.realm.RealmModel} and {@link io.realm.RealmList}
+     *                       column will respect this.
+     *                       No effects if the {@code acceptDefaultValue} is {@code false}.
      * @return created {@link RealmObjectProxy} object.
      */
     public abstract <E extends RealmModel> E newInstance(Class<E> clazz,
                                                          Object baseRealm,
                                                          Row row,
                                                          ColumnInfo columnInfo,
-                                                         boolean acceptDefaultValue);
+                                                         boolean acceptDefaultValue,
+                                                         List<String> excludeFields);
 
     /**
      * Returns the list of RealmObject classes that can be saved in this Realm.

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -85,10 +85,9 @@ public abstract class RealmProxyMediator {
      * Creates a new instance of an {@link RealmObjectProxy} for the given RealmObject class.
      *
      * @param clazz the {@link RealmObject} to create {@link RealmObjectProxy} for.
-     * @param columnInfo the {@link ColumnInfo} object for the RealmObject class of {@code E}.
      * @return created {@link RealmObjectProxy} object.
      */
-    public abstract <E extends RealmModel> E newInstance(Class<E> clazz, ColumnInfo columnInfo);
+    public abstract <E extends RealmModel> E newInstance(Class<E> clazz);
 
     /**
      * Returns the list of RealmObject classes that can be saved in this Realm.

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -83,9 +83,9 @@ public class CompositeMediator extends RealmProxyMediator {
     }
 
     @Override
-    public <E extends RealmModel> E newInstance(Class<E> clazz, ColumnInfo columnInfo) {
+    public <E extends RealmModel> E newInstance(Class<E> clazz) {
         RealmProxyMediator mediator = getMediator(clazz);
-        return mediator.newInstance(clazz, columnInfo);
+        return mediator.newInstance(clazz);
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -88,9 +88,10 @@ public class CompositeMediator extends RealmProxyMediator {
                                                 Object baseRealm,
                                                 Row row,
                                                 ColumnInfo columnInfo,
-                                                boolean acceptDefaultValue) {
+                                                boolean acceptDefaultValue,
+                                                List<String> excludeFields) {
         RealmProxyMediator mediator = getMediator(clazz);
-        return mediator.newInstance(clazz, baseRealm, row, columnInfo, acceptDefaultValue);
+        return mediator.newInstance(clazz, baseRealm, row, columnInfo, acceptDefaultValue, excludeFields);
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -34,6 +34,7 @@ import io.realm.RealmModel;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.RealmProxyMediator;
+import io.realm.internal.Row;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
 import io.realm.internal.Util;
@@ -83,9 +84,13 @@ public class CompositeMediator extends RealmProxyMediator {
     }
 
     @Override
-    public <E extends RealmModel> E newInstance(Class<E> clazz) {
+    public <E extends RealmModel> E newInstance(Class<E> clazz,
+                                                Object baseRealm,
+                                                Row row,
+                                                ColumnInfo columnInfo,
+                                                boolean acceptDefaultValue) {
         RealmProxyMediator mediator = getMediator(clazz);
-        return mediator.newInstance(clazz);
+        return mediator.newInstance(clazz, baseRealm, row, columnInfo, acceptDefaultValue);
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -98,9 +98,9 @@ public class FilterableMediator extends RealmProxyMediator {
     }
 
     @Override
-    public <E extends RealmModel> E newInstance(Class<E> clazz, ColumnInfo columnInfo) {
+    public <E extends RealmModel> E newInstance(Class<E> clazz) {
         checkSchemaHasClass(clazz);
-        return originalMediator.newInstance(clazz, columnInfo);
+        return originalMediator.newInstance(clazz);
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -34,6 +34,7 @@ import io.realm.RealmModel;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.RealmProxyMediator;
+import io.realm.internal.Row;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
 import io.realm.internal.Util;
@@ -98,9 +99,13 @@ public class FilterableMediator extends RealmProxyMediator {
     }
 
     @Override
-    public <E extends RealmModel> E newInstance(Class<E> clazz) {
+    public <E extends RealmModel> E newInstance(Class<E> clazz,
+                                                Object baseRealm,
+                                                Row row,
+                                                ColumnInfo columnInfo,
+                                                boolean acceptDefaultValue) {
         checkSchemaHasClass(clazz);
-        return originalMediator.newInstance(clazz);
+        return originalMediator.newInstance(clazz, baseRealm, row, columnInfo, acceptDefaultValue);
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -103,9 +103,10 @@ public class FilterableMediator extends RealmProxyMediator {
                                                 Object baseRealm,
                                                 Row row,
                                                 ColumnInfo columnInfo,
-                                                boolean acceptDefaultValue) {
+                                                boolean acceptDefaultValue,
+                                                List<String> excludeFields) {
         checkSchemaHasClass(clazz);
-        return originalMediator.newInstance(clazz, baseRealm, row, columnInfo, acceptDefaultValue);
+        return originalMediator.newInstance(clazz, baseRealm, row, columnInfo, acceptDefaultValue, excludeFields);
     }
 
     @Override


### PR DESCRIPTION
This change allows to specify default value of the field.
And this change also enables to call setter methods in model's constructor.

fixes #777 
fixes #2536 

TODO

* [x] add tests 
* [x] update CHANGELING.md
