### PR TITLE
List<String> helper method for RealmQuery.In

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -425,6 +425,21 @@ public final class RealmQuery<E extends RealmModel> {
     // In
 
     /**
+     * In comparison. This allows you to test if objects match any value in a list of values.
+     *
+     * @param fieldName the field to compare.
+     * @param values list of values to compare with and it cannot be null or empty.
+     * @return the query object.
+     * @throws java.lang.IllegalArgumentException if the field isn't a String field or {@code values} is {@code null} or empty.
+     */
+    public RealmQuery<E> in(String fieldName, List<String> values) {
+        if(values == null || values.size() < 1) {
+            throw new IllegalArgumentException(EMPTY_VALUES);
+        }
+        return in(fieldName, values.toArray(new String[0]), Case.SENSITIVE);
+    }
+    
+    /**
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.


### PR DESCRIPTION
We always need to convert a `List<String>` into `String[]` to use RealmQuery.In method. This method will be handy all the time.