### PR TITLE
Activated Realm's annotation processor on connectedTest when the project is using kapt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fixed native memory leak setting the value of a primary key (#3993).
+* Activated Realm's annotation processor on connectedTest when the project is using kapt (#4008).
 
 ## 2.2.2
 

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -66,6 +66,8 @@ class Realm implements Plugin<Project> {
         } else if (isKotlinProject && !preferAptOnKotlinProject) {
             project.dependencies.add("kapt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("kapt", "io.realm:realm-annotations-processor:${Version.VERSION}")
+            project.dependencies.add("kaptAndroidTest", "io.realm:realm-annotations:${Version.VERSION}")
+            project.dependencies.add("kaptAndroidTest", "io.realm:realm-annotations-processor:${Version.VERSION}")
         } else {
             assert hasAnnotationProcessorConfiguration
             project.dependencies.add("annotationProcessor", "io.realm:realm-annotations:${Version.VERSION}")


### PR DESCRIPTION
fixes #4008 

Work-around for now is adding following two lines to `dependencies` in your `build.gradle`

```
    kaptAndroidTest 'io.realm:realm-annotations:<your_realm_version>'
    kaptAndroidTest 'io.realm:realm-annotations-processor:<your_realm_version>'
```