### PR TITLE
fix duplicate check of accessors when adding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed a lint error in proxy classes when the 'minSdkVersion' of user's project is smaller than 11 (#3356).
 * Fixed a potential crash when there were lots of async queries waiting in the queue.
 * Fixed a bug causing the Realm Transformer to not transform field access in the model's constructors (#3361).
+* Fixed a bug causing a build failure when the Realm Transformer adds accessors to a model class that was already transformed in other project (#3469).
 
 ## 1.2.0
 

--- a/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
@@ -41,10 +41,10 @@ class BytecodeModifier {
         def methods = clazz.getDeclaredMethods()*.name
         clazz.declaredFields.each { CtField field ->
             if (!Modifier.isStatic(field.getModifiers()) && !field.hasAnnotation(Ignore.class)) {
-                if (!methods.contains("realmGet\$${field.name}")) {
+                if (!methods.contains("realmGet\$${field.name}".toString())) {
                     clazz.addMethod(CtNewMethod.getter("realmGet\$${field.name}", field))
                 }
-                if (!methods.contains("realmSet\$${field.name}")) {
+                if (!methods.contains("realmSet\$${field.name}".toString())) {
                     clazz.addMethod(CtNewMethod.setter("realmSet\$${field.name}", field))
                 }
             }


### PR DESCRIPTION
We need to pass `java.lang.String` object instead of `groovy.lang.GString` object to `contains()` since the `contains()` method accepts any type of object thus `groovy.lang.GString` is not converted to `java.lang.String`.

fixes #3469 