### PR TITLE
added thread check to Realm#createObject(Class,Object)

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -521,6 +521,7 @@ public class RealmTests {
         METHOD_DELETE_TYPE,
         METHOD_DELETE_ALL,
         METHOD_CREATE_OBJECT,
+        METHOD_CREATE_OBJECT_WITH_PRIMARY_KEY,
         METHOD_COPY_TO_REALM,
         METHOD_COPY_TO_REALM_OR_UPDATE,
         METHOD_CREATE_ALL_FROM_JSON,
@@ -562,6 +563,9 @@ public class RealmTests {
                             break;
                         case METHOD_CREATE_OBJECT:
                             realm.createObject(AllTypes.class);
+                            break;
+                        case METHOD_CREATE_OBJECT_WITH_PRIMARY_KEY:
+                            realm.createObject(AllJavaTypes.class, 1L);
                             break;
                         case METHOD_COPY_TO_REALM:
                             realm.copyToRealm(new AllTypes());

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -697,6 +697,7 @@ public final class Realm extends BaseRealm {
      *                                  expected value.
      */
     public <E extends RealmModel> E createObject(Class<E> clazz, Object primaryKeyValue) {
+        checkIfValid();
         Table table = schema.getTable(clazz);
         long rowIndex = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
         return get(clazz, rowIndex);


### PR DESCRIPTION
Thread check in `Realm#createObject(Class,Object)` seems to be missing.

@realm/java 