### PR TITLE
Throw correct exception for multiple logged in users

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -20,7 +20,6 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,7 +39,6 @@ import io.realm.internal.network.AuthenticationServer;
 import io.realm.rule.RunInLooperThread;
 import io.realm.util.SyncTestUtils;
 
-import static io.realm.util.SyncTestUtils.createRandomTestUser;
 import static io.realm.util.SyncTestUtils.createTestUser;
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -104,7 +104,9 @@ public class SyncUserTests {
     }
 
     private AuthenticateResponse getNewRandomUser() {
-        return SyncTestUtils.createLoginResponse(UUID.randomUUID().toString(), Long.MAX_VALUE);
+        String identity = UUID.randomUUID().toString();
+        String userTokenValue = UUID.randomUUID().toString();
+        return SyncTestUtils.createLoginResponse(userTokenValue, identity, Long.MAX_VALUE);
     }
 
     // Test that current user is cleared if it is logged out

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -89,23 +89,27 @@ public class SyncUserTests {
         AuthenticationServer originalAuthServer = SyncManager.getAuthServer();
         AuthenticationServer authServer = Mockito.mock(AuthenticationServer.class);
         SyncManager.setAuthServerImpl(authServer);
-
-        when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenAnswer(new Answer<AuthenticateResponse>() {
-            @Override
-            public AuthenticateResponse answer(InvocationOnMock invocationOnMock) throws Throwable {
-                return getNewRandomUser();
-            }
-        });
-        SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
-        SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
-
         try {
-            SyncUser.currentUser();
-            fail();
-        } catch (IllegalStateException ignore) {
+            // 1. Login two random users
+            when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenAnswer(new Answer<AuthenticateResponse>() {
+                @Override
+                public AuthenticateResponse answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    return getNewRandomUser();
+                }
+            });
+            SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
+            SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
+
+            // 2. Verify currentUser() now throws
+            try {
+                SyncUser.currentUser();
+                fail();
+            } catch (IllegalStateException ignore) {
+            }
         } finally {
             SyncManager.setAuthServerImpl(originalAuthServer);
         }
