### PR TITLE
Feature : Add a Fields Class generator.

### DIFF
--- a/realm-annotations/src/main/java/io/realm/annotations/QueryFieldBy.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/QueryFieldBy.java
@@ -1,0 +1,44 @@
+package io.realm.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * This annotation will generate an extra subset of fields inside the perspective Fields class
+ * to allow the annotated Object to be queried by its fields.
+ * <p>
+ *
+ * Example:
+ * * <pre>
+ * {@code
+ *   public class Dog extends RealmObject {
+ *       private int age;
+ *   }
+ *
+ *   public class Person extends RealmObject {
+ *      @QueryFieldBy(fields = "age")
+ *      private Dog dog;
+ *   }
+ *
+ *   // DOG_AGE field will now be generated in PersonFields class.
+ *   public final class PersonFields {
+ *       public static final String DOG_AGE = "dog.age";
+ *   }
+ *
+ *   // Query all people who have a dog which is 4 years old.
+ *   realm.where(Person.class).equalTo(PersonFields.DOG_AGE, 4);
+ * }
+ * </pre>
+ *
+ * <p>
+ * Primitive types are not allowed to be annotated with {@link QueryFieldBy}.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface QueryFieldBy {
+
+    String[] fields();
+}

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
@@ -23,6 +23,7 @@ public class Constants {
     public static final String REALM_PACKAGE_NAME = "io.realm";
     public static final String PROXY_SUFFIX = "RealmProxy";
     public static final String INTERFACE_SUFFIX = "RealmProxyInterface";
+    public static final String FIELDS_SUFFIX = "Fields";
     public static final String INDENT = "    ";
     public static final String TABLE_PREFIX = "class_";
     public static final String DEFAULT_MODULE_CLASS_NAME = "DefaultRealmModule";

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmObjectFieldsGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmObjectFieldsGenerator.java
@@ -1,0 +1,102 @@
+package io.realm.processor;
+
+import com.squareup.javawriter.JavaWriter;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.EnumSet;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
+import javax.tools.JavaFileObject;
+
+
+/**
+ * Generates a Fields class for each class annotated with @RealmClass
+ * Example:
+ * <pre>
+ * {@code
+ *
+ *   public class Person extends RealmObject {
+ *
+ *      private int id;
+ *      private String name;
+ *   }
+ *
+ *   // Generated class.
+ *   public final class PersonFields {
+ *       public static final String ID = "id";
+ *       public static final String NAME = "name";
+ *   }
+ *
+ *   // Query the person with an id of 1.
+ *   realm.where(Person.class).equalTo(PersonFields.ID, 1).findFirst();
+ * }
+ * </pre>
+ *
+ * @author Raee, Mulham (mulham.raee@gmail.com)
+ */
+public class RealmObjectFieldsGenerator {
+    private ProcessingEnvironment processingEnvironment;
+    private ClassMetaData metaData;
+    private final String simpleClassName;
+
+    public RealmObjectFieldsGenerator(ProcessingEnvironment processingEnvironment, ClassMetaData metaData) {
+        this.processingEnvironment = processingEnvironment;
+        this.metaData = metaData;
+        this.simpleClassName = metaData.getSimpleClassName();
+    }
+
+    public void generate() throws IOException {
+        String qualifiedGeneratedInterfaceName =
+                String.format("%s.%s", Constants.REALM_PACKAGE_NAME, Utils.getFieldsClassName(simpleClassName));
+        JavaFileObject sourceFile = processingEnvironment.getFiler().createSourceFile(qualifiedGeneratedInterfaceName);
+        JavaWriter writer = new JavaWriter(new BufferedWriter(sourceFile.openWriter()));
+
+        writer.setIndent(Constants.INDENT);
+
+        writer
+                .emitPackage(Constants.REALM_PACKAGE_NAME)
+                .emitEmptyLine()
+                .beginType(qualifiedGeneratedInterfaceName, "class", EnumSet.of(Modifier.PUBLIC, Modifier.FINAL));
+
+        for (VariableElement element : metaData.getFields()) {
+            String originalFieldName = element.getSimpleName().toString();
+            String generatedFieldName = generateFieldName(originalFieldName);
+
+            writer
+                    .emitField("String", generatedFieldName, EnumSet.of(Modifier.PUBLIC, Modifier.FINAL, Modifier.STATIC), originalFieldName);
+
+            QueryFieldBy queryFieldBy = element.getAnnotation(QueryFieldBy.class);
+            if (queryFieldBy != null) {
+
+                for (String field : queryFieldBy.fields()) {
+                    if (field.length() == 0) {
+                        continue;
+                    }
+
+                    writer
+                            .emitField("String", generatedFieldName + "_" + generateFieldName(field),
+                                    EnumSet.of(Modifier.PUBLIC, Modifier.FINAL, Modifier.STATIC), originalFieldName + "." + field);
+                }
+            }
+
+
+        }
+
+        writer.endType();
+        writer.close();
+    }
+
+    private String generateFieldName(String str) {
+        StringBuilder builder = new StringBuilder(str);
+        for (int i = str.length() - 1; i >= 0; i--) {
+            if (Character.isUpperCase(str.charAt(i))) {
+                builder.insert(i, '_');
+            }
+        }
+        return builder.toString().toUpperCase();
+    }
+
+}

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -52,6 +52,7 @@ import io.realm.annotations.RealmClass;
  *
  * <ol>
  *  <li>Create proxy classes for all classes marked with @RealmClass. They are named &lt;className&gt;RealmProxy.java</li>
+ *  <li>Create a fields class for each class marked with @RealmClass. They are named &lt;className&gt;Fields.java</li>
  *  <li>Create a DefaultRealmModule containing all RealmObject classes (if needed).</li>
  *  <li>Create a RealmProxyMediator class for all classes marked with {@code @RealmModule}. They are named {@code <moduleName>Mediator.java}</li>
  * </ol>
@@ -185,6 +186,13 @@ public class RealmProcessor extends AbstractProcessor {
             } catch (IOException e) {
                 Utils.error(e.getMessage(), classElement);
             } catch (UnsupportedOperationException e) {
+                Utils.error(e.getMessage(), classElement);
+            }
+
+            RealmObjectFieldsGenerator fieldsClassGenerator = new RealmObjectFieldsGenerator(processingEnv, metadata);
+            try {
+                fieldsClassGenerator.generate();
+            } catch (IOException e) {
                 Utils.error(e.getMessage(), classElement);
             }
         }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
