### PR TITLE
fix a bug that proguard configuration keeps all class names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### bug fixes
 
-* ProGuard configuration introduced in 2.1.0 unexpectedly keeps classes those do not have any fields with KeepMember annotation.
+* ProGuard configuration introduced in 2.1.0 unexpectedly keeps classes those do not have any fields with KeepMember annotation (#3689).
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.1.1
 
-### bug fixes
+### Bug fixes
 
-* ProGuard configuration introduced in 2.1.0 unexpectedly keeps classes those do not have any fields with KeepMember annotation (#3689).
+* ProGuard configuration introduced in 2.1.0 unexpectedly kept classes that did not have the @KeepMember annotation (#3689).
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.1
+
+### bug fixes
+
+* ProGuard configuration introduced in 2.1.0 unexpectedly keeps classes those do not have any fields with KeepMember annotation.
+
 ## 2.1.0
 
 ### Object Server API Changes (In Beta)

--- a/realm/realm-library/proguard-rules-common.pro
+++ b/realm/realm-library/proguard-rules-common.pro
@@ -5,7 +5,7 @@
 -keep,includedescriptorclasses @io.realm.internal.Keep class * { *; }
 
 -keep class io.realm.internal.KeepMember
--keep,includedescriptorclasses class * { @io.realm.internal.KeepMember *; }
+-keep,includedescriptorclasses @io.realm.internal.KeepMember class * { @io.realm.internal.KeepMember *; }
 
 -dontwarn javax.**
 -dontwarn io.realm.**

--- a/realm/realm-library/src/main/java/io/realm/internal/KeepMember.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/KeepMember.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  * This annotation is used to mark the fields and methods to be kept by ProGuard/DexGuard.
  * The ProGuard configuration must have '-keep class io.realm.internal.KeepMember'
  * and '-keep,includedescriptorclasses @io.realm.internal.KeepMember class * { @io.realm.internal.KeepMember *; }'.
+ * This annotation must be added to class as well to work.
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})

--- a/realm/realm-library/src/main/java/io/realm/internal/KeepMember.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/KeepMember.java
@@ -24,9 +24,9 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to mark the fields and methods to be kept by ProGuard/DexGuard.
  * The ProGuard configuration must have '-keep class io.realm.internal.KeepMember'
- * and '-keep,includedescriptorclasses class * { @io.realm.internal.KeepMember *; }'.
+ * and '-keep,includedescriptorclasses @io.realm.internal.KeepMember class * { @io.realm.internal.KeepMember *; }'.
  */
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD,ElementType.FIELD})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 public @interface KeepMember {
 }

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLogger.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLogger.java
@@ -22,6 +22,7 @@ import io.realm.internal.KeepMember;
  * Interface for custom loggers that can be registered at {@link RealmLog#add(RealmLogger)}.
  * The different log levels are described in {@link LogLevel}.
  */
+@KeepMember
 public interface RealmLogger {
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerSession.java
@@ -87,6 +87,7 @@ import io.realm.log.RealmLog;
  *
  * This object is thread safe.
  */
+@KeepMember
 public final class ObjectServerSession {
 
     private final HashMap<SessionState, FsmState> FSM = new HashMap<SessionState, FsmState>();


### PR DESCRIPTION
Our ProGuard configuration introduced in `2.1.0` unexpectedly keeps classes those do not have any fields with KeepMember annotation.

fixes #3689