### PR TITLE
Fix memory leak when unsubscribing from RxJava observables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Missing ProGuard configuration for libraries used by Sync extension (#3596).
 * Error handler was not called when sync session failed (#3597).
 * Permission error when a database file is located at external storage (#3140).
+* Memory leak when unsubscribing from a RealmResults/RealmObject RxJava Observable (#3552).
 
 ### Enhancements
 

--- a/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
@@ -326,7 +326,7 @@ public class RealmObservableFactory implements RxObservableFactory {
                 references.put(object, count - 1);
             } else if (count == 1) {
                 references.remove(object);
-            } else (count <= 0) {
+            } else {
                 throw new IllegalStateException("Invalid reference count: " + count);
             }
         }

--- a/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
@@ -322,10 +322,12 @@ public class RealmObservableFactory implements RxObservableFactory {
             Integer count = references.get(object);
             if (count == null) {
                 throw new IllegalStateException("Object does not have any references: " + object);
-            } else if (count > 0) {
+            } else if (count > 1) {
                 references.put(object, count - 1);
-            } else {
+            } else if (count == 1){
                 references.remove(object);
+            } else if (count <= 0) {
+                throw new IllegalStateException("Invalid reference count: " + count);
             }
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
@@ -324,9 +324,9 @@ public class RealmObservableFactory implements RxObservableFactory {
                 throw new IllegalStateException("Object does not have any references: " + object);
             } else if (count > 1) {
                 references.put(object, count - 1);
-            } else if (count == 1){
+            } else if (count == 1) {
                 references.remove(object);
-            } else if (count <= 0) {
+            } else (count <= 0) {
                 throw new IllegalStateException("Invalid reference count: " + count);
             }
         }


### PR DESCRIPTION
Fixes #3672 
Fixes #3552 

This PR fixes a bug that would leak all RealmResults/RealmObject instances on any long lived thread. Kind embarrassing since I looked into this a couple of weeks ago and couldn't find anything, but yay for a good repo case.

There is no unit test since the code in question is private and any test would be non-deterministic. If you think a unit test is required, I can move the helper class to our internal package and unit test it from there. That wouldn't have caught this particular case though as this bug was more about calling code and class not agreeing on the protocol for using the class.

@realm/java 