### PR TITLE
Set native library version to ReLinker

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -39,6 +39,7 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 24
+        versionName version
         project.archivesBaseName = "realm-android-library"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmCore.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmCore.java
@@ -26,6 +26,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Locale;
 
+import io.realm.BuildConfig;
+
 /**
  * Utility methods for Realm Core.
  */
@@ -56,7 +58,7 @@ public class RealmCore {
         if (libraryIsLoaded) {
             return;
         }
-        ReLinker.loadLibrary(context, "realm-jni");
+        ReLinker.loadLibrary(context, "realm-jni", BuildConfig.VERSION_NAME);
         libraryIsLoaded = true;
     }
 


### PR DESCRIPTION
Set native library version to `ReLinker` in order to prevent to use old native library.

fixes #3775 

@realm/java 