### PR TITLE
Zeroing memory before using it

### DIFF
--- a/realm/realm-library/src/benchmarks/java/io/realm/benchmarks/RealmObjectWriteBenchmarks.java
+++ b/realm/realm-library/src/benchmarks/java/io/realm/benchmarks/RealmObjectWriteBenchmarks.java
@@ -54,9 +54,23 @@ public class RealmObjectWriteBenchmarks {
     }
 
     @Benchmark
-    public void writeString(long reps) {
+    public void writeShortString(long reps) {
         for (long i = 0; i < reps; i++) {
             writeObject.setColumnString("Foo");
+        }
+    }
+
+    @Benchmark
+    public void writeMediumString(long reps) {
+        for (long i = 0; i < reps; i++) {
+            writeObject.setColumnString("ABCDEFHIJKLMNOPQ");
+        }
+    }
+
+    @Benchmark
+    public void writeLongString(long reps) {
+        for (long i = 0; i < reps; i++) {
+            writeObject.setColumnString("ABCDEFHIJKLMNOPQABCDEFHIJKLMNOPQABCDEFHIJKLMNOPQABCDEFHIJKLMNOPQ");
         }
     }
 

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -405,7 +405,9 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
         size_t error_code;
         buf_size = Xcode::find_utf8_buf_size(begin, end, error_code);
     }
-    m_data.reset(new char[buf_size]);  // throws
+    char *c = new char[buf_size]; // throws
+    std::memset(c, 0, buf_size);
+    m_data.reset(c);
     {
         const jchar* in_begin = chars.data();
         const jchar* in_end   = in_begin + chars.size();

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -405,8 +405,7 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
         size_t error_code;
         buf_size = Xcode::find_utf8_buf_size(begin, end, error_code);
     }
-    char *c = new char[buf_size]; // throws
-    std::memset(c, 0, buf_size);
+    char* c = new char[buf_size]; // throws
     m_data.reset(c);
     {
         const jchar* in_begin = chars.data();
@@ -421,6 +420,8 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
             throw invalid_argument(string_to_hex("in_begin != in_end when converting to UTF-8", chars.data(), chars.size(), error_code));
         }
         m_size = out_begin - m_data.get();
+        // FIXME: Does this help on string issues? Or does it only help lldb?
+        std::memset(c + m_size, 0, buf_size - m_size);
     }
 }
 

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -405,8 +405,8 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
         size_t error_code;
         buf_size = Xcode::find_utf8_buf_size(begin, end, error_code);
     }
-    char* c = new char[buf_size]; // throws
-    m_data.reset(c);
+    char* tmp_char_array = new char[buf_size]; // throws
+    m_data.reset(tmp_char_array);
     {
         const jchar* in_begin = chars.data();
         const jchar* in_end   = in_begin + chars.size();
@@ -421,7 +421,7 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
         }
         m_size = out_begin - m_data.get();
         // FIXME: Does this help on string issues? Or does it only help lldb?
-        std::memset(c + m_size, 0, buf_size - m_size);
+        std::memset(tmp_char_array + m_size, 0, buf_size - m_size);
     }
 }
 


### PR DESCRIPTION
I have noticed that while debugging in Android Studio, strings contain garbage. Java strings can contain `NULL` characters so it can be a simple artefact of that. But in the light of our string issues in the last two years,  it might be worth zeroing the memory before using it.

The impact on performance is evaluated using the microbenchmark (included in the project)  on a Samsung S III mini (I-8190N). Impact is minimal (writeLong is included to evaluate the variance).

| Test | String length | w/o `memset` | with `memset` |
|------|--------------|---------------|-----------------|
| writeLong |N/A | 15.63 μs | 16.09 μs |
| writeLongString | 64 | 23.71 μs | 24.86 μs |
| writeMediumString | 16 | 20.8 μs | 21.55 μs |
| writeShortString | 3 | 20.31 μs | 20.40 μs |
