### PR TITLE
update javadoc comments of JSON APIs in Realm class to mention available API level.

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -409,6 +409,8 @@ public final class Realm extends BaseRealm {
      * JSON properties with {@code null} value will map to the default value for the data type in Realm and unknown properties
      * will be ignored. If a {@link RealmObject} field is not present in the JSON object the {@link RealmObject} field
      * will be set to the default value for that type.
+     * <p>
+     * This API is only available in API level 11 or later.
      *
      * @param clazz type of Realm objects created.
      * @param inputStream the JSON array as a InputStream. All objects in the array must be of the specified class.
@@ -439,6 +441,8 @@ public final class Realm extends BaseRealm {
      * If updating a {@link RealmObject} and a field is not found in the JSON object, that field will not be updated.
      * If a new {@link RealmObject} is created and a field is not found in the JSON object, that field will be assigned
      * the default value for the field type.
+     * <p>
+     * This API is only available in API level 11 or later.
      *
      * @param clazz type of {@link io.realm.RealmObject} to create or update. It must have a primary key defined.
      * @param in the InputStream with a list of object data in JSON format.
@@ -585,6 +589,8 @@ public final class Realm extends BaseRealm {
      * properties with {@code null} value will map to the default value for the data type in Realm and unknown properties will
      * be ignored. If a {@link RealmObject} field is not present in the JSON object the {@link RealmObject} field will
      * be set to the default value for that type.
+     * <p>
+     * This API is only available in API level 11 or later.
      *
      * @param clazz type of Realm object to create.
      * @param inputStream the JSON object data as a InputStream.
@@ -632,6 +638,8 @@ public final class Realm extends BaseRealm {
      * {@link RealmObject} and a field is not found in the JSON object, that field will not be updated. If a new
      * {@link RealmObject} is created and a field is not found in the JSON object, that field will be assigned the
      * default value for the field type.
+     * <p>
+     * This API is only available in API level 11 or later.
      *
      * @param clazz type of {@link io.realm.RealmObject} to create or update. It must have a primary key defined.
      * @param in the {@link InputStream} with object data in JSON format.


### PR DESCRIPTION
`createAllFromJson(Class,InputStream)`, `createOrUpdateAllFromJson(Class,InputStream)`, `createObjectFromJson(Class,InputStream)` and `createOrUpdateObjectFromJson(Class,InputStream)` only supports API level 11 or later.

That should be mentioned in API reference. Actually related issue was created multiple times (#3356, #3455 ).

This PR adds a mention to the limitation of those APIs.

fixes #3455
