### PR TITLE
remove kapt dependency to io.realm:realm-annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.1
+
+### Bug fixes
+
+* Fixed a build error when the project is using Kotlin (#4087).
+
 ## 2.3.0
 
 ### Object Server API Changes 

--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -59,20 +59,14 @@ class Realm implements Plugin<Project> {
         project.repositories.add(project.getRepositories().jcenter())
         project.dependencies.add("compile", "io.realm:realm-annotations:${Version.VERSION}")
         if (usesAptPlugin) {
-            project.dependencies.add("apt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("apt", "io.realm:realm-annotations-processor:${Version.VERSION}")
-            project.dependencies.add("androidTestApt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("androidTestApt", "io.realm:realm-annotations-processor:${Version.VERSION}")
         } else if (isKotlinProject && !preferAptOnKotlinProject) {
-            project.dependencies.add("kapt", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("kapt", "io.realm:realm-annotations-processor:${Version.VERSION}")
-            project.dependencies.add("kaptAndroidTest", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("kaptAndroidTest", "io.realm:realm-annotations-processor:${Version.VERSION}")
         } else {
             assert hasAnnotationProcessorConfiguration
-            project.dependencies.add("annotationProcessor", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("annotationProcessor", "io.realm:realm-annotations-processor:${Version.VERSION}")
-            project.dependencies.add("androidTestAnnotationProcessor", "io.realm:realm-annotations:${Version.VERSION}")
             project.dependencies.add("androidTestAnnotationProcessor", "io.realm:realm-annotations-processor:${Version.VERSION}")
         }
     }


### PR DESCRIPTION
`realm-annotations-processor` has a transitive dependency to `realm-annotations`.
No need to add it manually.

And this change also fixes #4087.