+
     }
 
     private AuthenticateResponse getNewRandomUser() {

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -26,6 +26,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -90,7 +92,12 @@ public class SyncUserTests {
         AuthenticationServer authServer = Mockito.mock(AuthenticationServer.class);
         SyncManager.setAuthServerImpl(authServer);
 
-        when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenReturn(getNewRandomUser());
+        when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenAnswer(new Answer<AuthenticateResponse>() {
+            @Override
+            public AuthenticateResponse answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return getNewRandomUser();
+            }
+        });
         SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
         SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -20,23 +20,33 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Collection;
+import java.util.UUID;
 
+import io.realm.internal.network.AuthenticateResponse;
+import io.realm.internal.network.AuthenticationServer;
 import io.realm.rule.RunInLooperThread;
 import io.realm.util.SyncTestUtils;
 
+import static io.realm.util.SyncTestUtils.createRandomTestUser;
 import static io.realm.util.SyncTestUtils.createTestUser;
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class SyncUserTests {
@@ -71,6 +81,29 @@ public class SyncUserTests {
 
         // Invalid users should not be returned when asking the for the current user
         assertNull(SyncUser.currentUser());
+    }
+
+    @Test
+    public void currentUser_throwsIfMultipleUsersLoggedIn() {
+        AuthenticationServer originalAuthServer = SyncManager.getAuthServer();
+        AuthenticationServer authServer = Mockito.mock(AuthenticationServer.class);
+        SyncManager.setAuthServerImpl(authServer);
+
+        when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenReturn(getNewRandomUser());
+        SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
+        SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
+
+        try {
+            SyncUser.currentUser();
+            fail();
+        } catch (IllegalStateException ignore) {
+        } finally {
+            SyncManager.setAuthServerImpl(originalAuthServer);
+        }
+    }
+
+    private AuthenticateResponse getNewRandomUser() {
+        return SyncTestUtils.createLoginResponse(UUID.randomUUID().toString(), Long.MAX_VALUE);
     }
 
     // Test that current user is cleared if it is logged out

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
@@ -74,12 +74,12 @@ public class SyncTestUtils {
     }
 
     public static AuthenticateResponse createLoginResponse(long expires) {
-        return createLoginResponse(USER_TOKEN, expires);
+        return createLoginResponse(USER_TOKEN, "JohnDoe", expires);
     }
 
-    public static AuthenticateResponse createLoginResponse(String userTokenValue, long expires) {
+    public static AuthenticateResponse createLoginResponse(String userTokenValue, String userIdentity, long expires) {
         try {
-            Token userToken = new Token(userTokenValue, "JohnDoe", null, expires, null);
+            Token userToken = new Token(userTokenValue, userIdentity, null, expires, null);
             JSONObject response = new JSONObject();
             response.put("refresh_token", userToken.toJson());
             return AuthenticateResponse.from(response.toString());

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
@@ -35,21 +35,25 @@ public class SyncTestUtils {
     public static String REALM_TOKEN = UUID.randomUUID().toString();
     public static String DEFAULT_AUTH_URL = "http://objectserver.realm.io/auth";
 
+    public static SyncUser createRandomTestUser() {
+        return createTestUser(UUID.randomUUID().toString(), UUID.randomUUID().toString(), DEFAULT_AUTH_URL, Long.MAX_VALUE);
+    }
+
     public static SyncUser createTestUser() {
-        return createTestUser(DEFAULT_AUTH_URL, Long.MAX_VALUE);
+        return createTestUser(USER_TOKEN, REALM_TOKEN, DEFAULT_AUTH_URL, Long.MAX_VALUE);
     }
 
     public static SyncUser createTestUser(long expires) {
-        return createTestUser(DEFAULT_AUTH_URL, expires);
+        return createTestUser(USER_TOKEN, REALM_TOKEN, DEFAULT_AUTH_URL, expires);
     }
 
     public static SyncUser createTestUser(String authUrl) {
-        return createTestUser(authUrl, Long.MAX_VALUE);
+        return createTestUser(USER_TOKEN, REALM_TOKEN, authUrl, Long.MAX_VALUE);
     }
 
-    public static SyncUser createTestUser(String authUrl, long expires) {
-        Token userToken = new Token(USER_TOKEN, "JohnDoe", null, expires, null);
-        Token accessToken = new Token(REALM_TOKEN, "JohnDoe", "/foo", expires, new Token.Permission[] {Token.Permission.DOWNLOAD });
+    public static SyncUser createTestUser(String userTokenValue, String realmTokenValue, String authUrl, long expires) {
+        Token userToken = new Token(userTokenValue, "JohnDoe", null, expires, null);
+        Token accessToken = new Token(realmTokenValue, "JohnDoe", "/foo", expires, new Token.Permission[] {Token.Permission.DOWNLOAD });
         ObjectServerUser.AccessDescription desc = new ObjectServerUser.AccessDescription(accessToken, "/data/data/myapp/files/default", false);
 
         JSONObject obj = new JSONObject();
@@ -70,8 +74,12 @@ public class SyncTestUtils {
     }
 
     public static AuthenticateResponse createLoginResponse(long expires) {
+        return createLoginResponse(USER_TOKEN, expires);
+    }
+
+    public static AuthenticateResponse createLoginResponse(String userTokenValue, long expires) {
         try {
-            Token userToken = new Token(USER_TOKEN, "JohnDoe", null, expires, null);
+            Token userToken = new Token(userTokenValue, "JohnDoe", null, expires, null);
             JSONObject response = new JSONObject();
             response.put("refresh_token", userToken.toJson());
             return AuthenticateResponse.from(response.toString());

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
@@ -34,6 +34,7 @@ Java_io_realm_RealmFileUserStore_nativeGetCurrentUser (JNIEnv *env, jclass)
 {
     TR_ENTER()
     try {
+        // FIXME Latest version of master has a `SyncManager::get_current_user`. Switch to that when we upgrade
         const std::shared_ptr<SyncUser> &user = currentUserOrThrow();
         if (user->state() == SyncUser::State::Active) {
             return to_jstring(env, user->refresh_token().data());
@@ -122,7 +123,7 @@ static const std::shared_ptr<SyncUser>& currentUserOrThrow() //throws
     if (all_users.size() > 1) {
         throw std::runtime_error(ERR_MULTIPLE_LOGGED_IN_USERS);
     } else if (all_users.size() < 1) {
-        throw std::runtime_error(ERR_NO_LOGGED_IN_USER);
+        return nullptr;
     } else {
         return all_users.front();
     }

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
@@ -31,15 +31,10 @@ Java_io_realm_RealmFileUserStore_nativeGetCurrentUser (JNIEnv *env, jclass)
 {
     TR_ENTER()
     try {
-        try {
-            const std::shared_ptr<SyncUser> &user = SyncManager::shared().get_current_user();
-            if (user) {
-                return to_jstring(env, user->refresh_token().data());
-            } else {
-                return nullptr;
-            }
-        } catch (std::logic_error e) {
-            ThrowException(env, IllegalState, "Multiple users have been logged in. `currentUser` is only valid if one single user is logged in.");
+        const std::shared_ptr<SyncUser> &user = SyncManager::shared().get_current_user();
+        if (user) {
+            return to_jstring(env, user->refresh_token().data());
+        } else {
             return nullptr;
         }
     } CATCH_STD()

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
@@ -31,11 +31,15 @@ Java_io_realm_RealmFileUserStore_nativeGetCurrentUser (JNIEnv *env, jclass)
 {
     TR_ENTER()
     try {
-
-        const std::shared_ptr<SyncUser> &user = SyncManager::shared().get_current_user();
-        if (user) {
-            return to_jstring(env, user->refresh_token().data());
-        } else {
+        try {
+            const std::shared_ptr<SyncUser> &user = SyncManager::shared().get_current_user();
+            if (user) {
+                return to_jstring(env, user->refresh_token().data());
+            } else {
+                return nullptr;
+            }
+        } catch (std::logic_error e) {
+            ThrowException(env, IllegalState, "Multiple users have been logged in. `currentUser` is only valid if one single user is logged in.");
             return nullptr;
         }
     } CATCH_STD()

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -79,6 +79,9 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, IllegalArgument, ss.str());
     }
+    catch (std::logic_error e) {
+        ThrowException(env, IllegalState, e.what());
+    }
     catch (exception& e) {
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, FatalError, ss.str());

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -70,11 +70,12 @@ public class SyncUser {
     }
 
     /**
-     * Returns the last user that has logged in and who is still valid.
-     * A user is invalidated when he/she logs out or the user's access token expire.
+     * Returns the current user that is logged in and still valid.
+     * A user is invalidated when he/she logs out or the user's access token expires.
      *
-     * @return last {@link SyncUser} that has logged in and who is still valid. {@code null} if no current user or user has
-     *         been invalidated.
+     * @return current {@link SyncUser} that has logged in and is still valid. {@code null} if no user is logged in or the user has
+     *         expired.
+     * @throws IllegalStateException if multiple users are logged in.
      */
     public static SyncUser currentUser() {
         SyncUser user = SyncManager.getUserStore().get();


### PR DESCRIPTION
`SyncUser.currentUser` should throw IllegalStateException if multiple users are logged in.

@realm/java 