### PR TITLE
Integrating object store's schema concepts

### DIFF
--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -431,6 +431,7 @@ Java_io_realm_internal_SharedRealm_nativeGetSnapshotVersion(JNIEnv *env, jclass,
 JNIEXPORT void JNICALL
 Java_io_realm_internal_SharedRealm_nativeUpdateSchema(JNIEnv *env, jclass, jlong nativePtr,
                                                       jlong nativeSchemaPtr, jlong version,
+                                                      jobject migration,
                                                       jboolean inTransaction) {
     TR_ENTER()
     try {

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -430,12 +430,13 @@ Java_io_realm_internal_SharedRealm_nativeGetSnapshotVersion(JNIEnv *env, jclass,
 
 JNIEXPORT void JNICALL
 Java_io_realm_internal_SharedRealm_nativeUpdateSchema(JNIEnv *env, jclass, jlong nativePtr,
-                                                      jlong nativeSchemaPtr, jlong version) {
+                                                      jlong nativeSchemaPtr, jlong version,
+                                                      jboolean inTransaction) {
     TR_ENTER()
     try {
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(nativePtr));
         auto *schema = reinterpret_cast<Schema*>(nativeSchemaPtr);
-        shared_realm->update_schema(*schema, static_cast<uint64_t>(version));
+        shared_realm->update_schema(*schema, static_cast<uint64_t>(version), nullptr, to_bool(inTransaction));
     }
     CATCH_STD()
 }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -344,7 +344,7 @@ public final class Realm extends BaseRealm {
             if (syncAvailable) {
                 RealmSchema schema = new RealmSchema(realmObjectSchemas);
                 // Assumption: when SyncConfiguration then additive schema update mode
-                realm.sharedRealm.updateSchema(schema, version, true);
+                realm.sharedRealm.updateSchema(schema, version, null, true);
                 commitNeeded = true;
                 for (Class<? extends RealmModel> modelClass : modelClasses) {
                     columnInfoMap.put(modelClass, mediator.validateTable(modelClass, realm.sharedRealm, false));

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -316,12 +316,10 @@ public final class Realm extends BaseRealm {
         boolean syncAvailable = realm.configuration.isSyncConfiguration();
 
         try {
-            if (!syncAvailable) {
-                realm.beginTransaction();
-                if (version == UNVERSIONED) {
-                    commitNeeded = true;
-                    realm.setVersion(realm.configuration.getSchemaVersion());
-                }
+            realm.beginTransaction();
+            if (version == UNVERSIONED) {
+                commitNeeded = true;
+                realm.setVersion(realm.configuration.getSchemaVersion());
             }
 
             RealmProxyMediator mediator = realm.configuration.getSchemaMediator();
@@ -334,6 +332,7 @@ public final class Realm extends BaseRealm {
                 // Create and validate table
                 if (version == UNVERSIONED && !syncAvailable) {
                     mediator.createTable(modelClass, realm.sharedRealm);
+                    commitNeeded = true;
                 }
                 if (syncAvailable) {
                     RealmObjectSchema realmObjectSchema = mediator.createRealmObjectSchema(modelClass, realmSchemaCache);
@@ -345,7 +344,8 @@ public final class Realm extends BaseRealm {
             if (syncAvailable) {
                 RealmSchema schema = new RealmSchema(realmObjectSchemas);
                 // Assumption: when SyncConfiguration then additive schema update mode
-                realm.sharedRealm.updateSchema(schema, version);
+                realm.sharedRealm.updateSchema(schema, version, true);
+                commitNeeded = true;
                 for (Class<? extends RealmModel> modelClass : modelClasses) {
                     columnInfoMap.put(modelClass, mediator.validateTable(modelClass, realm.sharedRealm, false));
                 }
@@ -357,27 +357,15 @@ public final class Realm extends BaseRealm {
             if (version == UNVERSIONED) {
                 final Transaction transaction = realm.getConfiguration().getInitialDataTransaction();
                 if (transaction != null) {
-                    if (syncAvailable) {
-                        realm.executeTransaction(transaction);
-                        realm.executeTransaction(new Transaction() {
-                            @Override
-                            public void execute(Realm realm) {
-                                realm.setVersion(realm.configuration.getSchemaVersion());
-                            }
-                        });
-                    } else {
-                        transaction.execute(realm);
-                    }
+                    transaction.execute(realm);
+                    commitNeeded = true;
                 }
-
             }
         } finally {
-            if (!syncAvailable) {
-                if (commitNeeded) {
-                    realm.commitTransaction(false);
-                } else {
-                    realm.cancelTransaction();
-                }
+            if (commitNeeded) {
+                realm.commitTransaction(false);
+            } else {
+                realm.cancelTransaction();
             }
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -323,8 +323,9 @@ public final class SharedRealm implements Closeable {
         return nativeCompact(nativePtr);
     }
 
-    public void updateSchema(RealmSchema schema, long version) {
-        nativeUpdateSchema(nativePtr, schema.getNativePtr(), version);
+    // inTransaction: true is write transaction is already started and commit will be done by caller
+    public void updateSchema(RealmSchema schema, long version, boolean inTransaction) {
+        nativeUpdateSchema(nativePtr, schema.getNativePtr(), version, inTransaction);
     }
 
     @Override
@@ -398,5 +399,5 @@ public final class SharedRealm implements Closeable {
     private static native boolean nativeWaitForChange(long nativeSharedRealmPtr);
     private static native void nativeStopWaitForChange(long nativeSharedRealmPtr);
     private static native boolean nativeCompact(long nativeSharedRealmPtr);
-    private static native void nativeUpdateSchema(long nativePtr, long nativeSchemaPtr, long version);
+    private static native void nativeUpdateSchema(long nativePtr, long nativeSchemaPtr, long version, boolean inTransaction);
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.File;
 
 import io.realm.RealmConfiguration;
+import io.realm.RealmMigration;
 import io.realm.RealmSchema;
 import io.realm.internal.async.BadVersionException;
 
@@ -324,8 +325,8 @@ public final class SharedRealm implements Closeable {
     }
 
     // inTransaction: true is write transaction is already started and commit will be done by caller
-    public void updateSchema(RealmSchema schema, long version, boolean inTransaction) {
-        nativeUpdateSchema(nativePtr, schema.getNativePtr(), version, inTransaction);
+    public void updateSchema(RealmSchema schema, long version, RealmMigration migration, boolean inTransaction) {
+        nativeUpdateSchema(nativePtr, schema.getNativePtr(), version, migration, inTransaction);
     }
 
     @Override
@@ -399,5 +400,6 @@ public final class SharedRealm implements Closeable {
     private static native boolean nativeWaitForChange(long nativeSharedRealmPtr);
     private static native void nativeStopWaitForChange(long nativeSharedRealmPtr);
     private static native boolean nativeCompact(long nativeSharedRealmPtr);
-    private static native void nativeUpdateSchema(long nativePtr, long nativeSchemaPtr, long version, boolean inTransaction);
+    private static native void nativeUpdateSchema(long nativePtr, long nativeSchemaPtr, long version, Object migration,
+                                                  boolean inTransaction);
 }


### PR DESCRIPTION
This PR integrates object store's view of schema into the binding. 

To do:

- [x] `update_schema()` can call back to a manual migration function
- [x] wrapper for migration function
- [x] Realm Java has a bit of a complex flow when initializing a Realm file. Breaking it up to smaller transactions might leave the Realm file in an inconsistent state.

Depends on 
* https://github.com/realm/realm-object-store/pull/222

See also:
- https://github.com/realm/realm-java/issues/1625 
- https://github.com/realm/realm-java/issues/2231

@cmelchior @beeender