### PR TITLE
Append the version number to the name of all the artifacts uploaded to Bintray

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -558,7 +558,7 @@ android.productFlavors.all { flavor ->
             "${buildDir}/outputs/aar/realm-android-library-${flavor.name}-release.aar",
             '-u',
             "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}.aar?publish=0"
+            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-{project.version}.aar?publish=0"
     }
 
     task("bintraySources${flavor.name.capitalize()}", type: Exec) {
@@ -571,7 +571,7 @@ android.productFlavors.all { flavor ->
             "${buildDir}/libs/realm-android-library-${project.version}-sources.jar",
             '-u',
             "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-sources.jar?publish=0"
+            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-sources-{project.version}.jar?publish=0"
     }
 
     task("bintrayJavadoc${flavor.name.capitalize()}", type: Exec) {
@@ -584,7 +584,7 @@ android.productFlavors.all { flavor ->
             "${buildDir}/libs/realm-android-library-${project.version}-javadoc.jar",
             '-u',
             "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-javadoc.jar?publish=0"
+            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-javadoc-{project.version}.jar?publish=0"
     }
 
     task("bintrayPom${flavor.name.capitalize()}", type: Exec) {
@@ -597,7 +597,7 @@ android.productFlavors.all { flavor ->
             "${buildDir}/publications/${flavor.name}Publication/pom-default.xml",
             '-u',
             "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}.pom?publish=0"
+            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-{project.version}.pom?publish=0"
     }
 
     task("bintray${flavor.name.capitalize()}") {


### PR DESCRIPTION
Fixes #3514.

This might solve an issue regarding Bintray not updating the `maven-metadata.xml` file in the Maven repository