### PR TITLE
Use CMake's ability to do transitive dependency resolution

### DIFF
--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -77,10 +77,10 @@ if (NOT EXISTS ${core_lib_PATH})
 endif()
 
 add_library(lib_realm_core STATIC IMPORTED)
-set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_PATH})
 # -latomic is not set by default for mips and armv5.
 # See https://code.google.com/p/android/issues/detail?id=182094
-set_target_properties(lib_realm_core PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES atomic)
+set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_PATH}
+                                                IMPORTED_LINK_INTERFACE_LIBRARIES atomic)
 
 # Sync static library
 set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-${ANDROID_ABI}.a)
@@ -97,7 +97,9 @@ if (NOT EXISTS ${sync_lib_PATH})
     endif()
 endif()
 add_library(lib_realm_sync STATIC IMPORTED)
-set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_PATH})
+set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_PATH}
+                                                IMPORTED_LINK_INTERFACE_LIBRARIES lib_realm_core)
+
 target_link_libraries(lib_realm_sync lib_realm_core)
 
 # build application's shared lib

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -78,6 +78,9 @@ endif()
 
 add_library(lib_realm_core STATIC IMPORTED)
 set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_PATH})
+# -latomic is not set by default for mips and armv5.
+# See https://code.google.com/p/android/issues/detail?id=182094
+target_link_libraries(lib_realm_core atomic)
 
 # Sync static library
 set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-${ANDROID_ABI}.a)
@@ -95,6 +98,7 @@ if (NOT EXISTS ${sync_lib_PATH})
 endif()
 add_library(lib_realm_sync STATIC IMPORTED)
 set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_PATH})
+target_link_libraries(lib_realm_sync lib_realm_core)
 
 # build application's shared lib
 include_directories(${REALM_CORE_DIST_DIR}/include
@@ -172,12 +176,10 @@ endif()
 
 add_library(realm-jni SHARED ${jni_SRC} ${objectstore_SRC} ${objectstore_sync_SRC})
 add_dependencies(realm-jni jni_headers)
-# -latomic is not set by default for mips. See https://code.google.com/p/android/issues/detail?id=182094
 if (build_SYNC)
-# FIXME: The order matters! lib_realm_sync needs to be in front of lib_realm_core!! Find out why!!
-target_link_libraries(realm-jni log android atomic lib_realm_sync lib_realm_core)
+target_link_libraries(realm-jni log android lib_realm_sync)
 else()
-target_link_libraries(realm-jni log android atomic lib_realm_core)
+target_link_libraries(realm-jni log android lib_realm_core)
 endif()
 
 # Strip the release so files and backup the unstripped versions

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -80,7 +80,7 @@ add_library(lib_realm_core STATIC IMPORTED)
 set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_PATH})
 # -latomic is not set by default for mips and armv5.
 # See https://code.google.com/p/android/issues/detail?id=182094
-target_link_libraries(lib_realm_core atomic)
+set_target_properties(lib_realm_core PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES atomic)
 
 # Sync static library
 set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-${ANDROID_ABI}.a)

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -100,8 +100,6 @@ add_library(lib_realm_sync STATIC IMPORTED)
 set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_PATH}
                                                 IMPORTED_LINK_INTERFACE_LIBRARIES lib_realm_core)
 
-target_link_libraries(lib_realm_sync lib_realm_core)
-
 # build application's shared lib
 include_directories(${REALM_CORE_DIST_DIR}/include
     ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
Cmake has the ability to do transitive dependency resolution. This means that we can simply say that core depends on sync and that sync depends on core and cmake will do the rest, including ordering libraries correctly for the linker to consume. This also avoids some redundancy.

This PR came out of a debugging session with @kneth where we were both facing linking issues with atomic on MIPS because of the wrong ordering of the libraries during the invocation of `ld`.