### PR TITLE
Corrected RealmConfiguration#encryptionKey JavaDoc

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -453,7 +453,7 @@ public class RealmConfiguration {
         }
 
         /**
-         * Sets the 64 bit key used to encrypt and decrypt the Realm file.
+         * Sets the 64 byte key used to encrypt and decrypt the Realm file.
          * Sets the {@value io.realm.RealmConfiguration#KEY_LENGTH} bytes key used to encrypt and decrypt the Realm file.
          */
         public Builder encryptionKey(byte[] key) {


### PR DESCRIPTION
encryptionKey requires a 64 byte key instead of a 64 bit key. May lead to confusion