### PR TITLE
[CherryPick] Accelerate build with ccache and lcache (#3523)

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -30,6 +30,8 @@ if (!ext.coreArchiveDir) {
 ext.coreArchiveFile = rootProject.file("${ext.coreArchiveDir}/realm-sync-android-${project.coreVersion}.tar.gz")
 ext.coreDistributionDir = file("${projectDir}/distribution/realm-core/")
 ext.coreDir = file("${project.coreDistributionDir.getAbsolutePath()}/core-${project.coreVersion}")
+ext.ccachePath = project.findProperty('ccachePath') ?: System.getenv('NDK_CCACHE')
+ext.lcachePath = project.findProperty('lcachePath') ?: System.getenv('NDK_LCACHE')
 
 android {
     compileSdkVersion 24
@@ -50,6 +52,8 @@ android {
                           // JNI build currently (lack of lto linking support).
                           // This file should be removed and use the one from Android SDK cmake package when it supports lto.
                         "-DCMAKE_TOOLCHAIN_FILE=${project.file('src/main/cpp/android.toolchain.cmake').path}"
+                if (project.ccachePath) arguments "-DNDK_CCACHE=$project.ccachePath"
+                if (project.lcachePath) arguments "-DNDK_LCACHE=$project.lcachePath"
                 if (!project.hasProperty('android.injected.build.abi') && project.hasProperty('buildTargetABIs')) {
                     abiFilters(*project.getProperty('buildTargetABIs').trim().split('\\s*,\\s*'))
                 } else {

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -17,6 +17,11 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # Generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Setup lcache
+if(NDK_LCACHE)
+    set(CMAKE_CXX_CREATE_SHARED_LIBRARY "${NDK_LCACHE} ${CMAKE_CXX_CREATE_SHARED_LIBRARY}")
+endif()
+
 # Set flag build_SYNC
 if (REALM_FLAVOR STREQUAL base)
     set(build_SYNC OFF)
@@ -180,4 +185,3 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:realm-jni> ${unstripped_SO_DIR}
         COMMAND ${CMAKE_STRIP} $<TARGET_FILE:realm-jni>)
 endif()
-


### PR DESCRIPTION
See https://github.com/beeender/lcache for source code for lcache.
It is very simple right now. It identify if the link target is cached by
using checksums from command line + checksums of all input files.

The realm-library gradle check those paths from project properties first
, then the system env.

So those can be set in the ~/.gradle/gradle.properties like:
ccachePath=/usr/bin/ccache
lcachePath=/usr/bin/lcache

Or by system ENVs like:
NDK_CCACHE=/usr/bin/ccache
NDK_LCACHE=/usr/bin/lcache