### PR TITLE
fix a bug that realm-snnotations-processor is not deployed to ojo

### DIFF
--- a/realm/realm-annotations-processor/build.gradle
+++ b/realm/realm-annotations-processor/build.gradle
@@ -40,6 +40,11 @@ sourceSets {
 compileJava.dependsOn generateVersionClass
 compileTestJava.dependsOn ':realm-library:assemble'
 
+task ojoUpload() {
+    dependsOn "artifactoryPublish"
+    group = 'Publishing'
+}
+
 def commonPom = {
     licenses {
         license {


### PR DESCRIPTION
When `master` branch is built on CI, `ojoUpload` task in `realm/build.gradle` is executed.
However, that task is defined only in `realm/realm-library/build.gradle`, not in `realm/realm-annotations-processor/build.gradle`.

This PR defines `ojoUpload` task in `realm/realm-annotations-processor/build.gradle` as well.

@realm/java @emanuelez 