### PR TITLE
Disable flaky test

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/android/UserStoreTest.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/android/UserStoreTest.java
@@ -21,6 +21,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,6 +59,7 @@ public class UserStoreTest {
         }
     }
 
+    @Ignore("See https://github.com/realm/realm-java/issues/3555")
     @Test
     public void encrypt_decrypt_UsingAndroidKeyStoreUserStore() throws KeyStoreException {
         User user = createTestUser();


### PR DESCRIPTION
Life is to short for restarting CI all the time. Disabling this for now until we can figure out what is wrong with it.

/cc @nhachicha 