### PR TITLE
Disallow changing PK after object created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * `RealmConfiguration.Builder.assetFile(Context, String)` has been renamed to `RealmConfiguration.Builder.assetFile(String)`.
 * Object with primary key is now required to define it when the object is created. This means that `Realm.createObject(Class<E>)` and `DynamicRealm.createObject(String)` now throws `RealmException` if they are used to create an object with a primary key field. Use `Realm.createObject(Class<E>, Object)` or `DynamicRealm.createObject(String, Object)` instead.
 * Importing from JSON without the primary key field defined in the JSON object now throws `IllegalArgumentException`.
+* Primary key cannot be changing anymore after the `RealmObject` created.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * `RealmConfiguration.Builder.assetFile(Context, String)` has been renamed to `RealmConfiguration.Builder.assetFile(String)`.
 * Object with primary key is now required to define it when the object is created. This means that `Realm.createObject(Class<E>)` and `DynamicRealm.createObject(String)` now throws `RealmException` if they are used to create an object with a primary key field. Use `Realm.createObject(Class<E>, Object)` or `DynamicRealm.createObject(String, Object)` instead.
 * Importing from JSON without the primary key field defined in the JSON object now throws `IllegalArgumentException`.
-* Primary key cannot be changing anymore after the `RealmObject` created.
+* The primary key value of an object can no longer be changed after the object was created. Instead a new object must be created and all fields copied over.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * `RealmConfiguration.Builder.assetFile(Context, String)` has been renamed to `RealmConfiguration.Builder.assetFile(String)`.
 * Object with primary key is now required to define it when the object is created. This means that `Realm.createObject(Class<E>)` and `DynamicRealm.createObject(String)` now throws `RealmException` if they are used to create an object with a primary key field. Use `Realm.createObject(Class<E>, Object)` or `DynamicRealm.createObject(String, Object)` instead.
 * Importing from JSON without the primary key field defined in the JSON object now throws `IllegalArgumentException`.
