### PR TITLE
fix build error on Java 7 environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* build error on Java 7 environment (#3563).
+* Build error when using Java 7 (#3563).
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.2
+
+### Bug fixes
+
+* build error on Java 7 environment (#3563).
+
 ## 2.0.1
 
 ### Bug fixes

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/RealmPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/RealmPluginExtension.groovy
@@ -31,11 +31,12 @@ class RealmPluginExtension {
         this.syncEnabled = value;
 
         // remove realm android library first
-        project.getConfigurations().getByName("compile").getDependencies().removeIf() {
-            if (it.group != 'io.realm') {
-                return false
+        def iterator = project.getConfigurations().getByName("compile").getDependencies().iterator();
+        while (iterator.hasNext()) {
+            def item = iterator.next()
+            if (item.group == 'io.realm' && item.name.startsWith('realm-android-library')) {
+                iterator.remove()
             }
-            return it.name.startsWith('realm-android-library')
         }
 
         // then add again


### PR DESCRIPTION
This PR stops using `removeIf` in gradle plugin.
That method is available only on Java 8 or later.

fixes #3563

@realm/java 