### PR TITLE
remove duplicate init of the OS metadata

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -57,7 +57,7 @@ public class SyncUserTests {
     @BeforeClass
     public static void initUserStore() {
         Realm.init(InstrumentationRegistry.getInstrumentation().getContext());
-        UserStore userStore = new RealmFileUserStore(InstrumentationRegistry.getTargetContext().getFilesDir().getPath());
+        UserStore userStore = new RealmFileUserStore();
         SyncManager.setUserStore(userStore);
     }
 

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
@@ -85,16 +85,6 @@ Java_io_realm_RealmFileUserStore_nativeLogoutUser (JNIEnv *env, jclass, jstring 
 }
 
 
-JNIEXPORT void JNICALL
-Java_io_realm_RealmFileUserStore_nativeConfigureMetaDataSystem (JNIEnv *env, jclass, jstring baseFile)
-{
-    TR_ENTER()
-    try {
-        JStringAccessor base_file_path(env, baseFile); // throws
-        SyncManager::shared().configure_file_system(base_file_path, SyncManager::MetadataMode::NoEncryption);
-    } CATCH_STD()
-}
-
 JNIEXPORT jobjectArray JNICALL
 Java_io_realm_RealmFileUserStore_nativeGetAllUsers (JNIEnv *env, jclass)
 {

--- a/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
@@ -38,14 +38,14 @@ class ObjectServer {
         } catch (Exception ignore) {
         }
 
-        // Configure default UserStore
-        UserStore userStore = new RealmFileUserStore(context.getFilesDir().getPath());
-
-        SyncManager.init(appId, userStore);
-
         // init the "sync_manager.cpp" metadata Realm, this is also needed later, when re try
         // to schedule a client reset. in realm-java#master this is already done, when initialising
         // the RealmFileUserStore (not available now on releases)
         SyncManager.nativeConfigureMetaDataSystem(context.getFilesDir().getPath());
+
+        // Configure default UserStore
+        UserStore userStore = new RealmFileUserStore();
+
+        SyncManager.init(appId, userStore);
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmFileUserStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmFileUserStore.java
@@ -24,9 +24,6 @@ import java.util.Collections;
  * A User Store backed by a Realm file to store user.
  */
 public class RealmFileUserStore implements UserStore {
-    protected RealmFileUserStore(String path) {
-        nativeConfigureMetaDataSystem(path);
-    }
 
     /**
      * {@inheritDoc}
@@ -86,9 +83,6 @@ public class RealmFileUserStore implements UserStore {
         }
         return SyncUser.fromJson(userJson);
     }
-
-    // init and load the Metadata Realm containing SyncUsers
-    protected static native void nativeConfigureMetaDataSystem(String baseFile);
 
     // returns json data (token) of the current logged in user
     protected static native String nativeGetCurrentUser();


### PR DESCRIPTION
calling `nativeConfigureMetaDataSystem` once to init the ObjectStore metadata table needed for client reset action & store Sync users