### PR TITLE
Fix RealmCollection.contains not respecting custom equal methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug fixes
 
 * NPE problem in SharedRealm.finalize() (#3730).
-* `RealmList.contains()` and `RealmResults.contains()` now correctly uses custom `equals()` methods on Realm model classes.
+* `RealmList.contains()` and `RealmResults.contains()` now correctly use custom `equals()` method on Realm model classes.
 * Build error when the project is using Kotlin (#4087).
 * Bug causing classes to be replaced by classes already in Gradle's classpath (#3568).
 * NullPointerException when notifying a single object that it changed (#4086).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* NPE problem happened in SharedRealm.finalize() (#3730).
+* NPE problem in SharedRealm.finalize() (#3730).
 * `RealmList.contains()` and `RealmResults.contains()` now correctly uses custom `equals()` methods on Realm model classes.
 * Build error when the project is using Kotlin (#4087).
 * Bug causing classes to be replaced by classes already in Gradle's classpath (#3568).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fixed NPE problem happened in SharedRealm.finalize() (#3730).
+* `RealmList.contains()` and `RealmResults.contains()` now correctly uses custom `equals()` methods on Realm model classes.
 
 ## 2.3.0
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import io.realm.entities.AllJavaTypes;
+import io.realm.entities.CustomMethods;
 import io.realm.entities.Dog;
 import io.realm.entities.NullTypes;
 import io.realm.rule.TestRealmConfigurationFactory;
@@ -133,6 +134,38 @@ public class RealmCollectionTests extends CollectionTests {
         }
     }
 
+    private RealmCollection<CustomMethods> createCustomMethodsCollection(Realm realm, CollectionClass collectionClass) {
+        switch (collectionClass) {
+            case MANAGED_REALMLIST:
+                realm.beginTransaction();
+                CustomMethods top = realm.createObject(CustomMethods.class);
+                top.setName("Top");
+                for (int i = 0; i < TEST_SIZE; i++) {
+                    top.getMethods().add(new CustomMethods("Child" + i));
+                }
+                realm.commitTransaction();
+                return top.getMethods();
+
+            case UNMANAGED_REALMLIST:
+                RealmList<CustomMethods> list = new RealmList<CustomMethods>();
+                for (int i = 0; i < TEST_SIZE; i++) {
+                    list.add(new CustomMethods("Child" + i));
+                }
+                return list;
+
+            case REALMRESULTS:
+                realm.beginTransaction();
+                for (int i = 0; i < TEST_SIZE; i++) {
+                    realm.copyToRealm(new CustomMethods("Child" + i));
+                }
+                realm.commitTransaction();
+                return realm.where(CustomMethods.class).findAll();
+
+            default:
+                throw new AssertionError("Unsupported class: " + collectionClass);
+        }
+    }
+
     private OrderedRealmCollection<NullTypes> createEmptyCollection(Realm realm, CollectionClass collectionClass) {
         switch (collectionClass) {
             case MANAGED_REALMLIST:
@@ -179,6 +212,18 @@ public class RealmCollectionTests extends CollectionTests {
     @Test
     public void contains_null() {
         assertFalse(collection.contains(null));
+    }
+
+    // Test that the custom equal methods is being used when testing if an object is part of the
+    // collection
+    @Test
+    public void contains_customEqualMethod() {
+        RealmCollection<CustomMethods> collection = createCustomMethodsCollection(realm, collectionClass);
+        // This custom equals method will only consider the field `name` when comparing objects.
+        // So this unmanaged version should be equal to any object with the same value, managed
+        // or not.
+        CustomMethods unmanaged = new CustomMethods("Child0");
+        assertTrue(collection.contains(unmanaged));
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCollectionTests.java
@@ -222,8 +222,9 @@ public class RealmCollectionTests extends CollectionTests {
         // This custom equals method will only consider the field `name` when comparing objects.
         // So this unmanaged version should be equal to any object with the same value, managed
         // or not.
-        CustomMethods unmanaged = new CustomMethods("Child0");
-        assertTrue(collection.contains(unmanaged));
+        assertTrue(collection.contains(new CustomMethods("Child0")));
+        assertTrue(collection.contains(new CustomMethods("Child" + (TEST_SIZE - 1))));
+        assertFalse(collection.contains(new CustomMethods("Child" + TEST_SIZE)));
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -426,23 +426,6 @@ public class RealmObjectTests {
     }
 
     @Test
-    public void equals_reverseCustomMethod() {
-        realm.beginTransaction();
-        CustomMethods cm = realm.createObject(CustomMethods.class);
-        cm.setName("Foo");
-        realm.commitTransaction();
-
-        CustomMethods cm1 = realm.where(CustomMethods.class).findFirst();
-        CustomMethods cm2 = realm.where(CustomMethods.class).findFirst();
-
-        realm.beginTransaction();
-        cm1.reverseEquals = true;
-        realm.commitTransaction();
-
-        assertFalse(cm1.equals(cm2));
-    }
-
-    @Test
     public void equals_unmanagedCustomMethod() {
         CustomMethods cm1 = new CustomMethods();
         cm1.setName("Bar");

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -447,8 +447,8 @@ public class RealmObjectTests {
         realm.commitTransaction();
 
         CustomMethods cm3 = realm.where(CustomMethods.class).findFirst();
-        assertFalse(cm3.equals(cm2));
-        assertTrue(cm3.getName().equals(cm2.getName()));
+        assertTrue(cm3.equals(cm2));
+        assertTrue(cm2.equals(cm3));
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/CustomMethods.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/CustomMethods.java
@@ -48,14 +48,13 @@ public class CustomMethods extends RealmObject {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof CustomMethods)) {
-            return false;
-        }
-        CustomMethods other = (CustomMethods) o;
+        if (this == o) return true;
+        if (o == null || !(o instanceof CustomMethods)) return false;
 
-        // Only compare name. Managed and unmanaged objects will be equal as long as they have the
-        // same value
-        return other.name.equals(name);
+        CustomMethods that = (CustomMethods) o;
+
+        // Only compare name. Managed and unmanaged objects will be equal as long as they have the same value
+        return name != null ? name.equals(that.name) : that.name == null;
     }
 
     @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/CustomMethods.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/CustomMethods.java
@@ -16,6 +16,7 @@
 
 package io.realm.entities;
 
+import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
 
@@ -24,6 +25,14 @@ public class CustomMethods extends RealmObject {
     public static final int HASHCODE = 1;
 
     private String name;
+    private RealmList<CustomMethods> methods;
+
+    public CustomMethods() {
+    }
+
+    public CustomMethods(String name) {
+        this.name = name;
+    }
 
     public String getName() {
         return name;
@@ -33,20 +42,20 @@ public class CustomMethods extends RealmObject {
         this.name = name;
     }
 
-    @Ignore
-    public boolean reverseEquals;
+    public RealmList<CustomMethods> getMethods() {
+        return methods;
+    }
 
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof CustomMethods)) {
-            return reverseEquals;
+            return false;
         }
         CustomMethods other = (CustomMethods) o;
-        if (isManaged() == other.isManaged() && other.name.equals(name)) {
-            return !reverseEquals;
-        } else {
-            return reverseEquals;
-        }
+
+        // Only compare name. Managed and unmanaged objects will be equal as long as they have the
+        // same value
+        return other.name.equals(name);
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -709,33 +709,6 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
     }
 
     /**
-     * Returns {@code true} if the list contains the specified element when attached to a Realm. This
-     * method will query the native Realm underlying storage engine to quickly find the specified element.
-     * <p>
-     * If the list is not attached to a Realm, the default {@link List#contains(Object)}
-     * implementation will occur.
-     *
-     * @param object the element whose presence in this list is to be tested.
-     * @return {@code true} if this list contains the specified element otherwise {@code false}.
-     */
-    @Override
-    public boolean contains(Object object) {
-        boolean contains = false;
-        if (managedMode) {
-            realm.checkIfValid();
-            if (object instanceof RealmObjectProxy) {
-                RealmObjectProxy proxy = (RealmObjectProxy) object;
-                if (proxy.realmGet$proxyState().getRow$realm() != null && realm.getPath().equals(proxy.realmGet$proxyState().getRealm$realm().getPath()) && proxy.realmGet$proxyState().getRow$realm() != InvalidRow.INSTANCE) {
-                    contains = view.contains(proxy.realmGet$proxyState().getRow$realm().getIndex());
-                }
-            }
-        } else {
-            contains = unmanagedList.contains(object);
-        }
-        return contains;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -709,6 +709,40 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
     }
 
     /**
+     * Returns {@code true} if the list contains the specified element when attached to a Realm. This
+     * method will query the native Realm underlying storage engine to quickly find the specified element.
+     * <p>
+     * If the list is not attached to a Realm, the default {@link List#contains(Object)}
+     * implementation will occur.
+     *
+     * @param object the element whose presence in this list is to be tested.
+     * @return {@code true} if this list contains the specified element otherwise {@code false}.
+     */
+    @Override
+    public boolean contains(Object object) {
+        if (managedMode) {
+            realm.checkIfValid();
+
+            // Deleted objects can never be part of a RealmList
+            if (object instanceof RealmObjectProxy) {
+                RealmObjectProxy proxy = (RealmObjectProxy) object;
+                if (proxy.realmGet$proxyState().getRow$realm() == InvalidRow.INSTANCE) {
+                    return false;
+                }
+            }
+
+            for (E e : this) {
+                if (e.equals(object)) {
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            return unmanagedList.contains(object);
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -181,6 +181,33 @@ public class RealmResults<E extends RealmModel> extends AbstractList<E> implemen
     }
 
     /**
+     * Searches this {@link RealmResults} for the specified object.
+     *
+     * @param object the object to search for.
+     * @return {@code true} if {@code object} is an element of this {@code RealmResults},
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(Object object) {
+        if (isLoaded()) {
+            // Deleted objects can never be part of a RealmResults
+            if (object instanceof RealmObjectProxy) {
+                RealmObjectProxy proxy = (RealmObjectProxy) object;
+                if (proxy.realmGet$proxyState().getRow$realm() == InvalidRow.INSTANCE) {
+                    return false;
+                }
+            }
+
+            for (E e : this) {
+                if (e.equals(object)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns the element at the specified location in this list.
      *
      * @param location the index of the element to return.

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -181,25 +181,6 @@ public class RealmResults<E extends RealmModel> extends AbstractList<E> implemen
     }
 
     /**
-     * Searches this {@link RealmResults} for the specified object.
-     *
-     * @param object the object to search for.
-     * @return {@code true} if {@code object} is an element of this {@code RealmResults},
-     *         {@code false} otherwise
-     */
-    @Override
-    public boolean contains(Object object) {
-        boolean contains = false;
-        if (isLoaded() && object instanceof RealmObjectProxy) {
-            RealmObjectProxy proxy = (RealmObjectProxy) object;
-            if (realm.getPath().equals(proxy.realmGet$proxyState().getRealm$realm().getPath()) && proxy.realmGet$proxyState().getRow$realm() != InvalidRow.INSTANCE) {
-                contains = (table.sourceRowIndex(proxy.realmGet$proxyState().getRow$realm().getIndex()) != TableOrView.NO_MATCH);
-            }
-        }
-        return contains;
-    }
-
-    /**
      * Returns the element at the specified location in this list.
      *
      * @param location the index of the element to return.


### PR DESCRIPTION
Got reported directly, and fixing it was easier than creating the issue :D

EDIT: `static.realm.io` is still insanely slow so CI times out on the unit tests. Will move into review once that is fixed

