### PR TITLE
DefaultRealmModule not created for empty Kotlin projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.1.2
 
-### Enhancement
+### Bug fixes
 
-* The default Realm module is no longer generated if no model classes exists (#3746).
+* Kotlin projects no longer creates the `RealmDefaultModule` if no Realm model classes are present (#3746).
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* Kotlin projects no longer creates the `RealmDefaultModule` if no Realm model classes are present (#3746).
+* Kotlin projects no longer create the `RealmDefaultModule` if no Realm model classes are present (#3746).
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2
+
+### Enhancement
+
+* The default Realm module is no longer generated if no model classes exists (#3746).
+
 ## 2.1.1
 
 ### Object Server API Changes (In Beta)

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
@@ -101,8 +101,9 @@ public class ModuleMetaData {
             return false;
         }
 
-        // Add default realm module if needed.
-        if (libraryModules.size() == 0) {
+        // Default Realm module should only be created if some classes exists that can be part of it.
+        // i.e. library projects or projects with no model classes should not generate the module.
+        if (libraryModules.size() == 0 && availableClasses.size() > 0) {
             shouldCreateDefaultModule = true;
             String defautModuleName = Constants.REALM_PACKAGE_NAME + "." + Constants.DEFAULT_MODULE_CLASS_NAME;
             modules.put(defautModuleName, availableClasses);

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
@@ -106,8 +106,8 @@ public class ModuleMetaData {
         // The DefaultRealmModule should not be created in this case either.
         if (libraryModules.size() == 0 && availableClasses.size() > 0) {
             shouldCreateDefaultModule = true;
-            String defautModuleName = Constants.REALM_PACKAGE_NAME + "." + Constants.DEFAULT_MODULE_CLASS_NAME;
-            modules.put(defautModuleName, availableClasses);
+            String defaultModuleName = Constants.REALM_PACKAGE_NAME + "." + Constants.DEFAULT_MODULE_CLASS_NAME;
+            modules.put(defaultModuleName, availableClasses);
         }
 
         return true;

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
@@ -101,8 +101,9 @@ public class ModuleMetaData {
             return false;
         }
 
-        // Default Realm module should only be created if some classes exists that can be part of it.
-        // i.e. library projects or projects with no model classes should not generate the module.
+        // Create default Realm module if needed.
+        // Note: Kotlin will trigger the annotation processor even if no Realm annotations are used.
+        // The DefaultRealmModule should not be created in this case either.
         if (libraryModules.size() == 0 && availableClasses.size() > 0) {
             shouldCreateDefaultModule = true;
             String defautModuleName = Constants.REALM_PACKAGE_NAME + "." + Constants.DEFAULT_MODULE_CLASS_NAME;


### PR DESCRIPTION
Fixes #3746 

@realm/java 