### PR TITLE
Modern exception handling

### DIFF
--- a/realm/realm-library/src/main/cpp/io_realm_Property.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_Property.cpp
@@ -30,7 +30,7 @@ Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2IZZZ(JNIEnv *env
                                                                      jint type, jboolean is_primary, jboolean is_indexed,
                                                                      jboolean is_nullable) {
     TR_ENTER(env)
-    try {
+    return try_catch<jlong>(env, [&]() {
         JStringAccessor str(env, name_);
         PropertyType p_type = static_cast<PropertyType>(static_cast<int>(type));
         std::unique_ptr<Property> property(new Property(str, p_type, "", "", to_bool(is_primary), to_bool(is_indexed), to_bool(is_nullable)));
@@ -43,9 +43,7 @@ Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2IZZZ(JNIEnv *env
             throw std::invalid_argument("Invalid primary key type: " + typ);
         }
         return reinterpret_cast<jlong>(property.release());
-    }
-    CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT jlong JNICALL
@@ -53,24 +51,21 @@ Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2ILjava_lang_Stri
                                                                                      jstring name_, jint type,
                                                                                      jstring linkedToName_) {
     TR_ENTER(env)
-    try {
+    return try_catch<jlong>(env, [&]() {
         JStringAccessor name(env, name_);
         JStringAccessor link_name(env, linkedToName_);
         PropertyType p_type = static_cast<PropertyType>(static_cast<int>(type));
         bool is_nullable = (p_type == PropertyType::Object);
         std::unique_ptr<Property> property(new Property(name, p_type, link_name, "", false, false, is_nullable));
         return reinterpret_cast<jlong>(property.release());
-    }
-    CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT void JNICALL
 Java_io_realm_Property_nativeClose(JNIEnv *env, jclass, jlong property_ptr) {
     TR_ENTER_PTR(env, property_ptr)
-    try {
+    try_catch<void>(env, [&]() {
         Property *property = reinterpret_cast<Property *>(property_ptr);
         delete property;
-    }
-    CATCH_STD()
+    });
 }

--- a/realm/realm-library/src/main/cpp/io_realm_RealmObjectSchema.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmObjectSchema.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <jni.h>
+#include <exception>
 #include "io_realm_RealmObjectSchema.h"
 
 #include <object-store/src/object_schema.hpp>
@@ -26,58 +27,51 @@ using namespace realm;
 JNIEXPORT jlong JNICALL
 Java_io_realm_RealmObjectSchema_nativeCreateRealmObjectSchema(JNIEnv *env, jclass, jstring className_) {
     TR_ENTER(env)
-    try {
+    return try_catch<jlong>(env, [&]() {
         JStringAccessor name(env, className_);
         ObjectSchema *object_schema = new ObjectSchema();
         object_schema->name = name;
         return reinterpret_cast<jlong>(object_schema);
-    }
-    CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT void JNICALL
 Java_io_realm_RealmObjectSchema_nativeClose(JNIEnv *env, jclass, jlong native_ptr) {
     TR_ENTER_PTR(env, native_ptr)
-    try {
+    try_catch<void>(env, [&]() {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(native_ptr);
         delete object_schema;
-    }
-    CATCH_STD()
+    });
 }
 
 
 JNIEXPORT void JNICALL
 Java_io_realm_RealmObjectSchema_nativeAddProperty(JNIEnv *env, jclass, jlong native_ptr, jlong property_ptr) {
     TR_ENTER_PTR(env, native_ptr)
-    try {
+    try_catch<void>(env, [&]() {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(native_ptr);
         Property* property = reinterpret_cast<Property*>(property_ptr);
         object_schema->persisted_properties.push_back(*property);
         if (property->is_primary) {
             object_schema->primary_key = property->name;
         }
-    }
-    CATCH_STD()
+    });
 }
 
 JNIEXPORT jstring JNICALL
 Java_io_realm_RealmObjectSchema_nativeGetClassName(JNIEnv *env, jclass, jlong nativePtr) {
     TR_ENTER_PTR(env, nativePtr)
-    try {
+    return try_catch<jstring>(env, [&]() {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(nativePtr);
         auto name = object_schema->name;
         return to_jstring(env, name);
-    }
-    CATCH_STD()
-
-    return NULL;
+    });
 }
 
 JNIEXPORT jlongArray JNICALL
 Java_io_realm_RealmObjectSchema_nativeGetProperties(JNIEnv *env, jclass, jlong nativePtr) {
     TR_ENTER_PTR(env, nativePtr)
-    try {
+    return try_catch<jlongArray>(env, [&]() {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(nativePtr);
         size_t size = object_schema->persisted_properties.size();
         jlongArray native_ptr_array = env->NewLongArray(static_cast<jsize>(size));
@@ -93,9 +87,6 @@ Java_io_realm_RealmObjectSchema_nativeGetProperties(JNIEnv *env, jclass, jlong n
         env->SetLongArrayRegion(native_ptr_array, 0, static_cast<jsize>(size), tmp);
         delete tmp;
         return native_ptr_array;
-    }
-    CATCH_STD()
-
-    return NULL;
+    });
 }
 

--- a/realm/realm-library/src/main/cpp/io_realm_RealmSchema.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmSchema.cpp
@@ -28,7 +28,7 @@ using namespace realm;
 JNIEXPORT jlong JNICALL
 Java_io_realm_RealmSchema_nativeCreateFromList(JNIEnv *env, jclass, jlongArray objectSchemaPtrs_) {
     TR_ENTER(env)
-    try {
+    return try_catch<jlong>(env, [&]() {
         std::vector<ObjectSchema> object_schemas;
         JniLongArray array(env, objectSchemaPtrs_);
         for (jsize i = 0; i < array.len(); ++i) {
@@ -37,9 +37,7 @@ Java_io_realm_RealmSchema_nativeCreateFromList(JNIEnv *env, jclass, jlongArray o
         }
         auto *schema = new Schema(object_schemas);
         return reinterpret_cast<jlong>(schema);
-    }
-    CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT void JNICALL
@@ -52,7 +50,7 @@ Java_io_realm_RealmSchema_nativeClose(JNIEnv *env, jclass, jlong nativePtr) {
 JNIEXPORT jlongArray JNICALL
 Java_io_realm_RealmSchema_nativeGetAll(JNIEnv *env, jclass, jlong nativePtr) {
     TR_ENTER_PTR(env, nativePtr)
-    try {
+    return try_catch<jlongArray>(env, [&]() {
         Schema* schema = reinterpret_cast<Schema*>(nativePtr);
         size_t size = schema->size();
         jlongArray native_ptr_array = env->NewLongArray(static_cast<jsize>(size));
@@ -68,8 +66,6 @@ Java_io_realm_RealmSchema_nativeGetAll(JNIEnv *env, jclass, jlong nativePtr) {
         env->SetLongArrayRegion(native_ptr_array, 0, static_cast<jsize>(size), tmp);
         delete tmp;
         return native_ptr_array;
-    }
-    CATCH_STD()
-    return NULL;
+    });
 }
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CheckedRow.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CheckedRow.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <jni.h>
+#include <exception>
+
 #include "io_realm_internal_CheckedRow.h"
 #include "io_realm_internal_UncheckedRow.h"
 
@@ -24,214 +27,213 @@ using namespace realm;
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnCount
   (JNIEnv* env, jobject obj, jlong nativeRowPtr)
 {
-    if (!ROW(nativeRowPtr)->is_attached())
-        return 0;
+    return try_catch<jlong>(env, [&]() {
+        Row* row = reinterpret_cast<Row*>(nativeRowPtr);
+        if (!row->is_attached())
+            return static_cast<jlong>(0);
 
-    return Java_io_realm_internal_UncheckedRow_nativeGetColumnCount(env, obj, nativeRowPtr);
+        return Java_io_realm_internal_UncheckedRow_nativeGetColumnCount(env, obj, nativeRowPtr);
+    });
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnName
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex))
-        return NULL;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetColumnName(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jstring>(env, [&]() {
+        Row *row = reinterpret_cast<Row *>(nativeRowPtr);
+        ROW_AND_COL_INDEX_VALID(env, row, columnIndex);
+        return Java_io_realm_internal_UncheckedRow_nativeGetColumnName(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnIndex
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jstring columnName)
 {
-    if (!ROW(nativeRowPtr)->is_attached())
-        return 0;
+    return try_catch<jlong>(env, [&]() {
+        Row *row = reinterpret_cast<Row *>(nativeRowPtr);
+        if (!row->is_attached())
+            return static_cast<jlong>(0);
 
-    jlong ndx = Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(env, obj, nativeRowPtr, columnName);
-    if (ndx == to_jlong_or_not_found(realm::not_found)) {
-        JStringAccessor column_name(env, columnName);
-        ThrowException(env, IllegalArgument, concat_stringdata("Field not found: ", column_name));
-        return 0;
-    }
-    else {
-        return ndx;
-    }
+        jlong ndx = Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(env, obj, nativeRowPtr, columnName);
+        if (ndx == to_jlong_or_not_found(realm::not_found)) {
+            JStringAccessor column_name(env, columnName);
+            throw std::invalid_argument(concat_stringdata("Field not found: ", column_name));
+        }
+        else {
+            return ndx;
+        }
+    });
 }
 
 JNIEXPORT jint JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnType
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetColumnType(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jint>(env, [&]() {
+        ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex);
+        return Java_io_realm_internal_UncheckedRow_nativeGetColumnType(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLong
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetLong(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jlong>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int);
+        return Java_io_realm_internal_UncheckedRow_nativeGetLong(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeGetBoolean
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetBoolean(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jboolean>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool);
+        return Java_io_realm_internal_UncheckedRow_nativeGetBoolean(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_CheckedRow_nativeGetFloat
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetFloat(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jfloat>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float);
+        return Java_io_realm_internal_UncheckedRow_nativeGetFloat(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_CheckedRow_nativeGetDouble
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetDouble(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jdouble>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double);
+        return Java_io_realm_internal_UncheckedRow_nativeGetDouble(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetTimestamp
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetTimestamp(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jlong>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp);
+        return Java_io_realm_internal_UncheckedRow_nativeGetTimestamp(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetString
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetString(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jstring>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String);
+        return Java_io_realm_internal_UncheckedRow_nativeGetString(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_CheckedRow_nativeGetByteArray
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetByteArray(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jbyteArray>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary);
+        return Java_io_realm_internal_UncheckedRow_nativeGetByteArray(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLink
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetLink(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jlong>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link);
+        return Java_io_realm_internal_UncheckedRow_nativeGetLink(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeIsNullLink
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeIsNullLink(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jboolean>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link);
+        return Java_io_realm_internal_UncheckedRow_nativeIsNullLink(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLinkView
   (JNIEnv* env, jclass obj, jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_LinkList))
-        return 0;
-
-    return Java_io_realm_internal_UncheckedRow_nativeGetLinkView(env, obj, nativeRowPtr, columnIndex);
+    return try_catch<jlong>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_LinkList);
+        return Java_io_realm_internal_UncheckedRow_nativeGetLinkView(env, obj, nativeRowPtr, columnIndex);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLong
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetLong(env, obj, nativeRowPtr, columnIndex, value);
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int);
+        Java_io_realm_internal_UncheckedRow_nativeSetLong(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetBoolean
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jboolean value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetBoolean(env, obj, nativeRowPtr, columnIndex, value);
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool);
+        Java_io_realm_internal_UncheckedRow_nativeSetBoolean(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetFloat
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jfloat value)
-{
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetFloat(env, obj, nativeRowPtr, columnIndex, value);
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jfloat value) {
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float);
+        Java_io_realm_internal_UncheckedRow_nativeSetFloat(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetDouble
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jdouble value)
-{
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetDouble(env, obj, nativeRowPtr, columnIndex, value);
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jdouble value) {
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double);
+        Java_io_realm_internal_UncheckedRow_nativeSetDouble(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetTimestamp
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value)
-{
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetTimestamp(env, obj, nativeRowPtr, columnIndex, value);
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value) {
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp);
+        Java_io_realm_internal_UncheckedRow_nativeSetTimestamp(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetString
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jstring value)
-{
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetString(env, obj, nativeRowPtr, columnIndex, value);
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jstring value) {
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String);
+        Java_io_realm_internal_UncheckedRow_nativeSetString(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetByteArray
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jbyteArray value)
-{
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetByteArray(env, obj, nativeRowPtr, columnIndex, value);
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jbyteArray value) {
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary);
+        Java_io_realm_internal_UncheckedRow_nativeSetByteArray(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLink
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value)
-{
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeSetLink(env, obj, nativeRowPtr, columnIndex, value);
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value) {
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link);
+        Java_io_realm_internal_UncheckedRow_nativeSetLink(env, obj, nativeRowPtr, columnIndex, value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeNullifyLink
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
-{
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
-        return;
-
-    Java_io_realm_internal_UncheckedRow_nativeNullifyLink(env, obj, nativeRowPtr, columnIndex);
+  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex) {
+    try_catch<void>(env, [&]() {
+        ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link);
+        Java_io_realm_internal_UncheckedRow_nativeNullifyLink(env, obj, nativeRowPtr, columnIndex);
+    });
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableView.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableView.cpp
@@ -19,18 +19,20 @@
 #include "io_realm_internal_TableView.h"
 #include "realm/array.hpp"
 #include <ostream>
+#include <exception>
+#include <vector>
 
+using namespace std;
 using namespace realm;
 
-// if you disable the validation, please remember to call sync_in_needed() 
+// if you disable the validation, please remember to call sync_in_needed()
 #define VIEW_VALID_AND_IN_SYNC(env, ptr) view_valid_and_in_sync(env, ptr)
 
-inline bool view_valid_and_in_sync(JNIEnv* env, jlong nativeViewPtr) {
+inline void view_valid_and_in_sync(JNIEnv* env, jlong nativeViewPtr) {
     bool valid = (TV(nativeViewPtr) != NULL);
     if (valid) {
         if (!TV(nativeViewPtr)->is_attached()) {
-            ThrowException(env, IllegalState, "The Realm has been closed and is no longer accessible.");
-            return false;
+            throw illegal_state("The Realm has been closed and is no longer accessible.");
         }
         // depends_on_deleted_linklist() will return true if and only if the current TableView was created from a
         // query on a RealmList and that RealmList was then deleted (as a result of the object being deleted).
@@ -40,31 +42,27 @@ inline bool view_valid_and_in_sync(JNIEnv* env, jlong nativeViewPtr) {
             TV(nativeViewPtr)->sync_if_needed();
         }
     }
-    return valid;
 }
 
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_createNativeTableView(
     JNIEnv* env, jobject, jobject, jlong)
 {
-    try {
-        return reinterpret_cast<jlong>( new TableView() );
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        return reinterpret_cast<jlong>(new TableView());
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinct(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-        return;
-    if (!COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
-        return;
-    if (!TV(nativeViewPtr)->get_parent().has_search_index(S(columnIndex))) {
-        ThrowException(env, UnsupportedOperation, "The field must be indexed before distinct() can be used.");
-        return;
-    }
-    try {
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex);
+        if (!TV(nativeViewPtr)->get_parent().has_search_index(S(columnIndex))) {
+            throw unsupported_operation("The field must be indexed before distinct() can be used.");
+        }
+
         switch (TV(nativeViewPtr)->get_column_type(S(columnIndex))) {
             case type_Bool:
             case type_Int:
@@ -73,30 +71,25 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinct(
                 TV(nativeViewPtr)->distinct(S(columnIndex));
                 break;
             default:
-                ThrowException(env, IllegalArgument, "Invalid type - Only String, Date, boolean, byte, short, int, long and their boxed variants are supported.");
-                break;
+                throw invalid_argument("Invalid type - Only String, Date, boolean, byte, short, int, long and their boxed variants are supported.");
         }
-    } CATCH_STD()
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinctMulti(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlongArray columnIndexes)
 {
-    if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-        return;
-    try {
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
         TableView* tv = TV(nativeViewPtr);
         JniLongArray indexes(env, columnIndexes);
         jsize indexes_len = indexes.len();
         std::vector<std::vector<size_t>> columns;
         std::vector<bool> ascending;
         for (int i = 0; i < indexes_len; ++i) {
-            if (!COL_INDEX_VALID(env, tv, indexes[i])) {
-                return;
-            }
+            COL_INDEX_VALID(env, tv, indexes[i]);
             if (!tv->get_parent().has_search_index(S(indexes[i]))) {
-                ThrowException(env, IllegalArgument, "The field must be indexed before distinct(...) can be used.");
-                return;
+                throw invalid_argument("The field must be indexed before distinct(...) can be used.");
             }
             switch (tv->get_column_type(S(indexes[i]))) {
                 case type_Bool:
@@ -107,225 +100,200 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeDistinctMulti(
                     ascending.push_back(true);
                     break;
                 default:
-                    ThrowException(env, IllegalArgument, "Invalid type - Only String, Date, boolean, byte, short, int, long and their boxed variants are supported.");
-                    return;
+                    throw invalid_argument("Invalid type - Only String, Date, boolean, byte, short, int, long and their boxed variants are supported.");
             }
         }
         tv->distinct(SortDescriptor(tv->get_parent(), columns, ascending));
-    } CATCH_STD()
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativePivot(
     JNIEnv *env, jobject, jlong dataTablePtr, jlong stringCol, jlong intCol, jint operation, jlong resultTablePtr)
 {
 
-    try {
+    try_catch<void>(env, [&]() {
         TV(dataTablePtr)->sync_if_needed();
         TableView* dataTable = TV(dataTablePtr);
         Table* resultTable = TBL(resultTablePtr);
         Table::AggrType pivotOp;
         switch (operation) {
-        case 0:
-            pivotOp = Table::aggr_count;
-            break;
-        case 1:
-            pivotOp = Table::aggr_sum;
-            break;
-        case 2:
-            pivotOp = Table::aggr_avg;
-            break;
-        case 3:
-            pivotOp = Table::aggr_min;
-            break;
-        case 4:
-            pivotOp = Table::aggr_max;
-            break;
-        default:
-            ThrowException(env, UnsupportedOperation, "No pivot operation specified.");
-            return;
+            case 0:
+                pivotOp = Table::aggr_count;
+                break;
+            case 1:
+                pivotOp = Table::aggr_sum;
+                break;
+            case 2:
+                pivotOp = Table::aggr_avg;
+                break;
+            case 3:
+                pivotOp = Table::aggr_min;
+                break;
+            case 4:
+                pivotOp = Table::aggr_max;
+                break;
+            default:
+                throw unsupported_operation("No pivot operation specified.");
         }
         dataTable->aggregate(S(stringCol), S(intCol), pivotOp, *resultTable);
-    } CATCH_STD()
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeClose(
     JNIEnv*, jclass, jlong nativeViewPtr)
 {
-    if (nativeViewPtr == 0)
-        return;
-
     delete TV(nativeViewPtr);
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeSize(
     JNIEnv* env, jobject, jlong nativeViewPtr)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return 0;
-    } CATCH_STD()
-    return TV(nativeViewPtr)->size();   // noexcept
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        return TV(nativeViewPtr)->size();
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetSourceRowIndex
 (JNIEnv *env, jobject, jlong nativeViewPtr, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        ROW_INDEX_VALID(env, TV(nativeViewPtr), rowIndex);
+        if (!TV(nativeViewPtr)->is_row_attached(rowIndex)) {
             return to_jlong_or_not_found(-1);
-        if (!ROW_INDEX_VALID(env, TV(nativeViewPtr), rowIndex))
-            return to_jlong_or_not_found(-1);
-        if (!TV(nativeViewPtr)->is_row_attached(rowIndex))
-            return to_jlong_or_not_found(-1);
-    } CATCH_STD()
-    return TV(nativeViewPtr)->get_source_ndx(S(rowIndex));   // noexcept
+        }
+        return static_cast<jlong>(TV(nativeViewPtr)->get_source_ndx(S(rowIndex)));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetColumnCount
   (JNIEnv *env, jobject, jlong nativeViewPtr)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return 0;
-    } CATCH_STD()
-    return TV(nativeViewPtr)->get_column_count();
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        return TV(nativeViewPtr)->get_column_count();
+    });
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeGetColumnName
   (JNIEnv *env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) || !COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
-            return NULL;
+    return try_catch<jstring>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex);
         return to_jstring(env, TV(nativeViewPtr)->get_column_name( S(columnIndex)));
-    } CATCH_STD()
-    return NULL;
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetColumnIndex
    (JNIEnv *env, jobject, jlong nativeViewPtr, jstring columnName)
 
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return 0;
-        JStringAccessor columnName2(env, columnName); // throws
-        return to_jlong_or_not_found( TV(nativeViewPtr)->get_column_index(columnName2) ); // noexcept
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        JStringAccessor columnName2(env, columnName);
+        return to_jlong_or_not_found(TV(nativeViewPtr)->get_column_index(columnName2));
+    });
 }
 
 JNIEXPORT jint JNICALL Java_io_realm_internal_TableView_nativeGetColumnType
   (JNIEnv *env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) || !COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
-            return 0;
-    } CATCH_STD()
-    return static_cast<int>( TV(nativeViewPtr)->get_column_type( S(columnIndex)) );
+    return try_catch<jint>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex);
+        return static_cast<int>( TV(nativeViewPtr)->get_column_type( S(columnIndex)) );
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetLong(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Int))
-            return 0;
-    } CATCH_STD()
-    return TV(nativeViewPtr)->get_int( S(columnIndex), S(rowIndex));  // noexcept
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Int);
+        return TV(nativeViewPtr)->get_int( S(columnIndex), S(rowIndex));
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_TableView_nativeGetBoolean(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Bool))
-            return 0;
-    } CATCH_STD()
-    return TV(nativeViewPtr)->get_bool( S(columnIndex), S(rowIndex));  // noexcept
+    return try_catch<jboolean>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Bool);
+        return TV(nativeViewPtr)->get_bool( S(columnIndex), S(rowIndex));
+    });
 }
 
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_TableView_nativeGetFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Float))
-            return 0;
-    } CATCH_STD()
-    return TV(nativeViewPtr)->get_float( S(columnIndex), S(rowIndex));  // noexcept
+    return try_catch<jfloat>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Float);
+        return TV(nativeViewPtr)->get_float( S(columnIndex), S(rowIndex));
+    });
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableView_nativeGetDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Double))
-            return 0;
-    } CATCH_STD()
-    return TV(nativeViewPtr)->get_double( S(columnIndex), S(rowIndex));  // noexcept
+    return try_catch<jdouble>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Double);
+        return TV(nativeViewPtr)->get_double( S(columnIndex), S(rowIndex));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetTimestamp(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Timestamp))
-            return 0;
-    } CATCH_STD()
-    return to_milliseconds(TV(nativeViewPtr)->get_timestamp( S(columnIndex), S(rowIndex)));
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Timestamp);
+        return to_milliseconds(TV(nativeViewPtr)->get_timestamp( S(columnIndex), S(rowIndex)));
+    });
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeGetString(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_String))
-            return NULL;
-        
-        return to_jstring(env, TV(nativeViewPtr)->get_string( S(columnIndex), S(rowIndex)) // noexcept
-                          );
-    } CATCH_STD()
-    return NULL;
+    return try_catch<jstring>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_String);
+        return to_jstring(env, TV(nativeViewPtr)->get_string(S(columnIndex), S(rowIndex)));
+    });
 }
 
 JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_TableView_nativeGetByteArray(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Binary))
