### PR TITLE
resurrect buildTargetABIs property support

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -48,7 +48,11 @@ android {
                           // JNI build currently (lack of lto linking support).
                           // This file should be removed and use the one from Android SDK cmake package when it supports lto.
                         "-DCMAKE_TOOLCHAIN_FILE=${project.file('src/main/cpp/android.toolchain.cmake').path}"
-                abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'mips'
+                if (!project.hasProperty('android.injected.build.abi') && project.hasProperty('buildTargetABIs')) {
+                    abiFilters(*project.getProperty('buildTargetABIs').trim().split('\\s*,\\s*'))
+                } else {
+                    abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'mips'
+                }
             }
         }
     }


### PR DESCRIPTION
This PR enables us to specify `buildTargetABIs` property in command-line or in `~/.gradle/gradle.properties` like before and it will be ignored when we execute gradle from AS (AS automatically set appropriate ABI to `android.injected.build.abi`).

@realm/java 