### PR TITLE
Don't use a fixed name for the ROS container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,7 @@ try {
         rosEnv = docker.build 'ros:snapshot', "--build-arg ROS_DE_VERSION=${rosDeVersion} tools/sync_test_server"
       }
 
-      rosContainer = rosEnv.run("-v /tmp=/tmp/.ros " +
-              "--name ros")
+      rosContainer = rosEnv.run('-v /tmp=/tmp/.ros')
 
       try {
           buildEnv.inside("-e HOME=/tmp " +
@@ -47,7 +46,7 @@ try {
                   "-v ${env.HOME}/.android:/tmp/.android " +
                   "-v ${env.HOME}/ccache:/tmp/.ccache " +
                   "-v ${env.HOME}/lcache:/tmp/.lcache " +
-                  "--network container:ros") {
+                  "--network container:${rosContainer.id}") {
             stage('JVM tests') {
               try {
                 withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
@@ -107,7 +106,7 @@ try {
             }
           }
       } finally {
-          sh "docker logs ros"
+          sh "docker logs ${rosContainer.id}"
           rosContainer.stop()
       }
     }


### PR DESCRIPTION
This will allow avoiding issues when a previously running ROS container has not been closed for whatever reason. Fixes realm/ci#61