-            return NULL;
+    return try_catch<jbyteArray>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Binary);
         return tbl_GetByteArray<TableView>(env, nativeViewPtr, columnIndex, rowIndex);
-    } CATCH_STD()
-    return NULL;
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeGetLink
   (JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link))
-            return 0;
-    } CATCH_STD()
-    return TV(nativeViewPtr)->get_link( S(columnIndex), S(rowIndex));  // noexcept
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link);
+        return TV(nativeViewPtr)->get_link(S(columnIndex), S(rowIndex));
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_TableView_nativeIsNull
         (JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return 0;
-        return TV(nativeViewPtr)->get_parent().is_null( S(columnIndex), TV(nativeViewPtr)->get_source_ndx(S(rowIndex))) ? JNI_TRUE : JNI_FALSE;  // noexcept
-    } CATCH_STD()
-    return 0;
+    return try_catch<jboolean>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        return TV(nativeViewPtr)->get_parent().is_null(S(columnIndex), TV(nativeViewPtr)->get_source_ndx(S(rowIndex))) ? JNI_TRUE : JNI_FALSE;
+    });
 }
 
 // Setters
@@ -333,140 +301,126 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_TableView_nativeIsNull
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetLong(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jlong value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Int))
-            return;
-        TV(nativeViewPtr)->set_int( S(columnIndex), S(rowIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Int);
+        TV(nativeViewPtr)->set_int(S(columnIndex), S(rowIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetBoolean(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jboolean value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Bool))
-            return;
-        TV(nativeViewPtr)->set_bool( S(columnIndex), S(rowIndex), value != 0 ? true : false);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Bool);
+        TV(nativeViewPtr)->set_bool(S(columnIndex), S(rowIndex), value != 0 ? true : false);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jfloat value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Float))
-            return;
-        TV(nativeViewPtr)->set_float( S(columnIndex), S(rowIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Float);
+        TV(nativeViewPtr)->set_float(S(columnIndex), S(rowIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jdouble value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Double))
-            return;
-        TV(nativeViewPtr)->set_double( S(columnIndex), S(rowIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Double);
+        TV(nativeViewPtr)->set_double(S(columnIndex), S(rowIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetTimestampValue(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jlong timestampValue)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Timestamp))
-            return;
-        TV(nativeViewPtr)->set_timestamp( S(columnIndex), S(rowIndex), from_milliseconds(timestampValue));
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Timestamp);
+        TV(nativeViewPtr)->set_timestamp(S(columnIndex), S(rowIndex), from_milliseconds(timestampValue));
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetString(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jstring value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_String))
-            return;
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_String);
         if (!TV(nativeViewPtr)->get_parent().is_nullable(S(columnIndex))) {
-            ThrowNullValueException(env, &(TV(nativeViewPtr)->get_parent()), S(columnIndex));
-            return;
+            throw null_value(&(TV(nativeViewPtr)->get_parent()), S(columnIndex));
         }
