### PR TITLE
Added a support for androidTest on API 9 devices

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -131,17 +131,11 @@ dependencies {
     objectServerCompile 'com.squareup.okhttp3:okhttp:3.4.1'
     androidTestCompile 'io.reactivex:rxjava:1.1.0'
     androidTestCompile 'com.android.support:support-annotations:24.0.0'
-    androidTestCompile('com.android.support.test:rules:0.5') {
-        exclude group: 'org.hamcrest', module: 'hamcrest-core'
-    }
-    androidTestCompile('com.android.support.test:runner:0.5') {
-        exclude group: 'org.hamcrest', module: 'hamcrest-core'
-    }
-    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile('com.google.dexmaker:dexmaker-mockito:1.2') {
-        exclude group: 'org.hamcrest', module: 'hamcrest-core'
-    }
+    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
     androidTestCompile 'com.opencsv:opencsv:3.4'
     androidTestCompile 'dk.ilios:spanner:0.6.0'
     androidTestAnnotationProcessor project(':realm-annotations-processor')

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -131,10 +131,20 @@ dependencies {
     objectServerCompile 'com.squareup.okhttp3:okhttp:3.4.1'
     androidTestCompile 'io.reactivex:rxjava:1.1.0'
     androidTestCompile 'com.android.support:support-annotations:24.0.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile('com.android.support.test:rules:0.5') {
+        exclude group: 'junit', module: 'junit'
+    }
+    androidTestCompile('com.android.support.test:runner:0.5') {
+        exclude group: 'junit', module: 'junit'
+    }
+    androidTestCompile('junit:junit:4.12') {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+    androidTestCompile 'org.hamcrest:hamcrest-all:1.3'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestCompile('com.google.dexmaker:dexmaker-mockito:1.2') {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
     androidTestCompile 'com.opencsv:opencsv:3.4'
     androidTestCompile 'dk.ilios:spanner:0.6.0'
     androidTestAnnotationProcessor project(':realm-annotations-processor')

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     androidTestCompile('com.android.support.test:runner:0.5') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    androidTestCompile 'org.hamcrest:hamcrest-all:1.3'
+    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile('com.google.dexmaker:dexmaker-mockito:1.2') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -132,12 +132,9 @@ dependencies {
     androidTestCompile 'io.reactivex:rxjava:1.1.0'
     androidTestCompile 'com.android.support:support-annotations:24.0.0'
     androidTestCompile('com.android.support.test:rules:0.5') {
-        exclude group: 'junit', module: 'junit'
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
     androidTestCompile('com.android.support.test:runner:0.5') {
-        exclude group: 'junit', module: 'junit'
-    }
-    androidTestCompile('junit:junit:4.12') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
     androidTestCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/realm/realm-library/src/androidTest/AndroidManifest.xml
+++ b/realm/realm-library/src/androidTest/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <uses-sdk tools:overrideLibrary="dk.ilios.spanner"/>
     <uses-sdk
-        android:minSdkVersion="16"
+        android:minSdkVersion="9"
         android:targetSdkVersion="22"/>
 
     <application>

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonAbsentPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonAbsentPrimaryKeyTests.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import android.os.Build;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,6 +38,9 @@ import io.realm.entities.PrimaryKeyAsBoxedLong;
 import io.realm.entities.PrimaryKeyAsBoxedShort;
 import io.realm.entities.PrimaryKeyAsString;
 import io.realm.rule.TestRealmConfigurationFactory;
+
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+import static org.junit.Assume.assumeThat;
 
 @RunWith(Parameterized.class)
 public class RealmJsonAbsentPrimaryKeyTests {
@@ -122,6 +127,8 @@ public class RealmJsonAbsentPrimaryKeyTests {
     // Testing absent primary key value for createObjectFromJson() stream version
     @Test
     public void createObjectFromJson_primaryKey_isAbsent_fromJsonStream() throws JSONException, IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.beginTransaction();
         thrown.expect(IllegalArgumentException.class);
         realm.createObjectFromJson(clazz, TestHelper.stringToStream(jsonString));
@@ -140,6 +147,8 @@ public class RealmJsonAbsentPrimaryKeyTests {
     // Testing absent primary key value for createAllFromJson() stream version
     @Test
     public void createAllFromJson_primaryKey_isAbsent_fromJsonStream() throws JSONException, IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         JSONArray jsonArray = new JSONArray();
         jsonArray.put(new JSONObject(jsonString));
         realm.beginTransaction();
@@ -151,6 +160,8 @@ public class RealmJsonAbsentPrimaryKeyTests {
     // Testing absent primary key value for createOrUpdateAllFromJson() stream version
     @Test
     public void createOrUpdateAllFromJson_primaryKey_isAbsent_fromJsonStream() throws JSONException, IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         JSONArray jsonArray = new JSONArray();
         jsonArray.put(new JSONObject(jsonString));
         realm.beginTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
@@ -17,6 +17,7 @@
 package io.realm;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.text.TextUtils;
@@ -55,11 +56,13 @@ import io.realm.exceptions.RealmException;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static io.realm.internal.test.ExtraTests.assertArrayEquals;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 @RunWith(AndroidJUnit4.class)
 public class RealmJsonTests {
@@ -693,12 +696,16 @@ public class RealmJsonTests {
 
     @Test
     public void createAllFromJson_streamNull() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.createAllFromJson(AllTypes.class, (InputStream) null);
         assertEquals(0, realm.where(AllTypes.class).count());
     }
 
     @Test
     public void createObjectFromJson_streamAllSimpleTypes() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "all_simple_types.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -717,6 +724,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamDateAsLong() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "date_as_long.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -730,6 +739,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamDateAsString() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "date_as_string.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -743,6 +754,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamDateAsISO8601String() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "date_as_iso8601_string.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -761,6 +774,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamChildObject() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "single_child_object.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -773,6 +788,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamEmptyChildObjectList() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "realmlist_empty.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -785,6 +802,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamChildObjectList() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "realmlist.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -797,6 +816,8 @@ public class RealmJsonTests {
 
     @Test
     public void createAllFromJson_streamArray() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "array.json");
         realm.beginTransaction();
         realm.createAllFromJson(Dog.class, in);
@@ -810,6 +831,8 @@ public class RealmJsonTests {
     // Test if Json object doesn't have the field, then the field should have default value. Stream version.
     @Test
     public void createObjectFromJson_streamNoValues() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "other_json_object.json");
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, in);
@@ -831,6 +854,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamNullClass() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "array.json");
         realm.beginTransaction();
         assertNull(realm.createObjectFromJson(null, in));
@@ -840,6 +865,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamNullJson() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "all_types_invalid.json");
         realm.beginTransaction();
         try {
@@ -854,6 +881,8 @@ public class RealmJsonTests {
 
     @Test
     public void createObjectFromJson_streamNullInputStream() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.beginTransaction();
         assertNull(realm.createObjectFromJson(AnnotationTypes.class, (InputStream) null));
         realm.commitTransaction();
@@ -865,6 +894,8 @@ public class RealmJsonTests {
      */
     @Test
     public void createOrUpdateObjectFromJson_streamNullValues() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
         Date date = new Date(0);
         obj.setColumnLong(1); // ID
@@ -900,6 +931,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateObjectFromJson_streamNullClass() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream in = TestHelper.loadJsonFromAssets(context, "all_types_primary_key_field_only.json");
         realm.beginTransaction();
         assertNull(realm.createOrUpdateObjectFromJson(null, in));
@@ -909,6 +942,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateObjectFromJson_streamInvalidJson() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
         obj.setColumnLong(1);
         realm.beginTransaction();
@@ -929,6 +964,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateObjectFromJson_streamNoPrimaryKeyThrows() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         try {
             realm.createOrUpdateObjectFromJson(AllTypes.class, new TestHelper.StubInputStream());
             fail();
@@ -938,6 +975,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateAllFromJson_streamInvalidJSonCurlyBracketThrows() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         try {
             realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, TestHelper.stringToStream("{"));
             fail();
@@ -947,6 +986,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateObjectFromJson_streamIgnoreUnsetProperties() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.beginTransaction();
         realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, TestHelper.loadJsonFromAssets(context, "list_alltypes_primarykey.json"));
         realm.commitTransaction();
@@ -961,6 +1002,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateObjectFromJson_inputStream() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.beginTransaction();
 
         AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
@@ -982,6 +1025,8 @@ public class RealmJsonTests {
      */
     @Test
     public void createOrUpdateObjectFromJson_objectWithPrimaryKeySetValueDirectlyFromStream() throws JSONException, IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream stream = TestHelper.stringToStream("{\"id\": 1, \"name\": \"bar\"}");
         realm.beginTransaction();
         realm.createObject(OwnerPrimaryKey.class, 0); // id = 0
@@ -1215,6 +1260,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateAllFromJson_streamNoPrimaryKeyThrows() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         try {
             realm.createOrUpdateAllFromJson(AllTypes.class, new TestHelper.StubInputStream());
             fail();
@@ -1224,6 +1271,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateAllFromJson_streamInvalidJSonBracketThrows() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         try {
             realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, TestHelper.stringToStream("["));
             fail();
@@ -1289,6 +1338,8 @@ public class RealmJsonTests {
 
     @Test
     public void createOrUpdateAllFromJson_inputStream() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.beginTransaction();
         realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, TestHelper.loadJsonFromAssets(context, "list_alltypes_primarykey.json"));
         realm.commitTransaction();
@@ -1328,6 +1379,8 @@ public class RealmJsonTests {
     // Test creating objects form JSON stream, all nullable fields with null values or non-null values
     @Test
     public void createAllFromJson_nullTypesStreamJSONWithNulls() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.beginTransaction();
         realm.createAllFromJson(NullTypes.class, TestHelper.loadJsonFromAssets(context, "nulltypes.json"));
         realm.commitTransaction();
@@ -1485,6 +1538,8 @@ public class RealmJsonTests {
      */
     @Test
     public void createObjectFromJson_nullTypesJSONStreamToNotNullFields() throws IOException, JSONException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         String json = TestHelper.streamToString(TestHelper.loadJsonFromAssets(context, "nulltypes_invalid.json"));
         JSONArray array = new JSONArray(json);
 
@@ -1612,6 +1667,8 @@ public class RealmJsonTests {
      */
     @Test
     public void createObjectFromJson_objectWithPrimaryKeySetValueDirectlyFromStream() throws JSONException, IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         InputStream stream = TestHelper.stringToStream("{\"id\": 1, \"name\": \"bar\"}");
         realm.beginTransaction();
         realm.createObject(OwnerPrimaryKey.class, 0); // id = 0

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
@@ -17,6 +17,7 @@
 package io.realm;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -44,9 +45,11 @@ import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static io.realm.internal.test.ExtraTests.assertArrayEquals;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
 // tests API methods when using a model class implementing RealmModel instead
 // of extending RealmObject.
@@ -160,6 +163,8 @@ public class RealmModelTests {
 
     @Test
     public void createOrUpdateAllFromJson() throws IOException {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         realm.beginTransaction();
         realm.createOrUpdateAllFromJson(AllTypesRealmModel.class, TestHelper.loadJsonFromAssets(context, "list_alltypes_primarykey.json"));
         realm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -17,6 +17,7 @@
 package io.realm;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -2017,17 +2018,25 @@ public class RealmTests {
 
         try { realm.createObjectFromJson(AllTypesPrimaryKey.class, jsonObj);                fail(); } catch (IllegalStateException expected) {}
         try { realm.createObjectFromJson(AllTypesPrimaryKey.class, jsonObjStr);             fail(); } catch (IllegalStateException expected) {}
-        try { realm.createObjectFromJson(NoPrimaryKeyNullTypes.class, jsonObjStream);       fail(); } catch (IllegalStateException expected) {}
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            try { realm.createObjectFromJson(NoPrimaryKeyNullTypes.class, jsonObjStream);   fail(); } catch (IllegalStateException expected) {}
+        }
         try { realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, jsonObj);        fail(); } catch (IllegalStateException expected) {}
         try { realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, jsonObjStr);     fail(); } catch (IllegalStateException expected) {}
-        try { realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, jsonObjStream2); fail(); } catch (IllegalStateException expected) {}
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            try { realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, jsonObjStream2); fail(); } catch (IllegalStateException expected) {}
+        }
 
         try { realm.createAllFromJson(AllTypesPrimaryKey.class, jsonArr);                   fail(); } catch (IllegalStateException expected) {}
         try { realm.createAllFromJson(AllTypesPrimaryKey.class, jsonArrStr);                fail(); } catch (IllegalStateException expected) {}
-        try { realm.createAllFromJson(NoPrimaryKeyNullTypes.class, jsonArrStream);          fail(); } catch (IllegalStateException expected) {}
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            try { realm.createAllFromJson(NoPrimaryKeyNullTypes.class, jsonArrStream);      fail(); } catch (IllegalStateException expected) {}
+        }
         try { realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, jsonArr);           fail(); } catch (IllegalStateException expected) {}
         try { realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, jsonArrStr);        fail(); } catch (IllegalStateException expected) {}
-        try { realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, jsonArrStream2);    fail(); } catch (IllegalStateException expected) {}
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            try { realm.createOrUpdateAllFromJson(AllTypesPrimaryKey.class, jsonArrStream2);fail(); } catch (IllegalStateException expected) {}
+        }
     }
 
     // TODO: re-introduce this test mocking the ReferenceQueue instead of relying on the GC

--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
@@ -16,6 +16,7 @@
 package io.realm;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.support.test.InstrumentationRegistry;
@@ -48,12 +49,14 @@ import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;
 import io.realm.util.RealmBackgroundTask;
 
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 @RunWith(AndroidJUnit4.class)
 public class TypeBasedNotificationsTests {
@@ -250,6 +253,8 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_createObjectFromJson() {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         final Realm realm = looperThread.realm;
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
@@ -356,6 +361,8 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_createOrUpdateObjectFromJson() {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
+
         final Realm realm = looperThread.realm;
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableViewTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNITableViewTest.java
@@ -16,6 +16,7 @@
 
 package io.realm.internal;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Before;
@@ -28,6 +29,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
+import io.realm.Realm;
 import io.realm.RealmFieldType;
 import io.realm.rule.TestRealmConfigurationFactory;
 
@@ -35,6 +37,10 @@ import static junit.framework.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class JNITableViewTest {
+    static {
+        Realm.init(InstrumentationRegistry.getInstrumentation().getTargetContext());
+    }
+
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
 

--- a/realm/realm-library/src/main/AndroidManifest.xml
+++ b/realm/realm-library/src/main/AndroidManifest.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.realm" >
-
-</manifest>
+<manifest package="io.realm" />


### PR DESCRIPTION
This enables for us to reproduce #3804 on our unit test.

@realm/java 

After applying this change, our android test reproduces #3804 on ARM with API 9 device, and #3735 on x86  with API 9 emulator.