### PR TITLE
Ignore exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Fixed native memory leak setting the value of a primary key (#3993).
 
+### Object Server API Changes (In Beta)
+
+* Exceptions thrown error handlers are ignored but logged (#3559).
+
 ### Internal
 
 * Updated Realm Sync to 1.0.0-BETA-7.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Object Server API Changes (In Beta)
 
-* Exceptions thrown error handlers are ignored but logged (#3559).
+* Exceptions thrown in error handlers are ignored but logged (#3559).
 
 ### Internal
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -107,7 +107,10 @@ public class SyncSession {
      */
     public interface ErrorHandler {
         /**
-         * Callback for errors on a session object. Any exception thrown in an error handler will be logged but ignored.
+         * Callback for errors on a session object. It is not allowed to throw an exception inside an error handler.
+         * If the operations in an error handler can throw, it is safer to catch any exception in the error handler.
+         * When an exception is thrown in the error handler, the occurrence will be logged and the exception
+         * will be ignored.
          *
          * @param session {@link SyncSession} this error happened on.
          * @param error type of error.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -107,7 +107,7 @@ public class SyncSession {
      */
     public interface ErrorHandler {
         /**
-         * Callback for errors on a session object.
+         * Callback for errors on a session object. Any exception thrown in an error handler will be logged but ignored.
          *
          * @param session {@link SyncSession} this error happened on.
          * @param error type of error.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -44,7 +44,6 @@ import io.realm.internal.network.LogoutResponse;
 import io.realm.internal.objectserver.ObjectServerUser;
 import io.realm.internal.objectserver.Token;
 import io.realm.log.RealmLog;
-import io.realm.permissions.PermissionChange;
 import io.realm.permissions.PermissionModule;
 
 /**
@@ -203,7 +202,12 @@ public class SyncUser {
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
-                            callback.onError(error);
+                            try {
+                                callback.onError(error);
+                            } catch (Exception e) {
+                                RealmLog.info("onError has thrown an exception but ignoring it: %s", e.getMessage());
+                                e.printStackTrace();
+                            }
                         }
                     });
                 }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -205,8 +205,8 @@ public class SyncUser {
                             try {
                                 callback.onError(error);
                             } catch (Exception e) {
-                                RealmLog.info("onError has thrown an exception but ignoring it: %s", e.getMessage());
-                                e.printStackTrace();
+                                RealmLog.info("onError has thrown an exception but is ignoring it: %s",
+                                        Util.getStackTrace(e));
                             }
                         }
                     });

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -90,6 +90,7 @@ public class AuthTests {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
             e.printStackTrace();
+            fail();
         }
         looperThread.testComplete();
     }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -9,10 +9,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.realm.SyncCredentials;
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
 import io.realm.Realm;
+import io.realm.SyncCredentials;
 import io.realm.SyncUser;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.HttpUtils;
@@ -65,5 +65,32 @@ public class AuthTests {
                 looperThread.testComplete();
             }
         });
+    }
+
+    // The error handler throws an exception but it is ignored (but logged). That means, this test should not
+    // pass and not be stopped by an IllegalArgumentException.
+    @Test
+    @RunTestInLooperThread
+    public void loginAsync_errorHandlerThrows() {
+        SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
+        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
+            @Override
+            public void onSuccess(SyncUser user) {
+                fail();
+            }
+
+            @Override
+            public void onError(ObjectServerError error) {
+                assertEquals(ErrorCode.INVALID_CREDENTIALS, error.getErrorCode());
+                throw new IllegalArgumentException("BOOM");
+            }
+        });
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        looperThread.testComplete();
     }
 }


### PR DESCRIPTION
If an exception is thrown in an async error handler, the app's behaviour is highly unpredictable. We swallow the exception and log that it happens but let the app continue.

Closes #3559