### PR TITLE
Disabling sync/compact combo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.2
+
+### Object Server API Changes (In Beta)
+
+* Disabled `Realm.compactRealm()` when sync is enabled as it might corrupt the Realm (https://github.com/realm/realm-core/issues/2345).
+
 ## 2.2.1
 
 ### Object Server API Changes (In Beta)

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
@@ -403,7 +403,7 @@ public class SyncConfigurationTests {
     }
 
     // FIXME: This test can be removed when https://github.com/realm/realm-core/issues/2345 is resolved
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void compact_NotAllowed() {
         SyncUser user = createTestUser();
         String url = "realm://objectserver.realm.io/default";

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
@@ -401,4 +401,14 @@ public class SyncConfigurationTests {
         String configStr = config.toString();
         assertTrue(configStr != null && !configStr.isEmpty());
     }
+
+    // FIXME: This test can be removed when https://github.com/realm/realm-core/issues/2345 is resolved
+    @Test(expected = IllegalArgumentException.class)
+    public void compact_NotAllowed() {
+        SyncUser user = createTestUser();
+        String url = "realm://objectserver.realm.io/default";
+        SyncConfiguration config = new SyncConfiguration.Builder(user, url).build();
+
+        Realm.compactRealm(config);
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1555,10 +1555,13 @@ public final class Realm extends BaseRealm {
      *
      * @param configuration a {@link RealmConfiguration} pointing to a Realm file.
      * @return {@code true} if successful, {@code false} if any file operation failed.
-     * @throws IllegalArgumentException if the realm file is encrypted. Compacting an encrypted Realm file is not
-     *                                  supported yet.
+     * @throws IllegalArgumentException if Realm is synchronized.
      */
     public static boolean compactRealm(RealmConfiguration configuration) {
+        // FIXME: remove this restriction when https://github.com/realm/realm-core/issues/2345 is resolved
+        if (configuration.isSyncConfiguration()) {
+            throw new IllegalArgumentException("You cannot compact a sync'ed Realm.");
+        }
         return BaseRealm.compactRealm(configuration);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1555,12 +1555,12 @@ public final class Realm extends BaseRealm {
      *
      * @param configuration a {@link RealmConfiguration} pointing to a Realm file.
      * @return {@code true} if successful, {@code false} if any file operation failed.
-     * @throws IllegalArgumentException if Realm is synchronized.
+     * @throws UnsupportedOperationException if Realm is synchronized.
      */
     public static boolean compactRealm(RealmConfiguration configuration) {
         // FIXME: remove this restriction when https://github.com/realm/realm-core/issues/2345 is resolved
         if (configuration.isSyncConfiguration()) {
-            throw new IllegalArgumentException("You cannot compact a sync'ed Realm.");
+            throw new UnsupportedOperationException("Compacting is not supported yet on synced Realms. See https://github.com/realm/realm-core/issues/2345");
         }
         return BaseRealm.compactRealm(configuration);
     }


### PR DESCRIPTION
Due to https://github.com/realm/realm-core/issues/2345 we need to disable `Realm.compactRealm()` when the Realm is sync'ed.