### PR TITLE
Update Javadoc of Realm.compactRealm.

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -579,7 +579,6 @@ abstract class BaseRealm implements Closeable {
      * Compacts the Realm file defined by the given configuration.
      *
      * @param configuration configuration for the Realm to compact.
-     * @throws IllegalArgumentException if Realm is encrypted.
      * @return {@code true} if compaction succeeded, {@code false} otherwise.
      */
     static boolean compactRealm(final RealmConfiguration configuration) {


### PR DESCRIPTION
It is related #3520.

Compacting encrypted Realms is working, so Javadoc should be updated.