### PR TITLE
SyncUser.currentUser is now correctly cleared on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Renamed `User` to `SyncUser`, `Credentials` to `SyncCredentials` and `Session` to `SyncSession` to align names with Cocoa.
 
+### Bug fixes
+
+* `SyncUser.logout()` now correctly clears `SyncUser.currentUser()` (#3638).
+
 ### Enhancement
 
 * `Realm.compactRealm()` works for encrypted Realms.

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/UserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/UserTests.java
@@ -66,6 +66,21 @@ public class UserTests {
         assertNull(SyncUser.currentUser());
     }
 
+    // Test that current user is cleared if it is logged out
+    @Test
+    public void currentUser_clearedOnLogout() {
+        // Add an expired user to the user store
+        SyncUser user = SyncTestUtils.createTestUser(Long.MAX_VALUE);
+        UserStore userStore = new SharedPrefsUserStore(InstrumentationRegistry.getContext());
+        SyncManager.setUserStore(userStore);
+        userStore.put(UserStore.CURRENT_USER_KEY, user);
+
+        SyncUser savedUser = SyncUser.currentUser();
+        assertEquals(user, savedUser);
+        savedUser.logout();
+        assertNull(SyncUser.currentUser());
+    }
+
     // `all()` returns an empty list if no users are logged in
     @Test
     public void all_empty() {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -9,11 +9,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.realm.Credentials;
+import io.realm.SyncCredentials;
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
 import io.realm.Realm;
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.HttpUtils;
 import io.realm.rule.RunInLooperThread;
@@ -40,9 +40,9 @@ public class AuthTests {
 
     @Test
     public void login_userNotExist() {
-        Credentials credentials = Credentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
+        SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
         try {
-            User.login(credentials, Constants.AUTH_URL);
+            SyncUser.login(credentials, Constants.AUTH_URL);
             fail();
         } catch (ObjectServerError expected) {
             assertEquals(ErrorCode.UNKNOWN_ACCOUNT, expected.getErrorCode());
@@ -52,10 +52,10 @@ public class AuthTests {
     @Test
     @RunTestInLooperThread
     public void loginAsync_userNotExist() {
-        Credentials credentials = Credentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
-        User.loginAsync(credentials, Constants.AUTH_URL, new User.Callback() {
+        SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
+        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
             @Override
-            public void onSuccess(User user) {
+            public void onSuccess(SyncUser user) {
                 fail();
             }
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -19,7 +19,7 @@ package io.realm.objectserver.utils;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import io.realm.User;
+import io.realm.SyncUser;
 import io.realm.objectserver.utils.Constants;
 
 // Must be in `io.realm.objectserver` to work around package protected methods.


### PR DESCRIPTION
Fixes #3638  
Also fixed some compile errors. Not entirely sure how they where not caught by CI? 

@realm/java 

Also this impact #3639 (/cc @zaki50 )