### PR TITLE
Nh/fixes token renew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fixed native memory leak setting the value of a primary key (#3993).
+* Fixed bug, preventing Sync client to renew the access token (#4038) (#4039). 
 
 ### Internal
 

--- a/realm/realm-library/src/main/cpp/objectserver_shared.hpp
+++ b/realm/realm-library/src/main/cpp/objectserver_shared.hpp
@@ -61,8 +61,8 @@ public:
                 coordinator->wake_up_notifier_worker();
             }
         };
-        auto error_handler = [weak_session_ref](std::error_code error_code, bool is_fatal, const std::string message) {
-            if (error_code.category() != realm::sync::protocol_error_category() ||
+        auto error_handler = [weak_session_ref, local_realm_path](std::error_code error_code, bool is_fatal, const std::string message) {
+            if (error_code.category() != realm::sync::protocol_error_category() &&
                     error_code.category() != realm::sync::client_error_category()) {
                 // FIXME: Consider below when moving to the OS sync manager.
                 // Ignore this error since it may cause exceptions in java ErrorCode.fromInt(). Throwing exception there

--- a/realm/realm-library/src/main/cpp/objectserver_shared.hpp
+++ b/realm/realm-library/src/main/cpp/objectserver_shared.hpp
@@ -61,7 +61,7 @@ public:
                 coordinator->wake_up_notifier_worker();
             }
         };
-        auto error_handler = [weak_session_ref, local_realm_path](std::error_code error_code, bool is_fatal, const std::string message) {
+        auto error_handler = [weak_session_ref](std::error_code error_code, bool is_fatal, const std::string message) {
             if (error_code.category() != realm::sync::protocol_error_category() &&
                     error_code.category() != realm::sync::client_error_category()) {
                 // FIXME: Consider below when moving to the OS sync manager.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -392,6 +392,10 @@ public class SyncUser {
         }
     }
 
+    public void removeAccessToken (URI serverURL) {
+        syncUser.removeAccessToken(serverURL);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -44,7 +44,6 @@ import io.realm.internal.network.LogoutResponse;
 import io.realm.internal.objectserver.ObjectServerUser;
 import io.realm.internal.objectserver.Token;
 import io.realm.log.RealmLog;
-import io.realm.permissions.PermissionChange;
 import io.realm.permissions.PermissionModule;
 
 /**
@@ -390,10 +389,6 @@ public class SyncUser {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Could not create URL to the management Realm", e);
         }
-    }
-
-    public void removeAccessToken (URI serverURL) {
-        syncUser.removeAccessToken(serverURL);
     }
 
     @Override

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/BoundState.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/BoundState.java
@@ -58,11 +58,11 @@ class BoundState extends FsmState {
             //  this may cause the server to send a fatal error (203 bad refresh) if we try to bind
             //  the session with this token. To be safe we remove the token that has been considered by the
             //  the server to be invalid.
-            session.getUser().removeAccessToken(session.getServerUrl());
 
             // stop the session to avoid sending a bind to the server which will cause it to return
             // a fatal 203 (bad refresh)
             session.stopNativeSession();
+            session.removeAccessToken();
 
             // Create a new session & bind it
             session.createNativeSession();

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/BoundState.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/BoundState.java
@@ -52,7 +52,22 @@ class BoundState extends FsmState {
         // If a Realms access token has expired, trigger a rebind. If the user is still valid it will automatically
         // refresh it.
         if (error.getErrorCode() == ErrorCode.TOKEN_EXPIRED) {
+            //  the server can send a 202 (expired access token) even if the client
+            //  still consider this token to be valid (based on timestamps for example)
+            //
+            //  this may cause the server to send a fatal error (203 bad refresh) if we try to bind
+            //  the session with this token. To be safe we remove the token that has been considered by the
+            //  the server to be invalid.
+            session.getUser().removeAccessToken(session.getServerUrl());
+
+            // stop the session to avoid sending a bind to the server which will cause it to return
+            // a fatal 203 (bad refresh)
+            session.stopNativeSession();
+
+            // Create a new session & bind it
+            session.createNativeSession();
             gotoNextState(SessionState.BINDING);
+            
         } else {
             switch (error.getCategory()) {
                 case FATAL: gotoNextState(SessionState.STOPPED); break;

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerSession.java
@@ -23,10 +23,10 @@ import java.util.concurrent.Future;
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
 import io.realm.RealmAsyncTask;
-import io.realm.SyncSession;
 import io.realm.SessionState;
 import io.realm.SyncConfiguration;
 import io.realm.SyncManager;
+import io.realm.SyncSession;
 import io.realm.SyncUser;
 import io.realm.internal.KeepMember;
 import io.realm.internal.async.RealmAsyncTaskImpl;
@@ -238,6 +238,10 @@ public final class ObjectServerSession {
             nativeUnbind(nativeSessionPointer);
             nativeSessionPointer = 0;
         }
+    }
+
+    void removeAccessToken() {
+        user.removeAccessToken(configuration.getServerUrl());
     }
 
     // Bind with proper access tokens

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerUser.java
@@ -28,8 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.realm.SyncSession;
 import io.realm.SyncConfiguration;
+import io.realm.SyncSession;
 
 /**
  * Internal representation of a user on the Realm Object Server.
@@ -54,7 +54,7 @@ public class ObjectServerUser {
         this.loggedIn = true;
     }
 
-    public void setRefreshToken(final Token refreshToken) {
+    private void setRefreshToken(final Token refreshToken) {
         this.refreshToken = refreshToken; // Replace any existing token. TODO re-save the user with latest token.
     }
 
@@ -64,7 +64,7 @@ public class ObjectServerUser {
      *
      * Authenticating will happen automatically as part of opening a Realm.
      */
-    public boolean isAuthenticated(SyncConfiguration configuration) {
+    boolean isAuthenticated(SyncConfiguration configuration) {
         Token token = getAccessToken(configuration.getServerUrl());
         return token != null && token.expiresMs() > System.currentTimeMillis();
     }
@@ -92,16 +92,13 @@ public class ObjectServerUser {
         return identity;
     }
 
-    public Token getAccessToken(URI serverUrl) {
+    Token getAccessToken(URI serverUrl) {
         AccessDescription accessDescription = realms.get(serverUrl);
         return (accessDescription != null) ? accessDescription.accessToken : null;
     }
 
-    public void removeAccessToken(URI serverUrl) {
-        AccessDescription accessDescription = realms.get(serverUrl);
-        if (accessDescription != null) {
-            accessDescription.accessToken = null;
-        }
+    void removeAccessToken(URI serverUrl) {
+        realms.remove(serverUrl);
     }
 
     public void addRealm(URI uri, AccessDescription description) {

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectserver/ObjectServerUser.java
@@ -97,6 +97,13 @@ public class ObjectServerUser {
         return (accessDescription != null) ? accessDescription.accessToken : null;
     }
 
+    public void removeAccessToken(URI serverUrl) {
+        AccessDescription accessDescription = realms.get(serverUrl);
+        if (accessDescription != null) {
+            accessDescription.accessToken = null;
+        }
+    }
+
     public void addRealm(URI uri, AccessDescription description) {
         realms.put(uri, description);
     }


### PR DESCRIPTION
Fixes #4038 and  #4039. preventing Sync client to renew the access token.