### PR TITLE
Log the native backtrace when exception throws

### DIFF
--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -130,7 +130,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -Og -DNDEBUG")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${REALM_COMMON_CXX_FLAGS} ${WARNING_CXX_FLAGS} ${ABI_CXX_FLAGS}")
 
 # Set link flags
-set(REALM_LINKER_FLAGS "")
+set(REALM_LINKER_FLAGS "-Wl,--wrap=__cxa_throw")
 if (build_SYNC)
     set(REALM_LINKER_FLAGS "${REALM_LINKER_FLAGS} -lz")
 endif()

--- a/realm/realm-library/src/main/cpp/jni_util/exception_utils.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/exception_utils.cpp
@@ -1,0 +1,65 @@
+#include <unwind.h>
+#include <dlfcn.h>
+#include <iomanip>
+#include <android/log.h>
+
+struct BacktraceState
+{
+    void** current;
+    void** end;
+};
+
+static _Unwind_Reason_Code unwindCallback(struct _Unwind_Context* context, void* arg)
+{
+    BacktraceState* state = static_cast<BacktraceState*>(arg);
+    uintptr_t pc = _Unwind_GetIP(context);
+    if (pc) {
+        if (state->current == state->end) {
+            return _URC_END_OF_STACK;
+        } else {
+            *state->current++ = reinterpret_cast<void*>(pc);
+        }
+    }
+    return _URC_NO_REASON;
+}
+
+size_t captureBacktrace(void** buffer, size_t max)
+{
+    BacktraceState state = {buffer, buffer + max};
+    _Unwind_Backtrace(unwindCallback, &state);
+
+    return state.current - buffer;
+}
+
+void dumpBacktrace(std::ostream& os, void** buffer, size_t count)
+{
+    for (size_t idx = 0; idx < count; ++idx) {
+        uintptr_t addr = reinterpret_cast<uintptr_t>(buffer[idx]);
+        uintptr_t base_addr = 0;
+
+        Dl_info info;
+        if (dladdr(reinterpret_cast<void*>(addr), &info)) {
+            base_addr = reinterpret_cast<uintptr_t>(info.dli_fbase);
+        }
+
+        void* real_addr = (void *) (addr - base_addr);
+
+        os << " " << real_addr ;
+    }
+}
+
+extern "C" {
+void __real___cxa_throw(void *ex, void *info, void (*dest)(void *));
+
+void __wrap___cxa_throw(void *ex, void *info, void (*dest)(void *))
+{
+    const size_t max = 30;
+    void* buffer[max];
+    std::ostringstream oss;
+
+    dumpBacktrace(oss, buffer, captureBacktrace(buffer, max));
+
+    __android_log_print(ANDROID_LOG_ERROR, "Backtrace for Native exception: ", "%s", oss.str().c_str());
+    __real___cxa_throw(ex,info,dest);
+}
+}


### PR DESCRIPTION
It is always a pain for us that after converting c++ exception to
java's, all the native backtrace just lost.
This tries to hook into the __cxa_throw to log the native backtrace PCs
when exception throws.
The pc address can be then decoded through addr2line like:
addr2line -C -f -e librealm-jni.so 0xa0293 0xa0548 0xb8cd1 0x3acb3 0x15611

A more wicked idea would be totally implement a __cxa_throw function and
convert exceptions from there and unwind the callstack to where JNI borders
then return to java peacefully. It seems to be doable and we can get rid of
the `try CATCHSTD` blocks for every JNI call. Need more investigations.