### PR TITLE
delete realm file before test

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3831,6 +3831,7 @@ public class RealmTests {
                 .directory(externalFilesDir)
                 .name("external.realm")
                 .build();
+        Realm.deleteRealm(config);
 
         // test if it works when the namedPipeDir is empty.
         Realm realmOnExternalStorage = Realm.getInstance(config);


### PR DESCRIPTION
existing database file may cause `RealmMigrationNeededException`
@realm/java 