### PR TITLE
Don't swallow Java exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.2.3
 
+### Enhancements
+
+* Exceptions thrown in error handler are not swallowed (#3559).
+
 ### Bug fixes
 
 * Fixed native memory leak setting the value of a primary key (#3993).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.2.3
 
-### Enhancements
+### Object Server API Changes (In Beta)
 
-* Exceptions thrown in error handler are not swallowed (#3559).
+* Exceptions thrown in `SyncSession.ErrorHandler` are no longer swallowed by JNI (#3559).
 
 ### Bug fixes
 

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -778,7 +778,7 @@ public class TestHelper {
     }
 
     public static void awaitOrFail(CountDownLatch latch) {
-        awaitOrFail(latch, 10);
+        awaitOrFail(latch, 15);
     }
 
     public static void awaitOrFail(CountDownLatch latch, int numberOfSeconds) {

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -778,7 +778,7 @@ public class TestHelper {
     }
 
     public static void awaitOrFail(CountDownLatch latch) {
-        awaitOrFail(latch, 15);
+        awaitOrFail(latch, 10);
     }
 
     public static void awaitOrFail(CountDownLatch latch, int numberOfSeconds) {

--- a/realm/realm-library/src/main/cpp/jni_util/jni_exceptions.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_exceptions.hpp
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_JNI_EXCEPTIONS_HPP
+#define REALM_JNI_EXCEPTIONS_HPP
+
+#include <exception>
+#include <string>
+#include <utility>
+
+namespace realm {
+namespace jni_util {
+
+class JniPendingException : public std::runtime_error {
+    JniPendingException(std::string message) : runtime_error(std::move(message)) {}
+};
+
+} // jni_util
+} // realm
+
+#endif // defined(REALM_JNI_EXCEPTIONS_HPP)

--- a/realm/realm-library/src/main/cpp/jni_util/jni_exceptions.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_exceptions.hpp
@@ -1,32 +1,30 @@
-////////////////////////////////////////////////////////////////////////////
-//
-// Copyright 2015 Realm Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef REALM_JNI_EXCEPTIONS_HPP
 #define REALM_JNI_EXCEPTIONS_HPP
 
 #include <exception>
 #include <string>
-#include <utility>
 
 namespace realm {
 namespace jni_util {
 
 class JniPendingException : public std::runtime_error {
+public:
     JniPendingException(std::string message) : runtime_error(std::move(message)) {}
 };
 

--- a/realm/realm-library/src/main/cpp/jni_util/jni_exceptions.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_exceptions.hpp
@@ -23,6 +23,9 @@
 namespace realm {
 namespace jni_util {
 
+// JniPendingException is typically used in in wrappers of callbacks. If the callback has thrown a Java exception,
+// it is not to safe most call JNI methods. Instead of clearing the Java exception and continue, the wrapper can throw
+// this C++ exception and get quickly back to the JNI border (and back to Java) with the Java exception intact.
 class JniPendingException : public std::runtime_error {
 public:
     JniPendingException(std::string message) : runtime_error(std::move(message)) {}

--- a/realm/realm-library/src/main/cpp/objectserver_shared.hpp
+++ b/realm/realm-library/src/main/cpp/objectserver_shared.hpp
@@ -33,6 +33,7 @@
 #include "jni_util/jni_utils.hpp"
 #include "jni_util/java_global_weak_ref.hpp"
 #include "jni_util/java_method.hpp"
+#include "jni_util/jni_exceptions.hpp"
 
 
 // Wrapper class for realm::Session. This allows us to manage the C++ session and callback lifecycle correctly.
@@ -82,8 +83,7 @@ public:
                     local_env->CallVoidMethod(
                             obj, notify_error_handler, error_code.value(), local_env->NewStringUTF(message.c_str()));
                     if (local_env->ExceptionCheck() == JNI_TRUE) {
-                        local_env->ExceptionDescribe();
-                        throw std::runtime_error("Exception in error handler");
+                        throw realm::jni_util::JniPendingException("Exception in error handler");
                     }
                 });
             }

--- a/realm/realm-library/src/main/cpp/objectserver_shared.hpp
+++ b/realm/realm-library/src/main/cpp/objectserver_shared.hpp
@@ -81,6 +81,10 @@ public:
                             local_env, obj, "notifySessionError", "(ILjava/lang/String;)V");
                     local_env->CallVoidMethod(
                             obj, notify_error_handler, error_code.value(), local_env->NewStringUTF(message.c_str()));
+                    if (local_env->ExceptionCheck() == JNI_TRUE) {
+                        local_env->ExceptionDescribe();
+                        throw std::runtime_error("Exception in error handler");
+                    }
                 });
             }
         };

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -25,6 +25,7 @@
 #include "io_realm_internal_Util.h"
 #include "io_realm_internal_SharedRealm.h"
 #include "shared_realm.hpp"
+#include "jni_util/jni_exceptions.hpp"
 
 using namespace std;
 using namespace realm;
@@ -48,6 +49,11 @@ void ConvertException(JNIEnv* env, const char *file, int line)
     ostringstream ss;
     try {
         throw;
+    }
+    catch (JniPendingException& e) {
+        // We have a pending Java exception - probably from an error handler - and we really just want to get
+        // back to Java.
+        return;
     }
     catch (bad_alloc& e) {
         ss << e.what() << " in " << file << " line " << line;

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -51,13 +51,13 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         throw;
     }
     catch (JniPendingException& e) {
-        // We have a pending Java exception - probably from an error handler - and we really just want to get
+        // We have a pending Java exception - probably from a sync error handler - and we really just want to get
         // back to Java.
         if (env->ExceptionCheck() == JNI_TRUE) {
             return;
         }
 
-        // If we don't have a pending exception, something went wrong. But at least we can throw a Java
+        // If we don't have a pending exception, so something went wrong. But at least we can throw a Java
         // exception.
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, FatalError, ss.str());

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -53,7 +53,14 @@ void ConvertException(JNIEnv* env, const char *file, int line)
     catch (JniPendingException& e) {
         // We have a pending Java exception - probably from an error handler - and we really just want to get
         // back to Java.
-        return;
+        if (env->ExceptionCheck() == JNI_TRUE) {
+            return;
+        }
+
+        // If we don't have a pending exception, something went wrong. But at least we can throw a Java
+        // exception.
+        ss << e.what() << " in " << file << " line " << line;
+        ThrowException(env, FatalError, ss.str());
     }
     catch (bad_alloc& e) {
         ss << e.what() << " in " << file << " line " << line;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -90,7 +90,7 @@ public class AuthTests {
 
         try {
             latch.await();
-            Thread.sleep(2000);
+            Thread.sleep(1000);
             fail();
         }
         catch (IllegalArgumentException e) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -2,6 +2,7 @@ package io.realm.objectserver;
 
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -79,17 +80,23 @@ public class AuthTests {
         SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
             @Override
             public void onSuccess(SyncUser user) {
+                Log.d("REALM", "onSuccess");
                 fail();
             }
 
             @Override
             public void onError(ObjectServerError error) {
+                Log.d("REALM", "onError 1");
                 latch.countDown();
+                Log.d("REALM", "onError 2");
                 throw new IllegalArgumentException("Boom");
             }
         });
 
+        Log.d("REALM", "main 1");
         TestHelper.awaitOrFail(latch);
+        Log.d("REALM", "main 2");
         looperThread.testComplete();
+        Log.d("REALM", "main 3");
     }
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -90,7 +90,7 @@ public class AuthTests {
 
         try {
             latch.await();
-            Thread.sleep(5000);
+            Thread.sleep(2000);
             fail();
         }
         catch (IllegalArgumentException e) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -70,38 +70,26 @@ public class AuthTests {
         });
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     @RunTestInLooperThread
     public void loginAsync_throwExceptionInErrorHandler() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
 
-        try {
-            SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
-            SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
-                @Override
-                public void onSuccess(SyncUser user) {
-                    fail();
-                }
+        SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
+        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
+            @Override
+            public void onSuccess(SyncUser user) {
+                fail();
+            }
 
-                @Override
-                public void onError(ObjectServerError error) {
-                    latch.countDown();
-                    throw new IllegalArgumentException("Boom");
-                }
-            });
+            @Override
+            public void onError(ObjectServerError error) {
+                latch.countDown();
+                throw new IllegalArgumentException("Boom");
+            }
+        });
 
