### PR TITLE
Free the SharedRealm in phantom daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.1
+
+### Bug fixes
+
+* Fixed NPE problem happened in SharedRealm.finalize() (#3730).
+
 ## 2.3.0
 
 ### Object Server API Changes 


### PR DESCRIPTION
Treat the SharedRealm the same as other native objects.
SharedRealm.close will only call Object Store Realm::close without
deleting the ShareRealm pointer.
Then we don't need the finalizer anymore. Fix #3730 .
This is related with
https://github.com/realm/realm-object-store/pull/318
as well. It is possible that java close the Realm in any of the Object Store's 
callbacks. To avoid Object Store operating on a invalid SharedRealm
pointer, binding should try to make sure after callbacks. However, it
cannot be totally avoided since user could set the Realm instance to
null and the instance can be GCed at any time. It is still something
should be considered in the Object Store implementation.