### PR TITLE
Ignore android.injected.build.abi

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -54,7 +54,7 @@ android {
                         "-DCMAKE_TOOLCHAIN_FILE=${project.file('src/main/cpp/android.toolchain.cmake').path}"
                 if (project.ccachePath) arguments "-DNDK_CCACHE=$project.ccachePath"
                 if (project.lcachePath) arguments "-DNDK_LCACHE=$project.lcachePath"
-                if (!project.hasProperty('android.injected.build.abi') && project.hasProperty('buildTargetABIs')) {
+                if (project.hasProperty('buildTargetABIs')) {
                     abiFilters(*project.getProperty('buildTargetABIs').trim().split('\\s*,\\s*'))
                 } else {
                     // armeabi is not supported anymore.


### PR DESCRIPTION
It is set by AS randomly for some reasons, seems AS will inject ABIs
according to execution target. But it is not having the right ABI values
all the time. So just disable it, only check buildTargetABIs property.