### PR TITLE
Add the underlying information on RealmFileException.

### DIFF
--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -67,7 +67,7 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         ThrowException(env, IllegalArgument, ss.str());
     }
     catch (RealmFileException& e) {
-        ss << e.what() << " in " << file << " line " << line;
+        ss << e.what() << " (" <<  e.underlying() <<  ") in " << file << " line " << line;
         ThrowRealmFileException(env, ss.str(), e.kind());
     }
     catch (InvalidTransactionException& e) {


### PR DESCRIPTION
Add the underlying information on RealmFileException to help investigating incompatible lock file issue.