@@ -231,4 +231,8 @@ public class Utils {
     public static String getProxyInterfaceName(String className) {
         return className + Constants.INTERFACE_SUFFIX;
     }
+
+    public static String getFieldsClassName(String className) {
+        return className + Constants.FIELDS_SUFFIX;
+    }
 }


### PR DESCRIPTION
### Specifications
- A Fields class will be generated for each **RealmObject**  with the name className + Fields. (example: **PersonsFields**).
- The generated class contains all the fields as a **public static String** variables with a value of the field name itself.

### Goals
- Reduce bloated code required for quires, and the need to use literal Strings as query keys.
- Safer code and errors detection when changing fields name, as it will normally break all queries using this field. 
- This will also adds **autocomplete** which allows navigating through all fields of the class to select one to be queried.

### Example Code
```java
public class Dog extends RealmObject {
       private int age;
 }

public class Person extends RealmObject { 
       private int id;

       @QueryFieldBy(fields = "age")
       private Dog dog;
 }
 
// Generated classes.
public final class DogFields {
       public static final String AGE = "age";
 }

public final class PersonFields {
       public static final String ID = "id";
       public static final String DOG_AGE = "dog.age";
 }
 
// Query the person with an id of 1.
realm.where(Person.class).equalTo(PersonFields.ID, 1).findFirst();
// Query all people who have a dog which is 4 years old.
realm.where(Person.class).equalTo(PersonFields.DOG_AGE, 4).findAll();
```