### PR TITLE
Issue 3698

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Object Server API Changes (In Beta)
 
 * Add a default `UserStore` based on the Realm Object Store (`ObjectStoreUserStore`).
+* Change the order of arguments to SyncCredentials.custom to match iOS: token, provider, userInfo
 
 ## 2.2.3
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/CredentialsTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/CredentialsTests.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-
 @RunWith(AndroidJUnit4.class)
 public class CredentialsTests {
 
@@ -105,21 +104,6 @@ public class CredentialsTests {
         assertUsernamePassword(creds, "foo", "bar", false);
     }
 
-    private void assertUsernamePassword(SyncCredentials creds, String username, String password, boolean register) {
-        assertEquals(username, creds.getUserIdentifier());
-
-        Map<String, Object> userInfo = creds.getUserInfo();
-        assertEquals(SyncCredentials.IdentityProvider.USERNAME_PASSWORD, creds.getIdentityProvider());
-
-        assertEquals(password, userInfo.get("password"));
-
-        Boolean registerActual = (Boolean) userInfo.get("register");
-        if (registerActual == null) {
-            registerActual = Boolean.FALSE;
-        }
-        assertEquals(register, registerActual);
-    }
-
     // Only validate username. All passwords are allowed
     @Test
     public void usernamePassword_invalidUserName() {
@@ -137,8 +121,7 @@ public class CredentialsTests {
     @Test
     public void usernamePassword_nullPassword() {
         SyncCredentials creds = SyncCredentials.usernamePassword("foo", null, true);
-        Map<String, Object> userInfo = creds.getUserInfo();
-        assertEquals(null, userInfo.get("password"));
+        assertUsernamePassword(creds, "foo", null, true);
     }
 
     @Test
@@ -176,5 +159,20 @@ public class CredentialsTests {
             fail();
         } catch (IllegalArgumentException ignored) {
         }
+    }
+
+    private void assertUsernamePassword(SyncCredentials creds, String username, String password, boolean register) {
+        assertEquals(username, creds.getUserIdentifier());
+
+        Map<String, Object> userInfo = creds.getUserInfo();
+        assertEquals(SyncCredentials.IdentityProvider.USERNAME_PASSWORD, creds.getIdentityProvider());
+
+        assertEquals(password, userInfo.get("password"));
+
+        Boolean registerActual = (Boolean) userInfo.get("register");
+        if (registerActual == null) {
+            registerActual = Boolean.FALSE;
+        }
+        assertEquals(register, registerActual);
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -66,11 +66,37 @@ import io.realm.annotations.Beta;
 @Beta
 public class SyncCredentials {
 
-    private String identityProvider;
-    private String userIdentifier;
-    private Map<String, Object> userInfo;
+    private final String userIdentifier;
+    private final String identityProvider;
+    private final Map<String, Object> userInfo;
 
     // Factory constructors
+
+    /**
+     * Creates credentials based on a Facebook login.
+     *
+     * @param facebookToken a facebook userIdentifier acquired by logging into Facebook.
+     * @return a set of credentials that can be used to log into the Object Server using
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     * @throws IllegalArgumentException if user name is either {@code null} or empty.
+     */
+    public static SyncCredentials facebook(String facebookToken) {
+        assertStringNotEmpty(facebookToken, "facebookToken");
+        return new SyncCredentials(facebookToken, IdentityProvider.FACEBOOK, null);
+    }
+
+    /**
+     * Creates credentials based on a Google login.
+     *
+     * @param googleToken a google userIdentifier acquired by logging into Google.
+     * @return a set of credentials that can be used to log into the Object Server using
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     * @throws IllegalArgumentException if user name is either {@code null} or empty.
+     */
+    public static SyncCredentials google(String googleToken) {
+        assertStringNotEmpty(googleToken, "googleToken");
+        return new SyncCredentials(googleToken, IdentityProvider.GOOGLE, null);
+    }
 
     /**
      * Creates credentials based on a login with username and password. These credentials will only be verified
@@ -86,51 +112,33 @@ public class SyncCredentials {
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
     public static SyncCredentials usernamePassword(String username, String password, boolean createUser) {
-        if (username == null || username.equals("")) {
-            throw new IllegalArgumentException("Non-null 'username' required.");
-        }
+        assertStringNotEmpty(username, "username");
         Map<String, Object> userInfo = new HashMap<String, Object>();
         userInfo.put("register", createUser);
         userInfo.put("password", password);
-        return new SyncCredentials(IdentityProvider.USERNAME_PASSWORD, username, userInfo);
+        return new SyncCredentials(username, IdentityProvider.USERNAME_PASSWORD, userInfo);
     }
 
     /**
-     * Creates credentials based on a Facebook login.
+     * Creates credentials based on a login with username and password. These credentials will only be verified
+     * by the Object Server.  The user is not created if she does not exist.
      *
-     * @param facebookToken a facebook userIdentifier acquired by logging into Facebook.
+     * @param username username of the user.
+     * @param password the users password.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
-    public static SyncCredentials facebook(String facebookToken) {
-        if (facebookToken == null || facebookToken.equals("")) {
-            throw new IllegalArgumentException("Non-null 'facebookToken' required.");
-        }
-        return new SyncCredentials(IdentityProvider.FACEBOOK, facebookToken, null);
-    }
-
-    /**
-     * Creates credentials based on a Google login.
-     *
-     * @param googleToken a google userIdentifier acquired by logging into Google.
-     * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
-     * @throws IllegalArgumentException if user name is either {@code null} or empty.
-     */
-    public static SyncCredentials google(String googleToken) {
-        if (googleToken == null || googleToken.equals("")) {
-            throw new IllegalArgumentException("Non-null 'googleToken' required.");
-        }
-        return new SyncCredentials(IdentityProvider.GOOGLE, googleToken, null);
+    public static SyncCredentials usernamePassword(String username, String password) {
+        return usernamePassword(username, password, false);
     }
 
     /**
      * Creates a custom set of credentials. The behaviour will depend on the type of {@code identityProvider} and
      * {@code userInfo} used.
      *
-     * @param identityProvider provider used to verify the credentials.
      * @param userIdentifier String identifying the user. Usually a username of userIdentifier.
+     * @param identityProvider provider used to verify the credentials.
      * @param userInfo data describing the user further or {@code null} if the user does not have any extra data. The
      *              data will be serialized to JSON, so all values must be mappable to a valid JSON data type. Custom
      *              classes will be converted using {@code toString()}.
@@ -138,20 +146,22 @@ public class SyncCredentials {
      *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if any parameter is either {@code null} or empty.
      */
-    public static SyncCredentials custom(String identityProvider, String userIdentifier, Map<String, Object> userInfo) {
-        if (identityProvider == null || identityProvider.equals("")) {
-            throw new IllegalArgumentException("Non-null 'identityProvider' required.");
-        }
-        if (userIdentifier == null || userIdentifier.equals("")) {
-            throw new IllegalArgumentException("Non-null 'userIdentifier' required.");
-        }
+    public static SyncCredentials custom(String userIdentifier, String identityProvider, Map<String, Object> userInfo) {
+        assertStringNotEmpty(userIdentifier, "userIdentifier");
+        assertStringNotEmpty(identityProvider, "identityProvider");
         if (userInfo == null) {
             userInfo = new HashMap<String, Object>();
         }
-        return new SyncCredentials(identityProvider, userIdentifier, userInfo);
+        return new SyncCredentials(userIdentifier, identityProvider, userInfo);
     }
 
-    private SyncCredentials(String identityProvider, String token, Map<String, Object> userInfo) {
+    private static void assertStringNotEmpty(String string, String message) {
+        if (string == null || "".equals(string)) {
+            throw new IllegalArgumentException("Non-null '" + message + "' required.");
+        }
+    }
+
+    private SyncCredentials(String token, String identityProvider, Map<String, Object> userInfo) {
         this.identityProvider = identityProvider;
         this.userIdentifier = token;
         this.userInfo = (userInfo == null) ? new HashMap<String, Object>() : userInfo;

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -77,7 +77,7 @@ public class SyncCredentials {
      *
      * @param facebookToken a facebook userIdentifier acquired by logging into Facebook.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
     public static SyncCredentials facebook(String facebookToken) {
@@ -90,7 +90,7 @@ public class SyncCredentials {
      *
      * @param googleToken a google userIdentifier acquired by logging into Google.
      * @return a set of credentials that can be used to log into the Object Server using
-     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
     public static SyncCredentials google(String googleToken) {


### PR DESCRIPTION
Change the order of args for the custom method to match the iOS call
Add an overloaded 2 arg usernamePassword method that defaults createUser false
Add unit tests as appropriate