### PR TITLE
Handler null check for when AndroidNotifier is closed (#4131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Fixed NPE when async queries are not yet finished, but Realm instance is closed (#4131).
 * Fixed NPE problem happened in SharedRealm.finalize() (#3730).
 * Fixed a build error when the project is using Kotlin (#4087).
 * Fixed a bug causing classes to be replaced by classes already in Gradle's classpath (#3568).

--- a/realm/realm-library/src/main/java/io/realm/AndroidNotifier.java
+++ b/realm/realm-library/src/main/java/io/realm/AndroidNotifier.java
@@ -96,6 +96,10 @@ class AndroidNotifier implements RealmNotifier {
 
     @Override
     public void post(Runnable runnable) {
+        if (handler == null) {
+            return;
+        }
+        
         Looper looper = handler.getLooper();
         if (looper.getThread().isAlive()) {     // The receiving thread is alive
             handler.post(runnable);
@@ -117,6 +121,10 @@ class AndroidNotifier implements RealmNotifier {
 
     @Override
     public void completeAsyncResults(QueryUpdateTask.Result result) {
+        if (handler == null) {
+            return;
+        }
+        
         Looper looper = handler.getLooper();
         if (looper.getThread().isAlive()) {     // The receiving thread is alive
             handler.obtainMessage(HandlerControllerConstants.COMPLETED_ASYNC_REALM_RESULTS, result).sendToTarget();
@@ -125,6 +133,10 @@ class AndroidNotifier implements RealmNotifier {
 
     @Override
     public void completeAsyncObject(QueryUpdateTask.Result result) {
+        if (handler == null) {
+            return;
+        }
+        
         Looper looper = handler.getLooper();
         if (looper.getThread().isAlive()) {     // The receiving thread is alive
             handler.obtainMessage(HandlerControllerConstants.COMPLETED_ASYNC_REALM_OBJECT, result).sendToTarget();
@@ -133,6 +145,10 @@ class AndroidNotifier implements RealmNotifier {
 
     @Override
     public void throwBackgroundException(Throwable throwable) {
+        if (handler == null) {
+            return;
+        }
+        
         Looper looper = handler.getLooper();
         if (looper.getThread().isAlive()) {     // The receiving thread is alive
             handler.obtainMessage(
@@ -142,6 +158,10 @@ class AndroidNotifier implements RealmNotifier {
 
     @Override
     public void completeUpdateAsyncQueries(QueryUpdateTask.Result result) {
+        if (handler == null) {
+            return;
+        }
+        
         Looper looper = handler.getLooper();
         if (looper.getThread().isAlive()) {     // The receiving thread is alive
             handler.obtainMessage(HandlerControllerConstants.COMPLETED_UPDATE_ASYNC_QUERIES, result).sendToTarget();


### PR DESCRIPTION
Fixes https://github.com/realm/realm-java/issues/4131 which occurs when async queries are not yet finished, but Realm instance is closed.