### PR TITLE
SyncCredentials.accessToken + Integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,8 +138,7 @@ try {
 }
 
 def forwardAdbPorts() {
-  sh ''' adb reverse tcp:7800 tcp:7800 &&
-      adb reverse tcp:8080 tcp:8080 &&
+  sh ''' adb reverse tcp:9080 tcp:9080 &&
       adb reverse tcp:8888 tcp:8888
   '''
 }

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ To run a testing server locally:
 	./gradlew connectedObjectServerDebugAndroidTest
 	```
 
+Note that if using VirtualBox (Genymotion), the network needs to be bridged for the tests to work.
+This is done in `VirtualBox > Network`. Set "Adapter 2" to "Bridged Adapter".
+
 These tests may take as much as half an hour to complete.
 
 ## Contributing

--- a/dependencies.list
+++ b/dependencies.list
@@ -4,5 +4,7 @@ REALM_SYNC_VERSION=1.0.0-BETA-7.1
 REALM_SYNC_SHA256=5412b42d96dd525af3ec6a0b7943330c43beae2c663b32376b77278ea54e34a5
 
 # Object Server Release used by Integration tests
+# `realm` is stable releases, `realm-testing` is developer builds.
 # https://packagecloud.io/realm/realm?filter=debs
-REALM_OBJECT_SERVER_DE_VERSION=1.0.0-BETA-4.11-449
+# https://packagecloud.io/realm/realm-testing?filter=debs
+REALM_OBJECT_SERVER_DE_VERSION=1.0.0-BETA-5.1-74

--- a/realm/config/findbugs/findbugs-filter.xml
+++ b/realm/config/findbugs/findbugs-filter.xml
@@ -15,9 +15,4 @@
     <Match>
         <Class name="io.realm.PermissionChangeRealmProxy"/>
     </Match>
-    <Match>
-        <Class name="io.realm.internal.objectserver.Token$Permission" />
-        <Field name="ALL" />
-        <Bug pattern="MS_MUTABLE_ARRAY" />
-    </Match>
 </FindBugsFilter>

--- a/realm/config/findbugs/findbugs-filter.xml
+++ b/realm/config/findbugs/findbugs-filter.xml
@@ -109,4 +109,9 @@
         <Class name="io.realm.PermissionChangeRealmProxy" />
         <Bug pattern="BC_IMPOSSIBLE_CAST" />
     </Match>
+    <Match>
+        <Class name="io.realm.internal.objectserver.Token$Permission" />
+        <Field name="ALL" />
+        <Bug pattern="MS_MUTABLE_ARRAY" />
+    </Match>
 </FindBugsFilter>

--- a/realm/realm-library/src/androidTest/AndroidManifest.xml
+++ b/realm/realm-library/src/androidTest/AndroidManifest.xml
@@ -21,6 +21,23 @@
             android:exported="true"
             android:process=":remote">
         </service>
+
+         <!--
+          FIXME: Manifest merger doesn't seem to work correctly with test flavours.
+          Figure out why. For now place services here
+          -->
+        <service
+            android:name="io.realm.objectserver.service.SendOneCommit"
+            android:enabled="true"
+            android:exported="true"
+            android:process=":remote">
+        </service>
+        <service
+            android:name="io.realm.objectserver.service.SendsALot"
+            android:enabled="true"
+            android:exported="true"
+            android:process=":remote">
+        </service>
     </application>
 
 </manifest>

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -52,7 +52,7 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
     // Default Realm created by this Rule. It is guaranteed to be closed when the test finishes.
     public Realm realm;
     // Custom Realm used by the test. Saving the reference here will guarantee the instance is closed when exiting the test.
-    public Realm testRealm; // Custom test realm defined by the test case. This rule will gua
+    public Realm testRealm;
     public RealmConfiguration realmConfiguration;
     private CountDownLatch signalTestCompleted;
     private Handler backgroundHandler;

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -49,9 +49,9 @@ import static org.junit.Assert.fail;
  */
 public class RunInLooperThread extends TestRealmConfigurationFactory {
 
-    // Default Realm created by this Rule. It is guarenteed to be closed when the test finishes.
+    // Default Realm created by this Rule. It is guaranteed to be closed when the test finishes.
     public Realm realm;
-    // Custom Realm used by the test. Saving the reference here will guarentee the instance is closed when exiting the test.
+    // Custom Realm used by the test. Saving the reference here will guarantee the instance is closed when exiting the test.
     public Realm testRealm; // Custom test realm defined by the test case. This rule will gua
     public RealmConfiguration realmConfiguration;
     private CountDownLatch signalTestCompleted;

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -48,7 +48,11 @@ import static org.junit.Assert.fail;
  * and this class does not agree in which order to delete all open Realms.
  */
 public class RunInLooperThread extends TestRealmConfigurationFactory {
+
+    // Default Realm created by this Rule. It is guarenteed to be closed when the test finishes.
     public Realm realm;
+    // Custom Realm used by the test. Saving the reference here will guarentee the instance is closed when exiting the test.
+    public Realm testRealm; // Custom test realm defined by the test case. This rule will gua
     public RealmConfiguration realmConfiguration;
     private CountDownLatch signalTestCompleted;
     private Handler backgroundHandler;
@@ -72,6 +76,7 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
         super.after();
         realmConfiguration = null;
         realm = null;
+        testRealm = null;
         keepStrongReference = null;
     }
 
@@ -127,6 +132,9 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
                                 signalTestCompleted.countDown();
                                 if (realm != null) {
                                     realm.close();
+                                }
+                                if (testRealm != null) {
+                                    testRealm.close();
                                 }
                                 signalClosedRealm.countDown();
                             }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -197,4 +197,19 @@ public class SyncUserTests {
         assertTrue(str != null && !str.isEmpty());
     }
 
+    // Test that a login an access token logs the user in directly without touching the network
+    @Test
+    public void login_withAccessToken() {
+        AuthenticationServer authServer = Mockito.mock(AuthenticationServer.class);
+        when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenThrow(new AssertionError("Server contacted."));
+        AuthenticationServer originalServer = SyncManager.getAuthServer();
+        SyncManager.setAuthServerImpl(authServer);
+        try {
+            SyncCredentials credentials = SyncCredentials.accessToken("foo", "bar");
+            SyncUser user = SyncUser.login(credentials, "http://ros.realm.io/auth");
+            assertTrue(user.isValid());
+        } finally {
+            SyncManager.setAuthServerImpl(originalServer);
+        }
+    }
 }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -197,7 +197,7 @@ public class SyncUserTests {
         assertTrue(str != null && !str.isEmpty());
     }
 
-    // Test that a login an access token logs the user in directly without touching the network
+    // Test that a login with an access token logs the user in directly without touching the network
     @Test
     public void login_withAccessToken() {
         AuthenticationServer authServer = Mockito.mock(AuthenticationServer.class);

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -169,7 +169,7 @@ public class SyncCredentials {
     public static SyncCredentials accessToken(String accessToken, String identifier) {
         HashMap<String, Object> userInfo = new HashMap<String, Object>();
         userInfo.put("_token", accessToken);
-        return new SyncCredentials(IdentityProvider.ACCESS_TOKEN, identifier, userInfo);
+        return new SyncCredentials(identifier, IdentityProvider.ACCESS_TOKEN, userInfo);
     }
 
     private static void assertStringNotEmpty(String string, String message) {

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -137,7 +137,7 @@ public class SyncCredentials {
      * Creates a custom set of credentials. The behaviour will depend on the type of {@code identityProvider} and
      * {@code userInfo} used.
      *
-     * @param userIdentifier String identifying the user. Usually a username of userIdentifier.
+     * @param userIdentifier string identifying the user. Usually a username of userIdentifier.
      * @param identityProvider provider used to verify the credentials.
      * @param userInfo data describing the user further or {@code null} if the user does not have any extra data. The
      *              data will be serialized to JSON, so all values must be mappable to a valid JSON data type. Custom
@@ -161,8 +161,8 @@ public class SyncCredentials {
      * This means that providing this credential to {@link SyncUser#login(SyncCredentials, String)} will always
      * succeed, but accessing any Realm after might fail if the token is no longer valid.
      *
-     * @param accessToken Users access token.
-     * @param identifier User identifier.
+     * @param accessToken user's access token.
+     * @param identifier user identifier.
      * @return a set of credentials that can be used to log into the Object Server using
      *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
      */

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -151,6 +151,23 @@ public class SyncCredentials {
         return new SyncCredentials(identityProvider, userIdentifier, userInfo);
     }
 
+    /**
+     * Creates credentials from an existing access token. Since an access token is the proof that a user already
+     * has logged in. Credentials created this way are automatically assumed to have successfully logged in.
+     * This means that providing this credential to {@link SyncUser#login(SyncCredentials, String)} will always
+     * succeed, but accessing any Realm after might fail if the token is no longer valid.
+     *
+     * @param accessToken Users access token.
+     * @param identifier User identifier.
+     * @return a set of credentials that can be used to log into the Object Server using
+     *         {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     */
+    public static SyncCredentials accessToken(String accessToken, String identifier) {
+        HashMap<String, Object> userInfo = new HashMap<String, Object>();
+        userInfo.put("_token", accessToken);
+        return new SyncCredentials(IdentityProvider.ACCESS_TOKEN, identifier, userInfo);
+    }
+
     private SyncCredentials(String identityProvider, String token, Map<String, Object> userInfo) {
         this.identityProvider = identityProvider;
         this.userIdentifier = token;
@@ -191,6 +208,14 @@ public class SyncCredentials {
      * verifying that a given credential is valid.
      */
     public static final class IdentityProvider {
+
+        /**
+         * The provided identify is an already registered user (represented by the access token). Logging in with this
+         * type of identity will happen purely on the device without contacting the Realm Object Server. Acquiring
+         * access to individual Realms will still require talking to the Object Server.
+         */
+        public static final String ACCESS_TOKEN = "_access_token";
+
         /**
          * Any credentials verified by the debug identity provider will always be considered valid.
          * It is only available if configured on the Object Server, and it is disabled by default.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -50,11 +50,13 @@ public class SyncManager {
     /**
      * Debugging related options.
      */
+    @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static class Debug {
         /**
          * Set this to true to bypass the device online checking.
          */
         public static boolean skipOnlineChecking = false;
+
     }
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -53,7 +53,7 @@ public class SyncManager {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static class Debug {
         /**
-         * Set this to true to bypass the device online checking.
+         * Set this to true to bypass checking if the device is offline before making HTTP requests.
          */
         public static boolean skipOnlineChecking = false;
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -48,6 +48,16 @@ import io.realm.log.RealmLog;
 public class SyncManager {
 
     /**
+     * Debugging related options.
+     */
+    public static class Debug {
+        /**
+         * Set this to true to bypass the device online checking.
+         */
+        public static boolean skipOnlineChecking = false;
+    }
+
+    /**
      * APP ID sent to the Realm Object Server. Is automatically initialized to the package name for the app.
      */
     public static String APP_ID = null;

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -172,7 +172,7 @@ public class SyncUser {
         try {
             AuthenticateResponse result;
             if (credentials.getIdentityProvider().equals(SyncCredentials.IdentityProvider.ACCESS_TOKEN)) {
-                // Credentials using ACCESS_TOKEN as IdentityProvider are optimistically assumed to be valid already
+                // Credentials using ACCESS_TOKEN as IdentityProvider are optimistically assumed to be valid already.
                 // So log them in directly without contacting the authentication server. This is done by mirroring
                 // the JSON response expected from the server.
                 String userIdentifier = credentials.getUserIdentifier();

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -31,7 +31,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -31,6 +31,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -151,10 +152,20 @@ public class SyncUser {
             throw new IllegalArgumentException("Invalid URL " + authenticationUrl + ".", e);
         }
 
-        final AuthenticationServer server = SyncManager.getAuthServer();
         ObjectServerError error;
         try {
-            AuthenticateResponse result = server.loginUser(credentials, authUrl);
+            AuthenticateResponse result;
+            if (credentials.getIdentityProvider().equals(SyncCredentials.IdentityProvider.ACCESS_TOKEN)) {
+                // Credentials using ACCESS_TOKEN as IdentityProvider are optimistically assumed to be valid already
+                // So log them in directly without contacting the authentication server. This is done by mirroring
+                // the JSON response expected from the server.
+                String userIdentifier = credentials.getUserIdentifier();
+                String token = (String) credentials.getUserInfo().get("_token");
+                result = AuthenticateResponse.createValidResponseWithUser(userIdentifier, token);
+            } else {
+                final AuthenticationServer server = SyncManager.getAuthServer();
+                result = server.loginUser(credentials, authUrl);
+            }
             if (result.isValid()) {
                 ObjectServerUser syncUser = new ObjectServerUser(result.getRefreshToken(), authUrl);
                 SyncUser user = new SyncUser(syncUser);

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
@@ -78,8 +78,8 @@ public class AuthenticateResponse extends AuthServerResponse {
      * Helper method for creating a valid user login response. The user returned will be assumed to have all permissions
      * and doesn't expire.
      *
-     * @param identifier User identifier.
-     * @param refreshToken Users refresh token.
+     * @param identifier user identifier.
+     * @param refreshToken user's refresh token.
      */
     public static AuthenticateResponse createValidResponseWithUser(String identifier, String refreshToken) {
         try {

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
@@ -75,6 +75,24 @@ public class AuthenticateResponse extends AuthServerResponse {
     }
 
     /**
+     * Helper method for creating a valid user login response. The user returned will be assumed to have all permissions
+     * as doesn't expire.
+     *
+     * @param identifier User identifier.
+     * @param token Users refresh token.
+     * @return Response
+     */
+    public static AuthenticateResponse createValidResponseWithUser(String identifier, String token) {
+        try {
+            JSONObject response = new JSONObject();
+            response.put(JSON_FIELD_REFRESH_TOKEN, new Token(token, identifier, null, Long.MAX_VALUE, Token.Permission.ALL).toJson());
+            return new AuthenticateResponse(response.toString());
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
      * Creates an unsuccessful authentication response. This should only happen in case of network or I/O related
      * issues.
      *

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
@@ -99,7 +99,7 @@ public class AuthenticateResponse extends AuthServerResponse {
      * @param error the network or I/O error.
      */
     private AuthenticateResponse(ObjectServerError error) {
-        RealmLog.debug("AuthenticateResponse. Error " + error.getErrorMessage());
+        RealmLog.debug("AuthenticateResponse - Error: " + error);
         setError(error);
         this.accessToken = null;
         this.refreshToken = null;

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
@@ -76,16 +76,15 @@ public class AuthenticateResponse extends AuthServerResponse {
 
     /**
      * Helper method for creating a valid user login response. The user returned will be assumed to have all permissions
-     * as doesn't expire.
+     * and doesn't expire.
      *
      * @param identifier User identifier.
-     * @param token Users refresh token.
-     * @return Response
+     * @param refreshToken Users refresh token.
      */
-    public static AuthenticateResponse createValidResponseWithUser(String identifier, String token) {
+    public static AuthenticateResponse createValidResponseWithUser(String identifier, String refreshToken) {
         try {
             JSONObject response = new JSONObject();
-            response.put(JSON_FIELD_REFRESH_TOKEN, new Token(token, identifier, null, Long.MAX_VALUE, Token.Permission.ALL).toJson());
+            response.put(JSON_FIELD_REFRESH_TOKEN, new Token(refreshToken, identifier, null, Long.MAX_VALUE, Token.Permission.ALL).toJson());
             return new AuthenticateResponse(response.toString());
         } catch (JSONException e) {
             throw new RuntimeException(e);

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/NetworkStateReceiver.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/NetworkStateReceiver.java
@@ -25,6 +25,7 @@ import android.net.NetworkInfo;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import io.realm.SyncManager;
 import io.realm.internal.Util;
 
 /**
@@ -67,6 +68,9 @@ public class NetworkStateReceiver extends BroadcastReceiver {
      * @return {@code true} if device is online, otherwise {@code false}.
      */
     public static boolean isOnline(Context context) {
+        if (SyncManager.Debug.skipOnlineChecking) {
+            return true;
+        }
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo networkInfo = cm.getActiveNetworkInfo();
         return ((networkInfo != null && networkInfo.isConnectedOrConnecting()) || Util.isEmulator());

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -88,6 +88,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
                 .addHeader("Accept", "application/json")
                 .post(RequestBody.create(JSON, requestBody))
                 .build();
+        RealmLog.debug("Authenticate: " + requestBody);
         Call call = client.newCall(request);
         Response response = call.execute();
         return AuthenticateResponse.from(response);

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -89,7 +89,6 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
                 .post(RequestBody.create(JSON, requestBody))
                 .build();
         Call call = client.newCall(request);
-        RealmLog.debug("Authenticating: " + requestBody);
         Response response = call.execute();
         return AuthenticateResponse.from(response);
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -89,9 +89,8 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
                 .post(RequestBody.create(JSON, requestBody))
                 .build();
         Call call = client.newCall(request);
-        RealmLog.debug("Sending request: " + requestBody.toString());
+        RealmLog.debug("Authenticating: " + requestBody);
         Response response = call.execute();
-        RealmLog.debug("Authenticate response: " + response.toString());
         return AuthenticateResponse.from(response);
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -88,7 +88,6 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
                 .addHeader("Accept", "application/json")
                 .post(RequestBody.create(JSON, requestBody))
                 .build();
-        RealmLog.debug("Authenticate: " + requestBody);
         Call call = client.newCall(request);
         Response response = call.execute();
         return AuthenticateResponse.from(response);

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -25,6 +25,7 @@ import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
 import io.realm.SyncUser;
 import io.realm.internal.objectserver.Token;
+import io.realm.log.RealmLog;
 import okhttp3.Call;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -85,11 +86,12 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
                 .url(authenticationUrl)
                 .addHeader("Content-Type", "application/json")
                 .addHeader("Accept", "application/json")
-                .addHeader("Connection", "close") //  See https://github.com/square/okhttp/issues/2363
                 .post(RequestBody.create(JSON, requestBody))
                 .build();
         Call call = client.newCall(request);
+        RealmLog.debug("Sending request: " + requestBody.toString());
         Response response = call.execute();
+        RealmLog.debug("Authenticate response: " + response.toString());
         return AuthenticateResponse.from(response);
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/Token.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/Token.java
@@ -151,5 +151,7 @@ public class Token {
         DOWNLOAD,
         REFRESH,
         MANAGE;
+
+        public static final Permission[] ALL = { UPLOAD, DOWNLOAD, REFRESH, MANAGE };
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/Token.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/Token.java
@@ -23,6 +23,8 @@ import org.json.JSONObject;
 import java.util.Arrays;
 import java.util.Locale;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * This class represents a value from the Realm Authentication Server.
  */
@@ -97,6 +99,7 @@ public class Token {
         }
     }
 
+    @SuppressFBWarnings("MS_MUTABLE_ARRAY")
     public Permission[] permissions() {
         return Arrays.copyOf(permissions, permissions.length);
     }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -85,7 +85,7 @@ public class AuthTests extends BaseIntegrationTest {
                         assertEquals(SessionState.BOUND, SyncManager.getSession(config).getState());
                         looperThread.testComplete();
                     }
-                }, 1000);
+                }, 2000);
             }
 
             @Override

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -9,6 +9,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import io.realm.RealmConfiguration;
+import io.realm.SyncConfiguration;
 import io.realm.SyncCredentials;
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
@@ -63,6 +65,23 @@ public class AuthTests {
             public void onError(ObjectServerError error) {
                 assertEquals(ErrorCode.INVALID_CREDENTIALS, error.getErrorCode());
                 looperThread.testComplete();
+            }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void login_withAccessToken() {
+        SyncCredentials credentials = SyncCredentials.accessToken(Constants.USER_TOKEN, "access-token-user");
+        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
+            @Override
+            public void onSuccess(SyncUser user) {
+                SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.SYNC_SERVER_URL).build();
+            }
+
+            @Override
+            public void onError(ObjectServerError error) {
+                fail("Error thrown:" + error);
             }
         });
     }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -1,30 +1,22 @@
 package io.realm.objectserver;
 
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.FlakyTest;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.realm.RealmConfiguration;
-import io.realm.SessionState;
-import io.realm.SyncConfiguration;
-import io.realm.SyncCredentials;
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
 import io.realm.Realm;
+import io.realm.SessionState;
+import io.realm.SyncConfiguration;
+import io.realm.SyncCredentials;
 import io.realm.SyncManager;
 import io.realm.SyncSession;
 import io.realm.SyncUser;
-import io.realm.log.LogLevel;
-import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.Constants;
-import io.realm.objectserver.utils.HttpUtils;
+import io.realm.objectserver.utils.UserFactory;
 import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 
@@ -32,20 +24,9 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-public class AuthTests {
+public class AuthTests extends BaseIntegrationTest {
     @Rule
     public RunInLooperThread looperThread = new RunInLooperThread();
-
-    @BeforeClass
-    public static void setUp () throws Exception {
-        Realm.init(InstrumentationRegistry.getContext());
-        HttpUtils.startSyncServer();
-    }
-
-    @AfterClass
-    public static void tearDown () throws Exception {
-        HttpUtils.stopSyncServer();
-    }
 
     @Test
     public void login_userNotExist() {
@@ -78,10 +59,9 @@ public class AuthTests {
 
     @Test
     @RunTestInLooperThread
-    @Ignore("FIXME: This unit test crashes OkHttp right now, when it tries to acquire the Realm token. Figure out why")
     public void login_withAccessToken() {
-        RealmLog.setLevel(LogLevel.ALL);
-        SyncCredentials credentials = SyncCredentials.accessToken(Constants.USER_TOKEN, "access-token-user");
+        SyncUser admin = UserFactory.createAdminUser(Constants.AUTH_URL);
+        SyncCredentials credentials = SyncCredentials.accessToken(admin.getAccessToken(), "custom-admin-user");
         SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
             @Override
             public void onSuccess(SyncUser user) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -6,6 +6,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,6 +78,7 @@ public class AuthTests {
 
     @Test
     @RunTestInLooperThread
+    @Ignore("FIXME: This unit test crashes OkHttp right now, when it tries to acquire the Realm token. Figure out why")
     public void login_withAccessToken() {
         RealmLog.setLevel(LogLevel.ALL);
         SyncCredentials credentials = SyncCredentials.accessToken(Constants.USER_TOKEN, "access-token-user");

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -85,7 +85,7 @@ public class AuthTests extends BaseIntegrationTest {
                         assertEquals(SessionState.BOUND, SyncManager.getSession(config).getState());
                         looperThread.testComplete();
                     }
-                }, 2000);
+                }, 1000);
             }
 
             @Override

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -1,6 +1,7 @@
 package io.realm.objectserver;
 
 import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.FlakyTest;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.AfterClass;
@@ -10,12 +11,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.realm.RealmConfiguration;
+import io.realm.SessionState;
 import io.realm.SyncConfiguration;
 import io.realm.SyncCredentials;
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
 import io.realm.Realm;
+import io.realm.SyncManager;
+import io.realm.SyncSession;
 import io.realm.SyncUser;
+import io.realm.log.LogLevel;
+import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.HttpUtils;
 import io.realm.rule.RunInLooperThread;
@@ -72,16 +78,37 @@ public class AuthTests {
     @Test
     @RunTestInLooperThread
     public void login_withAccessToken() {
+        RealmLog.setLevel(LogLevel.ALL);
         SyncCredentials credentials = SyncCredentials.accessToken(Constants.USER_TOKEN, "access-token-user");
         SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
             @Override
             public void onSuccess(SyncUser user) {
-                SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.SYNC_SERVER_URL).build();
+                final SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.SYNC_SERVER_URL)
+                        .errorHandler(new SyncSession.ErrorHandler() {
+                            @Override
+                            public void onError(SyncSession session, ObjectServerError error) {
+                                fail("Session failed: " + error);
+                            }
+                        })
+                        .build();
+
+                final Realm realm = Realm.getInstance(config);
+                looperThread.testRealm = realm;
+
+                // FIXME: Right now we have no Java API for detecting when a session is established
+                // So we optimistically assume it has been connected after 1 second.
+                looperThread.postRunnableDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        assertEquals(SessionState.BOUND, SyncManager.getSession(config).getState());
+                        looperThread.testComplete();
+                    }
+                }, 1000);
             }
 
             @Override
             public void onError(ObjectServerError error) {
-                fail("Error thrown:" + error);
+                fail("Login failed: " + error);
             }
         });
     }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.BeforeClass;
 import org.mockito.internal.exceptions.ExceptionIncludingMockitoWarnings;
 
 import io.realm.Realm;
+import io.realm.SyncManager;
 import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.HttpUtils;
 
@@ -30,6 +31,7 @@ public class BaseIntegrationTest {
 
     @BeforeClass
     public static void setUp () throws Exception {
+        SyncManager.Debug.skipOnlineChecking = true;
         try {
             Realm.init(InstrumentationRegistry.getContext());
             HttpUtils.startSyncServer();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
@@ -20,14 +20,13 @@ import android.support.test.InstrumentationRegistry;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.mockito.internal.exceptions.ExceptionIncludingMockitoWarnings;
 
 import io.realm.Realm;
 import io.realm.SyncManager;
 import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.HttpUtils;
 
-public class BaseIntegrationTest {
+class BaseIntegrationTest {
 
     @BeforeClass
     public static void setUp () throws Exception {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Realm Inc.
+ * Copyright 2017 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,27 @@
  * limitations under the License.
  */
 
-package io.realm.objectserver.utils;
+package io.realm.objectserver;
 
-public class Constants {
+import android.support.test.InstrumentationRegistry;
 
-    public static String SYNC_SERVER_URL = "realm://127.0.0.1:7800/tests";
-    public static String SYNC_SERVER_URL_2 = "realm://127.0.0.1:7800/tests2";
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
-    public static String AUTH_SERVER_URL = "http://127.0.0.1:9080/";
-    public static String AUTH_URL = AUTH_SERVER_URL + "auth";
+import io.realm.Realm;
+import io.realm.objectserver.utils.HttpUtils;
+
+public class BaseIntegrationTest {
+
+    @BeforeClass
+    public static void setUp () throws Exception {
+        Realm.init(InstrumentationRegistry.getContext());
+        HttpUtils.startSyncServer();
+    }
+
+    @AfterClass
+    public static void tearDown () throws Exception {
+        HttpUtils.stopSyncServer();
+    }
+
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/BaseIntegrationTest.java
@@ -20,21 +20,32 @@ import android.support.test.InstrumentationRegistry;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.mockito.internal.exceptions.ExceptionIncludingMockitoWarnings;
 
 import io.realm.Realm;
+import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.HttpUtils;
 
 public class BaseIntegrationTest {
 
     @BeforeClass
     public static void setUp () throws Exception {
-        Realm.init(InstrumentationRegistry.getContext());
-        HttpUtils.startSyncServer();
+        try {
+            Realm.init(InstrumentationRegistry.getContext());
+            HttpUtils.startSyncServer();
+        } catch (Exception e) {
+            // Throwing an exception from this method will crash JUnit. Instead just log it.
+            // If this setup method fails, all unit tests in the class extending it will most likely fail as well.
+            RealmLog.error("Could not start Sync Server", e);
+        }
     }
 
     @AfterClass
     public static void tearDown () throws Exception {
-        HttpUtils.stopSyncServer();
+        try {
+            HttpUtils.stopSyncServer();
+        } catch (Exception e) {
+            RealmLog.error("Failed to stop Sync Server", e);
+        }
     }
-
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -79,7 +79,7 @@ public class ProcessCommitTests {
                     Looper.prepare();
                     Context targetContext = InstrumentationRegistry.getTargetContext();
 
-                    SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL, Constants.USER_TOKEN);
+                    SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL);
                     String realmUrl = Constants.SYNC_SERVER_URL;
                     final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
                             .name(SendOneCommit.class.getSimpleName())
@@ -139,7 +139,7 @@ public class ProcessCommitTests {
                     Looper.prepare();
                     Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-                    SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL, Constants.USER_TOKEN);
+                    SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL);
                     String realmUrl = Constants.SYNC_SERVER_URL_2;
                     final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
                             .name(SendsALot.class.getSimpleName())

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -51,13 +51,13 @@ import io.realm.objectserver.utils.UserFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-//@RunWith(AndroidJUnit4.class)
+@RunWith(AndroidJUnit4.class)
 public class ProcessCommitTests extends BaseIntegrationTest {
 
     // FIXME: Ignore for now. They do still not work. It might be caused by two processes each creating
     // a Sync Client, but it needs to be investigated.
-//    @Test
-//    @Ignore
+    @Test
+    @Ignore
     public void expectServerCommit() throws Throwable {
         final Throwable[] exception = new Throwable[1];
         final CountDownLatch testFinished = new CountDownLatch(1);
@@ -116,8 +116,8 @@ public class ProcessCommitTests extends BaseIntegrationTest {
     //     replicate integration tests from Cocoa
     //     add gradle task to start the sh script automatically (create pid file, ==> run or kill existing process
     //     check the requirement for the issue again
-//    @Test
-//    @Ignore
+    @Test
+    @Ignore
     public void expectALot() throws Throwable {
         final Throwable[] exception = new Throwable[1];
         final CountDownLatch testFinished = new CountDownLatch(1);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -54,6 +54,11 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class ProcessCommitTests extends BaseIntegrationTest {
 
+    @Test
+    public void noop() {
+        // Trying to CI not liking an empty test class
+    }
+
     // FIXME: Ignore for now. They do still not work. It might be caused by two processes each creating
     // a Sync Client, but it needs to be investigated.
     @Test

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -52,17 +52,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-public class ProcessCommitTests {
-    @BeforeClass
-    public static void setUp () throws Exception {
-        Realm.init(InstrumentationRegistry.getContext());
-        HttpUtils.startSyncServer();
-    }
-
-    @AfterClass
-    public static void tearDown () throws Exception {
-        HttpUtils.stopSyncServer();
-    }
+public class ProcessCommitTests extends BaseIntegrationTest {
 
     // FIXME: Ignore for now. They do still not work. It might be caused by two processes each creating
     // a Sync Client, but it needs to be investigated.

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -51,18 +51,13 @@ import io.realm.objectserver.utils.UserFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-@RunWith(AndroidJUnit4.class)
+//@RunWith(AndroidJUnit4.class)
 public class ProcessCommitTests extends BaseIntegrationTest {
-
-    @Test
-    public void noop() {
-        // Trying to CI not liking an empty test class
-    }
 
     // FIXME: Ignore for now. They do still not work. It might be caused by two processes each creating
     // a Sync Client, but it needs to be investigated.
-    @Test
-    @Ignore
+//    @Test
+//    @Ignore
     public void expectServerCommit() throws Throwable {
         final Throwable[] exception = new Throwable[1];
         final CountDownLatch testFinished = new CountDownLatch(1);
@@ -121,8 +116,8 @@ public class ProcessCommitTests extends BaseIntegrationTest {
     //     replicate integration tests from Cocoa
     //     add gradle task to start the sh script automatically (create pid file, ==> run or kill existing process
     //     check the requirement for the issue again
-    @Test
-    @Ignore
+//    @Test
+//    @Ignore
     public void expectALot() throws Throwable {
         final Throwable[] exception = new Throwable[1];
         final CountDownLatch testFinished = new CountDownLatch(1);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendOneCommit.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendOneCommit.java
@@ -36,7 +36,7 @@ public class SendOneCommit extends Service {
     public void onCreate() {
         super.onCreate();
         Realm.init(getApplicationContext());
-        SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL, Constants.USER_TOKEN);
+        SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL);
         String realmUrl = Constants.SYNC_SERVER_URL;
         final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
                 .name(SendOneCommit.class.getSimpleName())

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendOneCommit.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendOneCommit.java
@@ -20,6 +20,13 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
 
+import io.realm.Realm;
+import io.realm.SyncConfiguration;
+import io.realm.SyncUser;
+import io.realm.objectserver.model.ProcessInfo;
+import io.realm.objectserver.utils.Constants;
+import io.realm.objectserver.utils.UserFactory;
+
 /**
  * Open a sync Realm on a different process, then send one commit.
  */
@@ -28,12 +35,11 @@ public class SendOneCommit extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        // FIXME: Disable for now
-        /*
-        final SyncConfiguration syncConfig = new SyncConfiguration.Builder(this)
+        Realm.init(getApplicationContext());
+        SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL, Constants.USER_TOKEN);
+        String realmUrl = Constants.SYNC_SERVER_URL;
+        final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
                 .name(SendOneCommit.class.getSimpleName())
-                .serverUrl(Constants.SYNC_SERVER_URL)
-                .user(UserFactory.createDefaultUser(Constants.SYNC_SERVER_URL, Constants.USER_TOKEN))
                 .build();
         Realm.deleteRealm(syncConfig);
         Realm realm = Realm.getInstance(syncConfig);
@@ -46,9 +52,7 @@ public class SendOneCommit extends Service {
         realm.commitTransaction();
 
         realm.close();//FIXME the close may not give a chance to the sync client to process/upload the changeset
-        */
     }
-
 
     @Override
     public IBinder onBind(Intent intent) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendsALot.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendsALot.java
@@ -36,7 +36,7 @@ public class SendsALot extends Service {
     public void onCreate() {
         super.onCreate();
         Realm.init(getApplicationContext());
-        SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL, Constants.USER_TOKEN);
+        SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL);
         String realmUrl = Constants.SYNC_SERVER_URL_2;
         final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
                 .name(SendsALot.class.getSimpleName())

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendsALot.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/service/SendsALot.java
@@ -20,6 +20,13 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
 
+import io.realm.Realm;
+import io.realm.SyncConfiguration;
+import io.realm.SyncUser;
+import io.realm.objectserver.model.TestObject;
+import io.realm.objectserver.utils.Constants;
+import io.realm.objectserver.utils.UserFactory;
+
 /**
  * Open a sync Realm on a different process, then send one commit.
  */
@@ -28,13 +35,11 @@ public class SendsALot extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        // FIXME: Disable for now.
-        /*
-        User user = UserFactory.createDefaultUser(Constants.SYNC_SERVER_URL_2, Constants.USER_TOKEN);
-        final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user)
+        Realm.init(getApplicationContext());
+        SyncUser user = UserFactory.createDefaultUser(Constants.AUTH_URL, Constants.USER_TOKEN);
+        String realmUrl = Constants.SYNC_SERVER_URL_2;
+        final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
                 .name(SendsALot.class.getSimpleName())
-                .serverUrl(Constants.SYNC_SERVER_URL_2)
-                .user()
                 .build();
         Realm.deleteRealm(syncConfig);
         Realm realm = Realm.getInstance(syncConfig);
@@ -49,7 +54,6 @@ public class SendsALot extends Service {
         realm.commitTransaction();
 
         realm.close();//FIXME the close may not give a chance to the sync client to process/upload the changeset
-        */
     }
 
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
@@ -18,8 +18,8 @@ package io.realm.objectserver.utils;
 
 public class Constants {
 
-    public static String SYNC_SERVER_URL = "realm://127.0.0.1:9080/tests";
-    public static String SYNC_SERVER_URL_2 = "realm://127.0.0.1:9080/tests2";
+    public static String SYNC_SERVER_URL = "realm://127.0.0.1/tests";
+    public static String SYNC_SERVER_URL_2 = "realm://127.0.0.1/tests2";
 
     public static String AUTH_SERVER_URL = "http://127.0.0.1:9080/";
     public static String AUTH_URL = AUTH_SERVER_URL + "auth";

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
@@ -18,8 +18,8 @@ package io.realm.objectserver.utils;
 
 public class Constants {
 
-    public static String SYNC_SERVER_URL = "realm://127.0.0.1:7800/tests";
-    public static String SYNC_SERVER_URL_2 = "realm://127.0.0.1:7800/tests2";
+    public static String SYNC_SERVER_URL = "realm://127.0.0.1:9080/tests";
+    public static String SYNC_SERVER_URL_2 = "realm://127.0.0.1:9080/tests2";
 
     public static String AUTH_SERVER_URL = "http://127.0.0.1:9080/";
     public static String AUTH_URL = AUTH_SERVER_URL + "auth";

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
@@ -72,23 +72,22 @@ public class HttpUtils {
         // Dummy invalid request, which will trigger a 400 (BAD REQUEST), but indicate the auth
         // server is responsive
         Request request = new Request.Builder()
-                .post(RequestBody.create(MediaType.parse("application/json; charset=utf-8"), ""))
-                .url(Constants.AUTH_URL)
+                .url(Constants.AUTH_SERVER_URL)
                 .build();
 
         while (retryTimes != 0) {
             Response response = null;
             try {
                 response = client.newCall(request).execute();
-                if (response.code() == 400) {
+                if (response.isSuccessful()) {
                     return true;
                 }
                 RealmLog.error("Error response from auth server: %s", response.toString());
             } catch (IOException e) {
                 // TODO As long as the auth server hasn't started yet, OKHttp cannot parse the response
                 // correctly. At this point it is unknown weather is a bug in OKHttp or how an
-                // unknown host is reported. Disabling the log out put for now as it just pollutes the log.
-                // RealmLog.error(e);
+                // unknown host is reported. This can cause a lot of "false" errors in the log.
+                RealmLog.error(e);
                 Thread.sleep(100);
             } finally {
                 if (response != null) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
@@ -16,17 +16,13 @@
 
 package io.realm.objectserver.utils;
 
-import android.support.test.InstrumentationRegistry;
 
 import java.io.IOException;
 
-import io.realm.Realm;
 import io.realm.log.RealmLog;
 import okhttp3.Headers;
-import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
 
 /**
@@ -85,7 +81,7 @@ public class HttpUtils {
                 RealmLog.error("Error response from auth server: %s", response.toString());
             } catch (IOException e) {
                 // TODO As long as the auth server hasn't started yet, OKHttp cannot parse the response
-                // correctly. At this point it is unknown weather is a bug in OKHttp or how an
+                // correctly. At this point it is unknown weather is a bug in OKHttp or an
                 // unknown host is reported. This can cause a lot of "false" errors in the log.
                 RealmLog.error(e);
                 Thread.sleep(500);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
@@ -67,7 +67,7 @@ public class HttpUtils {
 
     // Checking the server
     private static boolean waitAuthServerReady() throws InterruptedException {
-        int retryTimes = 50;
+        int retryTimes = 20;
 
         // Dummy invalid request, which will trigger a 400 (BAD REQUEST), but indicate the auth
         // server is responsive
@@ -88,7 +88,7 @@ public class HttpUtils {
                 // correctly. At this point it is unknown weather is a bug in OKHttp or how an
                 // unknown host is reported. This can cause a lot of "false" errors in the log.
                 RealmLog.error(e);
-                Thread.sleep(100);
+                Thread.sleep(500);
             } finally {
                 if (response != null) {
                     response.close();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
@@ -85,7 +85,10 @@ public class HttpUtils {
                 }
                 RealmLog.error("Error response from auth server: %s", response.toString());
             } catch (IOException e) {
-                RealmLog.error(e);
+                // TODO As long as the auth server hasn't started yet, OKHttp cannot parse the response
+                // correctly. At this point it is unknown weather is a bug in OKHttp or how an
+                // unknown host is reported. Disabling the log out put for now as it just pollutes the log.
+                // RealmLog.error(e);
                 Thread.sleep(100);
             } finally {
                 if (response != null) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -16,25 +16,13 @@
 
 package io.realm.objectserver.utils;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
+import io.realm.SyncCredentials;
 import io.realm.SyncUser;
-import io.realm.objectserver.utils.Constants;
 
 // Must be in `io.realm.objectserver` to work around package protected methods.
 public class UserFactory {
-    // FIXME: Not working right now.
-    /*
-    public static User createDefaultUser(String SERVER_URL, String USER_TOKEN) {
-        try {
-            User user = User.createLocal();
-
-            user.addAccessToken(new URI(SERVER_URL), USER_TOKEN);
-            return user;
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
+    public static SyncUser createDefaultUser(String authUrl, String accessToken) {
+        SyncCredentials credentials = SyncCredentials.accessToken(accessToken, "sync-integration-user");
+        return SyncUser.login(credentials, authUrl);
     }
-    */
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -29,7 +29,7 @@ public class UserFactory {
 
     public static SyncUser createAdminUser(String authUrl) {
         // `admin` required as user identifier to be granted admin rights.
-        SyncCredentials credentials = SyncCredentials.custom("debug", "admin", null);
+        SyncCredentials credentials = SyncCredentials.custom("admin", "debug", null);
         return SyncUser.login(credentials, authUrl);
     }
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -21,8 +21,15 @@ import io.realm.SyncUser;
 
 // Must be in `io.realm.objectserver` to work around package protected methods.
 public class UserFactory {
-    public static SyncUser createDefaultUser(String authUrl, String accessToken) {
-        SyncCredentials credentials = SyncCredentials.accessToken(accessToken, "sync-integration-user");
+
+    public static SyncUser createDefaultUser(String authUrl) {
+        SyncCredentials credentials = SyncCredentials.usernamePassword("test-user", "myPassw0rd", true);
+        return SyncUser.login(credentials, authUrl);
+    }
+
+    public static SyncUser createAdminUser(String authUrl) {
+        // `admin` required as user identifier to be granted admin rights.
+        SyncCredentials credentials = SyncCredentials.custom("debug", "admin", null);
         return SyncUser.login(credentials, authUrl);
     }
 }

--- a/tools/sync_test_server/Dockerfile
+++ b/tools/sync_test_server/Dockerfile
@@ -5,6 +5,7 @@ ARG ROS_DE_VERSION
 # Add realm repo
 RUN apt-get update -qq \
     && apt-get install -y curl npm \
+    && curl -s https://packagecloud.io/install/repositories/realm/realm-testing/script.deb.sh \
     && curl -s https://packagecloud.io/install/repositories/realm/realm/script.deb.sh | bash
 
 # ROS npm dependencies

--- a/tools/sync_test_server/Dockerfile
+++ b/tools/sync_test_server/Dockerfile
@@ -5,8 +5,8 @@ ARG ROS_DE_VERSION
 # Add realm repo
 RUN apt-get update -qq \
     && apt-get install -y curl npm \
-    && curl -s https://packagecloud.io/install/repositories/realm/realm-testing/script.deb.sh \
-    && curl -s https://packagecloud.io/install/repositories/realm/realm/script.deb.sh | bash
+    # && curl -s https://packagecloud.io/install/repositories/realm/realm/script.deb.sh \
+    && curl -s https://packagecloud.io/install/repositories/realm/realm-testing/script.deb.sh | bash
 
 # ROS npm dependencies
 RUN npm init -y
@@ -14,6 +14,7 @@ RUN npm install winston temp httpdispatcher@1.0.0
 
 COPY keys/private.pem keys/public.pem configuration.yml /
 COPY ros-testing-server.js /usr/bin/
+
 # Install realm object server
 RUN apt-get update -qq \
     && apt-get install -y realm-object-server-developer=$ROS_DE_VERSION \

--- a/tools/sync_test_server/configuration.yml
+++ b/tools/sync_test_server/configuration.yml
@@ -19,7 +19,7 @@
 storage:
   ## The directory in which the realm server will store all its data files.
   ## This configuration option is MANDATORY.
-  root_path: /var/realm/sync-services
+  root_path: '/var/realm/sync-services'
 
 ## ----------------------------------------------------------------------------
 
@@ -27,19 +27,37 @@ auth:
   ## The path to the public and private keys (in PEM format) that will be used
   ## to validate identity tokens sent by clients.
   ## These configuration options are MANDATORY.
-  public_key_path: /public.pem
-  private_key_path: /private.pem
+  public_key_path: '/public.pem'
+  private_key_path: '/private.pem'
 
-  database:
-    ## The path for the administration database synchronisation endpoint. Do NOT
-    ## change this unless asked by Realm Support.
-    # sync_uri_path: '/public/admin'
+  sync_hosts:
+    ## The hosts for which the authentication service will consider itself
+    ## authoritative. It will decline to process any kind of requests for Realm
+    ## files at other URLs. Addresses specified here must include host and port
+    ## (authority part of the URL according to RFC 3986) on which the sync
+    ## server is externally reachable. In addition to hosts configured here,
+    ## the authentication service will always accept the following hosts:
+    # - localhost:27800
+    #
+    # Additionally if a proxy server for the given protocol is configured, it
+    # will also accept requests for Realm files at these hosts:
+    # - ${proxy:http:listen_address}:${proxy:http:listen_port}
+    # - ${proxy:https:listen_address}:${proxy:https:listen_port}
+    #
+    # The derived hosts will also include aliases for local addresses
+    # with the following host names: '127.0.0.1', 'localhost' and '::'.
 
   ttls:
-    ## The validity duration for Refresh Tokens. This should be a fairly high
-    ## value, typically ranging 12 hours - 3 days. This value is represented in
-    ## seconds. Default: 24 hours.
-    # refresh_token: 86400
+    ## The validity duration for Refresh Tokens. This can be a fairly high
+    ## value, ranging from a single day to multiple years, depending on
+    ## individual needs. Whenever the Refresh Token expires, clients will be
+    ## forced to delegate again to the authorizing party. If the credentials
+    ## there can be revoked by the user or are not opaquely managed by the
+    ## client, then this would force the user to manual intervention after the
+    ## expiration. Depending on the use case, this can be either desired or
+    ## should be prevented. This value is represented in seconds.
+    ## Default: 10 years.
+    # refresh_token: 315360000
 
     ## The validity duration for Access Tokens. This should be a fairly small
     ## number, especially if you are concerned with revocations being applied
@@ -47,6 +65,44 @@ auth:
     # access_token: 60
 
   providers:
+    ## Providers of authentication tokens. Each provider has a configuration
+    ## object associated with it. If a provider is included here and its
+    ## configuration is valid, it will be enabled.
+
+    ## Possible providers: cloudkit, debug, google, facebook, realm, password
+    ## Providers 'realm' and 'password' are always enabled:
+    ## - The 'realm' provider is used to derive access tokens from a refresh token.
+    ## - The 'password' provider is required for the dashboard to work. It supports
+    ##   authentication through username/password and uses a PBKDF2 implementation.
+
+    ## This enables login via CloudKit's user record name.
+    # cloudkit:
+      ## The key ID retrieved when adding the public key derived from the
+      ## specified private_key_path in CloudKit's Server-to-Server Keys,
+      ## available through the API Access settings in the CloudKit dashboard.
+      # key_id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+      ## The path to the certificate.
+      # private_key_path: 'cloudkit_eckey.pem'
+
+      ## The container identifier in reverse domain name notation.
+      # container: "iCloud.io.realm.exampleApp.ios"
+
+      ## The environment in which CloudKit should be used. The default is
+      ## 'development'. For the production deployment for apps on the AppStore
+      ## you must specify 'production'.
+      # environment: 'development'
+
+    ## This enables authentication via a Google Sign-In access token for a
+    ## specific app.
+    # google:
+      ## The client ID as retrieved when setting up the app in the Google
+      ## Developer Console.
+      # clientId: '012345678901-abcdefghijklmnopqrstvuvwxyz01234.apps.googleusercontent.com'
+
+    ## This enables authentication via a Facebook access token for a specific app.
+    ## This provider needs no configuration (uncommenting the next line enables it).
+    # facebook: {}
     debug: {}
 
 ## ----------------------------------------------------------------------------
@@ -98,7 +154,7 @@ proxy:
     ## The address/interface on which the HTTP proxy module should listen. This defaults
     ## to 127.0.0.1. If you wish to listen on all available interfaces,
     ## uncomment the following line.
-    listen_address: '0.0.0.0'
+    listen_address: '::'
 
     ## The port that the HTTP proxy module should bind to.
     # listen_port: 9080
@@ -119,7 +175,7 @@ proxy:
     ## The address/interface on which the HTTPS proxy module should listen. This defaults
     ## to 127.0.0.1. If you wish to listen on all available interfaces,
     ## uncomment the following line.
-    # listen_address: '0.0.0.0'
+    # listen_address: '::'
 
     ## The port that the HTTPS proxy module should bind to.
     # listen_port: 9443
@@ -131,68 +187,46 @@ network:
   ## the proxy module. The proxy module will automatically forward traffic to the
   ## internal modules on the ports they are configured to listen on in this section.
 
-  sync:
-    ## The address/interface on which the server should listen. This defaults
-    ## to 127.0.0.1. If you wish to listen on all available interfaces,
-    ## uncomment the following line.
-    listen_address: '0.0.0.0'
-
-    ## The port on which to listen. The Realm sync server uses port 27800 by
-    ## default. For most deployments, there should not be a need to change this.
-    listen_port: 7800
-
   http:
     ## The address/interface on which the server should listen for HTTP
     ## services. This includes Dashboard and Authentication APIs.
     ## This defaults to 127.0.0.1. If you wish to listen on all available
     ## interfaces, uncomment the following line.
-    listen_address: '0.0.0.0'
+    # listen_address: '0.0.0.0'
 
     ## The port on which to listen for incoming requests to the Dashboard
     ## and authentication APIs. This defaults to 27080.
-    listen_port: 8080
+    # listen_port: 27080
 
 ## ----------------------------------------------------------------------------
 
-  providers:
-    ## Providers of authentication tokens. Each provider has a configuration
-    ## object associated with it. If a provider is included here and its
-    ## configuration is valid, it will be enabled.
+sync:
+  ## Synchronization service settings, including clustering and load balancing.
 
-    ## Possible providers: cloudkit, debug, facebook, realm, password
-    ## Providers 'realm' and 'password' are always enabled:
-    ## - The 'realm' provider is used to derive access tokens from a refresh token.
-    ## - The 'password' provider is required for the dashboard to work. It supports
-    ##   authentication through username/password and uses a PBKDF2 implementation.
-
-    ## This enables login via CloudKit's user record name.
-    # cloudkit:
-      ## The key ID retrieved when adding the public key derived from the
-      ## specified private_key_path in CloudKit's Server-to-Server Keys,
-      ## available through the API Access settings in the CloudKit dashboard.
-      # key_id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-
-      ## The path to the certificate.
-      # private_key_path: 'cloudkit_eckey.pem'
-
-      ## The container identifier in reverse domain name notation.
-      # container: "iCloud.io.realm.exampleApp.ios"
-
-      ## The environment in which CloudKit should be used. The default is
-      ## 'development'. For the production deployment for apps on the AppStore
-      ## you must specify 'production'.
-      # environment: 'development'
-
-    ## This enables authentication via a Google Sign-In access token for a
-    ## specific app.
-    # google:
-      ## The client ID as retrieved when setting up the app in the Google
-      ## Developer Console.
-      # clientId: '012345678901-abcdefghijklmnopqrstvuvwxyz01234.apps.googleusercontent.com'
-
-    ## This enables authentication via a Facebook access token for a specific app.
-    ## This provider needs no configuration (uncommenting the next line enables it).
-    # facebook: {}
+  servers:
+    ## An array of entries describing the cluster configuration.
+    ##
+    ## If no servers are configured, a default entry is inserted with the
+    ## following settings:
+    ##   - id: '0'
+    ##     address: '0.0.0.0'
+    ##     port: 27800
+    ##
+    ## Each entry must contain the following entries:
+    ##
+    ##    'id': A unique string ID used to distinguish between backend servers.
+    ##          This must remain stable, even if the particular backend server
+    ##          is moved to a different address or port.
+    ##
+    ##    'address': The address of the cluster participant. If '0.0.0.0' or
+    ##               '::', a sync server will be started on localhost (listening
+    ##               on '127.0.0.1' or '::1', respectively). Otherwise, it is
+    ##               assumed that the sync server is an external process,
+    ##               potentially on a separate machine.
+    ##
+    ##    'port': The port on which to connect to the particular cluster node.
+    ##            If address was '0.0.0.0' or '::', this is also the port number
+    ##            on which the local cluster node will listen for connections.
 
 ## ----------------------------------------------------------------------------
 
@@ -213,12 +247,12 @@ logging:
   ##   error
   ##   fatal
   ##   off: all output suppressed
-  level: 'all'
+  # level: 'info'
 
   ## The file to which the synchronisation server should log. This should
   ## be a writable path from the perspective of the user under which the
   ## server runs. If no path is specified, the server will log to stdout.
-  path: '/tmp/realm-sync.log'
+  # path: '/var/log/realm-object-server.log'
 
 ## ----------------------------------------------------------------------------
 
@@ -228,3 +262,35 @@ performance:
   ## Only change this option if directed to by Realm support.
   # max_open_files: 256
 
+## ----------------------------------------------------------------------------
+
+backup:
+  ## The backup is a server that delivers continuous backup of the Realms in
+  ## storage.root_path specified above. The backup is delivered to all connected
+  ## backup clients. Backup clients must be started separately with network
+  ## configuration parameters matching those of the server.
+
+  enable:
+    ## Whether or not to enable the backup server.
+    # enable: true
+
+  network:
+    ## The address/interface on which the backup server should listen. This
+    ## defaults to 127.0.0.1. If you wish to listen on all available interfaces,
+    ## uncomment the following line.
+    # listen_address: '0.0.0.0'
+
+    ## The port on which to listen. The backup server uses port 27810 by
+    ## default. For most deployments, there should not be a need to change this.
+    # listen_port: 27810
+
+  logging:
+    ## The logging level of the backup server.
+    ## The values are identical to the logging levels described above.
+    ## The default level is 'info'.
+    # level: 'info'
+
+    ## The file to which the synchronisation server should log. This should
+    ## be a writable path from the perspective of the user under which the
+    ## server runs. If no path is specified, the server will log to stdout.
+    # path: '/var/log/realm-object-server-backup.log'

--- a/tools/sync_test_server/configuration.yml
+++ b/tools/sync_test_server/configuration.yml
@@ -46,6 +46,9 @@ auth:
     ## quickly. This value is represented in seconds. Default: 1 minute.
     # access_token: 60
 
+  providers:
+    debug: {}
+
 ## ----------------------------------------------------------------------------
 
 proxy:

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env nodejs
 
-var winston = require('winston');//logging
+var winston = require('winston'); //logging
 const temp = require('temp');
 const spawn = require('child_process').spawn;
 var http = require('http');
@@ -23,7 +23,7 @@ function handleRequest(request, response) {
     try {
         //log the request on console
         winston.log(request.url);
-        //Disptach
+        //Dispatch
         dispatcher.dispatch(request, response);
     } catch(err) {
         console.log(err);

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -37,9 +37,13 @@ function startRealmObjectServer() {
     temp.mkdir('ros', function(err, path) {
         if (!err) {
             winston.info("Starting sync server in ", path);
+            var env = Object.create( process.env );
+            winston.info(env.NODE_ENV);
+            env.NODE_ENV = 'development';
             syncServerChildProcess = spawn('realm-object-server',
                     ['--root', path,
-                    '--configuration', '/configuration.yml']);
+                    '--configuration', '/configuration.yml'],
+                    { env: env });
             // local config:
             syncServerChildProcess.stdout.on('data', (data) => {
                 winston.info(`stdout: ${data}`);

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -7,12 +7,10 @@ ROS_DE_VERSION=$(grep REALM_OBJECT_SERVER_DE_VERSION $DOCKERFILE_DIR/../../depen
 
 TMP_DIR=$(mktemp -d /tmp/sync-test.XXXX) || { echo "Failed to mktemp $TEST_TEMP_DIR" ; exit 1 ; }
 
-adb reverse tcp:7800 tcp:7800 && \
-adb reverse tcp:8080 tcp:8080 && \
 adb reverse tcp:9080 tcp:9080 && \
 adb reverse tcp:8888 tcp:8888 || { echo "Failed to reverse adb port." ; exit 1 ; }
 
 docker build $DOCKERFILE_DIR --build-arg ROS_DE_VERSION=$ROS_DE_VERSION -t sync-test-server || { echo "Failed to build Docker image." ; exit 1 ; }
 
 echo "See log files in $TMP_DIR"
-docker run -p 9080:9080 -p 8080:8080 -p 7800:7800 -p 8888:8888 -v$TMP_DIR:/tmp --name sync-test-server sync-test-server
+docker run -p 9080:9080 -p 8888:8888 -v$TMP_DIR:/tmp --name sync-test-server sync-test-server

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -9,9 +9,10 @@ TMP_DIR=$(mktemp -d /tmp/sync-test.XXXX) || { echo "Failed to mktemp $TEST_TEMP_
 
 adb reverse tcp:7800 tcp:7800 && \
 adb reverse tcp:8080 tcp:8080 && \
+adb reverse tcp:9080 tcp:9080 && \
 adb reverse tcp:8888 tcp:8888 || { echo "Failed to reverse adb port." ; exit 1 ; }
 
 docker build $DOCKERFILE_DIR --build-arg ROS_DE_VERSION=$ROS_DE_VERSION -t sync-test-server || { echo "Failed to build Docker image." ; exit 1 ; }
 
 echo "See log files in $TMP_DIR"
-docker run -p 8080:8080 -p 7800:7800 -p 8888:8888 -v$TMP_DIR:/tmp --name sync-test-server sync-test-server
+docker run -p 9080:9080 -p 8080:8080 -p 7800:7800 -p 8888:8888 -v$TMP_DIR:/tmp --name sync-test-server sync-test-server


### PR DESCRIPTION
This PR adds support for `SyncCredentials.accessToken()` which is required for #4005. I also found a number of issues with the integration tests. They have been fixed as well.

