### PR TITLE
use Context.registerReceiver() instead of AndroidManifest.xml to register NetworkStateReceiver for android.net.conn.CONNECTIVITY_CHANGE broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` broadcast caused `RuntimeException` if sync extension was disabled (#3505).
+* Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` was not delivered on Android 7 devices.
 
 
 ## 2.0.0

--- a/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal;
 
 import android.content.Context;

--- a/realm/realm-library/src/objectServer/AndroidManifest.xml
+++ b/realm/realm-library/src/objectServer/AndroidManifest.xml
@@ -5,11 +5,4 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application>
-        <receiver android:name=".internal.network.NetworkStateReceiver">
-            <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
-            </intent-filter>
-        </receiver>
-    </application>
 </manifest>

--- a/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm;
 
 import android.content.Context;

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SessionStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SessionStore.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.objectserver;
 
 import java.util.Collection;

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncObjectServerFacade.java
@@ -18,6 +18,8 @@ package io.realm.internal.objectserver;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -29,6 +31,7 @@ import io.realm.SyncManager;
 import io.realm.exceptions.RealmException;
 import io.realm.internal.Keep;
 import io.realm.internal.ObjectServerFacade;
+import io.realm.internal.network.NetworkStateReceiver;
 
 @SuppressWarnings({"unused", "WeakerAccess"}) // Used through reflection. See ObjectServerFacade
 @Keep
@@ -61,6 +64,9 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
         }
         if (applicationContext == null) {
             applicationContext = context;
+
+            applicationContext.registerReceiver(new NetworkStateReceiver(),
+                    new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
         }
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncUtil.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.realm.internal.objectserver;
 
 import java.net.URI;


### PR DESCRIPTION
On Android 7 device, android.net.conn.CONNECTIVITY_CHANGE is not deliverd to receivers registerd by AndroidManifest.xml.
See https://developer.android.com/topic/performance/background-optimization.html#connectivity-action

fixes #3511