### PR TITLE
Align Sync classes with Cocoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.1.0
 
+### Breaking changes
+
+* Renamed `User` to `SyncUser`, `Credentials` to `SyncCredentials` and `Session` to `SyncSession` to align names with Cocoa.
+
 ### Enhancement
 
 * `Realm.compactRealm()` works for encrypted Realms.

--- a/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/CounterActivity.java
+++ b/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/CounterActivity.java
@@ -31,7 +31,7 @@ import butterknife.OnClick;
 import io.realm.Realm;
 import io.realm.RealmChangeListener;
 import io.realm.SyncConfiguration;
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.examples.objectserver.model.CRDTCounter;
 
 public class CounterActivity extends AppCompatActivity {
@@ -40,7 +40,7 @@ public class CounterActivity extends AppCompatActivity {
 
     private Realm realm;
     private CRDTCounter counter;
-    private User user;
+    private SyncUser user;
 
     @BindView(R.id.text_counter) TextView counterView;
 
@@ -51,7 +51,7 @@ public class CounterActivity extends AppCompatActivity {
         ButterKnife.bind(this);
 
         // Check if we have a valid user, otherwise redirect to login
-        if (User.currentUser() == null) {
+        if (SyncUser.currentUser() == null) {
             gotoLoginActivity();
         }
     }
@@ -59,7 +59,7 @@ public class CounterActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        user = User.currentUser();
+        user = SyncUser.currentUser();
         if (user != null) {
             // Create a RealmConfiguration for our user
             SyncConfiguration config = new SyncConfiguration.Builder(user, REALM_URL)

--- a/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/LoginActivity.java
+++ b/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/LoginActivity.java
@@ -26,9 +26,9 @@ import android.widget.Toast;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import io.realm.Credentials;
+import io.realm.SyncCredentials;
 import io.realm.ObjectServerError;
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.UserStore;
 
 import static io.realm.ErrorCode.UNKNOWN_ACCOUNT;
@@ -76,11 +76,11 @@ public class LoginActivity extends AppCompatActivity {
         String username = this.username.getText().toString();
         String password = this.password.getText().toString();
 
-        Credentials creds = Credentials.usernamePassword(username, password, createUser);
+        SyncCredentials creds = SyncCredentials.usernamePassword(username, password, createUser);
         String authUrl = "http://" + BuildConfig.OBJECT_SERVER_IP + ":9080/auth";
-        User.Callback callback = new User.Callback() {
+        SyncUser.Callback callback = new SyncUser.Callback() {
             @Override
-            public void onSuccess(User user) {
+            public void onSuccess(SyncUser user) {
                 progressDialog.dismiss();
                 onLoginSuccess();
             }
@@ -103,7 +103,7 @@ public class LoginActivity extends AppCompatActivity {
             }
         };
 
-        User.loginAsync(creds, authUrl, callback);
+        SyncUser.loginAsync(creds, authUrl, callback);
     }
 
     @Override

--- a/examples/secureTokenAndroidKeyStore/src/main/java/examples/io/realm/securetokenandroidkeystore/securetokenandroidkeystore/MainActivity.java
+++ b/examples/secureTokenAndroidKeyStore/src/main/java/examples/io/realm/securetokenandroidkeystore/securetokenandroidkeystore/MainActivity.java
@@ -33,10 +33,10 @@ import java.util.UUID;
 import io.realm.Realm;
 import io.realm.SyncConfiguration;
 import io.realm.SyncManager;
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.android.SecureUserStore;
 import io.realm.internal.android.crypto.CipherClient;
-import io.realm.internal.objectserver.SyncUser;
+import io.realm.internal.objectserver.ObjectServerUser;
 import io.realm.internal.objectserver.Token;
 
 /**
@@ -87,7 +87,7 @@ public class MainActivity extends AppCompatActivity {
         try {
             SyncManager.setUserStore(new SecureUserStore(MainActivity.this));
             // the rest of Sync logic ...
-            User user = createTestUser(0);
+            SyncUser user = createTestUser(0);
             String url = "realm://objectserver.realm.io/default";
             SyncConfiguration secureConfig = new SyncConfiguration.Builder(user, url).build();
             Realm realm = Realm.getInstance(secureConfig);
@@ -101,10 +101,10 @@ public class MainActivity extends AppCompatActivity {
     private final static String USER_TOKEN = UUID.randomUUID().toString();
     private final static String REALM_TOKEN = UUID.randomUUID().toString();
 
-    private static User createTestUser(long expires) {
+    private static SyncUser createTestUser(long expires) {
         Token userToken = new Token(USER_TOKEN, "JohnDoe", null, expires, null);
         Token accessToken = new Token(REALM_TOKEN, "JohnDoe", "/foo", expires, new Token.Permission[] {Token.Permission.DOWNLOAD });
-        SyncUser.AccessDescription desc = new SyncUser.AccessDescription(accessToken, "/data/data/myapp/files/default", false);
+        ObjectServerUser.AccessDescription desc = new ObjectServerUser.AccessDescription(accessToken, "/data/data/myapp/files/default", false);
 
         JSONObject obj = new JSONObject();
         try {
@@ -117,7 +117,7 @@ public class MainActivity extends AppCompatActivity {
             obj.put("authUrl", "http://objectserver.realm.io/auth");
             obj.put("userToken", userToken.toJson());
             obj.put("realms", realmList);
-            return User.fromJson(obj.toString());
+            return SyncUser.fromJson(obj.toString());
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/AuthenticateRequestTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/AuthenticateRequestTests.java
@@ -42,7 +42,7 @@ public class AuthenticateRequestTests {
 
     @Test
     public void userLogin() throws URISyntaxException, JSONException {
-        AuthenticateRequest request = AuthenticateRequest.userLogin(Credentials.facebook("foo"));
+        AuthenticateRequest request = AuthenticateRequest.userLogin(SyncCredentials.facebook("foo"));
 
         JSONObject obj = new JSONObject(request.toJson());
         assertFalse(obj.has("path"));
@@ -65,11 +65,11 @@ public class AuthenticateRequestTests {
     @Test
     public void errorsNotWrapped() {
         AuthenticationServer authServer = Mockito.mock(AuthenticationServer.class);
-        when(authServer.loginUser(any(Credentials.class), any(URL.class))).thenReturn(SyncTestUtils.createErrorResponse(ErrorCode.ACCESS_DENIED));
+        when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenReturn(SyncTestUtils.createErrorResponse(ErrorCode.ACCESS_DENIED));
         SyncManager.setAuthServerImpl(authServer);
 
         try {
-            User.login(Credentials.facebook("foo"), "http://foo.bar/auth");
+            SyncUser.login(SyncCredentials.facebook("foo"), "http://foo.bar/auth");
             fail();
         } catch (ObjectServerError e) {
             assertEquals(ErrorCode.ACCESS_DENIED, e.getErrorCode());

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/CredentialsTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/CredentialsTests.java
@@ -35,7 +35,7 @@ public class CredentialsTests {
 
     @Test
     public void getUserInfo_isUnmodifiable() {
-        Credentials creds = Credentials.custom("foo", "bar", null);
+        SyncCredentials creds = SyncCredentials.custom("foo", "bar", null);
         Map<java.lang.String, Object> userInfo = creds.getUserInfo();
         try {
             userInfo.put("boom", null);
@@ -46,27 +46,27 @@ public class CredentialsTests {
 
     @Test
     public void facebook() {
-        Credentials creds = Credentials.facebook("foo");
+        SyncCredentials creds = SyncCredentials.facebook("foo");
 
-        assertEquals(Credentials.IdentityProvider.FACEBOOK, creds.getIdentityProvider());
+        assertEquals(SyncCredentials.IdentityProvider.FACEBOOK, creds.getIdentityProvider());
         assertEquals("foo", creds.getUserIdentifier());
         assertTrue(creds.getUserInfo().isEmpty());
     }
 
     @Test
     public void google() {
-        Credentials creds = Credentials.google("foo");
+        SyncCredentials creds = SyncCredentials.google("foo");
 
-        assertEquals(Credentials.IdentityProvider.GOOGLE, creds.getIdentityProvider());
+        assertEquals(SyncCredentials.IdentityProvider.GOOGLE, creds.getIdentityProvider());
         assertEquals("foo", creds.getUserIdentifier());
         assertTrue(creds.getUserInfo().isEmpty());
     }
 
     @Test
     public void twitter() {
-        Credentials creds = Credentials.twitter("foo");
+        SyncCredentials creds = SyncCredentials.twitter("foo");
 
-        assertEquals(Credentials.IdentityProvider.TWITTER, creds.getIdentityProvider());
+        assertEquals(SyncCredentials.IdentityProvider.TWITTER, creds.getIdentityProvider());
         assertEquals("foo", creds.getUserIdentifier());
         assertTrue(creds.getUserInfo().isEmpty());
     }
@@ -76,7 +76,7 @@ public class CredentialsTests {
         String[] invalidInput = { null, ""};
         for (String input : invalidInput) {
             try {
-                Credentials.facebook(input);
+                SyncCredentials.facebook(input);
                 fail(input + " should have failed");
             } catch (IllegalArgumentException ignored) {
             }
@@ -85,11 +85,11 @@ public class CredentialsTests {
 
     @Test
     public void usernamePassword() {
-        Credentials creds = Credentials.usernamePassword("foo", "bar", true);
+        SyncCredentials creds = SyncCredentials.usernamePassword("foo", "bar", true);
         assertEquals("foo", creds.getUserIdentifier());
         Map<String, Object> userInfo = creds.getUserInfo();
 
-        assertEquals(Credentials.IdentityProvider.USERNAME_PASSWORD, creds.getIdentityProvider());
+        assertEquals(SyncCredentials.IdentityProvider.USERNAME_PASSWORD, creds.getIdentityProvider());
         assertEquals("bar", userInfo.get("password"));
         assertTrue((Boolean) userInfo.get("register"));
     }
@@ -100,7 +100,7 @@ public class CredentialsTests {
         String[] invalidInput = { null, ""};
         for (String input : invalidInput) {
             try {
-                Credentials.usernamePassword(input, "bar", true);
+                SyncCredentials.usernamePassword(input, "bar", true);
                 fail(input + " should have failed");
             } catch (IllegalArgumentException ignored) {
             }
@@ -113,7 +113,7 @@ public class CredentialsTests {
         userInfo.put("custom", "property");
         for (String username : new String[]{null, ""}) {
             try {
-                Credentials.custom("facebook", username, userInfo);
+                SyncCredentials.custom("facebook", username, userInfo);
                 fail();
             } catch (IllegalArgumentException ignored) {
             }
@@ -124,7 +124,7 @@ public class CredentialsTests {
     public void custom() {
         Map<java.lang.String, Object> userInfo = new HashMap<String, Object>();
         userInfo.put("custom", "property");
-        Credentials creds = Credentials.custom("customProvider", "foo", userInfo);
+        SyncCredentials creds = SyncCredentials.custom("customProvider", "foo", userInfo);
 
         assertEquals("foo", creds.getUserIdentifier());
         assertEquals("customProvider", creds.getIdentityProvider());
@@ -139,7 +139,7 @@ public class CredentialsTests {
 
         for (String provider : new String[]{null, ""}) {
             try {
-                Credentials.custom(null, "foo", userInfo);
+                SyncCredentials.custom(null, "foo", userInfo);
                 fail();
             } catch (IllegalArgumentException ignored) {
             }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SchemaTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SchemaTests.java
@@ -17,7 +17,6 @@
 package io.realm;
 
 
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
@@ -44,7 +43,7 @@ public class SchemaTests {
 
     @Before
     public void setUp() {
-        User user = SyncTestUtils.createTestUser();
+        SyncUser user = SyncTestUtils.createTestUser();
         config = new SyncConfiguration.Builder(user, "realm://objectserver.realm.io/~/default").build();
     }
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 
 import io.realm.internal.network.AuthenticationServer;
 import io.realm.internal.network.OkHttpAuthenticationServer;
-import io.realm.internal.objectserver.SyncSession;
+import io.realm.internal.objectserver.ObjectServerSession;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static io.realm.util.SyncTestUtils.createTestUser;
@@ -43,7 +43,7 @@ public class SessionTests {
     private Context context;
     private AuthenticationServer authServer;
     private SyncConfiguration configuration;
-    private User user;
+    private SyncUser user;
 
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
@@ -62,14 +62,14 @@ public class SessionTests {
 
     @Test
     public void get_syncValues() {
-        SyncSession internalSession = new SyncSession(
+        ObjectServerSession internalSession = new ObjectServerSession(
                 configuration,
                 authServer,
                 configuration.getUser().getSyncUser(),
                 configuration.getSyncPolicy(),
                 configuration.getErrorHandler()
         );
-        Session session = new Session(internalSession);
+        SyncSession session = new SyncSession(internalSession);
 
         assertEquals("realm://objectserver.realm.io/JohnDoe/default", session.getServerUrl().toString());
         assertEquals(user, session.getUser());

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
@@ -84,7 +84,7 @@ public class SyncConfigurationTests {
         } catch (IllegalArgumentException ignore) {
         }
 
-        User user = createTestUser(0); // Create user that has expired credentials
+        SyncUser user = createTestUser(0); // Create user that has expired credentials
         try {
             new SyncConfiguration.Builder(user, "realm://ros.realm.io/default");
         } catch (IllegalArgumentException ignore) {
@@ -93,7 +93,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void serverUrl_setsFolderAndFileName() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String[][] validUrls = {
                 // <URL>, <Folder>, <FileName>
                 { "realm://objectserver.realm.io/~/default", "realm-object-server/" + user.getIdentity(), "default" },
@@ -183,9 +183,9 @@ public class SyncConfigurationTests {
     @Test
     public void errorHandler() {
         SyncConfiguration.Builder builder = new SyncConfiguration.Builder(createTestUser(), "realm://objectserver.realm.io/default");
-        Session.ErrorHandler errorHandler = new Session.ErrorHandler() {
+        SyncSession.ErrorHandler errorHandler = new SyncSession.ErrorHandler() {
             @Override
-            public void onError(Session session, ObjectServerError error) {
+            public void onError(SyncSession session, ObjectServerError error) {
 
             }
         };
@@ -196,16 +196,16 @@ public class SyncConfigurationTests {
     @Test
     public void errorHandler_fromSyncManager() {
         // Set default error handler
-        Session.ErrorHandler errorHandler = new Session.ErrorHandler() {
+        SyncSession.ErrorHandler errorHandler = new SyncSession.ErrorHandler() {
             @Override
-            public void onError(Session session, ObjectServerError error) {
+            public void onError(SyncSession session, ObjectServerError error) {
 
             }
         };
         SyncManager.setDefaultSessionErrorHandler(errorHandler);
 
         // Create configuration using the default handler
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         SyncConfiguration config = new SyncConfiguration.Builder(user, url).build();
         assertEquals(errorHandler, config.getErrorHandler());
@@ -215,7 +215,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void errorHandler_nullThrows() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         SyncConfiguration.Builder builder = new SyncConfiguration.Builder(user, url);
 
@@ -227,7 +227,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void equals() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         SyncConfiguration config = new SyncConfiguration.Builder(user, url)
                 .build();
@@ -236,7 +236,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void not_equals_same() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         SyncConfiguration config1 = new SyncConfiguration.Builder(user, url).build();
         SyncConfiguration config2 = new SyncConfiguration.Builder(user, url).build();
@@ -246,7 +246,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void equals_not() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url1 = "realm://objectserver.realm.io/default1";
         String url2 = "realm://objectserver.realm.io/default2";
         SyncConfiguration config1 = new SyncConfiguration.Builder(user, url1).build();
@@ -256,7 +256,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void hashCode_equal() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         SyncConfiguration config = new SyncConfiguration.Builder(user, url)
                 .build();
@@ -266,7 +266,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void hashCode_notEquals() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url1 = "realm://objectserver.realm.io/default1";
         String url2 = "realm://objectserver.realm.io/default2";
         SyncConfiguration config1 = new SyncConfiguration.Builder(user, url1).build();
@@ -276,7 +276,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void get_syncSpecificValues() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         SyncConfiguration config = new SyncConfiguration.Builder(user, url).build();
         assertTrue(user.equals(config.getUser()));
@@ -287,7 +287,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void encryption() {
-       User user = createTestUser();
+       SyncUser user = createTestUser();
        String url = "realm://objectserver.realm.io/default";
        SyncConfiguration config = new SyncConfiguration.Builder(user, url)
                .encryptionKey(TestHelper.getRandomKey())
@@ -297,7 +297,7 @@ public class SyncConfigurationTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void encryption_invalid_null() {
-       User user = createTestUser();
+       SyncUser user = createTestUser();
        String url = "realm://objectserver.realm.io/default";
 
        new SyncConfiguration.Builder(user, url).encryptionKey(null);
@@ -305,7 +305,7 @@ public class SyncConfigurationTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void encryption_invalid_wrong_length() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
 
         new SyncConfiguration.Builder(user, url).encryptionKey(new byte[]{1, 2, 3});
@@ -313,14 +313,14 @@ public class SyncConfigurationTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void directory_null() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         new SyncConfiguration.Builder(user, url).directory(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void directory_writeProtectedDir() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
 
         File dir = new File("/");
@@ -329,7 +329,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void directory_dirIsAFile() throws IOException {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
 
         File dir = configFactory.getRoot();
@@ -355,7 +355,7 @@ public class SyncConfigurationTests {
 
     @Test
     public void initialData() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
 
         SyncConfiguration config = new SyncConfiguration.Builder(user, url)

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncManagerTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncManagerTests.java
@@ -53,22 +53,22 @@ public class SyncManagerTests {
         context = InstrumentationRegistry.getContext();
         userStore = new UserStore() {
             @Override
-            public User put(String key, User user) {
+            public SyncUser put(String key, SyncUser user) {
                 return null;
             }
 
             @Override
-            public User get(String key) {
+            public SyncUser get(String key) {
                 return null;
             }
 
             @Override
-            public User remove(String key) {
+            public SyncUser remove(String key) {
                 return null;
             }
 
             @Override
-            public Collection<User> allUsers() {
+            public Collection<SyncUser> allUsers() {
                 return null;
             }
 
@@ -109,17 +109,17 @@ public class SyncManagerTests {
 
     @Test
     public void authListener() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         final int[] counter = {0, 0};
 
         AuthenticationListener authenticationListener = new AuthenticationListener() {
             @Override
-            public void loggedIn(User user) {
+            public void loggedIn(SyncUser user) {
                 counter[0]++;
             }
 
             @Override
-            public void loggedOut(User user) {
+            public void loggedOut(SyncUser user) {
                 counter[1]++;
             }
         };
@@ -138,17 +138,17 @@ public class SyncManagerTests {
 
     @Test
     public void authListener_remove() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         final int[] counter = {0, 0};
 
         AuthenticationListener authenticationListener = new AuthenticationListener() {
             @Override
-            public void loggedIn(User user) {
+            public void loggedIn(SyncUser user) {
                 counter[0]++;
             }
 
             @Override
-            public void loggedOut(User user) {
+            public void loggedOut(SyncUser user) {
                 counter[1]++;
             }
         };
@@ -167,12 +167,12 @@ public class SyncManagerTests {
 
     @Test
     public void session() {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";
         SyncConfiguration config = new SyncConfiguration.Builder(user, url)
                 .build();
 
-        Session session = SyncManager.getSession(config);
+        SyncSession session = SyncManager.getSession(config);
         assertEquals(user, session.getUser()); // see also SessionTests
     }
 }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/UserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/UserTests.java
@@ -49,8 +49,8 @@ public class UserTests {
 
     @Test
     public void toAndFromJson() {
-        User user1 = createTestUser();
-        User user2 = User.fromJson(user1.toJson());
+        SyncUser user1 = createTestUser();
+        SyncUser user2 = SyncUser.fromJson(user1.toJson());
         assertEquals(user1, user2);
     }
 
@@ -63,13 +63,13 @@ public class UserTests {
         userStore.put(UserStore.CURRENT_USER_KEY, SyncTestUtils.createTestUser(Long.MIN_VALUE));
 
         // Invalid users should not be returned when asking the for the current user
-        assertNull(User.currentUser());
+        assertNull(SyncUser.currentUser());
     }
 
     // `all()` returns an empty list if no users are logged in
     @Test
     public void all_empty() {
-        Collection<User> users = User.all();
+        Collection<SyncUser> users = SyncUser.all();
         assertTrue(users.isEmpty());
     }
 
@@ -82,7 +82,7 @@ public class UserTests {
         userStore.put(UserStore.CURRENT_USER_KEY, SyncTestUtils.createTestUser(Long.MIN_VALUE));
         userStore.put(UserStore.CURRENT_USER_KEY, SyncTestUtils.createTestUser(Long.MAX_VALUE));
 
-        Collection<User> users = User.all();
+        Collection<SyncUser> users = SyncUser.all();
         assertEquals(1, users.size());
         assertTrue(users.iterator().next().isValid());
     }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/android/UserStoreTest.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/android/UserStoreTest.java
@@ -30,9 +30,8 @@ import java.security.KeyStoreException;
 
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.UserStore;
-import io.realm.android.SecureUserStore;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static io.realm.util.SyncTestUtils.createTestUser;
@@ -62,11 +61,11 @@ public class UserStoreTest {
     @Ignore("See https://github.com/realm/realm-java/issues/3555")
     @Test
     public void encrypt_decrypt_UsingAndroidKeyStoreUserStore() throws KeyStoreException {
-        User user = createTestUser();
+        SyncUser user = createTestUser();
         UserStore userStore = new SecureUserStore(InstrumentationRegistry.getTargetContext());
-        User savedUser = userStore.put("crypted_entry", user);
+        SyncUser savedUser = userStore.put("crypted_entry", user);
         assertNull(savedUser);
-        User decrypted_entry = userStore.get("crypted_entry");
+        SyncUser decrypted_entry = userStore.get("crypted_entry");
         assertEquals(user, decrypted_entry);
      }
 }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
@@ -26,6 +26,7 @@ import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
 import io.realm.SyncUser;
 import io.realm.internal.network.AuthenticateResponse;
+import io.realm.internal.objectserver.ObjectServerUser;
 import io.realm.internal.objectserver.Token;
 
 public class SyncTestUtils {
@@ -40,7 +41,7 @@ public class SyncTestUtils {
     public static SyncUser createTestUser(long expires) {
         Token userToken = new Token(USER_TOKEN, "JohnDoe", null, expires, null);
         Token accessToken = new Token(REALM_TOKEN, "JohnDoe", "/foo", expires, new Token.Permission[] {Token.Permission.DOWNLOAD });
-        io.realm.internal.objectserver.SyncUser.AccessDescription desc = new io.realm.internal.objectserver.SyncUser.AccessDescription(accessToken, "/data/data/myapp/files/default", false);
+        ObjectServerUser.AccessDescription desc = new ObjectServerUser.AccessDescription(accessToken, "/data/data/myapp/files/default", false);
 
         JSONObject obj = new JSONObject();
         try {

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
@@ -24,9 +24,8 @@ import java.util.UUID;
 
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.internal.network.AuthenticateResponse;
-import io.realm.internal.objectserver.SyncUser;
 import io.realm.internal.objectserver.Token;
 
 public class SyncTestUtils {
@@ -34,14 +33,14 @@ public class SyncTestUtils {
     public static String USER_TOKEN = UUID.randomUUID().toString();
     public static String REALM_TOKEN = UUID.randomUUID().toString();
 
-    public static User createTestUser() {
+    public static SyncUser createTestUser() {
         return createTestUser(Long.MAX_VALUE);
     }
 
-    public static User createTestUser(long expires) {
+    public static SyncUser createTestUser(long expires) {
         Token userToken = new Token(USER_TOKEN, "JohnDoe", null, expires, null);
         Token accessToken = new Token(REALM_TOKEN, "JohnDoe", "/foo", expires, new Token.Permission[] {Token.Permission.DOWNLOAD });
-        SyncUser.AccessDescription desc = new SyncUser.AccessDescription(accessToken, "/data/data/myapp/files/default", false);
+        io.realm.internal.objectserver.SyncUser.AccessDescription desc = new io.realm.internal.objectserver.SyncUser.AccessDescription(accessToken, "/data/data/myapp/files/default", false);
 
         JSONObject obj = new JSONObject();
         try {
@@ -54,7 +53,7 @@ public class SyncTestUtils {
             obj.put("authUrl", "http://objectserver.realm.io/auth");
             obj.put("userToken", userToken.toJson());
             obj.put("realms", realmList);
-            return User.fromJson(obj.toString());
+            return SyncUser.fromJson(obj.toString());
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -41,7 +41,7 @@ set(classes_LIST
 set(jni_headers_PATH ${PROJECT_BINARY_DIR}/jni_include)
 if (build_SYNC)
     list(APPEND classes_LIST
-        io.realm.SyncManager io.realm.internal.objectserver.SyncSession)
+        io.realm.SyncManager io.realm.internal.objectserver.ObjectServerSession)
 endif()
 create_javah(TARGET jni_headers
     CLASSES ${classes_LIST}

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -141,7 +141,7 @@ file(GLOB jni_SRC
 if (NOT build_SYNC)
     list(REMOVE_ITEM jni_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_SyncManager.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_internal_objectserver_SyncSession.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_internal_objectserver_ObjectServerSession.cpp)
 endif()
 
 # Object Store source files

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_ObjectServerSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_ObjectServerSession.cpp
@@ -16,7 +16,7 @@
 
 #include <jni.h>
 
-#include "io_realm_internal_objectserver_SyncSession.h"
+#include "io_realm_internal_objectserver_ObjectServerSession.h"
 #include "objectserver_shared.hpp"
 #include "util.hpp"
 #include <realm/group_shared.hpp>

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_SyncSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_SyncSession.cpp
@@ -37,7 +37,7 @@ using namespace realm;
 using namespace sync;
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeCreateSession
+JNIEXPORT jlong JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeCreateSession
   (JNIEnv *env, jobject obj, jstring localRealmPath)
 {
     TR_ENTER(env)
@@ -49,7 +49,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeCr
     return 0;
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeBind
+JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeBind
   (JNIEnv *env, jobject, jlong sessionPointer, jstring remoteUrl, jstring accessToken)
 {
     TR_ENTER(env)
@@ -69,7 +69,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeBin
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeUnbind
+JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeUnbind
   (JNIEnv *env, jobject, jlong sessionPointer)
 {
     TR_ENTER(env)
@@ -78,7 +78,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeUnb
     delete session; // TODO Can we avoid killing the session here?
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeRefresh
+JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeRefresh
   (JNIEnv *env, jobject, jlong sessionPointer, jstring accessToken)
 {
     TR_ENTER(env)
@@ -93,7 +93,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_SyncSession_nativeRef
 }
 
 JNIEXPORT void JNICALL
-Java_io_realm_internal_objectserver_SyncSession_nativeNotifyCommitHappened
+Java_io_realm_internal_objectserver_ObjectServerSession_nativeNotifyCommitHappened
   (JNIEnv *env, jobject, jlong sessionPointer, jlong version)
 {
     TR_ENTER(env)

--- a/realm/realm-library/src/objectServer/java/io/realm/AuthenticationListener.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/AuthenticationListener.java
@@ -27,14 +27,14 @@ public interface AuthenticationListener {
     /**
      * A user was logged into the Object Server
      *
-     * @param user {@link User} that is now logged in.
+     * @param user {@link SyncUser} that is now logged in.
      */
-    void loggedIn(User user);
+    void loggedIn(SyncUser user);
 
     /**
      * A user was successfully logged out from the Object Server.
      *
-     * @param user {@link User} that was successfully logged out.
+     * @param user {@link SyncUser} that was successfully logged out.
      */
-    void loggedOut(User user);
+    void loggedOut(SyncUser user);
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/ObjectServerError.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ObjectServerError.java
@@ -112,7 +112,7 @@ public class ObjectServerError extends RuntimeException {
     /**
      * Returns the {@link ErrorCode.Category} category for this error.
      * Errors that are {@link ErrorCode.Category#RECOVERABLE} mean that it is still possible for a
-     * given {@link Session} to resume synchronization. {@link ErrorCode.Category#FATAL} errors
+     * given {@link SyncSession} to resume synchronization. {@link ErrorCode.Category#FATAL} errors
      * means that session has stopped and cannot be recovered.
      *
      * @return the error category.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -44,8 +44,8 @@ import io.realm.rx.RxObservableFactory;
  * An {@link SyncConfiguration} is used to setup a Realm that can be synchronized between devices using the Realm
  * Object Server.
  * <p>
- * A valid {@link User} is required to create a {@link SyncConfiguration}. See {@link Credentials} and
- * {@link User#loginAsync(Credentials, String, User.Callback)} for more information on
+ * A valid {@link SyncUser} is required to create a {@link SyncConfiguration}. See {@link SyncCredentials} and
+ * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)} for more information on
  * how to get a user object.
  * <p>
  * A minimal {@link SyncConfiguration} can be found below.
@@ -83,9 +83,9 @@ public final class SyncConfiguration extends RealmConfiguration {
     private static final char[] INVALID_CHARS = {'<', '>', ':', '"', '/', '\\', '|', '?', '*'};
 
     private final URI serverUrl;
-    private final User user;
+    private final SyncUser user;
     private final SyncPolicy syncPolicy;
-    private final Session.ErrorHandler errorHandler;
+    private final SyncSession.ErrorHandler errorHandler;
     private final boolean deleteRealmOnLogout;
 
     private SyncConfiguration(File directory,
@@ -100,10 +100,10 @@ public final class SyncConfiguration extends RealmConfiguration {
                                 RealmProxyMediator schemaMediator,
                                 RxObservableFactory rxFactory,
                                 Realm.Transaction initialDataTransaction,
-                                User user,
+                                SyncUser user,
                                 URI serverUrl,
                                 SyncPolicy syncPolicy,
-                                Session.ErrorHandler errorHandler,
+                                SyncSession.ErrorHandler errorHandler,
                                 boolean deleteRealmOnLogout
     ) {
         super(directory,
@@ -192,7 +192,7 @@ public final class SyncConfiguration extends RealmConfiguration {
      *
      * @return the user.
      */
-    public User getUser() {
+    public SyncUser getUser() {
         return user;
     }
 
@@ -206,14 +206,14 @@ public final class SyncConfiguration extends RealmConfiguration {
         return serverUrl;
     }
 
-    public Session.ErrorHandler getErrorHandler() {
+    public SyncSession.ErrorHandler getErrorHandler() {
         return errorHandler;
     }
 
     /**
-     * Returns {@code true} if the Realm file must be deleted once the {@link User} owning it logs out.
+     * Returns {@code true} if the Realm file must be deleted once the {@link SyncUser} owning it logs out.
      *
-     * @return {@code true} if the Realm file must be deleted if the {@link User} logs out. {@code false} if the file
+     * @return {@code true} if the Realm file must be deleted if the {@link SyncUser} logs out. {@code false} if the file
      *         is allowed to remain behind.
      */
     public boolean shouldDeleteRealmOnLogout() {
@@ -240,9 +240,9 @@ public final class SyncConfiguration extends RealmConfiguration {
         private RxObservableFactory rxFactory;
         private Realm.Transaction initialDataTransaction;
         private URI serverUrl;
-        private User user = null;
+        private SyncUser user = null;
         private SyncPolicy syncPolicy = new AutomaticSyncPolicy();
-        private Session.ErrorHandler errorHandler = SyncManager.defaultSessionErrorHandler;
+        private SyncSession.ErrorHandler errorHandler = SyncManager.defaultSessionErrorHandler;
         private File defaultFolder;
         private String defaultLocalFileName;
         private SharedRealm.Durability durability = SharedRealm.Durability.FULL;
@@ -270,17 +270,17 @@ public final class SyncConfiguration extends RealmConfiguration {
          * If file name and underlying path are too long to handle for FAT32, a shorter unique name will be generated.
          * See also @{link https://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx}.
          *
-         * @param user the user for this Realm. An authenticated {@link User} is required to open any Realm managed
+         * @param user the user for this Realm. An authenticated {@link SyncUser} is required to open any Realm managed
          *             by a Realm Object Server.
          * @param uri URI identifying the Realm.
          *
-         * @see User#isValid()
+         * @see SyncUser#isValid()
          */
-        public Builder(User user, String uri) {
+        public Builder(SyncUser user, String uri) {
             this(BaseRealm.applicationContext, user, uri);
         }
 
-        Builder(Context context, User user, String url) {
+        Builder(Context context, SyncUser user, String url) {
             if (context == null) {
                 throw new IllegalStateException("Call `Realm.init(Context)` before creating a SyncConfiguration");
             }
@@ -293,7 +293,7 @@ public final class SyncConfiguration extends RealmConfiguration {
             validateAndSet(url);
         }
 
-        private void validateAndSet(User user) {
+        private void validateAndSet(SyncUser user) {
             if (user == null) {
                 throw new IllegalArgumentException("Non-null `user` required.");
             }
@@ -488,7 +488,7 @@ public final class SyncConfiguration extends RealmConfiguration {
          *
          * @param syncPolicy policy to use.
          *
-         * @see Session
+         * @see SyncSession
          */
         Builder syncPolicy(SyncPolicy syncPolicy) {
             // Package protected until SyncPolicy API is more stable.
@@ -498,14 +498,14 @@ public final class SyncConfiguration extends RealmConfiguration {
 
         /**
          * Sets the error handler used by this configuration. This will override any handler set by calling
-         * {@link SyncManager#setDefaultSessionErrorHandler(Session.ErrorHandler)}.
+         * {@link SyncManager#setDefaultSessionErrorHandler(SyncSession.ErrorHandler)}.
          * <p>
          * Only errors not handled by the defined {@code SyncPolicy} will be reported to this error handler.
          *
          * @param errorHandler error handler used to report back errors when communicating with the Realm Object Server.
          * @throws IllegalArgumentException if {@code null} is given as an error handler.
          */
-        public Builder errorHandler(Session.ErrorHandler errorHandler) {
+        public Builder errorHandler(SyncSession.ErrorHandler errorHandler) {
             if (errorHandler == null) {
                 throw new IllegalArgumentException("Non-null 'errorHandler' required.");
             }
@@ -530,8 +530,8 @@ public final class SyncConfiguration extends RealmConfiguration {
         }
 
         /**
-         * Setting this will cause the local Realm file used to synchronize changes to be deleted if the {@link User}
-         * owning this Realm logs out from the device using {@link User#logout()}.
+         * Setting this will cause the local Realm file used to synchronize changes to be deleted if the {@link SyncUser}
+         * owning this Realm logs out from the device using {@link SyncUser#logout()}.
          * <p>
          * The default behavior is that the Realm file is allowed to stay behind, making it possible for users to log
          * in again and have access to their data faster.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -31,11 +31,11 @@ import io.realm.annotations.Beta;
  * <ol>
  * <li>
  *     Log in to 3rd party provider (Facebook, Google or Twitter). The result is usually an Authorization Grant that must be
- *     saved in a {@link Credentials} object of the proper type e.g., {@link Credentials#facebook(String)} for a
+ *     saved in a {@link SyncCredentials} object of the proper type e.g., {@link SyncCredentials#facebook(String)} for a
  *     Facebook login.
  * </li>
  * <li>
- *     Authenticate a {@link User} through the Object Server using these credentials. Once authenticated,
+ *     Authenticate a {@link SyncUser} through the Object Server using these credentials. Once authenticated,
  *     an Object Server user is returned. Then this user can be attached to a {@link SyncConfiguration}, which
  *     will make it possible to synchronize data between the local and remote Realm.
  *     <p>
@@ -64,7 +64,7 @@ import io.realm.annotations.Beta;
  * </pre>
  */
 @Beta
-public class Credentials {
+public class SyncCredentials {
 
     private String identityProvider;
     private String userIdentifier;
@@ -82,17 +82,17 @@ public class Credentials {
      *                   create a user twice when logging in, so this flag should only be set to {@code true} the first
      *                   time a users log in.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link User#loginAsync(Credentials, String, User.Callback)}.
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
-    public static Credentials usernamePassword(String username, String password, boolean createUser) {
+    public static SyncCredentials usernamePassword(String username, String password, boolean createUser) {
         if (username == null || username.equals("")) {
             throw new IllegalArgumentException("Non-null 'username' required.");
         }
         Map<String, Object> userInfo = new HashMap<String, Object>();
         userInfo.put("register", createUser);
         userInfo.put("password", password);
-        return new Credentials(IdentityProvider.USERNAME_PASSWORD, username, userInfo);
+        return new SyncCredentials(IdentityProvider.USERNAME_PASSWORD, username, userInfo);
     }
 
     /**
@@ -100,14 +100,14 @@ public class Credentials {
      *
      * @param facebookToken a facebook userIdentifier acquired by logging into Facebook.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link User#loginAsync(Credentials, String, User.Callback)}
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
-    public static Credentials facebook(String facebookToken) {
+    public static SyncCredentials facebook(String facebookToken) {
         if (facebookToken == null || facebookToken.equals("")) {
             throw new IllegalArgumentException("Non-null 'facebookToken' required.");
         }
-        return new Credentials(IdentityProvider.FACEBOOK, facebookToken, null);
+        return new SyncCredentials(IdentityProvider.FACEBOOK, facebookToken, null);
     }
 
     /**
@@ -115,14 +115,14 @@ public class Credentials {
      *
      * @param googleToken a google userIdentifier acquired by logging into Google.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link User#loginAsync(Credentials, String, User.Callback)}
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
-    public static Credentials google(String googleToken) {
+    public static SyncCredentials google(String googleToken) {
         if (googleToken == null || googleToken.equals("")) {
             throw new IllegalArgumentException("Non-null 'googleToken' required.");
         }
-        return new Credentials(IdentityProvider.GOOGLE, googleToken, null);
+        return new SyncCredentials(IdentityProvider.GOOGLE, googleToken, null);
     }
 
     /**
@@ -130,14 +130,14 @@ public class Credentials {
      *
      * @param twitterToken a google userIdentifier acquired by logging into Twitter.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link User#loginAsync(Credentials, String, User.Callback)}
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
-    public static Credentials twitter(String twitterToken) {
+    public static SyncCredentials twitter(String twitterToken) {
         if (twitterToken == null || twitterToken.equals("")) {
             throw new IllegalArgumentException("Non-null 'twitterToken' required.");
         }
-        return new Credentials(IdentityProvider.TWITTER, twitterToken, null);
+        return new SyncCredentials(IdentityProvider.TWITTER, twitterToken, null);
     }
 
     /**
@@ -150,10 +150,10 @@ public class Credentials {
      *              data will be serialized to JSON, so all values must be mappable to a valid JSON data type. Custom
      *              classes will be converted using {@code toString()}.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link User#loginAsync(Credentials, String, User.Callback)}.
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if any parameter is either {@code null} or empty.
      */
-    public static Credentials custom(String identityProvider, String userIdentifier, Map<String, Object> userInfo) {
+    public static SyncCredentials custom(String identityProvider, String userIdentifier, Map<String, Object> userInfo) {
         if (identityProvider == null || identityProvider.equals("")) {
             throw new IllegalArgumentException("Non-null 'identityProvider' required.");
         }
@@ -163,10 +163,10 @@ public class Credentials {
         if (userInfo == null) {
             userInfo = new HashMap<String, Object>();
         }
-        return new Credentials(identityProvider, userIdentifier, userInfo);
+        return new SyncCredentials(identityProvider, userIdentifier, userInfo);
     }
 
-    private Credentials(String identityProvider, String token, Map<String, Object> userInfo) {
+    private SyncCredentials(String identityProvider, String token, Map<String, Object> userInfo) {
         this.identityProvider = identityProvider;
         this.userIdentifier = token;
         this.userInfo = (userInfo == null) ? new HashMap<String, Object>() : userInfo;
@@ -192,7 +192,7 @@ public class Credentials {
 
     /**
      * Returns any custom user information associated with this credential.
-     * The type of information will depend on the type of {@link Credentials.IdentityProvider}
+     * The type of information will depend on the type of {@link SyncCredentials.IdentityProvider}
      * used.
      *
      * @return a map of additional information about the user.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -26,13 +26,13 @@ import io.realm.internal.Keep;
 import io.realm.internal.network.AuthenticationServer;
 import io.realm.internal.network.OkHttpAuthenticationServer;
 import io.realm.internal.objectserver.SessionStore;
-import io.realm.internal.objectserver.SyncSession;
+import io.realm.internal.objectserver.ObjectServerSession;
 import io.realm.log.RealmLog;
 
 /**
  * @Beta
  * The SyncManager is the central controller for interacting with the Realm Object Server.
- * It handles the creation of {@link Session}s and it is possible to configure session defaults and the underlying
+ * It handles the creation of {@link SyncSession}s and it is possible to configure session defaults and the underlying
  * network client using this class.
  * <p>
  * Through the SyncManager, it is possible to add authentication listeners. An authentication listener will
@@ -55,9 +55,9 @@ public final class SyncManager {
     public static final ThreadPoolExecutor NETWORK_POOL_EXECUTOR = new ThreadPoolExecutor(
             10, 10, 0, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<Runnable>(100));
 
-    private static final Session.ErrorHandler SESSION_NO_OP_ERROR_HANDLER = new Session.ErrorHandler() {
+    private static final SyncSession.ErrorHandler SESSION_NO_OP_ERROR_HANDLER = new SyncSession.ErrorHandler() {
         @Override
-        public void onError(Session session, ObjectServerError error) {
+        public void onError(SyncSession session, ObjectServerError error) {
             String errorMsg = String.format("Session Error[%s]: %s",
                     session.getConfiguration().getServerUrl(),
                     error.toString());
@@ -81,7 +81,7 @@ public final class SyncManager {
     private static volatile AuthenticationServer authServer = new OkHttpAuthenticationServer();
     private static volatile UserStore userStore;
 
-    static volatile Session.ErrorHandler defaultSessionErrorHandler = SESSION_NO_OP_ERROR_HANDLER;
+    static volatile SyncSession.ErrorHandler defaultSessionErrorHandler = SESSION_NO_OP_ERROR_HANDLER;
     @SuppressWarnings("FieldCanBeLocal")
     private static Thread clientThread;
 
@@ -107,7 +107,7 @@ public final class SyncManager {
 
     /**
      * Set the {@link UserStore} used by the Realm Object Server to save user information.
-     * If no Userstore is specified {@link User#currentUser()} will always return {@code null}.
+     * If no Userstore is specified {@link SyncUser#currentUser()} will always return {@code null}.
      *
      * @param userStore {@link UserStore} to use.
      * @throws IllegalArgumentException if {@code userStore} is {@code null}.
@@ -150,7 +150,7 @@ public final class SyncManager {
      *
      * @param errorHandler the default error handler used when interacting with a Realm managed by a Realm Object Server.
      */
-    public static void setDefaultSessionErrorHandler(Session.ErrorHandler errorHandler) {
+    public static void setDefaultSessionErrorHandler(SyncSession.ErrorHandler errorHandler) {
         if (errorHandler == null) {
             defaultSessionErrorHandler = SESSION_NO_OP_ERROR_HANDLER;
         } else {
@@ -159,14 +159,14 @@ public final class SyncManager {
     }
 
     /**
-     * Gets any cached {@link Session} for the given {@link SyncConfiguration} or create a new one if
+     * Gets any cached {@link SyncSession} for the given {@link SyncConfiguration} or create a new one if
      * no one exists.
      *
      * @param syncConfiguration configuration object for the synchronized Realm.
-     * @return the {@link Session} for the specified Realm.
+     * @return the {@link SyncSession} for the specified Realm.
      * @throws IllegalArgumentException if syncConfiguration is {@code null}.
      */
-    public static synchronized Session getSession(SyncConfiguration syncConfiguration) {
+    public static synchronized SyncSession getSession(SyncConfiguration syncConfiguration) {
         if (syncConfiguration == null) {
             throw new IllegalArgumentException("A non-empty 'syncConfiguration' is required.");
         }
@@ -174,14 +174,14 @@ public final class SyncManager {
         if (SessionStore.hasSession(syncConfiguration)) {
             return SessionStore.getPublicSession(syncConfiguration);
         } else {
-            SyncSession internalSession = new SyncSession(
+            ObjectServerSession internalSession = new ObjectServerSession(
                     syncConfiguration,
                     authServer,
                     syncConfiguration.getUser().getSyncUser(),
                     syncConfiguration.getSyncPolicy(),
                     syncConfiguration.getErrorHandler()
             );
-            Session publicSession = new Session(internalSession);
+            SyncSession publicSession = new SyncSession(internalSession);
             SessionStore.addSession(publicSession, internalSession);
             syncConfiguration.getUser().getSyncUser().addSession(publicSession);
             syncConfiguration.getSyncPolicy().onSessionCreated(internalSession);
@@ -211,20 +211,20 @@ public final class SyncManager {
     @SuppressWarnings("unused")
     private static void notifyErrorHandler(int errorCode, String errorMessage) {
         ObjectServerError error = new ObjectServerError(ErrorCode.fromInt(errorCode), errorMessage);
-        for (SyncSession session : SessionStore.getAllSessions()) {
+        for (ObjectServerSession session : SessionStore.getAllSessions()) {
             session.onError(error);
         }
     }
 
     // Notify listeners that a user logged in
-    static void notifyUserLoggedIn(User user) {
+    static void notifyUserLoggedIn(SyncUser user) {
         for (AuthenticationListener authListener : authListeners) {
             authListener.loggedIn(user);
         }
     }
 
     // Notify listeners that a user logged out successfully
-    static void notifyUserLoggedOut(User user) {
+    static void notifyUserLoggedOut(SyncUser user) {
         for (AuthenticationListener authListener : authListeners) {
             authListener.loggedOut(user);
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import io.realm.annotations.Beta;
 import io.realm.internal.Keep;
 import io.realm.log.RealmLog;
-import io.realm.internal.objectserver.SyncSession;
+import io.realm.internal.objectserver.ObjectServerSession;
 
 /**
  * @Beta
@@ -32,7 +32,7 @@ import io.realm.internal.objectserver.SyncSession;
  * is closed or the {@link SyncConfiguration} is no longer used.
  * <p>
  * A session is fully controlled by Realm, but can provide additional information in case of errors.
- * It is passed along in all {@link Session.ErrorHandler}s.
+ * It is passed along in all {@link SyncSession.ErrorHandler}s.
  * <p>
  * This object is thread safe.
  *
@@ -40,13 +40,13 @@ import io.realm.internal.objectserver.SyncSession;
  */
 @Keep
 @Beta
-public final class Session {
+public final class SyncSession {
 
-    private final SyncSession syncSession;
+    private final ObjectServerSession osSession;
 
-    Session(SyncSession rosSession) {
-        this.syncSession = rosSession;
-        rosSession.setUserSession(this);
+    SyncSession(ObjectServerSession osSession) {
+        this.osSession = osSession;
+        osSession.setUserSession(this);
     }
 
     /**
@@ -55,17 +55,17 @@ public final class Session {
      * @return SyncConfiguration that defines and controls this session.
      */
     public SyncConfiguration getConfiguration() {
-        return syncSession.getConfiguration();
+        return osSession.getConfiguration();
     }
 
     /**
-     * Returns the {@link User} defined by the {@link SyncConfiguration} that is used to connect to the
+     * Returns the {@link SyncUser} defined by the {@link SyncConfiguration} that is used to connect to the
      * Realm Object Server.
      *
-     * @return {@link User} used to authenticate the session on the Realm Object Server.
+     * @return {@link SyncUser} used to authenticate the session on the Realm Object Server.
      */
-    public User getUser() {
-        return syncSession.getConfiguration().getUser();
+    public SyncUser getUser() {
+        return osSession.getConfiguration().getUser();
     }
 
     /**
@@ -74,7 +74,7 @@ public final class Session {
      * @return {@link URI} describing the remote Realm.
      */
     public URI getServerUrl() {
-        return syncSession.getConfiguration().getServerUrl();
+        return osSession.getConfiguration().getServerUrl();
     }
 
     /**
@@ -83,19 +83,19 @@ public final class Session {
      * @return the current {@link SessionState} for this session.
      */
     public SessionState getState() {
-        return syncSession.getState();
+        return osSession.getState();
     }
 
-    SyncSession getSyncSession() {
-        return syncSession;
+    ObjectServerSession getOsSession() {
+        return osSession;
     }
 
     @Override
     protected void finalize() throws Throwable {
         super.finalize();
-        if (syncSession.getState() != SessionState.STOPPED) {
+        if (osSession.getState() != SessionState.STOPPED) {
             RealmLog.warn("Session was not closed before being finalized. This is a potential resource leak.");
-            syncSession.stop();
+            osSession.stop();
         }
     }
 
@@ -109,10 +109,10 @@ public final class Session {
         /**
          * Callback for errors on a session object.
          *
-         * @param session {@link Session} this error happened on.
+         * @param session {@link SyncSession} this error happened on.
          * @param error type of error.
          */
-        void onError(Session session, ObjectServerError error);
+        void onError(SyncSession session, ObjectServerError error);
     }
 }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/UserStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/UserStore.java
@@ -37,36 +37,36 @@ public interface UserStore {
     String CURRENT_USER_KEY = "realm$currentUser";
 
     /**
-     * Saves a {@link User} object under the given key. If another user already exists, it will be replaced.
+     * Saves a {@link SyncUser} object under the given key. If another user already exists, it will be replaced.
      *
      * @param key key used to store the User.
-     * @param user {@link User} object to store.
+     * @param user {@link SyncUser} object to store.
      * @return The previous user saved with this key or {@code null} if no user was replaced.
      *
      */
-    User put(String key, User user);
+    SyncUser put(String key, SyncUser user);
 
     /**
-     * Retrieves the {@link User} with the given key.
+     * Retrieves the {@link SyncUser} with the given key.
      *
-     * @param key {@link User} saved under the given key or {@code null} if no user exists for that key.
+     * @param key {@link SyncUser} saved under the given key or {@code null} if no user exists for that key.
      */
-    User get(String key);
+    SyncUser get(String key);
 
     /**
      * Removes the user with the given key from the store.
      *
      * @param key key for the user to remove.
-     * @return {@link User} that was removed or {@code null} if no user matched the key.
+     * @return {@link SyncUser} that was removed or {@code null} if no user matched the key.
      */
-    User remove(String key);
+    SyncUser remove(String key);
 
     /**
      * Returns a collection of all users saved in the User store.
      *
      * @return Collection of all users. If no users exist, an empty collection is returned.
      */
-    Collection<User> allUsers();
+    Collection<SyncUser> allUsers();
 
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/android/SharedPrefsUserStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/android/SharedPrefsUserStore.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.UserStore;
 
 /**
@@ -33,7 +33,7 @@ import io.realm.UserStore;
 public class SharedPrefsUserStore implements UserStore {
 
     private final SharedPreferences sp;
-    private User cachedCurrentUser; // Keep a quick reference to the current user
+    private SyncUser cachedCurrentUser; // Keep a quick reference to the current user
 
     public SharedPrefsUserStore(Context context) {
         sp = context.getSharedPreferences("realm_object_server_users", Context.MODE_PRIVATE);
@@ -43,7 +43,7 @@ public class SharedPrefsUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
-    public User put(String key, User user) {
+    public SyncUser put(String key, SyncUser user) {
         String previousUser = sp.getString(key, null);
         SharedPreferences.Editor editor = sp.edit();
         editor.putString(key, user.toJson());
@@ -55,7 +55,7 @@ public class SharedPrefsUserStore implements UserStore {
         }
 
         if (previousUser != null) {
-            return User.fromJson(previousUser);
+            return SyncUser.fromJson(previousUser);
         } else {
             return null;
         }
@@ -65,7 +65,7 @@ public class SharedPrefsUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
-    public User get(String key) {
+    public SyncUser get(String key) {
         if (UserStore.CURRENT_USER_KEY.equals(key) && cachedCurrentUser != null) {
             return cachedCurrentUser;
         }
@@ -75,7 +75,7 @@ public class SharedPrefsUserStore implements UserStore {
             return null;
         }
 
-        User user = User.fromJson(userData);
+        SyncUser user = SyncUser.fromJson(userData);
         if (UserStore.CURRENT_USER_KEY.equals(key)) {
             cachedCurrentUser = user;
         }
@@ -86,7 +86,7 @@ public class SharedPrefsUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
-    public User remove(String key) {
+    public SyncUser remove(String key) {
         String currentUser = sp.getString(key, null);
         SharedPreferences.Editor editor = sp.edit();
         editor.putString(key, null);
@@ -97,7 +97,7 @@ public class SharedPrefsUserStore implements UserStore {
         }
 
         if (currentUser != null) {
-            return User.fromJson(currentUser);
+            return SyncUser.fromJson(currentUser);
         } else {
             return null;
         }
@@ -107,11 +107,11 @@ public class SharedPrefsUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
-    public Collection<User> allUsers() {
+    public Collection<SyncUser> allUsers() {
         Map<String, ?> all = sp.getAll();
-        ArrayList<User> users = new ArrayList<User>(all.size());
+        ArrayList<SyncUser> users = new ArrayList<SyncUser>(all.size());
         for (Object userJson : all.values()) {
-            users.add(User.fromJson((String) userJson));
+            users.add(SyncUser.fromJson((String) userJson));
         }
         return users;
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/android/crypto/CipherClient.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/android/crypto/CipherClient.java
@@ -20,6 +20,8 @@ import android.content.Context;
 
 import java.security.KeyStoreException;
 
+import io.realm.SyncUser;
+
 /**
  * A Helper to use the crypto API, it allows encryption/decryption and has methods to help test if the KeyStore is locked and help unlocked it.
  * This hides the complexity of different Android API to achieve those operations.
@@ -41,7 +43,7 @@ public class CipherClient {
      * Takes some plain text {@link String} and return the encrypted version
      * of this {@link String} using the Android Key Store.
      *
-     * @param user represents the Token of a {@link io.realm.User}.
+     * @param user represents the Token of a {@link SyncUser}.
      * @return the encrypted Token.
      * @throws KeyStoreException in case the Key Store is locked or other error.
      */
@@ -63,7 +65,7 @@ public class CipherClient {
      * Takes a previously {@link #encrypt(String)} to decrypted it
      * using the Android Key Store.
      *
-     * @param user_encrypted represents the encrypted Token of a {@link io.realm.User}.
+     * @param user_encrypted represents the encrypted Token of a {@link SyncUser}.
      * @return the decrypted Token.
      * @throws KeyStoreException in case the KeyStore is locked or other error.
      */

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateRequest.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateRequest.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.realm.internal.objectserver.Token;
-import io.realm.Credentials;
+import io.realm.SyncCredentials;
 import io.realm.SyncManager;
 
 /**
@@ -42,7 +42,7 @@ public class AuthenticateRequest {
     /**
      * Generates a proper login request for a new user.
      */
-    public static AuthenticateRequest userLogin(Credentials credentials) {
+    public static AuthenticateRequest userLogin(SyncCredentials credentials) {
         if (credentials == null) {
            throw new IllegalArgumentException("Non-null credentials required.");
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticationServer.java
@@ -19,8 +19,8 @@ package io.realm.internal.network;
 import java.net.URI;
 import java.net.URL;
 
-import io.realm.Credentials;
-import io.realm.User;
+import io.realm.SyncCredentials;
+import io.realm.SyncUser;
 import io.realm.internal.objectserver.Token;
 
 /**
@@ -34,12 +34,12 @@ public interface AuthenticationServer {
      * Login a User on the Object Server. This will create a "UserToken" (Currently called RefreshToken) that acts as
      * the users credentials.
      */
-    AuthenticateResponse loginUser(Credentials credentials, URL authenticationUrl);
+    AuthenticateResponse loginUser(SyncCredentials credentials, URL authenticationUrl);
 
     /**
      * Requests access to a specific Realm. Only users with a valid user token can ask for permission to a remote Realm.
      * Permission to a Realm is granted through an "AccessToken". Each Realm have their own access token, and all
-     * tokens should be managed by {@link User}.
+     * tokens should be managed by {@link SyncUser}.
      */
     AuthenticateResponse loginToRealm(Token userToken, URI serverUrl,  URL authenticationUrl);
 
@@ -55,5 +55,5 @@ public interface AuthenticationServer {
      * own refresh token, but if the refresh token for some reason was shared or stolen all these devices will be
      * logged out as well.
      */
-    LogoutResponse logout(User user, URL authenticationUrl);
+    LogoutResponse logout(SyncUser user, URL authenticationUrl);
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/LogoutRequest.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/LogoutRequest.java
@@ -16,7 +16,7 @@
 
 package io.realm.internal.network;
 
-import io.realm.User;
+import io.realm.SyncUser;
 
 /**
  * This class encapsulates a request to log out a user on the Realm Authentication Server. It is responsible for
@@ -25,7 +25,7 @@ import io.realm.User;
 public class LogoutRequest {
     // TODO Endpoint not finished yet
 
-    LogoutRequest fromUser(User user) {
+    LogoutRequest fromUser(SyncUser user) {
         return new LogoutRequest();
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -20,10 +20,10 @@ import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
-import io.realm.Credentials;
+import io.realm.SyncCredentials;
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.internal.objectserver.Token;
 import okhttp3.Call;
 import okhttp3.MediaType;
@@ -46,7 +46,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
      * Authenticate the given credentials on the specified Realm Authentication Server.
      */
     @Override
-    public AuthenticateResponse loginUser(Credentials credentials, URL authenticationUrl) {
+    public AuthenticateResponse loginUser(SyncCredentials credentials, URL authenticationUrl) {
         try {
             String requestBody = AuthenticateRequest.userLogin(credentials).toJson();
             return authenticate(authenticationUrl, requestBody);
@@ -76,7 +76,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     }
 
     @Override
-    public LogoutResponse logout(User user, URL authenticationUrl) {
+    public LogoutResponse logout(SyncUser user, URL authenticationUrl) {
         throw new UnsupportedOperationException("Not yet implemented");
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/AuthenticatingState.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/AuthenticatingState.java
@@ -17,7 +17,7 @@
 package io.realm.internal.objectserver;
 
 import io.realm.ObjectServerError;
-import io.realm.Session;
+import io.realm.SyncSession;
 import io.realm.SessionState;
 import io.realm.internal.network.NetworkStateReceiver;
 import io.realm.log.RealmLog;
@@ -97,16 +97,16 @@ class AuthenticatingState extends FsmState {
         gotoNextState(SessionState.STOPPED);
     }
 
-    private synchronized void authenticate(final SyncSession session) {
+    private synchronized void authenticate(final ObjectServerSession session) {
         session.authenticateRealm(new Runnable() {
             @Override
             public void run() {
                 RealmLog.debug("Session[%s]: Access token acquired", session.getConfiguration().getPath());
                 gotoNextState(SessionState.BINDING);
             }
-        }, new Session.ErrorHandler() {
+        }, new SyncSession.ErrorHandler() {
             @Override
-            public void onError(Session s, ObjectServerError error) {
+            public void onError(SyncSession s, ObjectServerError error) {
                 RealmLog.debug("Session[%s]: Failed to get access token (%d)", session.getConfiguration().getPath(), error.getErrorCode());
                 session.onError(error);
             }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/FsmAction.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/FsmAction.java
@@ -17,10 +17,10 @@
 package io.realm.internal.objectserver;
 
 import io.realm.ObjectServerError;
-import io.realm.Session;
+import io.realm.SyncSession;
 
 /**
- * As {@link Session} is modeled as a state machine, this interface describe all
+ * As {@link SyncSession} is modeled as a state machine, this interface describe all
  * possible actions in that machine.
  * <p>
  * All states should implement this interface so all possible permutations of state/actions are covered.

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/FsmState.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/FsmState.java
@@ -16,26 +16,26 @@
 
 package io.realm.internal.objectserver;
 
-import io.realm.Session;
+import io.realm.SyncSession;
 import io.realm.ObjectServerError;
 import io.realm.SessionState;
 
 /**
- * Abstract class containing shared logic for all {@link Session} states. All states must extend
+ * Abstract class containing shared logic for all {@link SyncSession} states. All states must extend
  * this class as it contains the logic for entering and leaving states.
  */
 abstract class FsmState implements FsmAction {
 
-    volatile SyncSession session; // This is non-null when this state is active.
+    volatile ObjectServerSession session; // This is non-null when this state is active.
     private boolean exiting; // TODO: Remind me again what race condition necessitated this.
 
     /**
      * Entry into the state. This method is also responsible for executing any asynchronous work
      * this state might run.
      *
-     * This should only be called from {@link Session}.
+     * This should only be called from {@link SyncSession}.
      */
-    public void entry(SyncSession session) {
+    public void entry(ObjectServerSession session) {
         this.session = session;
         this.exiting = false;
         onEnterState();
@@ -43,9 +43,9 @@ abstract class FsmState implements FsmAction {
 
     /**
      * Called just before leaving the state. Once this method is called no more state changes can be triggered from
-     * this state until {@link #entry(SyncSession)} has been called again.
+     * this state until {@link #entry(ObjectServerSession)} has been called again.
      * <p>
-     * This should only be called from {@link Session}.
+     * This should only be called from {@link SyncSession}.
      */
     public void exit() {
         exiting = true;

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerSession.java
@@ -96,7 +96,7 @@ public final class ObjectServerSession {
     private final AuthenticationServer authServer;
     private final SyncSession.ErrorHandler errorHandler;
     private long nativeSessionPointer;
-    private final io.realm.internal.objectserver.SyncUser user;
+    private final ObjectServerUser user;
     RealmAsyncTask networkRequest;
     NetworkStateReceiver.ConnectionListener networkListener;
     private SyncPolicy syncPolicy;
@@ -116,7 +116,7 @@ public final class ObjectServerSession {
      */
     public ObjectServerSession(SyncConfiguration syncConfiguration,
                                AuthenticationServer authServer,
-                               io.realm.internal.objectserver.SyncUser user,
+                               ObjectServerUser user,
                                SyncPolicy policy,
                                SyncSession.ErrorHandler errorHandler) {
         this.configuration = syncConfiguration;
@@ -268,7 +268,7 @@ public final class ObjectServerSession {
 
             @Override
             protected void onSuccess(AuthenticateResponse response) {
-                io.realm.internal.objectserver.SyncUser.AccessDescription desc = new io.realm.internal.objectserver.SyncUser.AccessDescription(
+                ObjectServerUser.AccessDescription desc = new ObjectServerUser.AccessDescription(
                         response.getAccessToken(),
                         configuration.getPath(),
                         configuration.shouldDeleteRealmOnLogout()

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerUser.java
@@ -35,7 +35,7 @@ import io.realm.SyncConfiguration;
  * Internal representation of a user on the Realm Object Server.
  * The public API is defined by {@link io.realm.SyncUser}.
  */
-public class SyncUser {
+public class ObjectServerUser {
 
     private final String identity;
     private Token refreshToken;
@@ -47,7 +47,7 @@ public class SyncUser {
     /**
      * Create a new Realm Object Server User
      */
-    public SyncUser(Token refreshToken, URL authenticationUrl) {
+    public ObjectServerUser(Token refreshToken, URL authenticationUrl) {
         this.identity = refreshToken.identity();
         this.authenticationUrl = authenticationUrl;
         setRefreshToken(refreshToken);
@@ -161,7 +161,7 @@ public class SyncUser {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        SyncUser syncUser = (SyncUser) o;
+        ObjectServerUser syncUser = (ObjectServerUser) o;
 
         if (!identity.equals(syncUser.identity)) return false;
         if (!refreshToken.equals(syncUser.refreshToken)) return false;

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SessionStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SessionStore.java
@@ -21,29 +21,29 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import io.realm.Session;
+import io.realm.SyncSession;
 import io.realm.SyncManager;
 import io.realm.SyncConfiguration;
 
 /**
  * Private class for keeping track of sessions.
- * If {@link Session} and {@link SyncSession} are combined at some point, this class can
+ * If {@link SyncSession} and {@link ObjectServerSession} are combined at some point, this class can
  * be folded into {@link SyncManager};
  */
 public class SessionStore {
 
     // Map of between a local Realm path and any associated sessionInfo
-    private static HashMap<String, Session> sessions = new HashMap<String, Session>();
-    private static HashMap<String, SyncSession> privateSessions = new HashMap<String, SyncSession>();
+    private static HashMap<String, SyncSession> sessions = new HashMap<String, SyncSession>();
+    private static HashMap<String, ObjectServerSession> privateSessions = new HashMap<String, ObjectServerSession>();
 
-    static synchronized void removeSession(Session session) {
+    static synchronized void removeSession(SyncSession session) {
         if (session == null) {
             return;
         }
 
-        Iterator<Map.Entry<String, Session>> it = sessions.entrySet().iterator();
+        Iterator<Map.Entry<String, SyncSession>> it = sessions.entrySet().iterator();
         while (it.hasNext()) {
-            Map.Entry<String, Session> entry = it.next();
+            Map.Entry<String, SyncSession> entry = it.next();
             if (entry.getValue().equals(session)) {
                 it.remove();
                 break;
@@ -51,7 +51,7 @@ public class SessionStore {
         }
     }
 
-    public static synchronized void addSession(Session publicSession, SyncSession internalSession) {
+    public static synchronized void addSession(SyncSession publicSession, ObjectServerSession internalSession) {
         String localPath = publicSession.getConfiguration().getPath();
         sessions.put(localPath, publicSession);
         privateSessions.put(localPath, internalSession);
@@ -62,17 +62,17 @@ public class SessionStore {
         return sessions.containsKey(localPath);
     }
 
-    public static synchronized Session getPublicSession(SyncConfiguration config) {
+    public static synchronized SyncSession getPublicSession(SyncConfiguration config) {
         String localPath = config.getPath();
         return sessions.get(localPath);
     }
 
-    public static synchronized SyncSession getPrivateSession(Session session) {
+    public static synchronized ObjectServerSession getPrivateSession(SyncSession session) {
         String localPath = session.getConfiguration().getPath();
         return privateSessions.get(localPath);
     }
 
-    public static Collection<SyncSession> getAllSessions() {
+    public static Collection<ObjectServerSession> getAllSessions() {
         return privateSessions.values();
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/StoppedState.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/StoppedState.java
@@ -17,10 +17,10 @@
 package io.realm.internal.objectserver;
 
 import io.realm.ObjectServerError;
-import io.realm.Session;
+import io.realm.SyncSession;
 
 /**
- * STOPPED State. This is the final state for a {@link Session}. After this, all actions will throw an
+ * STOPPED State. This is the final state for a {@link SyncSession}. After this, all actions will throw an
  * {@link IllegalStateException}.
  */
 class StoppedState extends FsmState {

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncObjectServerFacade.java
@@ -25,7 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import io.realm.RealmConfiguration;
-import io.realm.Session;
+import io.realm.SyncSession;
 import io.realm.SyncConfiguration;
 import io.realm.SyncManager;
 import io.realm.exceptions.RealmException;
@@ -73,8 +73,8 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     @Override
     public void notifyCommit(RealmConfiguration configuration, long lastSnapshotVersion) {
         if (configuration instanceof SyncConfiguration) {
-            Session publicSession = SyncManager.getSession((SyncConfiguration) configuration);
-            SyncSession session = SessionStore.getPrivateSession(publicSession);
+            SyncSession publicSession = SyncManager.getSession((SyncConfiguration) configuration);
+            ObjectServerSession session = SessionStore.getPrivateSession(publicSession);
             session.notifyCommit(lastSnapshotVersion);
         } else {
             throw new IllegalArgumentException(WRONG_TYPE_OF_CONFIGURATION);
@@ -84,8 +84,8 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     @Override
     public void realmClosed(RealmConfiguration configuration) {
         if (configuration instanceof SyncConfiguration) {
-            Session publicSession = SyncManager.getSession((SyncConfiguration) configuration);
-            SyncSession session = SessionStore.getPrivateSession(publicSession);
+            SyncSession publicSession = SyncManager.getSession((SyncConfiguration) configuration);
+            ObjectServerSession session = SessionStore.getPrivateSession(publicSession);
             session.getSyncPolicy().onRealmClosed(session);
         } else {
             throw new IllegalArgumentException(WRONG_TYPE_OF_CONFIGURATION);
@@ -95,8 +95,8 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     @Override
     public void realmOpened(RealmConfiguration configuration) {
         if (configuration instanceof SyncConfiguration) {
-            Session publicSession = SyncManager.getSession((SyncConfiguration) configuration);
-            SyncSession session = SessionStore.getPrivateSession(publicSession);
+            SyncSession publicSession = SyncManager.getSession((SyncConfiguration) configuration);
+            ObjectServerSession session = SessionStore.getPrivateSession(publicSession);
             session.getSyncPolicy().onRealmOpened(session);
         } else {
             throw new IllegalArgumentException(WRONG_TYPE_OF_CONFIGURATION);

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/SyncUser.java
@@ -27,16 +27,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import io.realm.RealmAsyncTask;
-import io.realm.Session;
+import io.realm.SyncSession;
 import io.realm.SyncConfiguration;
-import io.realm.User;
 
 /**
  * Internal representation of a user on the Realm Object Server.
- * The public API is defined by {@link User}.
+ * The public API is defined by {@link io.realm.SyncUser}.
  */
 public class SyncUser {
 
@@ -44,7 +41,7 @@ public class SyncUser {
     private Token refreshToken;
     private URL authenticationUrl;
     private Map<URI, AccessDescription> realms = new HashMap<URI, AccessDescription>();
-    private List<Session> sessions = new ArrayList<Session>();
+    private List<SyncSession> sessions = new ArrayList<SyncSession>();
     private boolean loggedIn;
 
     /**
@@ -105,7 +102,7 @@ public class SyncUser {
     }
 
     // When a session is started, add it to the user so it can be tracked
-    public void addSession(Session session) {
+    public void addSession(SyncSession session) {
         sessions.add(session);
     }
 
@@ -140,7 +137,7 @@ public class SyncUser {
         return refreshToken;
     }
 
-    public List<Session> getSessions() {
+    public List<SyncSession> getSessions() {
         return sessions;
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/syncpolicy/AutomaticSyncPolicy.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/syncpolicy/AutomaticSyncPolicy.java
@@ -17,7 +17,7 @@
 package io.realm.internal.syncpolicy;
 
 import io.realm.ObjectServerError;
-import io.realm.internal.objectserver.SyncSession;
+import io.realm.internal.objectserver.ObjectServerSession;
 
 /**
  * This SyncPolicy will automatically start synchronizing changes to a Realm as soon as it is opened.
@@ -28,28 +28,28 @@ public class AutomaticSyncPolicy implements SyncPolicy {
     private int recurringErrors = 0;
 
     @Override
-    public void onRealmOpened(SyncSession session) {
+    public void onRealmOpened(ObjectServerSession session) {
         session.bind(); // Bind Realm first time it is opened.
     }
 
     @Override
-    public void onRealmClosed(SyncSession session) {
+    public void onRealmClosed(ObjectServerSession session) {
         // TODO In order to preserve resources we should ideally close the session as well, but first
         // we want to make sure that all local changes have been synchronized to the remote Realm.
     }
 
     @Override
-    public void onSessionCreated(SyncSession session) {
+    public void onSessionCreated(ObjectServerSession session) {
         session.start();
     }
 
     @Override
-    public void onSessionStopped(SyncSession session) {
+    public void onSessionStopped(ObjectServerSession session) {
         // Do nothing
     }
 
     @Override
-    public boolean onError(SyncSession session, ObjectServerError error) {
+    public boolean onError(ObjectServerSession session, ObjectServerError error) {
         switch(error.getCategory()) {
             case FATAL:
                 return false;   // Report all fatal errors to the user
@@ -63,7 +63,7 @@ public class AutomaticSyncPolicy implements SyncPolicy {
     /**
      * Returns {@code true} if we decide to rebind, {@code false} if the error was determined to no longer be solvable.
      */
-    private boolean rebind(SyncSession session) {
+    private boolean rebind(ObjectServerSession session) {
         // Track all calls to rebind(). If some error reported as RECOVERABLE keeps happening, we need to abort to
         // prevent run-away sessions. Right now we treat an error as recurring if it happens within 3 seconds of each
         // other. After 5 of such errors we terminate the session.

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/syncpolicy/SyncPolicy.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/syncpolicy/SyncPolicy.java
@@ -17,24 +17,24 @@
 package io.realm.internal.syncpolicy;
 
 import io.realm.ObjectServerError;
-import io.realm.Session;
+import io.realm.SyncSession;
 import io.realm.SyncConfiguration;
-import io.realm.internal.objectserver.SyncSession;
+import io.realm.internal.objectserver.ObjectServerSession;
 
 /**
  * Interface describing a given synchronization policy with the Realm Object Server.
  * <p>
- * The sole purpose of classes implementing this interface is to call {@link SyncSession#bind()} and
- * {@link SyncSession#unbind()} as needed, which will control when changes are synchronized between a local and
+ * The sole purpose of classes implementing this interface is to call {@link ObjectServerSession#bind()} and
+ * {@link ObjectServerSession#unbind()} as needed, which will control when changes are synchronized between a local and
  * remote Realm.
  *
- * The SyncPolicy is not responsible for managing the lifecycle of the {@link SyncSession} in general. So any
- * implementation of this class should avoid calling {@link SyncSession#stop()} and
- * {@link SyncSession#start()}.
+ * The SyncPolicy is not responsible for managing the lifecycle of the {@link ObjectServerSession} in general. So any
+ * implementation of this class should avoid calling {@link ObjectServerSession#stop()} and
+ * {@link ObjectServerSession#start()}.
  *
- * If a session is stopped, {@link SyncSession#unbind()} is automatically called and any further calls to
- * {@link SyncSession#bind()} and {@link SyncSession#unbind()} are ignored.
- * {@link #onSessionStopped(SyncSession)} ()} will then be called so the sync policy have a chance to clean up
+ * If a session is stopped, {@link ObjectServerSession#unbind()} is automatically called and any further calls to
+ * {@link ObjectServerSession#bind()} and {@link ObjectServerSession#unbind()} are ignored.
+ * {@link #onSessionStopped(ObjectServerSession)} ()} will then be called so the sync policy have a chance to clean up
  * any resources it might be using.
  */
 // Internal until we are sure this is the API we want
@@ -44,34 +44,34 @@ public interface SyncPolicy {
      * Called when the session object is created. At this point it is possible to register any relevant error and event
      * listeners in either the Android framework or for the session itself.
      *
-     * {@link SyncSession#start()} will be automatically called after this method.
+     * {@link ObjectServerSession#start()} will be automatically called after this method.
      *
-     * @param session the {@link Session} just created. It has not yet been started.
+     * @param session the {@link SyncSession} just created. It has not yet been started.
      */
-    void onSessionCreated(SyncSession session);
+    void onSessionCreated(ObjectServerSession session);
 
     /**
-     * The {@link SyncSession} has been stopped and will ignore any further calls to
-     * {@link SyncSession#bind()} and {@link SyncSession#unbind()}. All external resources should be
+     * The {@link ObjectServerSession} has been stopped and will ignore any further calls to
+     * {@link ObjectServerSession#bind()} and {@link ObjectServerSession#unbind()}. All external resources should be
      * cleaned up.
      *
-     * @param session {@link SyncSession} that has been stopped.
+     * @param session {@link ObjectServerSession} that has been stopped.
      */
-    void onSessionStopped(SyncSession session);
+    void onSessionStopped(ObjectServerSession session);
 
     /**
      * Called the first time a Realm is opened on any thread.
      *
-     * @param session {@link SyncSession} associated with this Realm.
+     * @param session {@link ObjectServerSession} associated with this Realm.
      */
-    void onRealmOpened(SyncSession session);
+    void onRealmOpened(ObjectServerSession session);
 
     /**
      * Called when the last Realm instance across all threads have been closed.
      *
-     * @param session {@link SyncSession} associated with this Realm.
+     * @param session {@link ObjectServerSession} associated with this Realm.
      */
-    void onRealmClosed(SyncSession session);
+    void onRealmClosed(ObjectServerSession session);
 
     /**
      * Called if an error occurred in the underlying session. In many cases this has caused the session to become
@@ -83,7 +83,7 @@ public interface SyncPolicy {
      *
      * This method is always called from a background thread, never the UI thread.
      *
-     * @see SyncConfiguration.Builder#errorHandler(Session.ErrorHandler)
+     * @see SyncConfiguration.Builder#errorHandler(SyncSession.ErrorHandler)
      */
-    boolean onError(SyncSession session, ObjectServerError error);
+    boolean onError(ObjectServerSession session, ObjectServerError error);
 }


### PR DESCRIPTION
`Credentials` -> `SyncCredentials`
`User` -> `SyncUser`
`Session` -> `SyncSession`

Also renamed internal `SyncSession` to `ObjectServerSession`  and internal `SyncUser` to `ObjectServerUser` to avoid complete confusion.

@realm/java