### PR TITLE
Always use CheckedRow when creating DynamicRealmObject

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -518,14 +518,14 @@ abstract class BaseRealm implements Closeable {
     // Used by RealmList/RealmResults
     // Invariant: if dynamicClassName != null -> clazz == DynamicRealmObject
     <E extends RealmModel> E get(Class<E> clazz, String dynamicClassName, long rowIndex) {
-        final Table table = (dynamicClassName != null) ? schema.getTable(dynamicClassName) : schema.getTable(clazz);
+        final boolean isDynamicRealmObject = dynamicClassName != null;
+        final Table table = isDynamicRealmObject ? schema.getTable(dynamicClassName) : schema.getTable(clazz);
 
         E result;
-        if (dynamicClassName != null) {
+        if (isDynamicRealmObject) {
             @SuppressWarnings("unchecked")
             E dynamicObj = (E) new DynamicRealmObject(this,
-                    (rowIndex != Table.NO_MATCH) ? table.getUncheckedRow(rowIndex) : InvalidRow.INSTANCE,
-                    false);
+                    (rowIndex != Table.NO_MATCH) ? table.getCheckedRow(rowIndex) : InvalidRow.INSTANCE);
             result = dynamicObj;
         } else {
             result = configuration.getSchemaMediator().newInstance(clazz, this,

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -95,12 +95,12 @@ public final class DynamicRealm extends BaseRealm {
      * @throws RealmException if object could not be created due to the primary key being invalid.
      * @throws IllegalStateException if the model clazz does not have an primary key defined.
      * @throws IllegalArgumentException if the {@code primaryKeyValue} doesn't have a value that can be converted to the
-     *                                  expectd value.
+     *                                  expected value.
      */
     public DynamicRealmObject createObject(String className, Object primaryKeyValue) {
         Table table = schema.getTable(className);
         long index = table.addEmptyRowWithPrimaryKey(primaryKeyValue);
-        return new DynamicRealmObject(this, table.getCheckedRow(index), false);
+        return new DynamicRealmObject(this, table.getCheckedRow(index));
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -32,6 +32,7 @@ import io.realm.internal.android.JsonUtils;
  * Class that wraps a normal RealmObject in order to allow dynamic access instead of a typed interface.
  * Using a DynamicRealmObject is slower than using the regular RealmObject class.
  */
+@SuppressWarnings("WeakerAccess")
 public final class DynamicRealmObject extends RealmObject implements RealmObjectProxy {
 
     private final ProxyState proxyState = new ProxyState(this);
@@ -67,24 +68,18 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         proxyState.setConstructionFinished();
     }
 
-    DynamicRealmObject(BaseRealm realm, Row row, boolean convertTocheckedRow) {
+    // row must not be an instance of UncheckedRow
+    DynamicRealmObject(BaseRealm realm, Row row) {
         proxyState.setRealm$realm(realm);
-        if (convertTocheckedRow) {
-            proxyState.setRow$realm((row instanceof CheckedRow) ? (CheckedRow) row : ((UncheckedRow) row).convertToChecked());
-        } else {
-            proxyState.setRow$realm(row);
-        }
+        proxyState.setRow$realm(row);
         proxyState.setConstructionFinished();
     }
 
-    DynamicRealmObject(String className, BaseRealm realm, Row row, boolean convertTocheckedRow) {
+    // row must not be an instance of UncheckedRow
+    DynamicRealmObject(String className, BaseRealm realm, Row row) {
         proxyState.setClassName(className);
         proxyState.setRealm$realm(realm);
-        if (convertTocheckedRow) {
-            proxyState.setRow$realm((row instanceof CheckedRow) ? (CheckedRow) row : ((UncheckedRow) row).convertToChecked());
-        } else {
-            proxyState.setRow$realm(row);
-        }
+        proxyState.setRow$realm(row);
         proxyState.setConstructionFinished();
     }
 
@@ -287,7 +282,7 @@ public final class DynamicRealmObject extends RealmObject implements RealmObject
         } else {
             long linkRowIndex = proxyState.getRow$realm().getLink(columnIndex);
             CheckedRow linkRow = proxyState.getRow$realm().getTable().getLinkTarget(columnIndex).getCheckedRow(linkRowIndex);
-            return new DynamicRealmObject(proxyState.getRealm$realm(), linkRow, false);
+            return new DynamicRealmObject(proxyState.getRealm$realm(), linkRow);
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -570,7 +570,7 @@ public final class RealmObjectSchema {
         if (function != null) {
             long size = table.size();
             for (long i = 0; i < size; i++) {
-                function.apply(new DynamicRealmObject(realm, table.getCheckedRow(i), false));
+                function.apply(new DynamicRealmObject(realm, table.getCheckedRow(i)));
             }
         }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -2102,7 +2102,7 @@ public final class RealmQuery<E extends RealmModel> {
         final E result;
         if (isDynamicQuery()) {
             //noinspection unchecked
-            result = (E) new DynamicRealmObject(className, realm, Row.EMPTY_ROW, false);
+            result = (E) new DynamicRealmObject(className, realm, Row.EMPTY_ROW);
         } else {
             result = realm.getConfiguration().getSchemaMediator().newInstance(
                     clazz, realm, Row.EMPTY_ROW, realm.getSchema().getColumnInfo(clazz),


### PR DESCRIPTION
fixes #3404 

DynamicRealmObject should not have `UncheckedRow` instance as a `row`. This PR fix that issue.

And this also removes a check of the `row` instance if it is an instance of `UncheckedRow` in some constructors of DynamicRealmObject since CheckedRow is never passed to it.