-        JStringAccessor value2(env, value);  // throws
-        TV(nativeViewPtr)->set_string( S(columnIndex), S(rowIndex), value2);
-    } CATCH_STD()
+        JStringAccessor value2(env, value);
+        TV(nativeViewPtr)->set_string(S(columnIndex), S(rowIndex), value2);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetByteArray(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jbyteArray byteArray)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Binary))
-            return;
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Binary);
 
         JniByteArray bytesAccessor(env, byteArray);
         TV(nativeViewPtr)->set_binary(S(columnIndex), S(rowIndex), bytesAccessor);
-    } CATCH_STD()
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSetLink
   (JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex, jlong targetIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link))
-            return;
-        TV(nativeViewPtr)->set_link( S(columnIndex), S(rowIndex), S(targetIndex));
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link);
+        TV(nativeViewPtr)->set_link(S(columnIndex), S(rowIndex), S(targetIndex));
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_TableView_nativeIsNullLink
   (JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link))
-            return 0;
-        return TV(nativeViewPtr)->is_null_link( S(columnIndex), S(rowIndex));
-    } CATCH_STD()
-    return 0;
+    return try_catch<jboolean>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link);
+        return TV(nativeViewPtr)->is_null_link(S(columnIndex), S(rowIndex));
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeNullifyLink
   (JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link))
-            return;
-        TV(nativeViewPtr)->nullify_link( S(columnIndex), S(rowIndex));
-    } CATCH_STD()
+    return try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, rowIndex, type_Link);
+        TV(nativeViewPtr)->nullify_link(S(columnIndex), S(rowIndex));
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeClear(
     JNIEnv* env, jobject, jlong nativeViewPtr)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return;
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
         TV(nativeViewPtr)->clear(RemoveMode::unordered);
-    } CATCH_STD()
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeRemoveRow(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong rowIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !ROW_INDEX_VALID(env, TV(nativeViewPtr), rowIndex))
-            return;
-        TV(nativeViewPtr)->remove( S(rowIndex), RemoveMode::unordered);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        ROW_INDEX_VALID(env, TV(nativeViewPtr), rowIndex);
+        TV(nativeViewPtr)->remove(S(rowIndex), RemoveMode::unordered);
+    });
 }
 
 // FindFirst*
@@ -474,50 +428,42 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeRemoveRow(
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstInt(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int))
-            return 0;
-        return to_jlong_or_not_found( TV(nativeViewPtr)->find_first_int( S(columnIndex), value) );
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int);
+        return to_jlong_or_not_found(TV(nativeViewPtr)->find_first_int(S(columnIndex), value));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstBool(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jboolean value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Bool))
-            return 0;
-        size_t res = TV(nativeViewPtr)->find_first_bool( S(columnIndex), value != 0 ? true : false);
-        return to_jlong_or_not_found( res );
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Bool);
+        size_t res = TV(nativeViewPtr)->find_first_bool(S(columnIndex), value != 0 ? true : false);
+        return to_jlong_or_not_found(res);
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jfloat value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float))
-            return 0;
-        return to_jlong_or_not_found( TV(nativeViewPtr)->find_first_float( S(columnIndex), value) );
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float);
+        return to_jlong_or_not_found(TV(nativeViewPtr)->find_first_float(S(columnIndex), value));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jdouble value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double))
-            return 0;
-        return to_jlong_or_not_found( (TV(nativeViewPtr)->find_first_double( S(columnIndex), value)) );
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double);
+        return to_jlong_or_not_found((TV(nativeViewPtr)->find_first_double(S(columnIndex), value)));
+    });
 }
 
 // FIXME: find_first_timestamp() isn't implemented
@@ -525,12 +471,12 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstDouble(
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstDate(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong dateTimeValue)
 {
-    try {
+    try_catch<>(env, [&]() {
         if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
             !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_DateTime))
             return 0;
         return to_jlong_or_not_found( TV(nativeViewPtr)->find_first_datetime( S(columnIndex), DateTime(dateTimeValue)) );
-    } CATCH_STD()
+    });
     return 0;
 }
 */
@@ -538,15 +484,13 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstDate(
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstString(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jstring value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_String))
-            return 0;
-        JStringAccessor value2(env, value); // throws
-        size_t searchIndex = TV(nativeViewPtr)->find_first_string( S(columnIndex), value2);
-        return to_jlong_or_not_found( searchIndex );
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_String);
+        JStringAccessor value2(env, value);
+        size_t searchIndex = TV(nativeViewPtr)->find_first_string(S(columnIndex), value2);
+        return to_jlong_or_not_found(searchIndex);
+    });
 }
 
 // FindAll*
@@ -554,54 +498,46 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindFirstString(
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllInt(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int))
-            return 0;
-        TableView* pResultView = new TableView( TV(nativeViewPtr)->find_all_int( S(columnIndex), value) );
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int);
+        TableView* pResultView = new TableView(TV(nativeViewPtr)->find_all_int(S(columnIndex), value));
         return reinterpret_cast<jlong>(pResultView);
-    } CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllBool(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jboolean value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Bool))
-            return 0;
-        TableView* pResultView = new TableView( TV(nativeViewPtr)->find_all_bool( S(columnIndex),
-                                                value != 0 ? true : false) );
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Bool);
+        TableView* pResultView = new TableView(TV(nativeViewPtr)->find_all_bool(S(columnIndex),
+                                               value != 0 ? true : false));
         return reinterpret_cast<jlong>(pResultView);
-    } CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jfloat value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float))
-            return 0;
-        TableView* pResultView = new TableView( TV(nativeViewPtr)->find_all_float( S(columnIndex), value) );
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float);
+        TableView* pResultView = new TableView(TV(nativeViewPtr)->find_all_float(S(columnIndex), value));
         return reinterpret_cast<jlong>(pResultView);
-    } CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jdouble value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double))
-            return 0;
-        TableView* pResultView = new TableView( TV(nativeViewPtr)->find_all_double( S(columnIndex), value) );
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double);
+        TableView* pResultView = new TableView(TV(nativeViewPtr)->find_all_double(S(columnIndex), value));
         return reinterpret_cast<jlong>(pResultView);
-    } CATCH_STD()
-    return 0;
+    });
 }
 
 // FIXME: find_all_timestamp() isn't implemented
@@ -609,14 +545,14 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllDouble(
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllDate(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jlong dateTimeValue)
 {
-    try {
+    try_catch<>(env, [&]() {
         if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
             !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_DateTime))
             return 0;
         TableView* pResultView = new TableView( TV(nativeViewPtr)->find_all_datetime( S(columnIndex),
                                                 DateTime(dateTimeValue)) );
         return reinterpret_cast<jlong>(pResultView);
-    } CATCH_STD()
+    });
     return 0;
 }
 */
@@ -624,15 +560,13 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllDate(
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllString(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jstring value)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_String))
-            return 0;
-        JStringAccessor value2(env, value); // throws
-        TableView* pResultView = new TableView( TV(nativeViewPtr)->find_all_string( S(columnIndex), value2) );
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_String);
+        JStringAccessor value2(env, value);
+        TableView* pResultView = new TableView(TV(nativeViewPtr)->find_all_string(S(columnIndex), value2));
         return reinterpret_cast<jlong>(pResultView);
-    } CATCH_STD()
-    return 0;
+    });
 }
 
 // Integer aggregates
@@ -640,57 +574,51 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindAllString(
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeSumInt(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int))
-            return 0;
-        return TV(nativeViewPtr)->sum_int( S(columnIndex));
-    } CATCH_STD()
-    return 0;
+    try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int);
+        return TV(nativeViewPtr)->sum_int(S(columnIndex));
+    });
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableView_nativeAverageInt(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int))
-            return 0;
-        return static_cast<jdouble>( TV(nativeViewPtr)->average_int( S(columnIndex)));
-    } CATCH_STD()
-    return 0;
+    return try_catch<jdouble>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int);
+        return static_cast<jdouble>(TV(nativeViewPtr)->average_int(S(columnIndex)));
+    });
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMaximumInt(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int);
         size_t return_ndx;
-        int64_t result = TV(nativeViewPtr)->maximum_int( S(columnIndex), &return_ndx);
+        int64_t result = TV(nativeViewPtr)->maximum_int(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewLong(env, result);
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMinimumInt(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Int);
         size_t return_ndx;
-        int64_t result = TV(nativeViewPtr)->minimum_int( S(columnIndex), &return_ndx);
+        int64_t result = TV(nativeViewPtr)->minimum_int(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewLong(env, result);
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 // float aggregates
@@ -698,57 +626,51 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMinimumInt(
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableView_nativeSumFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float))
-            return 0;
-        return TV(nativeViewPtr)->sum_float( S(columnIndex));
-    } CATCH_STD()
-    return 0;
+    return try_catch<jdouble>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float);
+        return TV(nativeViewPtr)->sum_float(S(columnIndex));
+    });
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableView_nativeAverageFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float))
-            return 0;
-        return TV(nativeViewPtr)->average_float( S(columnIndex));
-    } CATCH_STD()
-    return 0;
+    return try_catch<jdouble>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float);
+        return TV(nativeViewPtr)->average_float(S(columnIndex));
+    });
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMaximumFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float);
         size_t return_ndx;
