### PR TITLE
removed includedescriptorclasses option to supprt built-in shrinker of Android Gradle Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Kotlin projects no longer create the `RealmDefaultModule` if no Realm model classes are present (#3746).
+* Remove `includedescriptorclasses` option from ProGuard rule file in order to support built-in shrinker of ANdroid Gradle Plugin (#3714).
 * Unexpected `RealmMigrationNeededException` was thrown when a field was added to synced Realm.
 
 ## 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug fixes
 
 * Kotlin projects no longer create the `RealmDefaultModule` if no Realm model classes are present (#3746).
-* Remove `includedescriptorclasses` option from ProGuard rule file in order to support built-in shrinker of ANdroid Gradle Plugin (#3714).
+* Remove `includedescriptorclasses` option from ProGuard rule file in order to support built-in shrinker of Android Gradle Plugin (#3714).
 * Unexpected `RealmMigrationNeededException` was thrown when a field was added to synced Realm.
 
 ## 2.1.1

--- a/realm/realm-library/proguard-rules-common.pro
+++ b/realm/realm-library/proguard-rules-common.pro
@@ -2,16 +2,16 @@
 -keep @io.realm.annotations.RealmModule class *
 
 -keep class io.realm.internal.Keep
--keep,includedescriptorclasses @io.realm.internal.Keep class * { *; }
+-keep @io.realm.internal.Keep class * { *; }
 
 -keep class io.realm.internal.KeepMember
--keep,includedescriptorclasses @io.realm.internal.KeepMember class * { @io.realm.internal.KeepMember *; }
+-keep @io.realm.internal.KeepMember class * { @io.realm.internal.KeepMember *; }
 
 -dontwarn javax.**
 -dontwarn io.realm.**
 -keep class io.realm.RealmCollection
 -keep class io.realm.OrderedRealmCollection
--keepclasseswithmembernames,includedescriptorclasses class io.realm.** {
+-keepclasseswithmembernames class io.realm.** {
     native <methods>;
 }
 

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
@@ -26,6 +26,7 @@ public class RealmFileException extends RuntimeException {
     /**
      * The specific kind of this {@link RealmFileException}.
      */
+    @Keep
     public enum Kind {
         /**
          * Thrown for any I/O related exception scenarios when a Realm is opened.

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLogger.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLogger.java
@@ -16,13 +16,13 @@
 
 package io.realm.log;
 
-import io.realm.internal.KeepMember;
+import io.realm.internal.Keep;
 
 /**
  * Interface for custom loggers that can be registered at {@link RealmLog#add(RealmLogger)}.
  * The different log levels are described in {@link LogLevel}.
  */
-@KeepMember
+@Keep // This interface is used as a parameter type of a native method in SharedRealm.java
 public interface RealmLogger {
 
     /**
@@ -34,6 +34,5 @@ public interface RealmLogger {
      * @param throwable optional exception to log.
      * @param message optional additional message.
      */
-    @KeepMember
     void log(int level, String tag, Throwable throwable, String message);
 }


### PR DESCRIPTION
fixes #3714

@realm/java 