### PR TITLE
Count 'cpuX' files in /sys/devices/system/cpu as a more accurate way

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -126,6 +126,7 @@ repositories {
 dependencies {
     objectServerAnnotationProcessor project(':realm-annotations-processor')
     provided 'io.reactivex:rxjava:1.1.0'
+    provided 'net.sourceforge.findbugs:annotations:1.3.2'
     compile "io.realm:realm-annotations:${version}"
     compile 'com.getkeepsafe.relinker:relinker:1.2.2'
     objectServerCompile 'com.squareup.okhttp3:okhttp:3.4.1'


### PR DESCRIPTION
  of counting processors and setting the max threads for the Executor. (#3810)