-        float result = TV(nativeViewPtr)->maximum_float( S(columnIndex), &return_ndx);
+        float result = TV(nativeViewPtr)->maximum_float(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewFloat(env, result);
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMinimumFloat(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Float);
         size_t return_ndx;
-        float result = TV(nativeViewPtr)->minimum_float( S(columnIndex), &return_ndx);
+        float result = TV(nativeViewPtr)->minimum_float(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewFloat(env, result);
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 // double aggregates
@@ -756,57 +678,51 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMinimumFloat(
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableView_nativeSumDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double))
-            return 0;
-        return TV(nativeViewPtr)->sum_double( S(columnIndex));
-    } CATCH_STD()
-    return 0;
+    return try_catch<jdouble>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double);
+        return TV(nativeViewPtr)->sum_double(S(columnIndex));
+    });
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableView_nativeAverageDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double))
-            return 0;
-        return static_cast<jdouble>( TV(nativeViewPtr)->average_double( S(columnIndex)) );
-    } CATCH_STD()
-    return 0;
+    return try_catch<jdouble>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double);
+        return static_cast<jdouble>(TV(nativeViewPtr)->average_double(S(columnIndex)));
+    });
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMaximumDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double);
         size_t return_ndx;
-        double result = TV(nativeViewPtr)->maximum_double( S(columnIndex), &return_ndx);
+        double result = TV(nativeViewPtr)->maximum_double(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewDouble(env, result);
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMinimumDouble(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Double);
         size_t return_ndx;
-        double result = TV(nativeViewPtr)->minimum_double( S(columnIndex), &return_ndx);
+        double result = TV(nativeViewPtr)->minimum_double(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewDouble(env, result);
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 
@@ -815,47 +731,44 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMinimumDouble(
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMaximumTimestamp(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Timestamp))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Timestamp);
 
         size_t return_ndx;
-        Timestamp result = TV(nativeViewPtr)->maximum_timestamp( S(columnIndex), &return_ndx);
+        Timestamp result = TV(nativeViewPtr)->maximum_timestamp(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewLong(env, to_milliseconds(result));
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableView_nativeMinimumTimestamp(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Timestamp))
-            return NULL;
+    return try_catch<jobject>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_AND_TYPE_VALID(env, TV(nativeViewPtr), columnIndex, type_Timestamp);
 
         size_t return_ndx;
-        Timestamp result = TV(nativeViewPtr)->minimum_timestamp( S(columnIndex), &return_ndx);
+        Timestamp result = TV(nativeViewPtr)->minimum_timestamp(S(columnIndex), &return_ndx);
         if (return_ndx != npos) {
             return NewLong(env, to_milliseconds(result));
         }
-    } CATCH_STD()
-    return NULL;
+        return static_cast<jobject>(nullptr);
+    });
 }
 
 // sort
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSort(
     JNIEnv* env, jobject, jlong nativeViewPtr, jlong columnIndex, jboolean ascending)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) ||
-            !COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex))
-            return;
-        int colType = TV(nativeViewPtr)->get_column_type( S(columnIndex) );
-    
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        COL_INDEX_VALID(env, TV(nativeViewPtr), columnIndex);
+        int colType = TV(nativeViewPtr)->get_column_type(S(columnIndex));
+
         switch (colType) {
             case type_Bool:
             case type_Int:
@@ -863,21 +776,19 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSort(
             case type_Double:
             case type_String:
             case type_Timestamp:
-                TV(nativeViewPtr)->sort( S(columnIndex), ascending != 0 ? true : false);
+                TV(nativeViewPtr)->sort(S(columnIndex), ascending != 0 ? true : false);
                 break;
             default:
-                ThrowException(env, IllegalArgument, "Sort is not supported on binary data, object references and RealmList.");
-                return;
+                throw invalid_argument("Sort is not supported on binary data, object references and RealmList.");
         }
-    } CATCH_STD()
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSortMulti(
   JNIEnv* env, jobject, jlong nativeViewPtr, jlongArray columnIndices, jbooleanArray ascending)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return;
+    try_catch<void>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
 
         JniLongArray long_arr(env, columnIndices);
         JniBooleanArray bool_arr(env, ascending);
@@ -885,16 +796,13 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSortMulti(
         jsize asc_len = bool_arr.len();
 
         if (arr_len == 0) {
-            ThrowException(env, IllegalArgument, "You must provide at least one field name.");
-            return;
+            throw invalid_argument("You must provide at least one field name.");
         }
         if (asc_len == 0) {
-            ThrowException(env, IllegalArgument, "You must provide at least one sort order.");
-            return;
+            throw invalid_argument("You must provide at least one sort order.");
         }
         if (arr_len != asc_len) {
-            ThrowException(env, IllegalArgument, "Number of fields and sort orders do not match.");
-            return;
+            throw invalid_argument("Number of fields and sort orders do not match.");
         }
 
         TableView* tv = TV(nativeViewPtr);
@@ -902,10 +810,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSortMulti(
         std::vector<bool> ascendings;
 
         for (int i = 0; i < arr_len; ++i) {
-            if (!COL_INDEX_VALID(env, tv, long_arr[i])) {
-                return;
-            }
-            int colType = tv->get_column_type( S(long_arr[i]) );
+            COL_INDEX_VALID(env, tv, long_arr[i]);
+            int colType = tv->get_column_type(S(long_arr[i]));
             switch (colType) {
                 case type_Bool:
                 case type_Int:
@@ -914,74 +820,66 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableView_nativeSortMulti(
                 case type_String:
                 case type_Timestamp:
                     indices.push_back(std::vector<size_t> { S(long_arr[i]) });
-                    ascendings.push_back( B(bool_arr[i]) );
+                    ascendings.push_back(B(bool_arr[i]));
                     break;
                 default:
-                    ThrowException(env, IllegalArgument, "Sort is not supported on binary data, object references and RealmList.");
-                    return;
+                    throw invalid_argument("Sort is not supported on binary data, object references and RealmList.");
             }
         }
         tv->sort(SortDescriptor(tv->get_parent(), indices, ascendings));
-    } CATCH_STD()
+    });
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_TableView_nativeToJson(
     JNIEnv *env, jobject, jlong nativeViewPtr)
 {
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return NULL;
-        
+    return try_catch<jstring>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+
         // Write table to string in JSON format
         std::stringstream ss;
         ss.sync_with_stdio(false); // for performance
         TV(nativeViewPtr)->to_json(ss);
         const std::string str = ss.str();
         return to_jstring(env, str);
-    } CATCH_STD()
-    return NULL;
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeWhere(
     JNIEnv *env, jobject, jlong nativeViewPtr)
 {
     TR_ENTER_PTR(env, nativeViewPtr)
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr))
-            return 0;
-
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
         Query *queryPtr = new Query(TV(nativeViewPtr)->get_parent().where(TV(nativeViewPtr)));
         return reinterpret_cast<jlong>(queryPtr);
-    } CATCH_STD()
-    return 0;
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeSyncIfNeeded(
     JNIEnv* env, jobject, jlong nativeViewPtr)
 {
-    bool valid = (TV(nativeViewPtr) != NULL);
-    if (valid) {
-        if (!TV(nativeViewPtr)->is_attached()) {
-            ThrowException(env, IllegalState, "The Realm has been closed and is no longer accessible.");
-            return 0;
+    return try_catch<jlong>(env, [&]() {
+        bool valid = (TV(nativeViewPtr) != NULL);
+        if (valid) {
+            if (!TV(nativeViewPtr)->is_attached()) {
+                throw illegal_state("The Realm has been closed and is no longer accessible.");
+            }
         }
-    }
-    try {
-        return (jlong) TV(nativeViewPtr)->sync_if_needed();
-    } CATCH_STD()
-    return 0;
+
+        return static_cast<jlong>(TV(nativeViewPtr)->sync_if_needed());
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableView_nativeFindBySourceNdx
         (JNIEnv *env, jobject, jlong nativeViewPtr, jlong sourceIndex)
 {
     TR_ENTER_PTR(env, nativeViewPtr);
-    try {
-        if (!VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr) || !ROW_INDEX_VALID(env, &(TV(nativeViewPtr)->get_parent()), sourceIndex))
-            return -1;
+    return try_catch<jlong>(env, [&]() {
+        VIEW_VALID_AND_IN_SYNC(env, nativeViewPtr);
+        ROW_INDEX_VALID(env, &(TV(nativeViewPtr)->get_parent()), sourceIndex);
 
         size_t ndx = TV(nativeViewPtr)->find_by_source_ndx(sourceIndex);
         return to_jlong_or_not_found(ndx);
-    } CATCH_STD()
-    return -1;
+    });
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TestUtil.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TestUtil.cpp
@@ -1,3 +1,7 @@
+#include <jni.h>
+#include <realm/group_shared.hpp>
+#include <realm/string_data.hpp>
+
 #include "io_realm_internal_TestUtil.h"
 #include "util.hpp"
 
@@ -24,62 +28,61 @@ Java_io_realm_internal_TestUtil_testThrowExceptions(JNIEnv *env, jclass, jlong e
 static jstring
 throwOrGetExpectedMessage(JNIEnv *env, jlong testcase, bool should_throw)
 {
-    std::string expect;
 
-    switch (ExceptionKind(testcase)) {
-        case ClassNotFound:
-            expect = "java.lang.ClassNotFoundException: Class 'parm1' could not be located.";
-            if (should_throw)
-                ThrowException(env, ClassNotFound, "parm1", "parm2");
-            break;
-        case IllegalArgument:
-            expect = "java.lang.IllegalArgumentException: Illegal Argument: parm1";
-            if (should_throw)
-                ThrowException(env, IllegalArgument, "parm1", "parm2");
-            break;
-        case IndexOutOfBounds:
-            expect = "java.lang.ArrayIndexOutOfBoundsException: parm1";
-            if (should_throw)
-                ThrowException(env, IndexOutOfBounds, "parm1", "parm2");
-            break;
-        case UnsupportedOperation:
-            expect = "java.lang.UnsupportedOperationException: parm1";
-            if (should_throw)
-                ThrowException(env, UnsupportedOperation, "parm1", "parm2");
-            break;
-        case OutOfMemory:
-            expect = "io.realm.internal.OutOfMemoryError: parm1 parm2";
-            if (should_throw)
-                ThrowException(env, OutOfMemory, "parm1", "parm2");
-            break;
-        case FatalError:
-            expect = "io.realm.exceptions.RealmError: Unrecoverable error. parm1";
-            if (should_throw)
-                ThrowException(env, FatalError, "parm1", "parm2");
-            break;
-        case RuntimeError:
-            expect = "java.lang.RuntimeException: parm1";
-            if (should_throw)
-                ThrowException(env, RuntimeError, "parm1", "parm2");
-            break;
-        case BadVersion:
-            expect = "io.realm.internal.async.BadVersionException: parm1";
-            if (should_throw)
-                ThrowException(env, BadVersion, "parm1", "parm2");
-            break;
-        case IllegalState:
-            expect = "java.lang.IllegalStateException: parm1";
-            if (should_throw)
-                ThrowException(env, IllegalState, "parm1");
-            break;
-        // FIXME: This is difficult to test right now. Need to refactor the test.
-        // See https://github.com/realm/realm-java/issues/3348
-        // case RealmFileError:
-        default:
-            break;
-    }
-    if (should_throw) {
-        return NULL;
-    }
-    return to_jstring(env, expect);
+    return try_catch<jstring>(env, [&]() {
+        std::string expect;
+        switch (ExceptionKind(testcase)) {
+            case ClassNotFound:
+                expect = "java.lang.ClassNotFoundException: Class 'parm1' could not be located.";
+                if (should_throw)
+                    throw class_not_found("parm1");
+                break;
+            case IllegalArgument:
+                expect = "java.lang.IllegalArgumentException: Illegal Argument: parm1";
+                if (should_throw)
+                    throw std::invalid_argument("parm1");
+                break;
+            case IndexOutOfBounds:
+                expect = "java.lang.ArrayIndexOutOfBoundsException: parm1";
+                if (should_throw)
+                    throw std::range_error("parm1");
+                break;
+            case UnsupportedOperation:
+                expect = "java.lang.UnsupportedOperationException: parm1";
+                if (should_throw)
+                    throw unsupported_operation("parm1");
+                break;
+            case OutOfMemory:
+                expect = "io.realm.internal.OutOfMemoryError: std::bad_alloc";
+                if (should_throw)
+                    throw std::bad_alloc();
+                break;
+            case FatalError:
+                expect = "io.realm.exceptions.RealmError: Unrecoverable error. parm1";
+                if (should_throw)
+                    throw fatal_error("parm1");
+                break;
+            case RuntimeError:
+                expect = "java.lang.RuntimeException: parm1";
+                if (should_throw)
+                    throw std::runtime_error("parm1");
+                break;
+            case BadVersion:
+                expect = "io.realm.internal.async.BadVersionException: ";
+                if (should_throw)
+                    throw realm::SharedGroup::BadVersion();
+                break;
+            case IllegalState:
+                expect = "java.lang.IllegalStateException: parm1";
+                if (should_throw)
+                    throw illegal_state("parm1");
+                break;
+                // FIXME: This is difficult to test right now. Need to refactor the test.
+                // See https://github.com/realm/realm-java/issues/3348
+                // case RealmFileError:
+            default:
+                break;
+        }
+        return to_jstring(env, realm::StringData(expect));
+    });
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <exception>
+
+#include <realm/row.hpp>
+
 #include "io_realm_internal_UncheckedRow.h"
 #include "util.hpp"
 
@@ -23,309 +27,287 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnCount
   (JNIEnv *env, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW(nativeRowPtr)->is_attached())
-        return 0;
-
-    return ROW(nativeRowPtr)->get_column_count(); // noexcept
+    return try_catch<jlong>(env, [&]() {
+        Row* row = reinterpret_cast<Row*>(nativeRowPtr);
+        if (!row->is_attached()) {
+            return static_cast<jlong>(0);
+        }
+        return static_cast<jlong>(row->get_column_count());
+    });
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnName
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    try {
-        return to_jstring(env, ROW(nativeRowPtr)->get_column_name( S(columnIndex)));
-    } CATCH_STD();
-    return NULL;
+    return try_catch<jstring>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return to_jstring(env, ROW(nativeRowPtr)->get_column_name(S(columnIndex)));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex
   (JNIEnv* env, jobject, jlong nativeRowPtr, jstring columnName)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW(nativeRowPtr)->is_attached())
-        return 0;
-
-    try {
-        JStringAccessor columnName2(env, columnName); // throws
-        return to_jlong_or_not_found( ROW(nativeRowPtr)->get_column_index(columnName2) ); // noexcept
-    } CATCH_STD()
-    return 0;
+    return try_catch<jlong>(env, [&]() {
+        if (!ROW(nativeRowPtr)->is_attached()) {
+            return static_cast<jlong>(0);
+        }
+        JStringAccessor columnName2(env, columnName);
+        return to_jlong_or_not_found(ROW(nativeRowPtr)->get_column_index(columnName2));
+    });
 }
 
 JNIEXPORT jint JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnType
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    return static_cast<jint>( ROW(nativeRowPtr)->get_column_type( S(columnIndex)) ); // noexcept
+    return try_catch<jint>(env, [&]() {
+        return static_cast<jint>(ROW(nativeRowPtr)->get_column_type(S(columnIndex)));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetIndex
   (JNIEnv* env, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    return ROW(nativeRowPtr)->get_index();
+    return try_catch<jlong>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return ROW(nativeRowPtr)->get_index();
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLong
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    return ROW(nativeRowPtr)->get_int( S(columnIndex) );
+    return try_catch<jlong>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return ROW(nativeRowPtr)->get_int(S(columnIndex));
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeGetBoolean
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    return ROW(nativeRowPtr)->get_bool( S(columnIndex) );
+    return try_catch<jboolean>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return ROW(nativeRowPtr)->get_bool(S(columnIndex));
+    });
 }
 
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_UncheckedRow_nativeGetFloat
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    return ROW(nativeRowPtr)->get_float( S(columnIndex) );
+    return try_catch<jfloat>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return ROW(nativeRowPtr)->get_float(S(columnIndex));
+    });
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_UncheckedRow_nativeGetDouble
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    return ROW(nativeRowPtr)->get_double( S(columnIndex) );
+    return try_catch<jdouble>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return ROW(nativeRowPtr)->get_double(S(columnIndex));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetTimestamp
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    return to_milliseconds(ROW(nativeRowPtr)->get_timestamp( S(columnIndex) ));
+    return try_catch<jlong>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return to_milliseconds(ROW(nativeRowPtr)->get_timestamp(S(columnIndex)));
+    });
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetString
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    try {
-        StringData value = ROW(nativeRowPtr)->get_string( S(columnIndex) );
+    return try_catch<jstring>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        StringData value = ROW(nativeRowPtr)->get_string(S(columnIndex));
         return to_jstring(env,  value);
-    } CATCH_STD()
-    return NULL;
+    });
 }
 
 JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_UncheckedRow_nativeGetByteArray
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
+    return try_catch<jbyteArray>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
 