-            Thread.sleep(1000); // let the exception propagate
-            TestHelper.awaitOrFail(latch);
-            fail();
-        }
-        catch (IllegalArgumentException e) {
-            assertEquals("Boom", e.getMessage());
-        }
-        catch (Exception ignored) {
-            fail();
-        }
-        finally {
-            looperThread.testComplete();
-        }
+        TestHelper.awaitOrFail(latch);
+        looperThread.testComplete();
     }
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -75,23 +75,23 @@ public class AuthTests {
     public void loginAsync_throwExceptionInErrorHandler() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
 
-        SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
-        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
-            @Override
-            public void onSuccess(SyncUser user) {
-                fail();
-            }
-
-            @Override
-            public void onError(ObjectServerError error) {
-                latch.countDown();
-                throw new IllegalArgumentException("Boom");
-            }
-        });
-
         try {
-            TestHelper.awaitOrFail(latch);
+            SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
+            SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
+                @Override
+                public void onSuccess(SyncUser user) {
+                    fail();
+                }
+
+                @Override
+                public void onError(ObjectServerError error) {
+                    latch.countDown();
+                    throw new IllegalArgumentException("Boom");
+                }
+            });
+
             Thread.sleep(1000); // let the exception propagate
+            TestHelper.awaitOrFail(latch);
             fail();
         }
         catch (IllegalArgumentException e) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -16,6 +16,7 @@ import io.realm.ObjectServerError;
 import io.realm.Realm;
 import io.realm.SyncCredentials;
 import io.realm.SyncUser;
+import io.realm.TestHelper;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.HttpUtils;
 import io.realm.rule.RunInLooperThread;
@@ -78,8 +79,8 @@ public class AuthTests {
         SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
             @Override
             public void onSuccess(SyncUser user) {
-                    fail();
-                }
+                fail();
+            }
 
             @Override
             public void onError(ObjectServerError error) {
@@ -89,8 +90,8 @@ public class AuthTests {
         });
 
         try {
-            latch.await();
-            Thread.sleep(1000);
+            TestHelper.awaitOrFail(latch);
+            Thread.sleep(1000); // let the exception propagate
             fail();
         }
         catch (IllegalArgumentException e) {


### PR DESCRIPTION
If a Java callback (often error handler) throws an exception, we should return to Java as soon as possible. By throwing a custom C++ exception, we can quickly get back. The custom exception is used to signal that the normal handling of C++ exception should not take place. 

Closes #3559.

To do:
 * [x] Updating change log

@realm/java 