### PR TITLE
fix artifactoryPublish task in realm-annotations-processor

### DIFF
--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -12,8 +12,8 @@ buildscript {
         classpath 'com.novoda:gradle-android-command-plugin:1.3.0'
         classpath 'com.github.skhatri:gradle-s3-plugin:1.0.2'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.5'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "io.realm:realm-transformer:${file('../version.txt').text.trim()}"
     }
 }

--- a/realm/realm-annotations-processor/build.gradle
+++ b/realm/realm-annotations-processor/build.gradle
@@ -61,13 +61,13 @@ def commonPom = {
 
 publishing {
     publications {
-        realmPublication(MavenPublication) {
+        basePublication(MavenPublication) {
             groupId 'io.realm'
             artifactId = 'realm-annotations-processor'
             from components.java
             pom.withXml {
                 Node root = asNode()
-                root.appendNode('name', 'realm-gradle-plugin')
+                root.appendNode('name', 'realm-annotations-processor')
                 root.appendNode('description', 'Annotation Processor for Realm. Realm is a mobile database: a replacement for SQLite & ORMs')
                 root.appendNode('url', 'http://realm.io')
                 root.children().last() + commonPom
@@ -96,7 +96,7 @@ bintray {
     dryRun = false
     publish = false
 
-    publications = ['realmPublication']
+    publications = ['basePublication']
     pkg {
         repo = 'maven'
         name = 'realm-annotations-processor'
@@ -119,7 +119,7 @@ artifactory {
             password = project.hasProperty('bintrayKey') ? bintrayKey : 'noKey'
         }
         defaults {
-            publications ('realmPublication')
+            publications ('basePublication')
         }
     }
 }

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -364,10 +364,9 @@ artifactory {
             repoKey = 'oss-snapshot-local'
             username = project.hasProperty('bintrayUser') ? bintrayUser : 'noUser'
             password = project.hasProperty('bintrayKey') ? bintrayKey : 'noKey'
-            maven = true
         }
         defaults {
-            publishConfigs('basePublication', 'objectServerPublication')
+            publications('basePublication', 'objectServerPublication')
             publishPom = true
             publishIvy = false
         }


### PR DESCRIPTION
fix NPE when executing `artifactoryPublish` task in `realm-annotations-processor`.

```
:****:****-annotations-processor:artifactoryPublish FAILED
:ojoRealm FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':****-annotations-processor:artifactoryPublish'.
> java.lang.NullPointerException (no error message)

```

@realm/java @emanuelez 