-    BinaryData bin = ROW(nativeRowPtr)->get_binary( S(columnIndex) );
-    if (bin.is_null()) {
-        return NULL;
-    }
-    else if (bin.size() <= MAX_JSIZE) {
-        jbyteArray jresult = env->NewByteArray(static_cast<jsize>(bin.size()));
-        if (jresult)
-            env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()), reinterpret_cast<const jbyte*>(bin.data()));  // throws
-        return jresult;
-    }
-    else {
-        ThrowException(env, IllegalArgument, "Length of ByteArray is larger than an Int.");
-        return NULL;
-    }
+        BinaryData bin = ROW(nativeRowPtr)->get_binary( S(columnIndex) );
+        if (bin.is_null()) {
+            return static_cast<jbyteArray>(nullptr);
+        }
+        else if (bin.size() <= MAX_JSIZE) {
+            jbyteArray jresult = env->NewByteArray(static_cast<jsize>(bin.size()));
+            if (jresult)
+                env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()), reinterpret_cast<const jbyte*>(bin.data()));
+            return jresult;
+        }
+        else {
+            throw std::invalid_argument("Length of ByteArray is larger than an Int.");
+        }
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLink
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    if (ROW(nativeRowPtr)->is_null_link( S(columnIndex) ))
-        return jlong(-1);
-
-    return ROW(nativeRowPtr)->get_link( S(columnIndex) );
+    return try_catch<jlong>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        if (ROW(nativeRowPtr)->is_null_link(S(columnIndex))) {
+            return static_cast<jlong>(-1);
+        }
+        return static_cast<jlong>(ROW(nativeRowPtr)->get_link(S(columnIndex)));
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNullLink
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    return ROW(nativeRowPtr)->is_null_link( S(columnIndex) );
+    return try_catch<jboolean>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        return static_cast<jboolean>(ROW(nativeRowPtr)->is_null_link(S(columnIndex)));
+    });
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLinkView
   (JNIEnv* env, jclass, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
-
-    LinkViewRef* link_view_ptr = const_cast<LinkViewRef*>(&(LangBindHelper::get_linklist_ptr(*ROW(nativeRowPtr), S(columnIndex))));
-    return reinterpret_cast<jlong>(link_view_ptr);
+    return try_catch<jlong>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        LinkViewRef* link_view_ptr = const_cast<LinkViewRef*>(&(LangBindHelper::get_linklist_ptr(*ROW(nativeRowPtr), S(columnIndex))));
+        return reinterpret_cast<jlong>(link_view_ptr);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLong
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jlong value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    try {
-        ROW(nativeRowPtr)->set_int( S(columnIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        ROW(nativeRowPtr)->set_int(S(columnIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetBoolean
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jboolean value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    try {
-        ROW(nativeRowPtr)->set_bool( S(columnIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        ROW(nativeRowPtr)->set_bool(S(columnIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetFloat
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jfloat value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    try {
-        ROW(nativeRowPtr)->set_float( S(columnIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        ROW(nativeRowPtr)->set_float(S(columnIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetDouble
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jdouble value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    try {
-        ROW(nativeRowPtr)->set_double( S(columnIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        ROW(nativeRowPtr)->set_double(S(columnIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetTimestamp
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jlong value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    try {
-        ROW(nativeRowPtr)->set_timestamp( S(columnIndex), from_milliseconds(value));
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        ROW(nativeRowPtr)->set_timestamp(S(columnIndex), from_milliseconds(value));
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetString
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jstring value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
 
-    try {
-        if ((value == NULL) && !(ROW(nativeRowPtr)->get_table()->is_nullable( S(columnIndex) ))) {
-            ThrowNullValueException(env, ROW(nativeRowPtr)->get_table(), S(columnIndex));
-            return;
+        if ((value == NULL) && !(ROW(nativeRowPtr)->get_table()->is_nullable(S(columnIndex)))) {
+            throw null_value(ROW(nativeRowPtr)->get_table(), S(columnIndex));
         }
-        JStringAccessor value2(env, value); // throws
-        ROW(nativeRowPtr)->set_string( S(columnIndex), value2);
-    } CATCH_STD()
+        JStringAccessor value2(env, value);
+        ROW(nativeRowPtr)->set_string(S(columnIndex), value2);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetByteArray
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jbyteArray value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
 
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    jbyte* bytePtr = NULL;
-    try {
+        jbyte* bytePtr = NULL;
         if (value == NULL) {
             if (!(ROW(nativeRowPtr)->get_table()->is_nullable(S(columnIndex)))) {
-                ThrowNullValueException(env, ROW(nativeRowPtr)->get_table(), S(columnIndex));
-                return;
+                throw null_value(ROW(nativeRowPtr)->get_table(), S(columnIndex));
             }
             ROW(nativeRowPtr)->set_binary(S(columnIndex), BinaryData());
         }
         else {
             bytePtr = env->GetByteArrayElements(value, NULL);
             if (!bytePtr) {
-                ThrowException(env, IllegalArgument, "doByteArray");
-                return;
+                throw std::invalid_argument("doByteArray");
             }
             size_t dataLen = S(env->GetArrayLength(value));
             ROW(nativeRowPtr)->set_binary( S(columnIndex), BinaryData(reinterpret_cast<char*>(bytePtr), dataLen));
         }
-    } CATCH_STD()
 
-    if (bytePtr) {
-        env->ReleaseByteArrayElements(value, bytePtr, JNI_ABORT);
-    }
+        if (bytePtr) {
+            env->ReleaseByteArrayElements(value, bytePtr, JNI_ABORT);
+        }
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLink
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jlong value)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    try {
-        ROW(nativeRowPtr)->set_link( S(columnIndex), value);
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        ROW(nativeRowPtr)->set_link(S(columnIndex), value);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeNullifyLink
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-
-    try {
-        ROW(nativeRowPtr)->nullify_link( S(columnIndex) );
-    } CATCH_STD()
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        ROW(nativeRowPtr)->nullify_link(S(columnIndex));
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeClose
@@ -339,30 +321,34 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsAttached
   (JNIEnv* env, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(env, nativeRowPtr)
-    return ROW(nativeRowPtr)->is_attached();
+    return try_catch<jboolean>(env, [&]() {
+        return ROW(nativeRowPtr)->is_attached();
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeHasColumn
   (JNIEnv* env, jobject obj, jlong nativeRowPtr, jstring columnName)
 {
-    jlong ndx = Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(env, obj, nativeRowPtr, columnName);
-    return ndx != to_jlong_or_not_found(realm::not_found);
+    return try_catch<jboolean>(env, [&]() {
+        jlong ndx = Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(env, obj, nativeRowPtr, columnName);
+        return ndx != to_jlong_or_not_found(realm::not_found);
+    });
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNull
   (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex) {
     TR_ENTER_PTR(env, nativeRowPtr)
-    return ROW(nativeRowPtr)->is_null(columnIndex);
+    return try_catch<jboolean>(env, [&]() {
+        return ROW(nativeRowPtr)->is_null(columnIndex);
+    });
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetNull
   (JNIEnv *env, jobject, jlong nativeRowPtr, jlong columnIndex) {
     TR_ENTER_PTR(env, nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return;
-    if (!TBL_AND_COL_NULLABLE(env, ROW(nativeRowPtr)->get_table(), columnIndex))
-        return;
-    try {
+    try_catch<void>(env, [&]() {
+        ROW_VALID(env, ROW(nativeRowPtr));
+        TBL_AND_COL_NULLABLE(env, ROW(nativeRowPtr)->get_table(), columnIndex);
         ROW(nativeRowPtr)->set_null(columnIndex);
-    } CATCH_STD()
+    });
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
@@ -50,21 +50,23 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
         return JNI_ERR;
     }
     else {
-        g_vm = vm;
-        // Loading classes and constructors for later use - used by box typed fields and a few methods' return value
-        java_lang_long        = GetClass(env, "java/lang/Long");
-        java_lang_long_init   = env->GetMethodID(java_lang_long, "<init>", "(J)V");
-        java_lang_float       = GetClass(env, "java/lang/Float");
-        java_lang_float_init  = env->GetMethodID(java_lang_float, "<init>", "(F)V");
-        java_lang_double      = GetClass(env, "java/lang/Double");
-        java_lang_double_init = env->GetMethodID(java_lang_double, "<init>", "(D)V");
-        realmlog_class        = GetClass(env, "io/realm/log/RealmLog");
-        log_trace             = env->GetStaticMethodID(realmlog_class, "trace", "(Ljava/lang/String;[Ljava/lang/Object;)V");
-        log_debug             = env->GetStaticMethodID(realmlog_class, "debug", "(Ljava/lang/String;[Ljava/lang/Object;)V");
-        log_info              = env->GetStaticMethodID(realmlog_class, "info", "(Ljava/lang/String;[Ljava/lang/Object;)V");
-        log_warn              = env->GetStaticMethodID(realmlog_class, "warn", "(Ljava/lang/String;[Ljava/lang/Object;)V");
-        log_error             = env->GetStaticMethodID(realmlog_class, "error", "(Ljava/lang/String;[Ljava/lang/Object;)V");
-        log_fatal             = env->GetStaticMethodID(realmlog_class, "fatal", "(Ljava/lang/String;[Ljava/lang/Object;)V");
+        try_catch<void>(env, [&]() {
+            g_vm = vm;
+            // Loading classes and constructors for later use - used by box typed fields and a few methods' return value
+            java_lang_long        = GetClass(env, "java/lang/Long");
+            java_lang_long_init   = env->GetMethodID(java_lang_long, "<init>", "(J)V");
+            java_lang_float       = GetClass(env, "java/lang/Float");
+            java_lang_float_init  = env->GetMethodID(java_lang_float, "<init>", "(F)V");
+            java_lang_double      = GetClass(env, "java/lang/Double");
+            java_lang_double_init = env->GetMethodID(java_lang_double, "<init>", "(D)V");
+            realmlog_class        = GetClass(env, "io/realm/log/RealmLog");
+            log_trace             = env->GetStaticMethodID(realmlog_class, "trace", "(Ljava/lang/String;[Ljava/lang/Object;)V");
+            log_debug             = env->GetStaticMethodID(realmlog_class, "debug", "(Ljava/lang/String;[Ljava/lang/Object;)V");
+            log_info              = env->GetStaticMethodID(realmlog_class, "info", "(Ljava/lang/String;[Ljava/lang/Object;)V");
+            log_warn              = env->GetStaticMethodID(realmlog_class, "warn", "(Ljava/lang/String;[Ljava/lang/Object;)V");
+            log_error             = env->GetStaticMethodID(realmlog_class, "error", "(Ljava/lang/String;[Ljava/lang/Object;)V");
+            log_fatal             = env->GetStaticMethodID(realmlog_class, "fatal", "(Ljava/lang/String;[Ljava/lang/Object;)V");
+        });
     }
 
     return JNI_VERSION_1_6;
@@ -107,6 +109,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Util_nativeGetMemUsage(JNIEnv*, j
 JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeGetTablePrefix(
     JNIEnv* env, jclass)
 {
-    realm::StringData sd(TABLE_PREFIX);
-    return to_jstring(env, sd);
+    return try_catch<jstring>(env, [&]() {
+        realm::StringData sd(TABLE_PREFIX);
+        return to_jstring(env, sd);
+    });
 }

--- a/realm/realm-library/src/main/cpp/tablebase_tpl.hpp
+++ b/realm/realm-library/src/main/cpp/tablebase_tpl.hpp
@@ -17,13 +17,15 @@
 #ifndef REALM_JNI_TABLEBASE_TPL_HPP
 #define REALM_JNI_TABLEBASE_TPL_HPP
 
+#include <string>
+#include <exception>
+
 #include <realm.hpp>
 
 template <class T>
 jbyteArray tbl_GetByteArray(JNIEnv* env, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_VALID(env, reinterpret_cast<T*>(nativeTablePtr), columnIndex, rowIndex))
-        return NULL;
+    TBL_AND_INDEX_VALID(env, reinterpret_cast<T*>(nativeTablePtr), columnIndex, rowIndex);
 
     realm::BinaryData bin = reinterpret_cast<T*>(nativeTablePtr)->get_binary( S(columnIndex), S(rowIndex));
     if (bin.is_null()) {
@@ -32,12 +34,11 @@ jbyteArray tbl_GetByteArray(JNIEnv* env, jlong nativeTablePtr, jlong columnIndex
     if (bin.size() <= MAX_JSIZE) {
         jbyteArray jresult = env->NewByteArray(static_cast<jsize>(bin.size()));
         if (jresult)
-            env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()), reinterpret_cast<const jbyte*>(bin.data()));  // throws
+            env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()), reinterpret_cast<const jbyte*>(bin.data()));
         return jresult;
     }
     else {
-        ThrowException(env, IllegalArgument, "Length of ByteArray is larger than an Int.");
-        return NULL;
+        throw std::invalid_argument(std::string("Length of ByteArray is larger than an Int."));
     }
 }
 

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -43,194 +43,169 @@ jmethodID session_error_handler;
 
 void ThrowRealmFileException(JNIEnv* env, const std::string& message, realm::RealmFileException::Kind kind);
 
-void ConvertException(JNIEnv* env, const char *file, int line)
-{
-    ostringstream ss;
+jthrowable JThrowableNew(JNIEnv* env, const char* class_name, const char* message) {
+    jclass j_exception_class = env->FindClass(class_name);
+    if (j_exception_class == nullptr) {
+        return nullptr;
+    }
+    jmethodID constructor = env->GetMethodID(j_exception_class, "<init>", "(Ljava/lang/String;)V");
+    if (constructor == nullptr) {
+        env->DeleteLocalRef(j_exception_class);
+        return nullptr;
+    }
+    jstring j_str = env->NewStringUTF(message);
+    jobject exception = env->NewObject(j_exception_class, constructor, j_str);
+    env->DeleteLocalRef(j_exception_class);
+    return reinterpret_cast<jthrowable>(exception);
+}
+
+jthrowable JThrowableNew(JNIEnv* env, const char* class_name, const char* message, jbyte kind) {
+    jclass j_exception_class = env->FindClass(class_name);
+    if (j_exception_class == nullptr) {
+        return nullptr;
+    }
+    jmethodID constructor = env->GetMethodID(j_exception_class, "<init>", "(BLjava/lang/String;)V");
+    if (constructor == nullptr) {
+        env->DeleteLocalRef(j_exception_class);
+        return nullptr;
+    }
+    jstring j_str = env->NewStringUTF(message);
+    jobject exception = env->NewObject(j_exception_class, constructor, kind, j_str);
+    env->DeleteLocalRef(j_exception_class);
+    return reinterpret_cast<jthrowable>(exception);
+}
+
+void ConvertException(JNIEnv* env) {
+    const char out_of_memory_error[]             = "io/realm/internal/OutOfMemoryError";
+    const char illegal_state_exception[]         = "java/lang/IllegalStateException";
+    const char illegal_argument_exception[]      = "java/lang/IllegalArgumentException";
+    const char realm_error[]                     = "io/realm/exceptions/RealmError";
+    const char bad_version[]                     = "io/realm/internal/async/BadVersionException";
+    const char realm_file_exception[]            = "io/realm/exceptions/RealmFileException";
+    const char index_out_of_bound_exception[]    = "java/lang/ArrayIndexOutOfBoundsException";
+    const char unsupported_operation_exception[] = "java/lang/UnsupportedOperationException";
+    const char class_not_found_exception[]       = "java/lang/ClassNotFoundException";
+    const char runtime_exception[]               = "java/lang/RuntimeException";
+
+    jthrowable j_exception;
+
+    // we are going to "throw" a Java exception so it is safest to clear
+    // already occurred exceptions
+    env->ExceptionClear();
+
     try {
         throw;
     }
     catch (bad_alloc& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowException(env, OutOfMemory, ss.str());
+        j_exception = JThrowableNew(env, out_of_memory_error, e.what());
     }
     catch (CrossTableLinkTarget& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowException(env, IllegalState, ss.str());
+        j_exception = JThrowableNew(env, illegal_state_exception, e.what());
     }
     catch (SharedGroup::BadVersion& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowException(env, BadVersion, ss.str());
+        j_exception = JThrowableNew(env, bad_version, ""); // never comes with an error message
     }
     catch (invalid_argument& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowException(env, IllegalArgument, ss.str());
+        ostringstream ss;
+        ss << "Illegal Argument: " << e.what();
+        j_exception = JThrowableNew(env, illegal_argument_exception, ss.str().c_str());
     }
-    catch (RealmFileException& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowRealmFileException(env, ss.str(), e.kind());
+    catch (illegal_state& e) {
+        j_exception = JThrowableNew(env, illegal_state_exception, e.what());
     }
     catch (InvalidTransactionException& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowException(env, IllegalState, ss.str());
+        j_exception = JThrowableNew(env, illegal_state_exception, e.what());
+    }
+    catch (range_error& e) {
+        j_exception = JThrowableNew(env, index_out_of_bound_exception, e.what());
     }
     catch (InvalidEncryptionKeyException& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowException(env, IllegalArgument, ss.str());
+        j_exception = JThrowableNew(env, illegal_argument_exception, e.what());
+    }
+    catch (unsupported_operation& e) {
+        j_exception = JThrowableNew(env, unsupported_operation_exception, e.what());
+    }
+    catch (fatal_error& e) {
+        ostringstream ss;
+        ss << "Unrecoverable error. " << e.what();
+        j_exception = JThrowableNew(env, realm_error, ss.str().c_str());
+    }
+    catch (class_not_found& e) {
+        ostringstream ss;
+        ss << "Class '" << e.what() << "' could not be located.";
+        j_exception = JThrowableNew(env, class_not_found_exception, ss.str().c_str());
+    }
+    catch (RealmFileException& e) {
+        // File exceptions are handled a bit different - we wish to send back information about
+        // what the actual cause was. For that, we have the exception
+        // io.realm.exceptions.RealmFileException which constructor takes two parameters:
+        //   - kind of exception (kind_code)
+        //   - message (jstr)
+
+        jbyte kind_code;
+        switch (e.kind()) {
+            case realm::RealmFileException::Kind::AccessError:
+                kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_ACCESS_ERROR;
+                break;
+            case realm::RealmFileException::Kind::PermissionDenied:
+                kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_PERMISSION_DENIED;
+                break;
+            case realm::RealmFileException::Kind::Exists:
+                kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_EXISTS;
+                break;
+            case realm::RealmFileException::Kind::NotFound:
+                kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_NOT_FOUND;
+                break;
+            case realm::RealmFileException::Kind::IncompatibleLockFile:
+                kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_IMCOMPATIBLE_LOCK_FILE;
+                break;
+            case realm::RealmFileException::Kind::FormatUpgradeRequired:
+                kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_FORMAT_UPGRADE_REQUIRED;
+                break;
+        }
+        j_exception = JThrowableNew(env, realm_file_exception, e.what(), kind_code);
+    }
+    catch (null_value& e) {
+        std::ostringstream ss;
+        ss << "Trying to set a non-nullable field '"
+           << e.get_table()->get_column_name(e.get_column_index())
+           << "' in '"
+           << e.get_table()->get_name()
+           << "' to null.";
+        j_exception = JThrowableNew(env, illegal_argument_exception, ss.str().c_str());
+    }
+    catch (runtime_error& e) {
+        j_exception = JThrowableNew(env, runtime_exception, e.what());
     }
     catch (exception& e) {
-        ss << e.what() << " in " << file << " line " << line;
-        ThrowException(env, FatalError, ss.str());
+        std::ostringstream ss;
+        ss << "Unrecoverable error: " << e.what();
+        j_exception = JThrowableNew(env, realm_error, ss.str().c_str());
     }
-    /* catch (...) is not needed if we only throw exceptions derived from std::exception */
-}
 
-void ThrowException(JNIEnv* env, ExceptionKind exception, const char *classStr)
-{
-    ThrowException(env, exception, classStr, "");
-}
+    /* Catch (...) is not needed if we only throw exceptions derived from std::exception */
 
-void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& classStr, const std::string& itemStr)
-{
-    string message;
-    jclass jExceptionClass = NULL;
-
-    TR_ERR(env, "jni: ThrowingException %d, %s, %s.", exception, classStr.c_str(), itemStr.c_str())
-
-    switch (exception) {
-        case ClassNotFound:
-            jExceptionClass = env->FindClass("java/lang/ClassNotFoundException");
-            message = "Class '" + classStr + "' could not be located.";
-            break;
-
-        case IllegalArgument:
-            jExceptionClass = env->FindClass("java/lang/IllegalArgumentException");
-            message = "Illegal Argument: " + classStr;
-            break;
-
-        case IndexOutOfBounds:
-            jExceptionClass = env->FindClass("java/lang/ArrayIndexOutOfBoundsException");
-            message = classStr;
-            break;
-
-        case UnsupportedOperation:
-            jExceptionClass = env->FindClass("java/lang/UnsupportedOperationException");
-            message = classStr;
-            break;
-
-        case OutOfMemory:
-            jExceptionClass = env->FindClass("io/realm/internal/OutOfMemoryError");
-            message = classStr + " " + itemStr;
-            break;
-
-        case FatalError:
-            jExceptionClass = env->FindClass("io/realm/exceptions/RealmError");
-            message = "Unrecoverable error. " + classStr;
-            break;
-
-        case RuntimeError:
-            jExceptionClass = env->FindClass("java/lang/RuntimeException");
-            message = classStr;
-            break;
-
-        case BadVersion:
-            jExceptionClass = env->FindClass("io/realm/internal/async/BadVersionException");
-            message = classStr;
-            break;
-
-        case IllegalState:
-            jExceptionClass = env->FindClass("java/lang/IllegalStateException");
-            message = classStr;
-            break;
-
-        // Should never get here.
-        case ExceptionKindMax:
-        default:
-            break;
-    }
-    if (jExceptionClass != NULL) {
-        env->ThrowNew(jExceptionClass, message.c_str());
-        TR_ERR(env, "Exception has been throw: %s", message.c_str())
+    if (j_exception != nullptr) {
+        env->Throw(j_exception);
+        TR_ERR_NO_VA_ARG(env, "Exception has been throw")
     }
     else {
         TR_ERR_NO_VA_ARG(env, "ERROR: Couldn't throw exception.")
     }
-
-    env->DeleteLocalRef(jExceptionClass);
-}
-
-void ThrowRealmFileException(JNIEnv* env, const std::string& message, realm::RealmFileException::Kind kind)
-{
-    jclass cls = env->FindClass("io/realm/exceptions/RealmFileException");
-
-    jmethodID constructor = env->GetMethodID(cls, "<init>", "(BLjava/lang/String;)V");
-    // Initial value to suppress gcc warning.
-    jbyte kind_code;
-    switch (kind) {
-        case realm::RealmFileException::Kind::AccessError:
-            kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_ACCESS_ERROR;
-            break;
-        case realm::RealmFileException::Kind::PermissionDenied:
-            kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_PERMISSION_DENIED;
-            break;
-        case realm::RealmFileException::Kind::Exists:
-            kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_EXISTS;
-            break;
-        case realm::RealmFileException::Kind::NotFound:
-            kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_NOT_FOUND;
-            break;
-        case realm::RealmFileException::Kind::IncompatibleLockFile:
-            kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_IMCOMPATIBLE_LOCK_FILE;
-            break;
-        case realm::RealmFileException::Kind::FormatUpgradeRequired:
-            kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_FORMAT_UPGRADE_REQUIRED;
-            break;
-    }
-    jstring jstr = env->NewStringUTF(message.c_str());
-    jobject exception = env->NewObject(cls, constructor, kind_code, jstr);
-    env->Throw(reinterpret_cast<jthrowable>(exception));
-    env->DeleteLocalRef(cls);
-    env->DeleteLocalRef(exception);
+    env->DeleteLocalRef(j_exception);
 }
 
 jclass GetClass(JNIEnv* env, const char* classStr)
 {
     jclass localRefClass = env->FindClass(classStr);
     if (localRefClass == NULL) {
-        ThrowException(env, ClassNotFound, classStr);
-        return NULL;
+        throw class_not_found(classStr);
     }
 
-    jclass myClass = reinterpret_cast<jclass>( env->NewGlobalRef(localRefClass) );
+    jclass myClass = reinterpret_cast<jclass>(env->NewGlobalRef(localRefClass));
     env->DeleteLocalRef(localRefClass);
     return myClass;
 }
-
-void ThrowNullValueException(JNIEnv* env, Table* table, size_t col_ndx) {
-    std::ostringstream ss;
-    ss << "Trying to set a non-nullable field '"
-       << table->get_column_name(col_ndx)
-       << "' in '"
-       << table->get_name()
-       << "' to null.";
-    ThrowException(env, IllegalArgument, ss.str());
-}
-
-bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, realm::BinaryData& bin)
-{
-    const char* data = static_cast<char*>(env->GetDirectBufferAddress(jByteBuffer));
-    if (!data) {
-        ThrowException(env, IllegalArgument, "ByteBuffer is invalid");
-        return false;
-    }
-    jlong size = env->GetDirectBufferCapacity(jByteBuffer);
-    if (size < 0) {
-        ThrowException(env, IllegalArgument, "Can't get BufferCapacity.");
-        return false;
-    }
-    bin = BinaryData(data, S(size));
-    return true;
-}
-
 
 //*********************************************************************
 // String handling

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -20,6 +20,9 @@
 #include <string>
 #include <sstream>
 #include <memory>
+#include <functional>
+#include <type_traits>
+#include <exception>
 
 #include <jni.h>
 
@@ -58,11 +61,73 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved);
 #define STRINGIZE_DETAIL(x) #x
 #define STRINGIZE(x) STRINGIZE_DETAIL(x)
 
-// Exception handling
-#define CATCH_STD() \
-    catch (...) { \
-        ConvertException(env, __FILE__, __LINE__); \
+void ConvertException(JNIEnv* env);
+
+// Exception handling using lambdas
+// Credit: http://stackoverflow.com/questions/29202377/how-do-i-force-the-compiler-to-recognize-lambda-type-in-templated-function
+template<typename T, typename F>
+T try_catch(JNIEnv* env, F func) {
+    try {
+        // if an exception already has occurred, it is not possible to call any JNI
+        // functions, and we don't wish to try to execute the JNI function
+        // alternatively, we could clear the exception but then we can easily miss
+        // an error stage
+        if (env->ExceptionCheck() == JNI_FALSE) {
+            // the actual JNI code is executed
+            // it might throw C++ exceptions
+            return func();
+        }
     }
+    catch (std::exception& e) {
+        // we don't wish to do the exception handling in here; this is a templated function, and we might end up
+        // with multiple copies of the code for no good reason
+        ConvertException(env);
+    }
+
+    // when a Java exception is thrown, we return to Java with any return value; as soon as the execution point is
+    // back at the JVM, the Java exception is thrown, and the returned value isn't used for anything
+    return static_cast<T>(0);
+}
+
+// we need to have specialized C++ exceptions so we know what kind of error state has been reached
+// illegal_state - the internal state of the Realm is wrong; it is not serious but execution cannot continue
+class illegal_state : public std::runtime_error {
+public:
+    illegal_state(const std::string& msg) : std::runtime_error(msg) {};
+    illegal_state(const char* msg) : std::runtime_error(msg) {};
+};
+
+// unsupported_operation - the operation is either not supported or implemented; see also java.lang.UnsupportedOperationException
+class unsupported_operation : public std::runtime_error {
+public:
+    unsupported_operation(const std::string& msg) : std::runtime_error(msg) {};
+    unsupported_operation(const char* msg) : std::runtime_error(msg) {};
+};
+
+// fatal_error - the app cannot recover from its error state
+class fatal_error : public std::runtime_error {
+public:
+    fatal_error(const std::string& msg) : std::runtime_error(msg) {};
+    fatal_error(const char* msg) : std::runtime_error(msg) {};
+};
+
+// class_not_found - looking on a class in JVM failed; see also java.lang.ClassNotFoundException
+class class_not_found : public std::runtime_error {
+public:
+    class_not_found(const std::string& msg) : std::runtime_error(msg) {};
+    class_not_found(const char* msg) : std::runtime_error(msg) {};
+};
+
+// null_value - trying to set a required field to null
+class null_value : public std::exception {
+public:
+    null_value(realm::Table* table, std::size_t column_index) : table (table), column_index (column_index) {};
+    realm::Table* get_table() { return table; };
+    std::size_t get_column_index() { return column_index; };
+private:
+    realm::Table* table;
+    std::size_t column_index;
+};
 
 template <typename T>
 std::string num_to_string(T pNumber)
@@ -108,11 +173,6 @@ enum ExceptionKind {
     // new exception kind.
     ExceptionKindMax // Always keep this as the last one!
 };
-
-void ConvertException(JNIEnv* env, const char *file, int line);
-void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& classStr, const std::string& itemStr="");
-void ThrowException(JNIEnv* env, ExceptionKind exception, const char *classStr);
-void ThrowNullValueException(JNIEnv* env, realm::Table *table, size_t col_ndx);
 
 jclass GetClass(JNIEnv* env, const char* classStr);
 
@@ -223,7 +283,7 @@ inline jlong to_jlong_or_not_found(size_t res) {
 }
 
 template <class T>
-inline bool TableIsValid(JNIEnv* env, T* objPtr)
+inline void TableIsValid(JNIEnv* env, T* objPtr)
 {
     bool valid = (objPtr != NULL);
     if (valid) {
@@ -236,251 +296,227 @@ inline bool TableIsValid(JNIEnv* env, T* objPtr)
     }
     if (!valid) {
         TR_ERR(env, "Table %p is no longer attached!", VOID_PTR(objPtr))
-        ThrowException(env, IllegalState, "Table is no longer valid to operate on.");
+        throw illegal_state("Table is no longer valid to operate on.");
     }
-    return valid;
 }
 
-inline bool RowIsValid(JNIEnv* env, realm::Row* rowPtr)
+inline void RowIsValid(JNIEnv* env, realm::Row* rowPtr)
 {
     bool valid = (rowPtr != NULL && rowPtr->is_attached());
     if (!valid) {
         TR_ERR(env, "Row %p is no longer attached!", VOID_PTR(rowPtr))
-        ThrowException(env, IllegalState, "Object is no longer valid to operate on. Was it deleted by another thread?");
+        throw illegal_state("Object is no longer valid to operate on. Was it deleted by another thread?");
     }
-    return valid;
 }
 
 // Requires an attached Table
 template <class T>
-bool RowIndexesValid(JNIEnv* env, T* pTable, jlong startIndex, jlong endIndex, jlong range)
+void RowIndexesValid(JNIEnv* env, T* pTable, jlong startIndex, jlong endIndex, jlong range)
 {
     size_t maxIndex = pTable->size();
     if (endIndex == -1)
         endIndex = maxIndex;
     if (startIndex < 0) {
         TR_ERR(env, "startIndex %" PRId64 " < 0 - invalid!", S64(startIndex))
-        ThrowException(env, IndexOutOfBounds, "startIndex < 0.");
-        return false;
+        throw std::range_error("startIndex < 0.");
     }
     if (realm::util::int_greater_than(startIndex, maxIndex)) {
         TR_ERR(env, "startIndex %" PRId64 " > %" PRId64 " - invalid!", S64(startIndex), S64(maxIndex))
-        ThrowException(env, IndexOutOfBounds, "startIndex > available rows.");
-        return false;
+        throw std::range_error("startIndex > available rows.");
     }
 
     if (realm::util::int_greater_than(endIndex, maxIndex)) {
         TR_ERR(env, "endIndex %" PRId64 " > %" PRId64 " - invalid!", S64(endIndex), S64(maxIndex))
-        ThrowException(env, IndexOutOfBounds, "endIndex > available rows.");
-        return false;
+        throw std::range_error("endIndex > available rows.");
     }
     if (startIndex > endIndex) {
         TR_ERR(env, "startIndex %" PRId64 " > endIndex %" PRId64 " - invalid!", S64(startIndex), S64(endIndex))
-        ThrowException(env, IndexOutOfBounds, "startIndex > endIndex.");
-        return false;
+        throw std::range_error("startIndex > endIndex.");
     }
 
     if (range != -1 && range < 0) {
         TR_ERR(env, "range %" PRId64 " < 0 - invalid!", S64(range))
-        ThrowException(env, IndexOutOfBounds, "range < 0.");
-        return false;
+        throw std::range_error("range < 0.");
     }
-
-    return true;
 }
 
 template <class T>
-inline bool RowIndexValid(JNIEnv* env, T pTable, jlong rowIndex, bool offset=false)
+inline void RowIndexValid(JNIEnv* env, T pTable, jlong rowIndex, bool offset=false)
 {
     if (rowIndex < 0) {
-        ThrowException(env, IndexOutOfBounds, "rowIndex is less than 0.");
-        return false;
+        throw std::range_error("rowIndex is less than 0.");
     }
     size_t size = pTable->size();
-    if (size > 0 && offset)
+    if (size > 0 && offset) {
         size -= 1;
-    bool rowErr = realm::util::int_greater_than_or_equal(rowIndex, size);
-    if (rowErr) {
+    }
+    if (realm::util::int_greater_than_or_equal(rowIndex, size)) {
         TR_ERR(env, "rowIndex %" PRId64 " > %" PRId64 " - invalid!", S64(rowIndex), S64(size))
-        ThrowException(env, IndexOutOfBounds,
+        throw std::range_error(
             "rowIndex > available rows: " +
             num_to_string(rowIndex) + " > " + num_to_string(size));
     }
-    return !rowErr;
 }
 
 template <class T>
-inline bool TblRowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset=false)
+inline void TblRowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset=false)
 {
     if (std::is_same<realm::Table, T>::value) {
-        if (!TableIsValid(env, TBL(pTable)))
-            return false;
+        TableIsValid(env, TBL(pTable));
     }
-    return RowIndexValid(env, pTable, rowIndex, offset);
+    RowIndexValid(env, pTable, rowIndex, offset);
 }
 
 template <class T>
-inline bool ColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
+inline void ColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
 {
     if (columnIndex < 0) {
-        ThrowException(env, IndexOutOfBounds, "columnIndex is less than 0.");
-        return false;
+        throw std::range_error("columnIndex is less than 0.");
     }
-    bool colErr = realm::util::int_greater_than_or_equal(columnIndex, pTable->get_column_count());
-    if (colErr) {
+    if (realm::util::int_greater_than_or_equal(columnIndex, pTable->get_column_count())) {
         TR_ERR(env, "columnIndex %" PRId64 " > %" PRId64 " - invalid!", S64(columnIndex), S64(pTable->get_column_count()))
-        ThrowException(env, IndexOutOfBounds, "columnIndex > available columns.");
+        throw std::range_error("columnIndex > available columns.");
     }
-    return !colErr;
 }
 
 template <class T>
-inline bool TblColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
+inline void TblColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
 {
     if (std::is_same<realm::Table, T>::value) {
-        if (!TableIsValid(env, TBL(pTable)))
-            return false;
+        TableIsValid(env, TBL(pTable));
     }
-    return ColIndexValid(env, pTable, columnIndex);
+    ColIndexValid(env, pTable, columnIndex);
 }
 
-inline bool RowColIndexValid(JNIEnv* env, realm::Row* pRow, jlong columnIndex)
+inline void RowColIndexValid(JNIEnv* env, realm::Row* pRow, jlong columnIndex)
 {
-    return RowIsValid(env, pRow) && ColIndexValid(env, pRow->get_table(), columnIndex);
-}
-
-template <class T>
-inline bool IndexValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
-{
-    return ColIndexValid(env, pTable, columnIndex)
-        && RowIndexValid(env, pTable, rowIndex);
+    RowIsValid(env, pRow);
+    ColIndexValid(env, pRow->get_table(), columnIndex);
 }
 
 template <class T>
-inline bool TblIndexValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
+inline void IndexValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
 {
-    return TableIsValid(env, pTable)
-        && IndexValid(env, pTable, columnIndex, rowIndex);
+    ColIndexValid(env, pTable, columnIndex);
+    RowIndexValid(env, pTable, rowIndex);
 }
 
 template <class T>
-inline bool TblIndexInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
+inline void TblIndexValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
 {
-    if (!TblColIndexValid(env, pTable, columnIndex))
-        return false;
-    bool rowErr = realm::util::int_greater_than(rowIndex, pTable->size()+1);
-    if (rowErr) {
+    TableIsValid(env, pTable);
+    IndexValid(env, pTable, columnIndex, rowIndex);
+}
+
+template <class T>
+inline void TblIndexInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
+{
+    TblColIndexValid(env, pTable, columnIndex);
+    if (realm::util::int_greater_than(rowIndex, pTable->size()+1)) {
         TR_ERR(env, "rowIndex %" PRId64 " > %" PRId64 " - invalid!", S64(rowIndex), S64(pTable->size()))
-        ThrowException(env, IndexOutOfBounds,
+        throw std::range_error(
             "rowIndex " + num_to_string(rowIndex) +
             " > available rows " + num_to_string(pTable->size()) + ".");
     }
-    return !rowErr;
 }
 
 template <class T>
-inline bool TypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
+inline void TypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
 {
     size_t col = static_cast<size_t>(columnIndex);
     int colType = pTable->get_column_type(col);
     if (colType != expectColType) {
         TR_ERR(env, "Expected columnType %d, but got %d.", expectColType, pTable->get_column_type(col))
-        ThrowException(env, IllegalArgument, "ColumnType invalid.");
-        return false;
+        throw std::invalid_argument("ColumnType invalid.");
     }
-    return true;
 }
 
 template <class T>
-inline bool TypeIsLinkLike(JNIEnv* env, T* pTable, jlong columnIndex)
+inline void TypeIsLinkLike(JNIEnv* env, T* pTable, jlong columnIndex)
 {
     size_t col = static_cast<size_t>(columnIndex);
     int colType = pTable->get_column_type(col);
     if (colType == realm::type_Link || colType == realm::type_LinkList) {
-        return true;
+        return;
     }
 
     TR_ERR(env, "Expected columnType %d or %d, but got %d", realm::type_Link, realm::type_LinkList, colType)
-    ThrowException(env, IllegalArgument, "ColumnType invalid: expected type_Link or type_LinkList");
-    return false;
+    throw std::invalid_argument("ColumnType invalid: expected type_Link or type_LinkList");
 }
 
 template <class T>
-inline bool ColIsNullable(JNIEnv* env, T* pTable, jlong columnIndex)
+inline void ColIsNullable(JNIEnv* env, T* pTable, jlong columnIndex)
 {
     size_t col = static_cast<size_t>(columnIndex);
     int colType = pTable->get_column_type(col);
     if (colType == realm::type_Link) {
-        return true;
+        return;
     }
 
     if (colType == realm::type_LinkList) {
-        ThrowException(env, IllegalArgument, "RealmList is not nullable.");
-        return false;
+        throw std::invalid_argument("RealmList is not nullable.");
     }
 
     if (pTable->is_nullable(col)) {
-        return true;
+        return;
     }
 
     TR_ERR_NO_VA_ARG(env, "Expected nullable column type")
-    ThrowException(env, IllegalArgument, "This field is not nullable.");
-    return false;
+    throw std::invalid_argument("This field is not nullable.");
 }
 
 template <class T>
-inline bool ColIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
+inline void ColIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
 {
-    return ColIndexValid(env, pTable, columnIndex)
-        && TypeValid(env, pTable, columnIndex, expectColType);
+    ColIndexValid(env, pTable, columnIndex);
+    TypeValid(env, pTable, columnIndex, expectColType);
 }
 template <class T>
-inline bool TblColIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
+inline void TblColIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
 {
-    return TableIsValid(env, pTable)
-        && ColIndexAndTypeValid(env, pTable, columnIndex, expectColType);
+    TableIsValid(env, pTable);
+    ColIndexAndTypeValid(env, pTable, columnIndex, expectColType);
 }
 
 template <class T>
-inline bool TblColIndexAndLinkOrLinkList(JNIEnv* env, T* pTable, jlong columnIndex) {
-    return TableIsValid(env, pTable)
-        && TypeIsLinkLike(env, pTable, columnIndex);
+inline void TblColIndexAndLinkOrLinkList(JNIEnv* env, T* pTable, jlong columnIndex) {
+    TableIsValid(env, pTable);
+    TypeIsLinkLike(env, pTable, columnIndex);
 }
 
 // FIXME Usually this is called after TBL_AND_INDEX_AND_TYPE_VALID which will validate Table as well.
 // Try to avoid duplicated checks to improve performance.
 template <class T>
-inline bool TblColIndexAndNullable(JNIEnv* env, T* pTable, jlong columnIndex) {
-    return TableIsValid(env, pTable)
-        && ColIsNullable(env, pTable, columnIndex);
+inline void TblColIndexAndNullable(JNIEnv* env, T* pTable, jlong columnIndex) {
+    TableIsValid(env, pTable);
+    ColIsNullable(env, pTable, columnIndex);
 }
 
-inline bool RowColIndexAndTypeValid(JNIEnv* env, realm::Row* pRow, jlong columnIndex, int expectColType)
+inline void RowColIndexAndTypeValid(JNIEnv* env, realm::Row* pRow, jlong columnIndex, int expectColType)
 {
-    return RowIsValid(env, pRow)
-        && ColIndexAndTypeValid(env, pRow->get_table(), columnIndex, expectColType);
-}
-
-template <class T>
-inline bool IndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
-{
-    return IndexValid(env, pTable, columnIndex, rowIndex)
-        && TypeValid(env, pTable, columnIndex, expectColType);
-}
-template <class T>
-inline bool TblIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
-{
-    return TableIsValid(env, pTable) && IndexAndTypeValid(env, pTable, columnIndex, rowIndex, expectColType);
+    RowIsValid(env, pRow);
+    ColIndexAndTypeValid(env, pRow->get_table(), columnIndex, expectColType);
 }
 
 template <class T>
-inline bool TblIndexAndTypeInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
+inline void IndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
 {
-    return TblIndexInsertValid(env, pTable, columnIndex, rowIndex)
-        && TypeValid(env, pTable, columnIndex, expectColType);
+    IndexValid(env, pTable, columnIndex, rowIndex);
+    TypeValid(env, pTable, columnIndex, expectColType);
+}
+template <class T>
+inline void TblIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
+{
+    TableIsValid(env, pTable);
+    IndexAndTypeValid(env, pTable, columnIndex, rowIndex, expectColType);
 }
 
-bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, realm::BinaryData& data);
+template <class T>
+inline void TblIndexAndTypeInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
+{
+    TblIndexInsertValid(env, pTable, columnIndex, rowIndex);
+    TypeValid(env, pTable, columnIndex, expectColType);
+}
 
 
 // Utility function for appending StringData, which is returned


### PR DESCRIPTION
Migrating the old C macro based exception handling to modern C++ lambda functions. Only C++ exception is thrown in the C++ code, and they are converted to Java exception. The idea is that all JNI border functions must wrap all code in `try_catch()`. When writing C++ code (core, object store or JNI), only C++ exceptions should be thrown - no need to "throw" Java exception. The function `try_catch()` takes care of it.

I do dislike big PRs, and this is definitely a big one. Let me give a short guide to the reviewers:

* Focus on `util.hpp` and `util.cpp`
* Take one JNI method to see how it works

@realm/java 