### PR TITLE
distinctAsync now respects other query parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Bug fixes
 
-* Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` broadcast caused `RuntimeException` if sync extension was disabled (#3505).
-* Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` was not delivered on Android 7 devices.
-
+* `android.net.conn.CONNECTIVITY_CHANGE` broadcast caused `RuntimeException` if sync extension was disabled (#3505).
+* `android.net.conn.CONNECTIVITY_CHANGE` was not delivered on Android 7 devices.
+* `distinctAsync` did not respect any other query parameters (#3537).
 
 ## 2.0.0
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -1621,6 +1621,30 @@ public class RealmAsyncQueryTests {
     }
 
     @Test
+    @RunTestInLooperThread()
+    public void distinctAsync_rememberQueryParams() {
+        final Realm realm = looperThread.realm;
+        realm.beginTransaction();
+        final int TEST_SIZE = 10;
+        for (int i = 0; i < TEST_SIZE; i++) {
+            realm.createObject(AllJavaTypes.class, i);
+        }
+        realm.commitTransaction();
+
+        RealmResults<AllJavaTypes> results = realm.where(AllJavaTypes.class)
+                .notEqualTo(AllJavaTypes.FIELD_ID, TEST_SIZE / 2)
+                .distinctAsync(AllJavaTypes.FIELD_ID);
+
+        results.addChangeListener(new RealmChangeListener<RealmResults<AllJavaTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllJavaTypes> results) {
+                assertEquals(TEST_SIZE - 1, results.size());
+                looperThread.testComplete();
+            }
+        });
+    }
+
+    @Test
     @RunTestInLooperThread
     public void distinctAsync_notIndexedFields() throws Throwable {
         Realm realm = looperThread.realm;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -1639,6 +1639,7 @@ public class RealmAsyncQueryTests {
             @Override
             public void onChange(RealmResults<AllJavaTypes> results) {
                 assertEquals(TEST_SIZE - 1, results.size());
+                assertEquals(0, results.where().equalTo(AllJavaTypes.FIELD_ID, TEST_SIZE / 2).count());
                 looperThread.testComplete();
             }
         });

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -116,7 +116,8 @@ static jlong getDistinctViewWithHandover
             case type_Int:
             case type_Timestamp:
             case type_String: {
-                TableView tableView(table->get_distinct_view(S(columnIndex)) );
+                TableView tableView(query->find_all());
+                tableView.distinct(S(columnIndex));
 
                 // handover the result
                 auto sharedRealm = *(reinterpret_cast<SharedRealm*>(bgSharedRealmPtr));


### PR DESCRIPTION
Closes #3537 

@realm/java 