-* Now `Realm.beginTransaction()`, `Realm.executeTransaction()` and `Realm.waitForChange()` throw `RealmMigrationNeededException` if a remote process introduces an incompatible schema changes (#3409).
+* Now `Realm.beginTransaction()`, `Realm.executeTransaction()` and `Realm.waitForChange()` throw `RealmMigrationNeededException` if a remote process introduces incompatible schema changes (#3409).
 * The primary key value of an object can no longer be changed after the object was created. Instead a new object must be created and all fields copied over.
 
 ### Enhancements

--- a/realm-annotations/src/main/java/io/realm/annotations/PrimaryKey.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/PrimaryKey.java
@@ -25,10 +25,11 @@ import java.lang.annotation.Target;
  * The @PrimaryKey annotation will mark a field as a primary key inside Realm. Only one field in a
  * RealmObject class can have this annotation, and the field should uniquely identify the object.
  * Trying to insert an object with an existing primary key will result in an
- * {@link io.realm.exceptions.RealmPrimaryKeyConstraintException}.
- *
+ * {@link io.realm.exceptions.RealmPrimaryKeyConstraintException}. Primary key cannot be changed
+ * after the object created.
+ * <p>
  * Primary keys also count as having the {@link Index} annotation.
- *
+ * <p>
  * It is allowed to apply this annotation on the following primitive types: byte, short, int, and long.
  * String, Byte, Short, Integer, and Long are also allowed, and further permitted to have {@code null}
  * as a primary key value.

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
@@ -30,6 +30,9 @@ public class Constants {
             "throw new IllegalArgumentException(\"Trying to set non-nullable field '%s' to null.\")";
     static final String STATEMENT_EXCEPTION_NO_PRIMARY_KEY_IN_JSON =
             "throw new IllegalArgumentException(\"JSON object doesn't have the primary key field '%s'.\")";
+    static final String STATEMENT_EXCEPTION_PRIMARY_KEY_CANNOT_BE_CHANGED =
+            "throw new io.realm.exceptions.RealmException(\"Primary key field '%s' cannot be changed after object" +
+                    " created.\")";
 
     static final Map<String, String> JAVA_TO_REALM_TYPES;
     static {

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
@@ -32,7 +32,7 @@ public class Constants {
             "throw new IllegalArgumentException(\"JSON object doesn't have the primary key field '%s'.\")";
     static final String STATEMENT_EXCEPTION_PRIMARY_KEY_CANNOT_BE_CHANGED =
             "throw new io.realm.exceptions.RealmException(\"Primary key field '%s' cannot be changed after object" +
-                    " created.\")";
+                    " was created.\")";
 
     static final Map<String, String> JAVA_TO_REALM_TYPES;
     static {

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -239,21 +239,26 @@ public class RealmProxyClassGenerator {
                 writer.emitStatement("proxyState.getRealm$realm().checkIfValid()");
                 // Although setting null value for String and bytes[] can be handled by the JNI code, we still generate the same code here.
                 // Compared with getter, null value won't trigger more native calls in setter which is relatively cheaper.
-                if (metadata.isNullable(field)) {
-                    writer.beginControlFlow("if (value == null)")
-                        .emitStatement("proxyState.getRow$realm().setNull(%s)", fieldIndexVariableReference(field))
-                        .emitStatement("return")
-                    .endControlFlow();
-                } else if (!metadata.isNullable(field) && !Utils.isPrimitiveType(field)) {
-                    // Same reason, throw IAE earlier.
-                    writer
-                        .beginControlFlow("if (value == null)")
-                            .emitStatement(Constants.STATEMENT_EXCEPTION_ILLEGAL_NULL_VALUE, fieldName)
-                        .endControlFlow();
+                if (field.equals(metadata.getPrimaryKey())) {
+                    // Primary key is not allowed to be changed after object created.
+                    writer.emitStatement(Constants.STATEMENT_EXCEPTION_PRIMARY_KEY_CANNOT_BE_CHANGED, fieldName);
+                } else {
+                    if (metadata.isNullable(field)) {
+                        writer.beginControlFlow("if (value == null)")
+                                .emitStatement("proxyState.getRow$realm().setNull(%s)", fieldIndexVariableReference(field))
+                                .emitStatement("return")
+                                .endControlFlow();
+                    } else if (!metadata.isNullable(field) && !Utils.isPrimitiveType(field)) {
+                        // Same reason, throw IAE earlier.
+                        writer
+                                .beginControlFlow("if (value == null)")
+                                .emitStatement(Constants.STATEMENT_EXCEPTION_ILLEGAL_NULL_VALUE, fieldName)
+                                .endControlFlow();
+                    }
+                    writer.emitStatement(
+                            "proxyState.getRow$realm().set%s(%s, value)",
+                            realmType, fieldIndexVariableReference(field));
                 }
-                writer.emitStatement(
-                        "proxyState.getRow$realm().set%s(%s, value)",
-                        realmType, fieldIndexVariableReference(field));
                 writer.endMethod();
             } else if (Utils.isRealmModel(field)) {
                 /**
@@ -1169,6 +1174,11 @@ public class RealmProxyClassGenerator {
                 String setter = metadata.getSetter(fieldName);
                 String getter = metadata.getGetter(fieldName);
 
+                if (field.equals(metadata.getPrimaryKey())) {
+                    // PK has been set when creating object.
+                    continue;
+                }
+
                 if (Utils.isRealmModel(field)) {
                     writer
                         .emitEmptyLine()
@@ -1513,6 +1523,10 @@ public class RealmProxyClassGenerator {
         for (VariableElement field : metadata.getFields()) {
             String fieldName = field.getSimpleName().toString();
             String qualifiedFieldType = field.asType().toString();
+            if (field.equals(metadata.getPrimaryKey())) {
+                // Primary key has already been set when adding new row or finding the existing row.
+                continue;
+            }
             if (Utils.isRealmModel(field)) {
                 RealmJsonTypeHelper.emitFillRealmObjectWithJsonValue(
                         interfaceName,

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -105,11 +105,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
     public void realmSet$columnString(String value) {
         proxyState.getRealm$realm().checkIfValid();
-        if (value == null) {
-            proxyState.getRow$realm().setNull(columnInfo.columnStringIndex);
-            return;
-        }
-        proxyState.getRow$realm().setString(columnInfo.columnStringIndex, value);
+        throw new io.realm.exceptions.RealmException("Primary key field 'columnString' cannot be changed after" +
+                " object created.");
     }
 
     @SuppressWarnings("cast")
@@ -414,13 +411,6 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 throw new IllegalArgumentException("JSON object doesn't have the primary key field 'columnString'.");
             }
         }
-        if (json.has("columnString")) {
-            if (json.isNull("columnString")) {
-                ((AllTypesRealmProxyInterface) obj).realmSet$columnString(null);
-            } else {
-                ((AllTypesRealmProxyInterface) obj).realmSet$columnString((String) json.getString("columnString"));
-            }
-        }
         if (json.has("columnLong")) {
             if (json.isNull("columnLong")) {
                 throw new IllegalArgumentException("Trying to set non-nullable field 'columnLong' to null.");
@@ -636,7 +626,6 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         } else {
             some.test.AllTypes realmObject = realm.createObject(some.test.AllTypes.class, ((AllTypesRealmProxyInterface) newObject).realmGet$columnString());
             cache.put(newObject, (RealmObjectProxy) realmObject);
-            ((AllTypesRealmProxyInterface) realmObject).realmSet$columnString(((AllTypesRealmProxyInterface) newObject).realmGet$columnString());
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnLong(((AllTypesRealmProxyInterface) newObject).realmGet$columnLong());
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnFloat(((AllTypesRealmProxyInterface) newObject).realmGet$columnFloat());
             ((AllTypesRealmProxyInterface) realmObject).realmSet$columnDouble(((AllTypesRealmProxyInterface) newObject).realmGet$columnDouble());

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -119,8 +119,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
     public void realmSet$columnString(String value) {
         proxyState.getRealm$realm().checkIfValid();
-        throw new io.realm.exceptions.RealmException("Primary key field 'columnString' cannot be changed after" +
-                " object created.");
+        throw new io.realm.exceptions.RealmException("Primary key field 'columnString' cannot be changed after object was created.");
     }
 
     @SuppressWarnings("cast")

--- a/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
@@ -17,7 +17,6 @@
 package io.realm;
 
 import android.support.test.runner.AndroidJUnit4;
-import android.util.Log;
 
 import org.junit.After;
 import org.junit.Before;
@@ -88,6 +87,7 @@ public class BulkInsertTests {
     public void insert() {
         AllJavaTypes obj = new AllJavaTypes();
         obj.setFieldIgnored("cookie");
+        obj.setFieldId(42);
         obj.setFieldLong(42);
         obj.setFieldString("obj1");
 
@@ -98,6 +98,7 @@ public class BulkInsertTests {
 
         AllJavaTypes allTypes = new AllJavaTypes();
         allTypes.setFieldString("String");
+        allTypes.setFieldId(1L);
         allTypes.setFieldLong(1L);
         allTypes.setFieldFloat(1F);
         allTypes.setFieldDouble(1D);
@@ -765,6 +766,7 @@ public class BulkInsertTests {
     @Test
     public void insertOrUpdate_managedObject() {
         AllJavaTypes obj = new AllJavaTypes();
+        obj.setFieldId(42);
         obj.setFieldIgnored("cookie");
         obj.setFieldLong(42);
         obj.setFieldString("obj1");
@@ -808,11 +810,11 @@ public class BulkInsertTests {
         realm.insertOrUpdate(unmanagedObject);
         realm.commitTransaction();
 
-        AllJavaTypes first = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_LONG, 8).findFirst();
+        AllJavaTypes first = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_ID, 8).findFirst();
         assertNotNull(first);
-        assertEquals(8, first.getFieldLong(), 0);
+        assertEquals(8, first.getFieldId(), 0);
         assertNotNull(first.getFieldObject());
-        assertEquals(42, first.getFieldObject().getFieldLong());
+        assertEquals(42, first.getFieldObject().getFieldId());
         assertEquals(2, realm.where(AllJavaTypes.class).count());
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
@@ -94,8 +94,8 @@ public abstract class CollectionTests {
             }
 
             // Add all items to the RealmList on the first object
-            AllJavaTypes firstObj = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_LONG, 0).findFirst();
-            RealmResults<AllJavaTypes> listData = realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_LONG, Sort.ASCENDING);
+            AllJavaTypes firstObj = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_ID, 0).findFirst();
+            RealmResults<AllJavaTypes> listData = realm.where(AllJavaTypes.class).findAllSorted(AllJavaTypes.FIELD_ID, Sort.ASCENDING);
             RealmList<AllJavaTypes> list = firstObj.getFieldList();
             for (int i = 0; i < listData.size(); i++) {
                 list.add(listData.get(i));

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -37,6 +37,15 @@ import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.NullTypes;
 import io.realm.entities.Owner;
+import io.realm.entities.PrimaryKeyAsBoxedByte;
+import io.realm.entities.PrimaryKeyAsBoxedInteger;
+import io.realm.entities.PrimaryKeyAsBoxedLong;
+import io.realm.entities.PrimaryKeyAsBoxedShort;
+import io.realm.entities.PrimaryKeyAsByte;
+import io.realm.entities.PrimaryKeyAsInteger;
+import io.realm.entities.PrimaryKeyAsLong;
+import io.realm.entities.PrimaryKeyAsShort;
+import io.realm.entities.PrimaryKeyAsString;
 import io.realm.exceptions.RealmException;
 import io.realm.rule.TestRealmConfigurationFactory;
 
@@ -68,7 +77,7 @@ public class DynamicRealmObjectTests {
         RealmConfiguration realmConfig = configFactory.createConfiguration();
         realm = Realm.getInstance(realmConfig);
         realm.beginTransaction();
-        typedObj = realm.createObject(AllJavaTypes.class, 0);
+        typedObj = realm.createObject(AllJavaTypes.class, 1);
         typedObj.setFieldString("str");
         typedObj.setFieldShort((short) 1);
         typedObj.setFieldInt(1);
@@ -223,6 +232,49 @@ public class DynamicRealmObjectTests {
             } finally {
                 realm.cancelTransaction();
             }
+        }
+    }
+
+    private void callSetterOnPrimaryKey(String className, DynamicRealmObject object) {
+        switch (className) {
+            case PrimaryKeyAsByte.CLASS_NAME:
+                object.setByte(PrimaryKeyAsByte.FIELD_ID, (byte) 42);
+                break;
+            case PrimaryKeyAsShort.CLASS_NAME:
+                object.setShort(PrimaryKeyAsShort.FIELD_ID, (short) 42);
+                break;
+            case PrimaryKeyAsInteger.CLASS_NAME:
+                object.setInt(PrimaryKeyAsInteger.FIELD_ID, 42);
+                break;
+            case PrimaryKeyAsLong.CLASS_NAME:
+                object.setLong(PrimaryKeyAsLong.FIELD_ID, 42);
+                break;
+            case PrimaryKeyAsString.CLASS_NAME:
+                object.setString(PrimaryKeyAsString.FIELD_PRIMARY_KEY, "42");
+                break;
+            default:
+                fail();
+        }
+    }
+
+    @Test
+    public void typedSetter_changePrimaryKeyThrows() {
+        final String[] primaryKeyClasses = {PrimaryKeyAsByte.CLASS_NAME, PrimaryKeyAsShort.CLASS_NAME,
+                PrimaryKeyAsInteger.CLASS_NAME, PrimaryKeyAsLong.CLASS_NAME, PrimaryKeyAsString.CLASS_NAME};
+        for (String pkClass : primaryKeyClasses) {
+            dynamicRealm.beginTransaction();
+            DynamicRealmObject object;
+            if (pkClass.equals(PrimaryKeyAsString.CLASS_NAME)) {
+                object = dynamicRealm.createObject(pkClass, "");
+            } else {
+                object = dynamicRealm.createObject(pkClass, 0);
+            }
+            try {
+                callSetterOnPrimaryKey(pkClass, object);
+                fail();
+            } catch (RealmException ignored) {
+            }
+            dynamicRealm.cancelTransaction();
         }
     }
 
@@ -463,6 +515,28 @@ public class DynamicRealmObjectTests {
             }
         } finally {
             realm.cancelTransaction();
+        }
+    }
+
+    @Test
+    public void setNull_changePrimaryKeyThrows() {
+        final String[] primaryKeyClasses = {PrimaryKeyAsBoxedByte.CLASS_NAME, PrimaryKeyAsBoxedShort.CLASS_NAME,
+                PrimaryKeyAsBoxedInteger.CLASS_NAME, PrimaryKeyAsBoxedLong.CLASS_NAME, PrimaryKeyAsString.CLASS_NAME};
+        for (String pkClass : primaryKeyClasses) {
+            dynamicRealm.beginTransaction();
+            DynamicRealmObject object;
+            try {
+                if (pkClass.equals(PrimaryKeyAsString.CLASS_NAME)) {
+                    object = dynamicRealm.createObject(pkClass, "");
+                    object.setNull(PrimaryKeyAsString.FIELD_PRIMARY_KEY);
+                } else {
+                    object = dynamicRealm.createObject(pkClass, 0);
+                    object.setNull("id");
+                }
+                fail();
+            } catch (RealmException ignored) {
+            }
+            dynamicRealm.cancelTransaction();
         }
     }
 
@@ -784,7 +858,7 @@ public class DynamicRealmObjectTests {
                             dObj.set(AllJavaTypes.FIELD_INT, "foo");
                             break;
                         case LONG:
-                            dObj.set(AllJavaTypes.FIELD_LONG, "foo");
+                            dObj.set(AllJavaTypes.FIELD_ID, "foo");
                             break;
                         case FLOAT:
                             dObj.set(AllJavaTypes.FIELD_FLOAT, "foo");
@@ -823,6 +897,37 @@ public class DynamicRealmObjectTests {
         }
     }
 
+    private void testChangePrimaryKeyThroughUntypedSetter(String value) {
+        final String[] primaryKeyClasses = {PrimaryKeyAsBoxedByte.CLASS_NAME, PrimaryKeyAsBoxedShort.CLASS_NAME,
+                PrimaryKeyAsBoxedInteger.CLASS_NAME, PrimaryKeyAsBoxedLong.CLASS_NAME, PrimaryKeyAsString.CLASS_NAME};
+        for (String pkClass : primaryKeyClasses) {
+            dynamicRealm.beginTransaction();
+            DynamicRealmObject object;
+            try {
+                if (pkClass.equals(PrimaryKeyAsString.CLASS_NAME)) {
+                    object = dynamicRealm.createObject(pkClass, "");
+                    object.set(PrimaryKeyAsString.FIELD_PRIMARY_KEY, value);
+                } else {
+                    object = dynamicRealm.createObject(pkClass, 0);
+                    object.set("id", value);
+                }
+                fail();
+            } catch (RealmException ignored) {
+            }
+            dynamicRealm.cancelTransaction();
+        }
+    }
+
+    @Test
+    public void untypedSetter_setValue_changePrimaryKeyThrows() {
+        testChangePrimaryKeyThroughUntypedSetter("42");
+    }
+
+    @Test
+    public void untypedSetter_setNull_changePrimaryKeyThrows() {
+        testChangePrimaryKeyThroughUntypedSetter(null);
+    }
+
     @Test
     public void isNull_nullNotSupportedField() {
         assertFalse(dObjTyped.isNull(AllJavaTypes.FIELD_INT));
@@ -844,10 +949,10 @@ public class DynamicRealmObjectTests {
 
     @Test
     public void getFieldNames() {
-        String[] expectedKeys = {AllJavaTypes.FIELD_STRING, AllJavaTypes.FIELD_SHORT, AllJavaTypes.FIELD_INT,
-                AllJavaTypes.FIELD_LONG, AllJavaTypes.FIELD_BYTE, AllJavaTypes.FIELD_FLOAT, AllJavaTypes.FIELD_DOUBLE,
-                AllJavaTypes.FIELD_BOOLEAN, AllJavaTypes.FIELD_DATE, AllJavaTypes.FIELD_BINARY,
-                AllJavaTypes.FIELD_OBJECT, AllJavaTypes.FIELD_LIST};
+        String[] expectedKeys = {AllJavaTypes.FIELD_STRING, AllJavaTypes.FIELD_ID, AllJavaTypes.FIELD_LONG,
+                AllJavaTypes.FIELD_SHORT, AllJavaTypes.FIELD_INT, AllJavaTypes.FIELD_BYTE, AllJavaTypes.FIELD_FLOAT,
+                AllJavaTypes.FIELD_DOUBLE, AllJavaTypes.FIELD_BOOLEAN, AllJavaTypes.FIELD_DATE,
+                AllJavaTypes.FIELD_BINARY, AllJavaTypes.FIELD_OBJECT, AllJavaTypes.FIELD_LIST};
         String[] keys = dObjTyped.getFieldNames();
         assertArrayEquals(expectedKeys, keys);
     }
@@ -934,6 +1039,7 @@ public class DynamicRealmObjectTests {
         assertTrue(str.contains(NullTypes.FIELD_OBJECT_NULL + ":null"));
         assertTrue(str.contains(NullTypes.FIELD_LIST_NULL + ":RealmList<NullTypes>[0]"));
     }
+
 
     public void testExceptionMessage() {
         // test for https://github.com/realm/realm-java/issues/2141

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -272,7 +272,7 @@ public class DynamicRealmObjectTests {
             try {
                 callSetterOnPrimaryKey(pkClass, object);
                 fail();
-            } catch (RealmException ignored) {
+            } catch (IllegalArgumentException ignored) {
             }
             dynamicRealm.cancelTransaction();
         }
@@ -534,7 +534,7 @@ public class DynamicRealmObjectTests {
                     object.setNull("id");
                 }
                 fail();
-            } catch (RealmException ignored) {
+            } catch (IllegalArgumentException ignored) {
             }
             dynamicRealm.cancelTransaction();
         }
@@ -912,7 +912,7 @@ public class DynamicRealmObjectTests {
                     object.set("id", value);
                 }
                 fail();
-            } catch (RealmException ignored) {
+            } catch (IllegalArgumentException ignored) {
             }
             dynamicRealm.cancelTransaction();
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -269,6 +269,7 @@ public class DynamicRealmObjectTests {
             } else {
                 object = dynamicRealm.createObject(pkClass, 0);
             }
+
             try {
                 callSetterOnPrimaryKey(pkClass, object);
                 fail();
@@ -525,14 +526,15 @@ public class DynamicRealmObjectTests {
         for (String pkClass : primaryKeyClasses) {
             dynamicRealm.beginTransaction();
             DynamicRealmObject object;
+            boolean isStringPK = pkClass.equals(PrimaryKeyAsString.CLASS_NAME);
+            if (isStringPK) {
+                object = dynamicRealm.createObject(pkClass, "");
+            } else {
+                object = dynamicRealm.createObject(pkClass, 0);
+            }
+
             try {
-                if (pkClass.equals(PrimaryKeyAsString.CLASS_NAME)) {
-                    object = dynamicRealm.createObject(pkClass, "");
-                    object.setNull(PrimaryKeyAsString.FIELD_PRIMARY_KEY);
-                } else {
-                    object = dynamicRealm.createObject(pkClass, 0);
-                    object.setNull("id");
-                }
+                object.setNull(isStringPK ? PrimaryKeyAsString.FIELD_PRIMARY_KEY : "id");
                 fail();
             } catch (IllegalArgumentException ignored) {
             }
@@ -903,14 +905,15 @@ public class DynamicRealmObjectTests {
         for (String pkClass : primaryKeyClasses) {
             dynamicRealm.beginTransaction();
             DynamicRealmObject object;
+            boolean isStringPK = pkClass.equals(PrimaryKeyAsString.CLASS_NAME);
+            if (isStringPK) {
+                object = dynamicRealm.createObject(pkClass, "");
+            } else {
+                object = dynamicRealm.createObject(pkClass, 0);
+            }
+
             try {
-                if (pkClass.equals(PrimaryKeyAsString.CLASS_NAME)) {
-                    object = dynamicRealm.createObject(pkClass, "");
-                    object.set(PrimaryKeyAsString.FIELD_PRIMARY_KEY, value);
-                } else {
-                    object = dynamicRealm.createObject(pkClass, 0);
-                    object.set("id", value);
-                }
+                object.set(isStringPK ? PrimaryKeyAsString.FIELD_PRIMARY_KEY : "id", value);
                 fail();
             } catch (IllegalArgumentException ignored) {
             }

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
@@ -126,7 +126,7 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
     }
 
     private void createNewObject() {
-        Number currentMax = realm.where(AllJavaTypes.class).max(AllJavaTypes.FIELD_LONG);
+        Number currentMax = realm.where(AllJavaTypes.class).max(AllJavaTypes.FIELD_ID);
         long nextId = 0;
         if (currentMax != null) {
             nextId = currentMax.longValue() + 1;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAnnotationTests.java
@@ -179,23 +179,6 @@ public class RealmAnnotationTests {
         }
     }
 
-    // It should be allowed to override the primary key value with the same value
-    @Test
-    public void primaryKey_defaultStringValue() {
-        realm.beginTransaction();
-        realm.createObject(PrimaryKeyAsString.class, "");
-        realm.commitTransaction();
-    }
-
-    // It should be allowed to override the primary key value with the same value
-    @Test
-    public void primaryKey_defaultLongValue() {
-        realm.beginTransaction();
-        PrimaryKeyAsLong str = realm.createObject(PrimaryKeyAsLong.class, 0);
-        str.setId(0);
-        realm.commitTransaction();
-    }
-
     @Test
     public void primaryKey_errorOnInsertingSameObject() {
         try {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
@@ -45,6 +45,7 @@ import io.realm.rule.TestRealmConfigurationFactory;
 
 import static io.realm.internal.test.ExtraTests.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 // tests API methods when using a model class implementing RealmModel instead
@@ -153,6 +154,7 @@ public class RealmModelTests {
         assertEquals(1, realm.where(AllTypesRealmModel.class).count());
 
         AllTypesRealmModel obj = realm.where(AllTypesRealmModel.class).findFirst();
+        assertNotNull(obj);
         assertEquals("Foo", obj.columnString);
     }
 
@@ -164,6 +166,7 @@ public class RealmModelTests {
 
         assertEquals(1, realm.where(AllTypesRealmModel.class).count());
         AllTypesRealmModel obj = realm.where(AllTypesRealmModel.class).findFirst();
+        assertNotNull(obj);
         assertEquals("Bar", obj.columnString);
         assertEquals(2.23F, obj.columnFloat, 0.000000001);
         assertEquals(2.234D, obj.columnDouble, 0.000000001);
@@ -206,12 +209,13 @@ public class RealmModelTests {
         populateTestRealm(realm, TEST_DATA_SIZE);
 
         AllTypesRealmModel typedObj = realm.where(AllTypesRealmModel.class).findFirst();
+        assertNotNull(typedObj);
         DynamicRealmObject dObj = new DynamicRealmObject(typedObj);
 
         realm.beginTransaction();
-        dObj.setLong(AllTypesRealmModel.FIELD_LONG, 42L);
-        assertEquals(42, dObj.getLong(AllTypesRealmModel.FIELD_LONG));
-        assertEquals(42, typedObj.columnLong);
+        dObj.setByte(AllTypesRealmModel.FIELD_BYTE, (byte) 42);
+        assertEquals(42, dObj.getLong(AllTypesRealmModel.FIELD_BYTE));
+        assertEquals(42, typedObj.columnByte);
 
         dObj.setBlob(AllTypesRealmModel.FIELD_BINARY, new byte[]{1, 2, 3});
         Assert.assertArrayEquals(new byte[]{1, 2, 3}, dObj.getBlob(AllTypesRealmModel.FIELD_BINARY));

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AllTypesPrimaryKey;
 import io.realm.entities.ConflictingFieldName;
@@ -48,6 +49,7 @@ import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.NullTypes;
 import io.realm.entities.StringAndInt;
+import io.realm.exceptions.RealmException;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.Row;
 import io.realm.internal.Table;
@@ -1570,6 +1572,15 @@ public class RealmObjectTests {
         list.first().setFieldDateNull(null);
         realm.commitTransaction();
         assertNull(realm.where(NullTypes.class).findFirst().getFieldDateNull());
+    }
+
+    @Test
+    public void setter_changePrimaryKeyThrows() {
+        realm.beginTransaction();
+        AllJavaTypes allJavaTypes = realm.createObject(AllJavaTypes.class, 42);
+        thrown.expect(RealmException.class);
+        allJavaTypes.setFieldId(111);
+        realm.cancelTransaction();
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -2314,7 +2314,7 @@ public class RealmQueryTests {
         realm.beginTransaction();
 
         AllJavaTypes emptyValues = new AllJavaTypes();
-        emptyValues.setFieldLong(1);
+        emptyValues.setFieldId(1);
         emptyValues.setFieldString("");
         emptyValues.setFieldBinary(new byte[0]);
         emptyValues.setFieldObject(emptyValues);
@@ -2322,7 +2322,7 @@ public class RealmQueryTests {
         realm.copyToRealm(emptyValues);
 
         AllJavaTypes nonEmpty = new AllJavaTypes();
-        nonEmpty.setFieldLong(2);
+        nonEmpty.setFieldId(2);
         nonEmpty.setFieldString("Foo");
         nonEmpty.setFieldBinary(new byte[]{1, 2, 3});
         nonEmpty.setFieldObject(nonEmpty);
@@ -2437,7 +2437,7 @@ public class RealmQueryTests {
         realm.beginTransaction();
 
         AllJavaTypes emptyValues = new AllJavaTypes();
-        emptyValues.setFieldLong(1);
+        emptyValues.setFieldId(1);
         emptyValues.setFieldString("");
         emptyValues.setFieldBinary(new byte[0]);
         emptyValues.setFieldObject(emptyValues);
@@ -2445,7 +2445,7 @@ public class RealmQueryTests {
         realm.copyToRealm(emptyValues);
 
         AllJavaTypes notEmpty = new AllJavaTypes();
-        notEmpty.setFieldLong(2);
+        notEmpty.setFieldId(2);
         notEmpty.setFieldString("Foo");
         notEmpty.setFieldBinary(new byte[]{1, 2, 3});
         notEmpty.setFieldObject(notEmpty);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -525,13 +525,15 @@ public class RealmTests {
                             realm.createAllFromJson(AllTypes.class, "[{}]");
                             break;
                         case METHOD_CREATE_OR_UPDATE_ALL_FROM_JSON:
-                            realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, "[{\"columnLong\":1}]");
+                            realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, "[{\"columnLong\":1," +
+                                    " \"columnBoolean\": true}]");
                             break;
                         case METHOD_CREATE_FROM_JSON:
                             realm.createObjectFromJson(AllTypes.class, "{}");
                             break;
                         case METHOD_CREATE_OR_UPDATE_FROM_JSON:
-                            realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, "{\"columnLong\":1}");
+                            realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, "{\"columnLong\":1," +
+                                    " \"columnBoolean\": true}");
                             break;
                         case METHOD_INSERT_COLLECTION:
                             realm.insert(Arrays.asList(new AllTypes(), new AllTypes()));
@@ -2098,7 +2100,7 @@ public class RealmTests {
         realm.beginTransaction();
         AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 42);
         assertEquals(1, realm.where(AllJavaTypes.class).count());
-        assertEquals(42, obj.getFieldLong());
+        assertEquals(42, obj.getFieldId());
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
@@ -32,6 +32,7 @@ public class AllJavaTypes extends RealmObject {
     public static String FIELD_SHORT = "fieldShort";
     public static String FIELD_INT = "fieldInt";
     public static String FIELD_LONG = "fieldLong";
+    public static String FIELD_ID = "fieldId";
     public static String FIELD_BYTE = "fieldByte";
     public static String FIELD_FLOAT = "fieldFloat";
     public static String FIELD_DOUBLE = "fieldDouble";
@@ -46,9 +47,10 @@ public class AllJavaTypes extends RealmObject {
 
     @Ignore private String fieldIgnored;
     @Index private String fieldString;
+    @PrimaryKey private long fieldId;
+    private long fieldLong;
     private short fieldShort;
     private int fieldInt;
-    @PrimaryKey private long fieldLong;
     private byte fieldByte;
     private float fieldFloat;
     private double fieldDouble;
@@ -63,6 +65,7 @@ public class AllJavaTypes extends RealmObject {
     }
 
     public AllJavaTypes(long fieldLong) {
+        this.fieldId = fieldLong;
         this.fieldLong = fieldLong;
     }
 
@@ -90,6 +93,14 @@ public class AllJavaTypes extends RealmObject {
         this.fieldShort = fieldShort;
     }
 
+    public long getFieldLong() {
+        return fieldLong;
+    }
+
+    public void setFieldLong(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
     public int getFieldInt() {
         return fieldInt;
     }
@@ -98,12 +109,12 @@ public class AllJavaTypes extends RealmObject {
         this.fieldInt = fieldInt;
     }
 
-    public long getFieldLong() {
-        return fieldLong;
+    public long getFieldId() {
+        return fieldId;
     }
 
-    public void setFieldLong(long fieldLong) {
-        this.fieldLong = fieldLong;
+    public void setFieldId(long fieldId) {
+        this.fieldId = fieldId;
     }
 
     public byte getFieldByte() {

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsBoxedLong.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsBoxedLong.java
@@ -24,6 +24,7 @@ public class PrimaryKeyAsBoxedLong extends RealmObject implements NullPrimaryKey
 
     public static final String CLASS_NAME = "PrimaryKeyAsBoxedLong";
     public static final String FIELD_PRIMARY_KEY = "id";
+    public static final String FIELD_NAME = "name";
 
     @PrimaryKey
     private Long id;

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsByte.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsByte.java
@@ -21,6 +21,9 @@ import io.realm.annotations.PrimaryKey;
 
 public class PrimaryKeyAsByte extends RealmObject {
 
+    public static final String CLASS_NAME = "PrimaryKeyAsByte";
+    public static final String FIELD_ID = "id";
+
     @PrimaryKey
     private byte id;
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsInteger.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsInteger.java
@@ -21,6 +21,9 @@ import io.realm.annotations.PrimaryKey;
 
 public class PrimaryKeyAsInteger extends RealmObject {
 
+    public static final String CLASS_NAME = "PrimaryKeyAsInteger";
+    public static final String FIELD_ID = "id";
+
     @PrimaryKey
     private int id;
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsLong.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsLong.java
@@ -21,6 +21,9 @@ import io.realm.annotations.PrimaryKey;
 
 public class PrimaryKeyAsLong extends RealmObject {
 
+    public static final String CLASS_NAME = "PrimaryKeyAsLong";
+    public static final String FIELD_ID = "id";
+
     @PrimaryKey
     private long id;
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsShort.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsShort.java
@@ -21,6 +21,9 @@ import io.realm.annotations.PrimaryKey;
 
 public class PrimaryKeyAsShort extends RealmObject {
 
+    public static final String CLASS_NAME = "PrimaryKeyAsShort";
+    public static final String FIELD_ID = "id";
+
     @PrimaryKey
     private short id;
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/pojo/AllTypesRealmModel.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/pojo/AllTypesRealmModel.java
@@ -29,6 +29,7 @@ import io.realm.entities.Dog;
 public class AllTypesRealmModel implements RealmModel {
     public static final String CLASS_NAME = "AllTypesRealmModel";
     public static final String FIELD_LONG = "columnLong";
+    public static final String FIELD_BYTE = "columnByte";
     public static final String FIELD_DOUBLE = "columnDouble";
     public static final String FIELD_STRING = "columnString";
     public static final String FIELD_BINARY = "columnBinary";

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -100,8 +100,7 @@ public final class DynamicRealm extends BaseRealm {
     public DynamicRealmObject createObject(String className, Object primaryKeyValue) {
         Table table = schema.getTable(className);
         long index = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
-        DynamicRealmObject dynamicRealmObject = new DynamicRealmObject(this, table.getCheckedRow(index));
-        return dynamicRealmObject;
+        return new DynamicRealmObject(this, table.getCheckedRow(index));
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -813,8 +813,8 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
     private void checkIsPrimaryKey(String fieldName) {
         RealmObjectSchema objectSchema = proxyState.getRealm$realm().getSchema().getSchemaForClass(getType());
         if (objectSchema.hasPrimaryKey() && objectSchema.getPrimaryKey().equals(fieldName)) {
-            throw new IllegalArgumentException(String.format("Primary key field '%s' cannot be changed after object created."
-                    , fieldName));
+            throw new IllegalArgumentException(String.format(
+                    "Primary key field '%s' cannot be changed after object was created.", fieldName));
         }
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -813,7 +813,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
     private void checkIsPrimaryKey(String fieldName) {
         RealmObjectSchema objectSchema = proxyState.getRealm$realm().getSchema().getSchemaForClass(getType());
         if (objectSchema.hasPrimaryKey() && objectSchema.getPrimaryKey().equals(fieldName)) {
-            throw new RealmException(String.format("Primary key field '%s' cannot be changed after object created."
+            throw new IllegalArgumentException(String.format("Primary key field '%s' cannot be changed after object created."
                     , fieldName));
         }
     }


### PR DESCRIPTION
Thrown an exception if changing the pk after the object created.