### PR TITLE
RAII wrapper for some JNI resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 * "operation not permitted" issue when creating Realm file on some devices' external storage (#3629).
+* Crash on API 10 devices (#3726).
 
 ### Enhancements
 

--- a/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
@@ -30,6 +30,7 @@
 #include "io_realm_SyncManager.h"
 
 #include "jni_util/log.hpp"
+#include "jni_util/jni_utils.hpp"
 
 using namespace realm;
 using namespace realm::sync;
@@ -42,10 +43,7 @@ static jmethodID sync_manager_notify_error_handler = nullptr;
 
 static void error_handler(int error_code, std::string message)
 {
-    JNIEnv* env;
-    if (g_vm->GetEnv((void **) &env, JNI_VERSION_1_6) != JNI_OK) {
-        throw std::runtime_error("JVM is not attached to this thread. Called in error_handler.");
-    }
+    JNIEnv* env = JniUtils::get_env();
 
     env->CallStaticVoidMethod(sync_manager,
                               sync_manager_notify_error_handler, error_code, env->NewStringUTF(message.c_str()));

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -19,9 +19,11 @@
 #include <shared_realm.hpp>
 #include <object_store.hpp>
 #include "util.hpp"
+#include "jni_util/java_local_ref.hpp"
 #include "io_realm_internal_TableQuery.h"
 
 using namespace realm;
+using namespace realm::jni_util;
 
 #if 1
 #define QUERY_COL_TYPE_VALID(env, jPtr, col, type)  query_col_type_valid(env, jPtr, col, type)
@@ -1210,7 +1212,7 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_internal_TableQuery_nativeBatchUpdate
         // Step3: Run & export the queries against the latest shared group
         for (size_t i = 0; i < number_of_queries; ++i) {
             // Delete the local ref since we might have a long loop
-            JniLocalRef<jlongArray> local_ref(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
+            JavaLocalRef<jlongArray> local_ref(env, (jlongArray) env->GetObjectArrayElement(query_param_matrix, i));
             JniLongArray query_param_array(env, local_ref);
 
             switch (query_param_array[0]) { // 0, index of the type of query, the next indicies are parameters

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
@@ -22,7 +22,10 @@
 #include "mem_usage.hpp"
 #include "util.hpp"
 
+#include "jni_util/jni_utils.hpp"
+
 using std::string;
+using namespace realm::jni_util;
 
 //#define USE_VLD
 #if defined(_MSC_VER) && defined(_DEBUG) && defined(USE_VLD)
@@ -39,7 +42,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
         return JNI_ERR;
     }
     else {
-        g_vm = vm;
+        JniUtils::initialize(vm, JNI_VERSION_1_6);
         // Loading classes and constructors for later use - used by box typed fields and a few methods' return value
         java_lang_long        = GetClass(env, "java/lang/Long");
         java_lang_long_init   = env->GetMethodID(java_lang_long, "<init>", "(J)V");

--- a/realm/realm-library/src/main/cpp/java_binding_context.hpp
+++ b/realm/realm-library/src/main/cpp/java_binding_context.hpp
@@ -22,6 +22,8 @@
 
 #include "binding_context.hpp"
 
+#include "jni_util/java_global_weak_ref.hpp"
+
 namespace realm {
 
 namespace _impl {
@@ -36,22 +38,16 @@ private:
             :jni_env(env), java_notifier(notifier) { }
     };
 
-    // The JNIEnv for the thread which creates the Realm. This should only be used on the current thread.
-    JNIEnv* m_local_jni_env;
-    // All methods should be called from the thread which creates the realm except the destructor which might be
-    // called from finalizer/phantom daemon. So we need a jvm pointer to create JNIEnv there if needed.
-    JavaVM* m_jvm;
     // A weak global ref to the implementation of RealmNotifier
     // Java should hold a strong ref to it as long as the SharedRealm lives
-    jobject m_java_notifier;
-    // Method IDs from RealmNotifier implementation. Cache them as member vars.
-    jmethodID m_notify_by_other_method;
+    jni_util::JavaGlobalWeakRef m_java_notifier;
 
 public:
-    virtual ~JavaBindingContext();
+    virtual ~JavaBindingContext() {};
     virtual void changes_available();
 
-    explicit JavaBindingContext(const ConcreteJavaBindContext&);
+    explicit JavaBindingContext(const ConcreteJavaBindContext& concrete_context)
+            : m_java_notifier(concrete_context.jni_env, concrete_context.java_notifier) {}
     JavaBindingContext(const JavaBindingContext&) = delete;
     JavaBindingContext& operator=(const JavaBindingContext&) = delete;
     JavaBindingContext(JavaBindingContext&&) = delete;

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Realm Inc.
+ * Copyright 2017 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,29 @@
  * limitations under the License.
  */
 
-#include "java_binding_context.hpp"
-#include "jni_util/java_method.hpp"
+#include "java_global_weak_ref.hpp"
+#include "java_local_ref.hpp"
 
-using namespace realm;
-using namespace realm::_impl;
 using namespace realm::jni_util;
 
-void JavaBindingContext::changes_available()
+bool JavaGlobalWeakRef::call_with_local_ref(JNIEnv* env, std::function<Callback> callback)
 {
-    if (m_java_notifier) {
-        m_java_notifier.call_with_local_ref([&] (JNIEnv* env, jobject notifier_obj) {
-            // Method IDs from RealmNotifier implementation. Cache them as member vars.
-            static JavaMethod notify_by_other_method(env, notifier_obj, "notifyCommitByOtherThread", "()V");
-            env->CallVoidMethod(notifier_obj, notify_by_other_method);
-        });
+    if (!m_weak) {
+        return false;
     }
+
+    JavaLocalRef<jobject> obj(env, m_weak, need_to_create_local_ref);
+
+    if (!obj) {
+        return false;
+    }
+    callback(env, obj);
+    env->DeleteLocalRef(obj);
+    return true;
+}
+
+bool JavaGlobalWeakRef::call_with_local_ref(std::function<Callback> callback)
+{
+    return call_with_local_ref(JniUtils::get_env(), callback);
 }
 

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
@@ -31,7 +31,6 @@ bool JavaGlobalWeakRef::call_with_local_ref(JNIEnv* env, std::function<Callback>
         return false;
     }
     callback(env, obj);
-    env->DeleteLocalRef(obj);
     return true;
 }
 

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_JNI_UTIL_JAVA_GLOBAL_WEAK_REF_HPP
+#define REALM_JNI_UTIL_JAVA_GLOBAL_WEAK_REF_HPP
+
+#include <jni.h>
+#include <functional>
+
+#include "jni_utils.hpp"
+
+namespace realm {
+namespace jni_util {
+
+// RAII wrapper for weak global ref.
+class JavaGlobalWeakRef {
+public:
+    JavaGlobalWeakRef() : m_weak(nullptr) {}
+    JavaGlobalWeakRef(JNIEnv* env, jobject obj) : m_weak(obj ? env->NewWeakGlobalRef(obj) : nullptr) { }
+    ~JavaGlobalWeakRef()
+    {
+        if (m_weak) {
+            JniUtils::get_env()->DeleteWeakGlobalRef(m_weak);
+        }
+    }
+
+    inline operator bool() const noexcept
+    {
+        return m_weak != nullptr;
+    }
+
+    using Callback = void(JNIEnv* env, jobject obj);
+
+    // Acquire a local ref and run the callback with it if the weak ref is valid. The local ref will be deleted after
+    // callback finished. Return false if the weak ref is not valid anymore.
+    bool call_with_local_ref(JNIEnv* env, std::function<Callback> callback);
+    // Try to get an JNIEnv for current thread then run the callback.
+    bool call_with_local_ref(std::function<Callback> callback);
+
+private:
+    jweak m_weak;
+};
+
+} // namespace jni_util
+} // namespace realm
+
+#endif // REALM_JNI_UTIL_JAVA_GLOBAL_WEAK_REF_HPP
+

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
@@ -37,6 +37,12 @@ public:
         }
     }
 
+    // Implement those when needed.
+    JavaGlobalWeakRef(const JavaGlobalWeakRef&) = delete;
+    JavaGlobalWeakRef& operator=(const JavaGlobalWeakRef&) = delete;
+    JavaGlobalWeakRef(JavaGlobalWeakRef&& rhs) = delete;
+    JavaGlobalWeakRef& operator=(JavaGlobalWeakRef&& rhs) = delete;
+
     inline operator bool() const noexcept
     {
         return m_weak != nullptr;

--- a/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
@@ -33,7 +33,7 @@ template <typename T>
 class JavaLocalRef {
 public:
     // need_to_create is useful when acquire a local ref from a global weak ref.
-    inline JavaLocalRef(JNIEnv* env, T obj) noexcept : m_jobject( obj), m_env(env) {};
+    inline JavaLocalRef(JNIEnv* env, T obj) noexcept : m_jobject(obj), m_env(env) {};
     inline JavaLocalRef(JNIEnv* env, T obj, NeedToCreateLocalRef) noexcept
             : m_jobject(env->NewLocalRef(obj)), m_env(env) {};
     inline ~JavaLocalRef() { m_env->DeleteLocalRef(m_jobject); }

--- a/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
@@ -28,7 +28,7 @@ static constexpr NeedToCreateLocalRef need_to_create_local_ref{};
 // Wraps jobject and automatically calls DeleteLocalRef when this object is destroyed.
 // DeleteLocalRef is not necessary to be called in most cases since all local references will be cleaned up when the
 // program returns to Java from native. But if the local ref is created in a loop, consider to use this class to wrap it
-// because the size of local reference table is relative small (512 on Android).
+// because the size of local reference table is relative small (512 bytes on Android).
 template <typename T>
 class JavaLocalRef {
 public:

--- a/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_JNI_UTIL_JAVA_LOCAL_REF_HPP
+#define REALM_JNI_UTIL_JAVA_LOCAL_REF_HPP
+
+#include <jni.h>
+
+namespace realm {
+namespace jni_util {
+
+struct NeedToCreateLocalRef {};
+static constexpr NeedToCreateLocalRef need_to_create_local_ref{};
+
+// Wraps jobject and automatically calls DeleteLocalRef when this object is destroyed.
+// DeleteLocalRef is not necessary to be called in most cases since all local references will be cleaned up when the
+// program returns to Java from native. But if the local ref is created in a loop, consider to use this class to wrap it
+// because the size of local reference table is relative small (512 on Android).
+template <typename T>
+class JavaLocalRef {
+public:
+    // need_to_create is useful when acquire a local ref from a global weak ref.
+    inline JavaLocalRef(JNIEnv* env, T obj) noexcept : m_jobject( obj), m_env(env) {};
+    inline JavaLocalRef(JNIEnv* env, T obj, NeedToCreateLocalRef) noexcept
+            : m_jobject(env->NewLocalRef(obj)), m_env(env) {};
+    inline ~JavaLocalRef() { m_env->DeleteLocalRef(m_jobject); }
+
+    JavaLocalRef(const JavaLocalRef&) = delete;
+    JavaLocalRef& operator=(const JavaLocalRef&) = delete;
+    JavaLocalRef(JavaLocalRef&& rhs) = delete;
+    JavaLocalRef& operator=(JavaLocalRef&& rhs) = delete;
+
+    inline operator bool() const noexcept { return m_jobject != nullptr; };
+    inline operator T() const noexcept { return m_jobject; }
+
+private:
+    T m_jobject;
+    JNIEnv* m_env;
+};
+
+} // namespace realm
+} // namespace jni_util
+#endif // REALM_JNI_UTIL_JAVA_LOCAL_REF_HPP
+

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
@@ -23,12 +23,14 @@ using namespace realm::jni_util;
 JavaMethod::JavaMethod(JNIEnv *env, jclass cls, const char* method_name, const char* signature)
 {
     m_method_id = env->GetMethodID(cls, method_name, signature);
+    REALM_ASSERT_DEBUG(m_method_id != nullptr);
 }
 
 JavaMethod::JavaMethod(JNIEnv *env, jobject obj, const char* method_name, const char* signature)
 {
     jclass cls = env->GetObjectClass(obj);
     m_method_id = env->GetMethodID(cls, method_name, signature);
+    REALM_ASSERT_DEBUG(m_method_id != nullptr);
     env->DeleteLocalRef(cls);
 }
 

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "java_method.hpp"
+
+#include <realm/util/assert.hpp>
+
+using namespace realm::jni_util;
+
+JavaMethod::JavaMethod(JNIEnv *env, jclass cls, const char* method_name, const char* signature)
+{
+    m_method_id = env->GetMethodID(cls, method_name, signature);
+}
+
+JavaMethod::JavaMethod(JNIEnv *env, jobject obj, const char* method_name, const char* signature)
+{
+    jclass cls = env->GetObjectClass(obj);
+    m_method_id = env->GetMethodID(cls, method_name, signature);
+    env->DeleteLocalRef(cls);
+}
+
+JavaMethod::JavaMethod(JNIEnv *env, const char* class_name, const char* method_name, const char* signature)
+{
+    jclass cls = env->FindClass(class_name);
+    REALM_ASSERT_DEBUG(cls != nullptr);
+    m_method_id = env->GetMethodID(cls, method_name, signature);
+}
+

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_JNI_UTIL_JAVA_METHOD_HPP
+#define REALM_JNI_UTIL_JAVA_METHOD_HPP
+
+#include <jni.h>
+
+namespace realm {
+namespace jni_util {
+
+// RAII wrapper for java method ID. Since normally method ID stays unchanged for the whole JVM life cycle, it would be
+// safe to have a static JavaMethod object to avoid calling GetMethodID multiple times.
+class JavaMethod {
+public:
+    JavaMethod() : m_method_id(nullptr) {}
+    JavaMethod(JNIEnv *env, jclass cls, const char* method_name, const char* signature);
+    JavaMethod(JNIEnv *env, jobject obj, const char* method_name, const char* signature);
+    JavaMethod(JNIEnv *env, const char* class_name, const char* method_name, const char* signature);
+
+    JavaMethod(const JavaMethod&) = default;
+    JavaMethod& operator=(const JavaMethod&) = default;
+    JavaMethod(JavaMethod&& rhs) = delete;
+    JavaMethod& operator=(JavaMethod&& rhs) = delete;
+
+    ~JavaMethod() { }
+
+    inline operator bool() const noexcept { return m_method_id != nullptr; }
+    inline operator const jmethodID&() const noexcept { return m_method_id; }
+
+private:
+    jmethodID m_method_id;
+};
+
+} // namespace realm
+} // namespace jni_util
+
+#endif //REALM_JNI_UTIL_JAVA_METHOD_HPP

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
@@ -34,12 +34,13 @@ JNIEnv* JniUtils::get_env(bool attach_if_needed) {
     REALM_ASSERT_DEBUG(s_instance);
 
     JNIEnv* env;
-    if (s_instance->m_vm->GetEnv(reinterpret_cast<void**>(&env), s_instance->m_vm_version) != JNI_OK &&
-            attach_if_needed) {
-        jint ret = s_instance->m_vm->AttachCurrentThread(&env, nullptr);
-        REALM_ASSERT_DEBUG(ret == JNI_OK);
-    } else {
-        REALM_ASSERT_RELEASE(false);
+    if (s_instance->m_vm->GetEnv(reinterpret_cast<void**>(&env), s_instance->m_vm_version) != JNI_OK)
+        if (attach_if_needed) {
+            jint ret = s_instance->m_vm->AttachCurrentThread(&env, nullptr);
+            REALM_ASSERT_RELEASE(ret == JNI_OK);
+        } else {
+            REALM_ASSERT_RELEASE(false);
+        }
     }
 
     return env;

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
@@ -39,7 +39,7 @@ JNIEnv* JniUtils::get_env(bool attach_if_needed) {
         jint ret = s_instance->m_vm->AttachCurrentThread(&env, nullptr);
         REALM_ASSERT_DEBUG(ret == JNI_OK);
     } else {
-        REALM_ASSERT_DEBUG(false);
+        REALM_ASSERT_RELEASE(false);
     }
 
     return env;

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
@@ -34,7 +34,7 @@ JNIEnv* JniUtils::get_env(bool attach_if_needed) {
     REALM_ASSERT_DEBUG(s_instance);
 
     JNIEnv* env;
-    if (s_instance->m_vm->GetEnv(reinterpret_cast<void**>(&env), s_instance->m_vm_version) != JNI_OK)
+    if (s_instance->m_vm->GetEnv(reinterpret_cast<void**>(&env), s_instance->m_vm_version) != JNI_OK) {
         if (attach_if_needed) {
             jint ret = s_instance->m_vm->AttachCurrentThread(&env, nullptr);
             REALM_ASSERT_RELEASE(ret == JNI_OK);

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jni_utils.hpp"
+
+#include <realm/util/assert.hpp>
+
+#include <memory>
+
+using namespace realm::jni_util;
+
+static std::unique_ptr<JniUtils> s_instance;
+
+void JniUtils::initialize(JavaVM *vm, jint vm_version) noexcept {
+    REALM_ASSERT_DEBUG(!s_instance);
+
+    s_instance = std::unique_ptr<JniUtils>(new JniUtils(vm, vm_version));
+}
+
+JNIEnv* JniUtils::get_env(bool attach_if_needed) {
+    REALM_ASSERT_DEBUG(s_instance);
+
+    JNIEnv* env;
+    if (s_instance->m_vm->GetEnv(reinterpret_cast<void**>(&env), s_instance->m_vm_version) != JNI_OK &&
+            attach_if_needed) {
+        jint ret = s_instance->m_vm->AttachCurrentThread(&env, nullptr);
+        REALM_ASSERT_DEBUG(ret == JNI_OK);
+    } else {
+        REALM_ASSERT_DEBUG(false);
+    }
+
+    return env;
+}
+

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_JNI_UTIL_JNI_UTILS_HPP
+#define REALM_JNI_UTIL_JNI_UTILS_HPP
+
+#include <jni.h>
+
+namespace realm {
+namespace jni_util {
+
+// Util functions for JNI.
+class JniUtils {
+public:
+    ~JniUtils() {}
+
+    // Call this only once in JNI_OnLoad.
+    static void initialize(JavaVM* vm, jint vm_version) noexcept;
+    // When attach_if_needed is false, returns the JNIEnv if there is one attached to this thread. Assert if there is
+    // none. When attach_if_needed is true, try to attach and return a JNIEnv if necessary.
+    static JNIEnv* get_env(bool attach_if_needed = false);
+
+private:
+    JniUtils(JavaVM* vm, jint vm_version) noexcept : m_vm(vm), m_vm_version(vm_version) {}
+
+    JavaVM* m_vm;
+    jint m_vm_version;
+};
+
+} // namespace realm
+} // namespace jni_util
+
+#endif //REALM_JNI_UTIL_JNI_UTILS_HPP

--- a/realm/realm-library/src/main/cpp/objectserver_shared.hpp
+++ b/realm/realm-library/src/main/cpp/objectserver_shared.hpp
@@ -28,6 +28,9 @@
 #include <sync/sync_manager.hpp>
 
 #include "util.hpp"
+#include "jni_util/jni_utils.hpp"
+
+using namespace realm::jni_util;
 
 
 // Wrapper class for realm::Session. This allows us to manage the C++ session and callback lifecycle correctly.
@@ -55,8 +58,7 @@ public:
             }
         };
         auto error_handler = [&, global_obj_ref_tmp](int error_code, std::string message) {
-            JNIEnv *local_env;
-            g_vm->AttachCurrentThread(&local_env, nullptr);
+            JNIEnv *local_env = JniUtils::get_env(true);
             jclass java_session_class = local_env->GetObjectClass(global_obj_ref_tmp);
             jmethodID notify_error_handler = local_env->GetMethodID(java_session_class,
                                                                        "notifySessionError", "(ILjava/lang/String;)V");

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -32,7 +32,6 @@ using namespace realm::util;
 using namespace realm::jni_util;
 
 // Caching classes and constructors for boxed types.
-JavaVM* g_vm;
 jclass java_lang_long;
 jmethodID java_lang_long_init;
 jclass java_lang_float;

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -636,30 +636,6 @@ private:
     jint                m_releaseMode;
 };
 
-// Wraps jobject and automatically calls DeleteLocalRef when this object is destroyed.
-// DeleteLocalRef is not necessary to be called in most cases since all local references will be cleaned up when the
-// program returns to Java from native. But if the LocaRef is created in a loop, consider to use this class to wrap it
-// because the size of local reference table is relative small (512 on Android).
-template <typename T>
-class JniLocalRef {
-public:
-    JniLocalRef(JNIEnv* env, T obj) : m_jobject(obj), m_env(env) {};
-    ~JniLocalRef()
-    {
-        m_env->DeleteLocalRef(m_jobject);
-    }
-
-    inline operator T() const noexcept
-    {
-            return m_jobject;
-    }
-
-private:
-    T m_jobject;
-    JNIEnv* m_env;
-};
-
-extern JavaVM* g_vm;
 extern jclass java_lang_long;
 extern jmethodID java_lang_long_init;
 extern jclass java_lang_float;


### PR DESCRIPTION
* Move the global jvm pointer to JniUtils and add some helper functions.
* Wrapper for jmethodID, global weak ref.
* Refactor the wrapper for the local ref.
* Before using the global weak ref, always try to acquire a local ref
  first since until Android 4.0 weak global references could only be
  passed to NewLocalRef, NewGlobalRef, and DeleteWeakGlobalRef.
  See https://developer.android.com/training/articles/perf-jni.html#unsupported
  for more details. This fix #3726 .