### PR TITLE
add a task to clean jni header files when .so file is cleaned

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -424,6 +424,11 @@ if (project.hasProperty('dontCleanJniFiles')) {
         }
     }
 } else {
+    task cleanJniHeaders(type: Delete) {
+        delete project.file('src/main/cpp/jni_include')
+    }
+    clean.dependsOn cleanJniHeaders
+
     task cleanExternalBuildFiles(type: Delete) {
         delete project.file('.externalNativeBuild')
     }


### PR DESCRIPTION
generated jni header files must be cleaned when cleaning `.so` files.

@realm/java 