### PR TITLE
Fixed a bug that caused unexpected MigrationNeededException when a field was added to synced Realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Kotlin projects no longer create the `RealmDefaultModule` if no Realm model classes are present (#3746).
+* Unexpected `RealmMigrationNeededException` was thrown when a field was added to synced Realm.
 
 ## 2.1.1
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -659,7 +659,7 @@ public class RealmProxyClassGenerator {
 
         // create type dictionary for lookup
         writer.emitStatement("Map<String, RealmFieldType> columnTypes = new HashMap<String, RealmFieldType>()");
-        writer.beginControlFlow("for (long i = 0; i < " + metadata.getFields().size() + "; i++)");
+        writer.beginControlFlow("for (long i = 0; i < columnCount; i++)");
         writer.emitStatement("columnTypes.put(table.getColumnName(i), table.getColumnType(i))");
         writer.endControlFlow();
         writer.emitEmptyLine();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -375,7 +375,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             }
             final Row row = proxyState.getRow$realm();
             if (value == null) {
-                // Table#nullifyLink() does not support default value. Just use Row.
+                // Table#nullifyLink() does not support default value. Just using Row.
                 row.nullifyLink(columnInfo.columnObjectIndex);
                 return;
             }
@@ -527,7 +527,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
                 }
             }
             Map<String, RealmFieldType> columnTypes = new HashMap<String, RealmFieldType>();
-            for (long i = 0; i < 9; i++) {
+            for (long i = 0; i < columnCount; i++) {
                 columnTypes.put(table.getColumnName(i), table.getColumnType(i));
             }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -260,7 +260,7 @@ public class BooleansRealmProxy extends some.test.Booleans
                 }
             }
             Map<String, RealmFieldType> columnTypes = new HashMap<String, RealmFieldType>();
-            for (long i = 0; i < 4; i++) {
+            for (long i = 0; i < columnCount; i++) {
                 columnTypes.put(table.getColumnName(i), table.getColumnType(i));
             }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -980,7 +980,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
             }
             final Row row = proxyState.getRow$realm();
             if (value == null) {
-                // Table#nullifyLink() does not support default value. Just use Row.
+                // Table#nullifyLink() does not support default value. Just using Row.
                 row.nullifyLink(columnInfo.fieldObjectNullIndex);
                 return;
             }
@@ -1088,7 +1088,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
                 }
             }
             Map<String, RealmFieldType> columnTypes = new HashMap<String, RealmFieldType>();
-            for (long i = 0; i < 21; i++) {
+            for (long i = 0; i < columnCount; i++) {
                 columnTypes.put(table.getColumnName(i), table.getColumnType(i));
             }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -194,7 +194,7 @@ public class SimpleRealmProxy extends some.test.Simple
                 }
             }
             Map<String, RealmFieldType> columnTypes = new HashMap<String, RealmFieldType>();
-            for (long i = 0; i < 2; i++) {
+            for (long i = 0; i < columnCount; i++) {
                 columnTypes.put(table.getColumnName(i), table.getColumnType(i));
             }
 


### PR DESCRIPTION
In sync mode, `validateTable()` must get all fields in the tabla.

@realm/java 