### PR TITLE
Support annotationProcessor configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+
+### Enhancements
+
+* Supported `annotationProcessor` configuration provided by Android Gradle Plugin 2.2.0 or later. Realm plugin adds its annotation processor to `annotationProcessor` configuration instead of `apt` configuration if `annotationProcessor` configuration is provided and `com.neenbedankt.android-apt` plugin is not applied. In Kotlin project, `annotationProcessor` configuration is never used for now (#3026).
+
 ## 2.1.1
 
 ### Object Server API Changes (In Beta)
@@ -37,7 +43,7 @@
 * Permission error when a database file was located on external storage (#3140).
 * Memory leak when unsubscribing from a RealmResults/RealmObject RxJava Observable (#3552).
 
-### Enhancement
+### Enhancements
 
 * `Realm.compactRealm()` now works for encrypted Realms.
 * Added `first(E defaultValue)` and `last(E defaultValue)` methods to `RealmList` and `RealmResult`. These methods will return the provided object instead of throwing an `IndexOutOfBoundsException` if the list is empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-* Supported `annotationProcessor` configuration provided by Android Gradle Plugin 2.2.0 or later. Realm plugin adds its annotation processor to `annotationProcessor` configuration instead of `apt` configuration if `annotationProcessor` configuration is provided and `com.neenbedankt.android-apt` plugin is not applied. In Kotlin project, `annotationProcessor` configuration is never used for now (#3026).
+* Added support for the `annotationProcessor` configuration provided by Android Gradle Plugin 2.2.0 or later. Realm plugin adds its annotation processor to the `annotationProcessor` configuration instead of `apt` configuration if it is available and the `com.neenbedankt.android-apt` plugin is not used. In Kotlin projects, `kapt` is used instead of the `annotationProcessor` configurationi (#3026).
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-* Added support for the `annotationProcessor` configuration provided by Android Gradle Plugin 2.2.0 or later. Realm plugin adds its annotation processor to the `annotationProcessor` configuration instead of `apt` configuration if it is available and the `com.neenbedankt.android-apt` plugin is not used. In Kotlin projects, `kapt` is used instead of the `annotationProcessor` configurationi (#3026).
+* Added support for the `annotationProcessor` configuration provided by Android Gradle Plugin 2.2.0 or later. Realm plugin adds its annotation processor to the `annotationProcessor` configuration instead of `apt` configuration if it is available and the `com.neenbedankt.android-apt` plugin is not used. In Kotlin projects, `kapt` is used instead of the `annotationProcessor` configuration (#3026).
 
 ## 2.1.2
 

--- a/examples/introExample/build.gradle
+++ b/examples/introExample/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'android-command'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'realm-android'
 
 android {

--- a/examples/objectServerExample/build.gradle
+++ b/examples/objectServerExample/build.gradle
@@ -63,5 +63,5 @@ dependencies {
     compile 'com.android.support:support-v4:24.2.0'
     compile 'com.android.support:design:24.2.0'
     compile 'com.jakewharton:butterknife:8.3.0'
-    apt 'com.jakewharton:butterknife-compiler:8.3.0'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.3.0'
 }

--- a/examples/unitTestExample/build.gradle
+++ b/examples/unitTestExample/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'android-command'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'realm-android'
 
 android {

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -96,6 +96,6 @@ class Realm implements Plugin<Project> {
             return !hasAnnotationProcessorConfiguration
         }
         // for any Kotlin Projects that do not use 'android-apt' plugin
-        return !hasAnnotationProcessorConfiguration || forceApplyAptPluginOnKotlinProject
+        return forceApplyAptPluginOnKotlinProject
     }
 }

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -23,8 +23,6 @@ import io.realm.transformer.RealmTransformer
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.DependencyResolutionListener
-import org.gradle.api.artifacts.ResolvableDependencies
 
 class Realm implements Plugin<Project> {
 
@@ -44,27 +42,36 @@ class Realm implements Plugin<Project> {
         def syncEnabledDefault = false
         project.extensions.create('realm', RealmPluginExtension, project, syncEnabledDefault)
 
-        def usesKotlinPlugin = project.plugins.findPlugin('kotlin-android') != null
         def usesAptPlugin = project.plugins.findPlugin('com.neenbedankt.android-apt') != null
+        def usesKotlinPlugin = project.plugins.findPlugin('kotlin-android') != null
+        def hasAnnotationProcessorConfiguration = project.getConfigurations().findByName('annotationProcessor') != null
+        // TODO add a parameter in 'realm' block if this can be specified by users
+        def forceApplyAptPluginOnKotlinProject = false
 
-        def isKaptProject = usesKotlinPlugin && !usesAptPlugin
-
-        if (!isKaptProject) {
+        if (shouldApplyAndroidAptPlugin(usesAptPlugin, usesKotlinPlugin,
+                                        hasAnnotationProcessorConfiguration, forceApplyAptPluginOnKotlinProject)) {
             project.plugins.apply(AndroidAptPlugin)
+            usesAptPlugin = true
         }
 
         project.android.registerTransform(new RealmTransformer(project))
 
         project.repositories.add(project.getRepositories().jcenter())
         project.dependencies.add("compile", "io.realm:realm-annotations:${Version.VERSION}")
-        if (isKaptProject) {
-            project.dependencies.add("kapt", "io.realm:realm-annotations:${Version.VERSION}")
-            project.dependencies.add("kapt", "io.realm:realm-annotations-processor:${Version.VERSION}")
-        } else {
+        if (usesAptPlugin) {
             project.dependencies.add("apt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("apt", "io.realm:realm-annotations-processor:${Version.VERSION}")
             project.dependencies.add("androidTestApt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("androidTestApt", "io.realm:realm-annotations-processor:${Version.VERSION}")
+        } else if (usesKotlinPlugin) {
+            project.dependencies.add("kapt", "io.realm:realm-annotations:${Version.VERSION}")
+            project.dependencies.add("kapt", "io.realm:realm-annotations-processor:${Version.VERSION}")
+        } else {
+            assert hasAnnotationProcessorConfiguration
+            project.dependencies.add("annotationProcessor", "io.realm:realm-annotations:${Version.VERSION}")
+            project.dependencies.add("annotationProcessor", "io.realm:realm-annotations-processor:${Version.VERSION}")
+            project.dependencies.add("androidTestAnnotationProcessor", "io.realm:realm-annotations:${Version.VERSION}")
+            project.dependencies.add("androidTestAnnotationProcessor", "io.realm:realm-annotations-processor:${Version.VERSION}")
         }
     }
 
@@ -75,5 +82,20 @@ class Realm implements Plugin<Project> {
         } catch (Exception ignored) {
             return false
         }
+    }
+
+    private static boolean shouldApplyAndroidAptPlugin(boolean usesAptPlugin, boolean usesKotlinPlugin,
+                                                       boolean hasAnnotationProcessorConfiguration,
+                                                       boolean forceApplyAptPluginOnKotlinProject) {
+        if (usesAptPlugin) {
+            // for any projects that use `android-apt` plugin
+            return false
+        }
+        if (!usesKotlinPlugin) {
+            // for any Java Projects that do not use 'android-apt' plugin
+            return !hasAnnotationProcessorConfiguration
+        }
+        // for any Kotlin Projects that do not use 'android-apt' plugin
+        return !hasAnnotationProcessorConfiguration || forceApplyAptPluginOnKotlinProject
     }
 }

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -88,7 +88,7 @@ class Realm implements Plugin<Project> {
                                                        boolean hasAnnotationProcessorConfiguration,
                                                        boolean preferAptOnKotlinProject) {
         if (usesAptPlugin) {
-            // for any projects that use `android-apt` plugin
+            // for any projects that uses android-apt plugin already. No need to apply it twice.
             return false
         }
         if (!usesKotlinPlugin) {

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -45,7 +45,7 @@ class Realm implements Plugin<Project> {
         def usesAptPlugin = project.plugins.findPlugin('com.neenbedankt.android-apt') != null
         def usesKotlinPlugin = project.plugins.findPlugin('kotlin-android') != null
         def hasAnnotationProcessorConfiguration = project.getConfigurations().findByName('annotationProcessor') != null
-        // TODO add a parameter in 'realm' block if this can be specified by users
+        // TODO add a parameter in 'realm' block if this should be specified by users
         def forceApplyAptPluginOnKotlinProject = false
 
         if (shouldApplyAndroidAptPlugin(usesAptPlugin, usesKotlinPlugin,

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -46,10 +46,10 @@ class Realm implements Plugin<Project> {
         def usesKotlinPlugin = project.plugins.findPlugin('kotlin-android') != null
         def hasAnnotationProcessorConfiguration = project.getConfigurations().findByName('annotationProcessor') != null
         // TODO add a parameter in 'realm' block if this should be specified by users
-        def forceApplyAptPluginOnKotlinProject = false
+        def preferAptOnKotlinProject = false
 
         if (shouldApplyAndroidAptPlugin(usesAptPlugin, usesKotlinPlugin,
-                                        hasAnnotationProcessorConfiguration, forceApplyAptPluginOnKotlinProject)) {
+                                        hasAnnotationProcessorConfiguration, preferAptOnKotlinProject)) {
             project.plugins.apply(AndroidAptPlugin)
             usesAptPlugin = true
         }
@@ -63,7 +63,7 @@ class Realm implements Plugin<Project> {
             project.dependencies.add("apt", "io.realm:realm-annotations-processor:${Version.VERSION}")
             project.dependencies.add("androidTestApt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("androidTestApt", "io.realm:realm-annotations-processor:${Version.VERSION}")
-        } else if (usesKotlinPlugin) {
+        } else if (usesKotlinPlugin && !preferAptOnKotlinProject) {
             project.dependencies.add("kapt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("kapt", "io.realm:realm-annotations-processor:${Version.VERSION}")
         } else {
@@ -86,7 +86,7 @@ class Realm implements Plugin<Project> {
 
     private static boolean shouldApplyAndroidAptPlugin(boolean usesAptPlugin, boolean usesKotlinPlugin,
                                                        boolean hasAnnotationProcessorConfiguration,
-                                                       boolean forceApplyAptPluginOnKotlinProject) {
+                                                       boolean preferAptOnKotlinProject) {
         if (usesAptPlugin) {
             // for any projects that use `android-apt` plugin
             return false
@@ -96,6 +96,6 @@ class Realm implements Plugin<Project> {
             return !hasAnnotationProcessorConfiguration
         }
         // for any Kotlin Projects that do not use 'android-apt' plugin
-        return forceApplyAptPluginOnKotlinProject
+        return preferAptOnKotlinProject && !hasAnnotationProcessorConfiguration
     }
 }


### PR DESCRIPTION
Supported `annotationProcessor` configuration provided by Android Gradle Plugin 2.2.0 or later.

Realm plugin adds its annotation processor to `annotationProcessor` configuration instead of `apt` configuration if `annotationProcessor` configuration is provided and `com.neenbedankt.android-apt` plugin is not applied.

In Kotlin project, `annotationProcessor` configuration is never used for now

The projects that satisfy all following conditions must apply `com.neenbedankt.android-apt` manually (or modify the configurations to `annotationProsessor` or its variants).

* Java project (not Kotlin project).
* Not applying `com.neenbedankt.android-apt` plugin manually.
* Using `apt` or its variants (`*Apt`) configurations.

fixes #3026 

In this PR, Realm gradle plugin chooses a configuration by following rules.

First, `com.neenbedankt.android-apt` plugin was already applied manually by the user, Realm plugin always uses `apt` configuration.

If `com.neenbedankt.android-apt` was not applied by the user, Realm plugin uses :

| project language |`preferAptOnKotlinProject` | `annotationProcessor` configuration defined |  configuration used by Realm Plugin
| ----- | -------- | ------ | ----
| Java |  ignored | true | `annotationProcessor`
| Java |  ignored | false | `apt` (with applying `android-apt`)
| Kotlin | true | true | `annotationProcessor`
| Kotlin | true | false | `apt` (with applying `android-apt`)
| Kotlin | false | ignored | `kapt`

**Currently we don't provide a way to set `preferAptOnKotlinProject` to `true`.**

