### PR TITLE
Clean .so files that were created by old build script

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -511,6 +511,8 @@ if (project.hasProperty('dontCleanJniFiles')) {
 } else {
     task cleanExternalBuildFiles(type: Delete) {
         delete project.file('.externalNativeBuild')
+        // Clean .so files that were created by old build script (realm/realm-jni/build.gradle).
+        delete project.file('src/main/jniLibs')
     }
     clean.dependsOn cleanExternalBuildFiles
 }


### PR DESCRIPTION
Credit to @zaki50 to add this fix.

After a gradle clean `realm/realm-library/src/main/jniLibs` was not cleared causing the packager to use old generated _.so_  in the AAR instead of the freshly compiled inside `externalNativeBuild` ex `./realm/realm-library/.externalNativeBuild/cmake/objectServerDebug/obj/x86/librealm-jni.so`

without this fix it might include old _.so_ not containing the sync symbols.