### PR TITLE
fixed a bug causing ConcurrentModificationException on some Gradle 3.1 environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` broadcast caused `RuntimeException` if sync extension was disabled (#3505).
 * Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` was not delivered on Android 7 devices.
+* Fixed a bug causing the `ConcurrentModificationException` while building application (#3501).
 
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` broadcast caused `RuntimeException` if sync extension was disabled (#3505).
 * Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` was not delivered on Android 7 devices.
-* Fixed a bug causing the `ConcurrentModificationException` while building in application (#3501).
+* Fixed a bug causing the `ConcurrentModificationException` while building an application (#3501).
 
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` broadcast caused `RuntimeException` if sync extension was disabled (#3505).
 * Fixed a bug that `android.net.conn.CONNECTIVITY_CHANGE` was not delivered on Android 7 devices.
-* Fixed a bug causing the `ConcurrentModificationException` while building application (#3501).
+* Fixed a bug causing the `ConcurrentModificationException` while building in application (#3501).
 
 
 ## 2.0.0

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -41,7 +41,8 @@ class Realm implements Plugin<Project> {
             throw new GradleException('Realm gradle plugin only supports android gradle plugin 1.5.0 or later.')
         }
 
-        project.extensions.create('realm', RealmPluginExtension)
+        def syncEnabledDefault = false
+        project.extensions.create('realm', RealmPluginExtension, project, syncEnabledDefault)
 
         def usesKotlinPlugin = project.plugins.findPlugin('kotlin-android') != null
         def usesAptPlugin = project.plugins.findPlugin('com.neenbedankt.android-apt') != null
@@ -51,6 +52,8 @@ class Realm implements Plugin<Project> {
         if (!isKaptProject) {
             project.plugins.apply(AndroidAptPlugin)
         }
+
+        project.android.registerTransform(new RealmTransformer(project))
 
         project.repositories.add(project.getRepositories().jcenter())
         project.dependencies.add("compile", "io.realm:realm-annotations:${Version.VERSION}")
@@ -63,21 +66,6 @@ class Realm implements Plugin<Project> {
             project.dependencies.add("androidTestApt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("androidTestApt", "io.realm:realm-annotations-processor:${Version.VERSION}")
         }
-
-        // Using afterEvaluate is now deprecated so this callback is used instead
-        def compileDeps = project.getConfigurations().getByName("compile").getDependencies()
-        project.getGradle().addListener(new DependencyResolutionListener() {
-            @Override
-            void beforeResolve(ResolvableDependencies resolvableDependencies) {
-                project.android.registerTransform(new RealmTransformer(project))
-                def suffix = project.realm.syncEnabled?'-object-server':''
-                compileDeps.add(project.getDependencies().create("io.realm:realm-android-library${suffix}:${Version.VERSION}"))
-                project.getGradle().removeListener(this)
-            }
-
-            @Override
-            void afterResolve(ResolvableDependencies resolvableDependencies) {}
-        })
     }
 
     private static boolean isTransformAvailable() {

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/RealmPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/RealmPluginExtension.groovy
@@ -16,6 +16,33 @@
 
 package io.realm.gradle
 
+import org.gradle.api.Project
+
 class RealmPluginExtension {
-    boolean syncEnabled = false
+    private Project project
+    def boolean syncEnabled
+
+    RealmPluginExtension(Project project, boolean syncEnabledDefault) {
+        this.project = project
+        setSyncEnabled(syncEnabledDefault)
+    }
+
+    void setSyncEnabled(value) {
+        this.syncEnabled = value;
+
+        // remove realm android library first
+        project.getConfigurations().getByName("compile").getDependencies().removeIf() {
+            if (it.group != 'io.realm') {
+                return false
+            }
+            return it.name.startsWith('realm-android-library')
+        }
+
+        // then add again
+        project.dependencies.add("compile", "io.realm:${getArtifactName(syncEnabled)}:${Version.VERSION}")
+    }
+
+    static String getArtifactName(boolean syncEnabled) {
+        return "realm-android-library${syncEnabled ? '-object-server' : ''}"
+    }
 }

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/RealmPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/RealmPluginExtension.groovy
@@ -39,10 +39,7 @@ class RealmPluginExtension {
         }
 
         // then add again
-        project.dependencies.add("compile", "io.realm:${getArtifactName(syncEnabled)}:${Version.VERSION}")
-    }
-
-    static String getArtifactName(boolean syncEnabled) {
-        return "realm-android-library${syncEnabled ? '-object-server' : ''}"
+        def artifactName = "realm-android-library${syncEnabled ? '-object-server' : ''}"
+        project.dependencies.add("compile", "io.realm:${artifactName}:${Version.VERSION}")
     }
 }


### PR DESCRIPTION
fixes #3501

This PR changes the way to add the dependencies.
`DependencyResolutionListener` was removed and the setter of `syncEnabled` property in `RealmPluginExtension` modifies `compile` dependencies instead.

This worked as expected with the project provided in https://github.com/realm/realm-java/issues/3501#issuecomment-250413228

@realm/java @emanuelez 