### PR TITLE
Wait forever in debugging mode

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -785,7 +785,7 @@ public class TestHelper {
         try {
             if (android.os.Debug.isDebuggerConnected()) {
                 // If we are debugging the tests, just wait without a timeout. In case we are stopping at a break point
-                // and timeout happnes.
+                // and timeout happens.
                 latch.await();
             } else if (!latch.await(numberOfSeconds, TimeUnit.SECONDS)) {
                 fail("Test took longer than " + numberOfSeconds + " seconds");

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -783,7 +783,11 @@ public class TestHelper {
 
     public static void awaitOrFail(CountDownLatch latch, int numberOfSeconds) {
         try {
-            if (!latch.await(numberOfSeconds, TimeUnit.SECONDS)) {
+            if (android.os.Debug.isDebuggerConnected()) {
+                // If we are debugging the tests, just wait without a timeout. In case we are stopping at a break point
+                // and timeout happnes.
+                latch.await();
+            } else if (!latch.await(numberOfSeconds, TimeUnit.SECONDS)) {
                 fail("Test took longer than " + numberOfSeconds + " seconds");
             }
         } catch (InterruptedException e) {


### PR DESCRIPTION
It is quite annoy when we stop at a breakpoint the awaitOrFail timeout
happens. By checking if the debugger connected, we can know we are
actually debugging the test and don't want to be interrupted by the
timeout.