### PR TITLE
Implement fine gained notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Breaking changes
 
 * `RealmResults.distinct()` returns a new `RealmResults` object instead of filtering on the original object (#2947).
-* `RealmResults` is auto-updated continuously. Any transaction on the current thread which may have an impact on the order or elements of the `RealmResults` will change the `RealmResults` immediately instead of change it in the next event loop. The standard `RealmResults.iterator()` will continue to work as normal, which means that you can still delete or modify elements without impacting the iterator. The same is not true for simple for-loops. In some cases a simple for-loop will not work (https://realm.io/docs/java/2.3.1/api/io/realm/OrderedRealmCollection.html#loops), and you must use the new createSnapshot() method.
+* `RealmResults` is auto-updated continuously. Any transaction on the current thread which may have an impact on the order or elements of the `RealmResults` will change the `RealmResults` immediately instead of change it in the next event loop. The standard `RealmResults.iterator()` will continue to work as normal, which means that you can still delete or modify elements without impacting the iterator. The same is not true for simple for-loops. In some cases a simple for-loop will not work (https://realm.io/docs/java/latest/api/io/realm/OrderedRealmCollection.html#loops), and you must use the new createSnapshot() method.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Breaking changes
 
 * `RealmResults.distinct()` returns a new `RealmResults` object instead of filtering on the original object (#2947).
-* `RealmResults` is auto-updated continuously. Any transaction on the current thread which may have an impact on the order or elements of the `RealmResults` will change the `RealmResults` immediately instead of change it in the next event loop. The standard `RealmResults.iterator()` will continue to work as normal, which means that you can still delete or modify elements without impacting the iterator. The same is not true for simple for-loops. In some cases a simple for-loop will not work (https://realm.io/docs/java/latest/api/io/realm/OrderedRealmCollection.html#loops), and you must use the new createSnapshot() method.
+* `RealmResults` is auto-updated continuously. Any transaction on the current thread which may have an impact on the order or elements of the `RealmResults` will change the `RealmResults` immediately instead of change it in the next event loop. The standard `RealmResults.iterator()` will continue to work as normal, which means that you can still delete or modify elements without impacting the iterator. The same is not true for simple for-loops. In some cases a simple for-loop will not work (https://realm.io/docs/java/3.0.0/api/io/realm/OrderedRealmCollection.html#loops), and you must use the new createSnapshot() method.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * `RealmResults.distinct()` returns a new `RealmResults` object instead of filtering on the original object (#2947).
 * `RealmResults` is auto-updated continuously. Any transaction on the current thread which may have an impact on the order or elements of the `RealmResults` will change the `RealmResults` immediately instead of change it in the next event loop. The standard `RealmResults.iterator()` will continue to work as normal, which means that you can still delete or modify elements without impacting the iterator. The same is not true for simple for-loops. In some cases a simple for-loop will not work (https://realm.io/docs/java/latest/api/io/realm/OrderedRealmCollection.html#loops), and you must use the new createSnapshot() method.
 
+### Deprecated
+
+* `RealmResults.removeChangeListeners()`. Use `RealmResults.removeAllChangeListeners()` instead.
+
 ### Enhancements
 
 * Added support for sorting by link's field (#672).

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -465,7 +465,7 @@ public class NotificationsTest {
             @Override
             public void onChange(Realm object) {
                 listenerBCalled.incrementAndGet();
-                if (listenerACalled.get() == 1) {
+                if (listenerBCalled.get() == 1) {
                     // 2. Reverse order.
                     realm.removeAllChangeListeners();
                     realm.addChangeListener(this);
@@ -476,6 +476,8 @@ public class NotificationsTest {
                         public void execute(Realm realm) {
                         }
                     });
+                } else if (listenerBCalled.get() == 2) {
+                    assertEquals(1, listenerACalled.get());
                 }
             }
         };

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.realm.entities.AllTypes;
+import io.realm.rule.RunInLooperThread;
+import io.realm.rule.RunTestInLooperThread;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertArrayEquals;
+
+// Tests for the ordered collection fine grained notifications.
+// This should be expanded to test the notifications for RealmList as well in the future.
+@RunWith(AndroidJUnit4.class)
+public class OrderedCollectionChangeSetTests {
+
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+    @Rule
+    public final RunInLooperThread looperThread = new RunInLooperThread();
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    private void populateData(Realm realm, int testSize) {
+        realm.beginTransaction();
+        for (int i = 0; i < testSize; i++) {
+            realm.createObject(AllTypes.class).setColumnLong(i);
+        }
+        realm.commitTransaction();
+    }
+
+    // The args should be [startIndex1, length1, startIndex2, length2, ...]
+    private void checkRanges(OrderedCollectionChangeSet.Range[] ranges, long... indexAndLen) {
+        if ((indexAndLen.length % 2 != 0))  {
+            fail("The 'indexAndLen' array length is not an even number.");
+        }
+        if (ranges.length != indexAndLen.length / 2) {
+            fail("The lengths of 'ranges' and 'indexAndLen' don't match.");
+        }
+        for (int i = 0; i < ranges.length; i++) {
+            OrderedCollectionChangeSet.Range range = ranges[i];
+            long startIndex = indexAndLen[i * 2];
+            long length = indexAndLen[i * 2 + 1];
+            if (range.startIndex != startIndex || range.length != length) {
+                fail("Range at index " + i + " doesn't match start index " + startIndex + " length " + length + ".");
+            }
+        }
+    }
+
+    // Deletes AllTypes objects which's columnLong is in the indices array.
+    private void deleteObjects(Realm realm, long... indices) {
+        for (long index : indices) {
+            realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, index).findFirst().deleteFromRealm();
+        }
+    }
+
+    // Creates AllTypes objects with columnLong set to the value elements in indices array.
+    private void createObjects(Realm realm, long... indices) {
+        for (long index : indices) {
+            realm.createObject(AllTypes.class).setColumnLong(index);
+        }
+    }
+
+    // Modifies AllTypes objects which's columnLong is in the indices array.
+    private void modifyObjects(Realm realm, long... indices) {
+        for (long index : indices) {
+            AllTypes obj = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, index).findFirst();
+            assertNotNull(obj);
+            obj.setColumnString("modified");
+        }
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void deletion() {
+        Realm realm = looperThread.realm;
+        populateData(realm, 10);
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
+        results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+                checkRanges(changes.getDeletionRanges(),
+                        0, 1,
+                        2, 3,
+                        8, 2);
+                assertArrayEquals(changes.getDeletions(), new long[]{0, 2, 3, 4, 8, 9});
+                assertEquals(0, changes.getChangeRanges().length);
+                assertEquals(0, changes.getInsertionRanges().length);
+                assertEquals(0, changes.getChanges().length);
+                assertEquals(0, changes.getInsertions().length);
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        deleteObjects(realm,
+                0,
+                2, 3, 4,
+                8, 9);
+        realm.commitTransaction();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void insertion() {
+        Realm realm = looperThread.realm;
+        realm.beginTransaction();
+        createObjects(realm, 0, 2, 5, 6, 7, 9);
+        realm.commitTransaction();
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
+        results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+                checkRanges(changes.getInsertionRanges(),
+                        1, 1,
+                        3, 2,
+                        8, 1);
+                assertArrayEquals(changes.getInsertions(), new long[]{1, 3, 4, 8});
+                assertEquals(0, changes.getChangeRanges().length);
+                assertEquals(0, changes.getDeletionRanges().length);
+                assertEquals(0, changes.getChanges().length);
+                assertEquals(0, changes.getDeletions().length);
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        createObjects(realm,
+                1,
+                3, 4,
+                8);
+        realm.commitTransaction();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void changes() {
+        Realm realm = looperThread.realm;
+        populateData(realm, 10);
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
+        results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+                checkRanges(changes.getChangeRanges(),
+                        0, 1,
+                        2, 3,
+                        8, 2);
+                assertArrayEquals(changes.getChanges(), new long[]{0, 2, 3, 4, 8, 9});
+                assertEquals(0, changes.getInsertionRanges().length);
+                assertEquals(0, changes.getDeletionRanges().length);
+                assertEquals(0, changes.getInsertions().length);
+                assertEquals(0, changes.getDeletions().length);
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        modifyObjects(realm,
+                0,
+                2, 3, 4,
+                8, 9);
+        realm.commitTransaction();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void moves() {
+        Realm realm = looperThread.realm;
+        populateData(realm, 10);
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
+        results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+                checkRanges(changes.getDeletionRanges(),
+                        0, 1,
+                        9, 1);
+                assertArrayEquals(changes.getDeletions(), new long[]{0, 9});
+                checkRanges(changes.getInsertionRanges(),
+                        0, 1,
+                        9, 1);
+                assertArrayEquals(changes.getInsertions(), new long[]{0, 9});
+                assertEquals(0, changes.getChangeRanges().length);
+                assertEquals(0, changes.getChanges().length);
+                looperThread.testComplete();
+            }
+        });
+        realm.beginTransaction();
+        realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 0).findFirst().setColumnLong(10);
+        realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 9).findFirst().setColumnLong(0);
+        realm.commitTransaction();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void mixed_changes() {
+        Realm realm = looperThread.realm;
+        populateData(realm, 10);
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
+        results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+                checkRanges(changes.getDeletionRanges(),
+                        0, 2,
+                        5, 1);
+                assertArrayEquals(changes.getDeletions(), new long[]{0, 1, 5});
+
+                checkRanges(changes.getInsertionRanges(),
+                        0, 2,
+                        9, 2);
+                assertArrayEquals(changes.getInsertions(), new long[]{0, 1, 9, 10});
+
+                checkRanges(changes.getChangeRanges(),
+                        3, 2,
+                        8, 1);
+                assertArrayEquals(changes.getChanges(), new long[]{3, 4, 8});
+
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        createObjects(realm, 11, 12, -1, -2);
+        deleteObjects(realm, 0, 1, 5);
+        modifyObjects(realm, 12, 3, 4, 9);
+        realm.commitTransaction();
+        // After transaction, '*' means the object has been modified. 12 has been modified as well, but it is created
+        // and modified in the same transaction, should not be counted in the changes range.
+        // [-1, -2, 2, *3, *4, 6, 7, 8, *9, 11, 12]
+    }
+
+    // The change set should empty when the async query returns at the first time.
+    @Test
+    @RunTestInLooperThread
+    public void emptyChangeSet_findAllAsync(){
+        Realm realm = looperThread.realm;
+        populateData(realm, 10);
+        final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSortedAsync(AllTypes.FIELD_LONG);
+        results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+                assertSame(collection, results);
+                assertEquals(9, collection.size());
+                assertNull(changes);
+                looperThread.testComplete();
+            }
+        });
+
+        final CountDownLatch bgDeletionLatch = new CountDownLatch(1);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(looperThread.realmConfiguration)      ;
+                realm.beginTransaction();
+                realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, 0).findFirst().deleteFromRealm();
+                realm.commitTransaction();
+                realm.close();
+                bgDeletionLatch.countDown();
+            }
+        }).start();
+        TestHelper.awaitOrFail(bgDeletionLatch);
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
@@ -113,16 +113,16 @@ public class OrderedCollectionChangeSetTests {
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
-                checkRanges(changes.getDeletionRanges(),
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
+                checkRanges(changeSet.getDeletionRanges(),
                         0, 1,
                         2, 3,
                         8, 2);
-                assertArrayEquals(changes.getDeletions(), new int[]{0, 2, 3, 4, 8, 9});
-                assertEquals(0, changes.getChangeRanges().length);
-                assertEquals(0, changes.getInsertionRanges().length);
-                assertEquals(0, changes.getChanges().length);
-                assertEquals(0, changes.getInsertions().length);
+                assertArrayEquals(changeSet.getDeletions(), new int[]{0, 2, 3, 4, 8, 9});
+                assertEquals(0, changeSet.getChangeRanges().length);
+                assertEquals(0, changeSet.getInsertionRanges().length);
+                assertEquals(0, changeSet.getChanges().length);
+                assertEquals(0, changeSet.getInsertions().length);
                 looperThread.testComplete();
             }
         });
@@ -145,16 +145,16 @@ public class OrderedCollectionChangeSetTests {
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
-                checkRanges(changes.getInsertionRanges(),
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
+                checkRanges(changeSet.getInsertionRanges(),
                         1, 1,
                         3, 2,
                         8, 1);
-                assertArrayEquals(changes.getInsertions(), new int[]{1, 3, 4, 8});
-                assertEquals(0, changes.getChangeRanges().length);
-                assertEquals(0, changes.getDeletionRanges().length);
-                assertEquals(0, changes.getChanges().length);
-                assertEquals(0, changes.getDeletions().length);
+                assertArrayEquals(changeSet.getInsertions(), new int[]{1, 3, 4, 8});
+                assertEquals(0, changeSet.getChangeRanges().length);
+                assertEquals(0, changeSet.getDeletionRanges().length);
+                assertEquals(0, changeSet.getChanges().length);
+                assertEquals(0, changeSet.getDeletions().length);
                 looperThread.testComplete();
             }
         });
@@ -175,16 +175,16 @@ public class OrderedCollectionChangeSetTests {
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
-                checkRanges(changes.getChangeRanges(),
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
+                checkRanges(changeSet.getChangeRanges(),
                         0, 1,
                         2, 3,
                         8, 2);
-                assertArrayEquals(changes.getChanges(), new int[]{0, 2, 3, 4, 8, 9});
-                assertEquals(0, changes.getInsertionRanges().length);
-                assertEquals(0, changes.getDeletionRanges().length);
-                assertEquals(0, changes.getInsertions().length);
-                assertEquals(0, changes.getDeletions().length);
+                assertArrayEquals(changeSet.getChanges(), new int[]{0, 2, 3, 4, 8, 9});
+                assertEquals(0, changeSet.getInsertionRanges().length);
+                assertEquals(0, changeSet.getDeletionRanges().length);
+                assertEquals(0, changeSet.getInsertions().length);
+                assertEquals(0, changeSet.getDeletions().length);
                 looperThread.testComplete();
             }
         });
@@ -205,17 +205,17 @@ public class OrderedCollectionChangeSetTests {
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
-                checkRanges(changes.getDeletionRanges(),
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
+                checkRanges(changeSet.getDeletionRanges(),
                         0, 1,
                         9, 1);
-                assertArrayEquals(changes.getDeletions(), new int[]{0, 9});
-                checkRanges(changes.getInsertionRanges(),
+                assertArrayEquals(changeSet.getDeletions(), new int[]{0, 9});
+                checkRanges(changeSet.getInsertionRanges(),
                         0, 1,
                         9, 1);
-                assertArrayEquals(changes.getInsertions(), new int[]{0, 9});
-                assertEquals(0, changes.getChangeRanges().length);
-                assertEquals(0, changes.getChanges().length);
+                assertArrayEquals(changeSet.getInsertions(), new int[]{0, 9});
+                assertEquals(0, changeSet.getChangeRanges().length);
+                assertEquals(0, changeSet.getChanges().length);
                 looperThread.testComplete();
             }
         });
@@ -233,21 +233,21 @@ public class OrderedCollectionChangeSetTests {
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
-                checkRanges(changes.getDeletionRanges(),
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
+                checkRanges(changeSet.getDeletionRanges(),
                         0, 2,
                         5, 1);
-                assertArrayEquals(changes.getDeletions(), new int[]{0, 1, 5});
+                assertArrayEquals(changeSet.getDeletions(), new int[]{0, 1, 5});
 
-                checkRanges(changes.getInsertionRanges(),
+                checkRanges(changeSet.getInsertionRanges(),
                         0, 2,
                         9, 2);
-                assertArrayEquals(changes.getInsertions(), new int[]{0, 1, 9, 10});
+                assertArrayEquals(changeSet.getInsertions(), new int[]{0, 1, 9, 10});
 
-                checkRanges(changes.getChangeRanges(),
+                checkRanges(changeSet.getChangeRanges(),
                         3, 2,
                         8, 1);
-                assertArrayEquals(changes.getChanges(), new int[]{3, 4, 8});
+                assertArrayEquals(changeSet.getChanges(), new int[]{3, 4, 8});
 
                 looperThread.testComplete();
             }
@@ -272,16 +272,16 @@ public class OrderedCollectionChangeSetTests {
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
-                checkRanges(changes.getDeletionRanges(),
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
+                checkRanges(changeSet.getDeletionRanges(),
                         0, 2,
                         5, 1);
-                assertArrayEquals(changes.getDeletions(), new int[]{0, 1, 5});
+                assertArrayEquals(changeSet.getDeletions(), new int[]{0, 1, 5});
 
-                assertEquals(0, changes.getInsertionRanges().length);
-                assertEquals(0, changes.getInsertions().length);
-                assertEquals(0, changes.getChangeRanges().length);
-                assertEquals(0, changes.getChanges().length);
+                assertEquals(0, changeSet.getInsertionRanges().length);
+                assertEquals(0, changeSet.getInsertions().length);
+                assertEquals(0, changeSet.getChangeRanges().length);
+                assertEquals(0, changeSet.getChanges().length);
 
                 looperThread.testComplete();
             }
@@ -302,7 +302,7 @@ public class OrderedCollectionChangeSetTests {
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
                 fail("The listener should not be triggered since the collection has no changes compared with before.");
             }
         });
@@ -329,10 +329,10 @@ public class OrderedCollectionChangeSetTests {
         final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllSortedAsync(AllTypes.FIELD_LONG);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<AllTypes>>() {
             @Override
-            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changes) {
+            public void onChange(RealmResults<AllTypes> collection, OrderedCollectionChangeSet changeSet) {
                 assertSame(collection, results);
                 assertEquals(9, collection.size());
-                assertNull(changes);
+                assertNull(changeSet);
                 looperThread.testComplete();
             }
         });

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
@@ -118,7 +118,7 @@ public class OrderedCollectionChangeSetTests {
                         0, 1,
                         2, 3,
                         8, 2);
-                assertArrayEquals(changes.getDeletions(), new long[]{0, 2, 3, 4, 8, 9});
+                assertArrayEquals(changes.getDeletions(), new int[]{0, 2, 3, 4, 8, 9});
                 assertEquals(0, changes.getChangeRanges().length);
                 assertEquals(0, changes.getInsertionRanges().length);
                 assertEquals(0, changes.getChanges().length);
@@ -150,7 +150,7 @@ public class OrderedCollectionChangeSetTests {
                         1, 1,
                         3, 2,
                         8, 1);
-                assertArrayEquals(changes.getInsertions(), new long[]{1, 3, 4, 8});
+                assertArrayEquals(changes.getInsertions(), new int[]{1, 3, 4, 8});
                 assertEquals(0, changes.getChangeRanges().length);
                 assertEquals(0, changes.getDeletionRanges().length);
                 assertEquals(0, changes.getChanges().length);
@@ -180,7 +180,7 @@ public class OrderedCollectionChangeSetTests {
                         0, 1,
                         2, 3,
                         8, 2);
-                assertArrayEquals(changes.getChanges(), new long[]{0, 2, 3, 4, 8, 9});
+                assertArrayEquals(changes.getChanges(), new int[]{0, 2, 3, 4, 8, 9});
                 assertEquals(0, changes.getInsertionRanges().length);
                 assertEquals(0, changes.getDeletionRanges().length);
                 assertEquals(0, changes.getInsertions().length);
@@ -209,11 +209,11 @@ public class OrderedCollectionChangeSetTests {
                 checkRanges(changes.getDeletionRanges(),
                         0, 1,
                         9, 1);
-                assertArrayEquals(changes.getDeletions(), new long[]{0, 9});
+                assertArrayEquals(changes.getDeletions(), new int[]{0, 9});
                 checkRanges(changes.getInsertionRanges(),
                         0, 1,
                         9, 1);
-                assertArrayEquals(changes.getInsertions(), new long[]{0, 9});
+                assertArrayEquals(changes.getInsertions(), new int[]{0, 9});
                 assertEquals(0, changes.getChangeRanges().length);
                 assertEquals(0, changes.getChanges().length);
                 looperThread.testComplete();
@@ -237,17 +237,17 @@ public class OrderedCollectionChangeSetTests {
                 checkRanges(changes.getDeletionRanges(),
                         0, 2,
                         5, 1);
-                assertArrayEquals(changes.getDeletions(), new long[]{0, 1, 5});
+                assertArrayEquals(changes.getDeletions(), new int[]{0, 1, 5});
 
                 checkRanges(changes.getInsertionRanges(),
                         0, 2,
                         9, 2);
-                assertArrayEquals(changes.getInsertions(), new long[]{0, 1, 9, 10});
+                assertArrayEquals(changes.getInsertions(), new int[]{0, 1, 9, 10});
 
                 checkRanges(changes.getChangeRanges(),
                         3, 2,
                         8, 1);
-                assertArrayEquals(changes.getChanges(), new long[]{3, 4, 8});
+                assertArrayEquals(changes.getChanges(), new int[]{3, 4, 8});
 
                 looperThread.testComplete();
             }
@@ -276,7 +276,7 @@ public class OrderedCollectionChangeSetTests {
                 checkRanges(changes.getDeletionRanges(),
                         0, 2,
                         5, 1);
-                assertArrayEquals(changes.getDeletions(), new long[]{0, 1, 5});
+                assertArrayEquals(changes.getDeletions(), new int[]{0, 1, 5});
 
                 assertEquals(0, changes.getInsertionRanges().length);
                 assertEquals(0, changes.getInsertions().length);

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
@@ -65,7 +65,7 @@ public class OrderedCollectionChangeSetTests {
     }
 
     // The args should be [startIndex1, length1, startIndex2, length2, ...]
-    private void checkRanges(OrderedCollectionChangeSet.Range[] ranges, long... indexAndLen) {
+    private void checkRanges(OrderedCollectionChangeSet.Range[] ranges, int... indexAndLen) {
         if ((indexAndLen.length % 2 != 0))  {
             fail("The 'indexAndLen' array length is not an even number.");
         }
@@ -74,8 +74,8 @@ public class OrderedCollectionChangeSetTests {
         }
         for (int i = 0; i < ranges.length; i++) {
             OrderedCollectionChangeSet.Range range = ranges[i];
-            long startIndex = indexAndLen[i * 2];
-            long length = indexAndLen[i * 2 + 1];
+            int startIndex = indexAndLen[i * 2];
+            int length = indexAndLen[i * 2 + 1];
             if (range.startIndex != startIndex || range.length != length) {
                 fail("Range at index " + i + " doesn't match start index " + startIndex + " length " + length + ".");
             }
@@ -83,22 +83,22 @@ public class OrderedCollectionChangeSetTests {
     }
 
     // Deletes AllTypes objects which's columnLong is in the indices array.
-    private void deleteObjects(Realm realm, long... indices) {
-        for (long index : indices) {
+    private void deleteObjects(Realm realm, int... indices) {
+        for (int index : indices) {
             realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, index).findFirst().deleteFromRealm();
         }
     }
 
     // Creates AllTypes objects with columnLong set to the value elements in indices array.
-    private void createObjects(Realm realm, long... indices) {
-        for (long index : indices) {
+    private void createObjects(Realm realm, int... indices) {
+        for (int index : indices) {
             realm.createObject(AllTypes.class).setColumnLong(index);
         }
     }
 
     // Modifies AllTypes objects which's columnLong is in the indices array.
-    private void modifyObjects(Realm realm, long... indices) {
-        for (long index : indices) {
+    private void modifyObjects(Realm realm, int... indices) {
+        for (int index : indices) {
             AllTypes obj = realm.where(AllTypes.class).equalTo(AllTypes.FIELD_LONG, index).findFirst();
             assertNotNull(obj);
             obj.setColumnString("modified");
@@ -338,7 +338,7 @@ public class OrderedCollectionChangeSetTests {
         });
 
         final CountDownLatch bgDeletionLatch = new CountDownLatch(1);
-        // beginTransaction() will make the async query return immediately. So we have to create an object in another
+        // beginTransaction() will make the async query return immediately. So we have to delete an object in another
         // thread. Also, the latch has to be counted down after transaction committed so the async query results can
         // contain the modification in the background transaction.
         new Thread(new Runnable() {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -979,7 +979,7 @@ public class RealmResultsTests extends CollectionTests {
     @UiThreadTest
     public void addChangeListener_null() {
         try {
-            collection.addChangeListener(null);
+            collection.addChangeListener((RealmChangeListener)null);
             fail();
         } catch (IllegalArgumentException ignored) {
         }
@@ -1024,7 +1024,7 @@ public class RealmResultsTests extends CollectionTests {
     @UiThreadTest
     public void removeChangeListener_null() {
         try {
-            collection.removeChangeListener(null);
+            collection.removeChangeListener((RealmChangeListener)null);
             fail();
         } catch (IllegalArgumentException ignored) {
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -979,7 +979,7 @@ public class RealmResultsTests extends CollectionTests {
     @UiThreadTest
     public void addChangeListener_null() {
         try {
-            collection.addChangeListener((RealmChangeListener)null);
+            collection.addChangeListener((RealmChangeListener<RealmResults<AllTypes>>) null);
             fail();
         } catch (IllegalArgumentException ignored) {
         }
@@ -1024,7 +1024,7 @@ public class RealmResultsTests extends CollectionTests {
     @UiThreadTest
     public void removeChangeListener_null() {
         try {
-            collection.removeChangeListener((RealmChangeListener)null);
+            collection.removeChangeListener((RealmChangeListener) null);
             fail();
         } catch (IllegalArgumentException ignored) {
         }
@@ -1053,7 +1053,7 @@ public class RealmResultsTests extends CollectionTests {
         looperThread.keepStrongReference.add(collection);
         collection.addChangeListener(listenerA);
         collection.addChangeListener(listenerB);
-        collection.removeChangeListeners();
+        collection.removeAllChangeListeners();
 
         realm.beginTransaction();
         realm.createObject(AllTypes.class);

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
@@ -408,7 +408,7 @@ public class CollectionTests {
     }
 
     private static class TestIterator extends Collection.Iterator<Integer> {
-        public TestIterator(Collection collection) {
+        TestIterator(Collection collection) {
             super(collection);
         }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/ObserverPairListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/ObserverPairListTests.java
@@ -132,18 +132,15 @@ public class ObserverPairListTests {
 
         // Create a new Integer 1 to see if the equality is checked by the same object.
         //noinspection UnnecessaryBoxing
-        pair = new TestObserverPair(new Integer(1), testListener);
-        observerPairs.remove(pair);
+        observerPairs.remove(new Integer(1), testListener);
         assertEquals(1, observerPairs.size());
 
         // Different listener
-        pair = new TestObserverPair(ONE, new TestListener());
-        observerPairs.remove(pair);
+        observerPairs.remove(ONE, new TestListener());
         assertEquals(1, observerPairs.size());
 
         // Should remove now
-        pair = new TestObserverPair(ONE, testListener);
-        observerPairs.remove(pair);
+        observerPairs.remove(ONE, testListener);
         assertEquals(0, observerPairs.size());
     }
 
@@ -240,7 +237,8 @@ public class ObserverPairListTests {
     public void foreach_canRemove() {
         final AtomicInteger count = new AtomicInteger(0);
         final TestObserverPair pair1 = new TestObserverPair(ONE, new TestListener());
-        final TestObserverPair pair2 = new TestObserverPair(TWO, new TestListener());
+        final TestListener listener2 = new TestListener();
+        final TestObserverPair pair2 = new TestObserverPair(TWO, listener2);
         final TestObserverPair pair3 = new TestObserverPair(THREE, new TestListener());
         observerPairs.add(pair1);
         observerPairs.add(pair2);
@@ -250,7 +248,7 @@ public class ObserverPairListTests {
             @Override
             public void onCalled(TestObserverPair pair, Object observer) {
                 assertFalse(((Integer) observer) == 2);
-                observerPairs.remove(pair2);
+                observerPairs.remove(TWO, listener2);
                 count.getAndIncrement();
             }
         });

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -38,7 +38,7 @@ set(classes_LIST
     io.realm.internal.TableQuery io.realm.internal.SharedRealm io.realm.internal.TestUtil
     io.realm.log.LogLevel io.realm.log.RealmLog io.realm.Property io.realm.RealmSchema
     io.realm.RealmObjectSchema io.realm.internal.Collection
-    io.realm.internal.NativeObjectReference
+    io.realm.internal.NativeObjectReference io.realm.internal.CollectionChangeSet
 )
 # /./ is the workaround for the problem that AS cannot find the jni headers.
 # See https://github.com/googlesamples/android-ndk/issues/319

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "io_realm_internal_CollectionChangeSet.h"
+
+#include <collection_notifications.hpp>
+
+#include "util.hpp"
+
+using namespace realm;
+
+static void finalize_changeset(jlong ptr);
+static jlongArray index_set_to_jlong_array(JNIEnv* env, const IndexSet& index_set);
+static jlongArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_set);
+
+static void finalize_changeset(jlong ptr)
+{
+    TR_ENTER_PTR(ptr);
+    delete reinterpret_cast<CollectionChangeSet*>(ptr);
+}
+
+static jlongArray index_set_to_jlong_array(JNIEnv* env, const IndexSet& index_set)
+{
+    if (index_set.empty()) {
+        return env->NewLongArray(0);
+    }
+
+    std::vector<jlong> ranges_vector;
+    for (auto& changes : index_set) {
+        ranges_vector.push_back(changes.first);
+        ranges_vector.push_back(changes.second - changes.first);
+    }
+
+    if (ranges_vector.size() > io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH) {
+        ThrowException(env, IllegalState,
+                       "There are too many ranges changed in this change set. They cannot fit into an array.");
+        return nullptr;
+    }
+    jlongArray jlong_array = env->NewLongArray(static_cast<jsize>(ranges_vector.size()));
+    env->SetLongArrayRegion(jlong_array, 0, ranges_vector.size(), ranges_vector.data());
+    return jlong_array;
+}
+
+static jlongArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_set)
+{
+    if (index_set.empty()) {
+        return env->NewLongArray(0);
+    }
+
+    std::vector<jlong> indices_vector;
+    for (auto index : index_set.as_indexes()) {
+        indices_vector.push_back(index);
+    }
+    if (indices_vector.size() > io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH) {
+        ThrowException(env, IllegalState,
+                       "There are too many indices in this change set. They cannot fit into an array.");
+        return nullptr;
+    }
+    jlongArray jlong_array = env->NewLongArray(static_cast<jsize>(indices_vector.size()));
+    env->SetLongArrayRegion(jlong_array, 0, indices_vector.size(), indices_vector.data());
+    return jlong_array;
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_realm_internal_CollectionChangeSet_nativeGetFinalizerPtr(JNIEnv*, jclass)
+{
+    TR_ENTER()
+    return reinterpret_cast<jlong>(&finalize_changeset);
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_io_realm_internal_CollectionChangeSet_nativeGetRanges(JNIEnv *env, jclass, jlong native_ptr, jint type)
+{
+    TR_ENTER_PTR(native_ptr)
+    // no throws
+    auto& change_set = *reinterpret_cast<CollectionChangeSet*>(native_ptr);
+    switch (type) {
+        case io_realm_internal_CollectionChangeSet_TYPE_DELETION:
+            return index_set_to_jlong_array(env, change_set.deletions);
+        case io_realm_internal_CollectionChangeSet_TYPE_INSERTION:
+            return index_set_to_jlong_array(env, change_set.insertions);
+        case io_realm_internal_CollectionChangeSet_TYPE_MODIFICATION:
+            return index_set_to_jlong_array(env, change_set.modifications_new);
+        default:
+            break;
+    }
+
+    REALM_UNREACHABLE();
+    return nullptr;
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_io_realm_internal_CollectionChangeSet_nativeGetIndices(JNIEnv *env, jclass, jlong native_ptr, jint type)
+{
+    TR_ENTER_PTR(native_ptr)
+    // no throws
+    auto& change_set = *reinterpret_cast<CollectionChangeSet*>(native_ptr);
+    switch (type) {
+        case io_realm_internal_CollectionChangeSet_TYPE_DELETION:
+            return index_set_to_indices_array(env, change_set.deletions);
+        case io_realm_internal_CollectionChangeSet_TYPE_INSERTION:
+            return index_set_to_indices_array(env, change_set.insertions);
+        case io_realm_internal_CollectionChangeSet_TYPE_MODIFICATION:
+            return index_set_to_indices_array(env, change_set.modifications_new);
+        default:
+            break;
+    }
+
+    REALM_UNREACHABLE();
+    return nullptr;
+}
+

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
@@ -23,8 +23,8 @@
 using namespace realm;
 
 static void finalize_changeset(jlong ptr);
-static jlongArray index_set_to_jlong_array(JNIEnv* env, const IndexSet& index_set);
-static jlongArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_set);
+static jintArray index_set_to_jint_array(JNIEnv* env, const IndexSet& index_set);
+static jintArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_set);
 
 static void finalize_changeset(jlong ptr)
 {
@@ -32,13 +32,13 @@ static void finalize_changeset(jlong ptr)
     delete reinterpret_cast<CollectionChangeSet*>(ptr);
 }
 
-static jlongArray index_set_to_jlong_array(JNIEnv* env, const IndexSet& index_set)
+static jintArray index_set_to_jint_array(JNIEnv* env, const IndexSet& index_set)
 {
     if (index_set.empty()) {
-        return env->NewLongArray(0);
+        return env->NewIntArray(0);
     }
 
-    std::vector<jlong> ranges_vector;
+    std::vector<jint> ranges_vector;
     for (auto& changes : index_set) {
         ranges_vector.push_back(changes.first);
         ranges_vector.push_back(changes.second - changes.first);
@@ -52,18 +52,18 @@ static jlongArray index_set_to_jlong_array(JNIEnv* env, const IndexSet& index_se
         ThrowException(env, IllegalState, error_msg.str());
         return nullptr;
     }
-    jlongArray jlong_array = env->NewLongArray(static_cast<jsize>(ranges_vector.size()));
-    env->SetLongArrayRegion(jlong_array, 0, ranges_vector.size(), ranges_vector.data());
-    return jlong_array;
+    jintArray jint_array = env->NewIntArray(static_cast<jsize>(ranges_vector.size()));
+    env->SetIntArrayRegion(jint_array, 0, ranges_vector.size(), ranges_vector.data());
+    return jint_array;
 }
 
-static jlongArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_set)
+static jintArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_set)
 {
     if (index_set.empty()) {
-        return env->NewLongArray(0);
+        return env->NewIntArray(0);
     }
 
-    std::vector<jlong> indices_vector;
+    std::vector<jint> indices_vector;
     for (auto index : index_set.as_indexes()) {
         indices_vector.push_back(index);
     }
@@ -75,9 +75,9 @@ static jlongArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_
         ThrowException(env, IllegalState, error_msg.str());
         return nullptr;
     }
-    jlongArray jlong_array = env->NewLongArray(static_cast<jsize>(indices_vector.size()));
-    env->SetLongArrayRegion(jlong_array, 0, indices_vector.size(), indices_vector.data());
-    return jlong_array;
+    jintArray jint_array = env->NewIntArray(static_cast<jsize>(indices_vector.size()));
+    env->SetIntArrayRegion(jint_array, 0, indices_vector.size(), indices_vector.data());
+    return jint_array;
 }
 
 JNIEXPORT jlong JNICALL
@@ -87,7 +87,7 @@ Java_io_realm_internal_CollectionChangeSet_nativeGetFinalizerPtr(JNIEnv*, jclass
     return reinterpret_cast<jlong>(&finalize_changeset);
 }
 
-JNIEXPORT jlongArray JNICALL
+JNIEXPORT jintArray JNICALL
 Java_io_realm_internal_CollectionChangeSet_nativeGetRanges(JNIEnv *env, jclass, jlong native_ptr, jint type)
 {
     TR_ENTER_PTR(native_ptr)
@@ -95,18 +95,18 @@ Java_io_realm_internal_CollectionChangeSet_nativeGetRanges(JNIEnv *env, jclass, 
     auto& change_set = *reinterpret_cast<CollectionChangeSet*>(native_ptr);
     switch (type) {
         case io_realm_internal_CollectionChangeSet_TYPE_DELETION:
-            return index_set_to_jlong_array(env, change_set.deletions);
+            return index_set_to_jint_array(env, change_set.deletions);
         case io_realm_internal_CollectionChangeSet_TYPE_INSERTION:
-            return index_set_to_jlong_array(env, change_set.insertions);
+            return index_set_to_jint_array(env, change_set.insertions);
         case io_realm_internal_CollectionChangeSet_TYPE_MODIFICATION:
-            return index_set_to_jlong_array(env, change_set.modifications_new);
+            return index_set_to_jint_array(env, change_set.modifications_new);
         default:
             REALM_UNREACHABLE();
             break;
     }
 }
 
-JNIEXPORT jlongArray JNICALL
+JNIEXPORT jintArray JNICALL
 Java_io_realm_internal_CollectionChangeSet_nativeGetIndices(JNIEnv *env, jclass, jlong native_ptr, jint type)
 {
     TR_ENTER_PTR(native_ptr)

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
@@ -45,8 +45,11 @@ static jlongArray index_set_to_jlong_array(JNIEnv* env, const IndexSet& index_se
     }
 
     if (ranges_vector.size() > io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH) {
-        ThrowException(env, IllegalState,
-                       "There are too many ranges changed in this change set. They cannot fit into an array.");
+        std::ostringstream error_msg;
+        error_msg << "There are too many ranges changed in this change set. They cannot fit into an array." <<
+            " ranges_vector's size: " << ranges_vector.size() <<
+            " Java array's max size: " << io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH << ".";
+        ThrowException(env, IllegalState, error_msg.str());
         return nullptr;
     }
     jlongArray jlong_array = env->NewLongArray(static_cast<jsize>(ranges_vector.size()));
@@ -65,8 +68,11 @@ static jlongArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_
         indices_vector.push_back(index);
     }
     if (indices_vector.size() > io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH) {
-        ThrowException(env, IllegalState,
-                       "There are too many indices in this change set. They cannot fit into an array.");
+        std::ostringstream error_msg;
+        error_msg << "There are too many indices in this change set. They cannot fit into an array." <<
+            " indices_vector's size: " << indices_vector.size() <<
+            " Java array's max size: " << io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH << ".";
+        ThrowException(env, IllegalState, error_msg.str());
         return nullptr;
     }
     jlongArray jlong_array = env->NewLongArray(static_cast<jsize>(indices_vector.size()));
@@ -95,11 +101,9 @@ Java_io_realm_internal_CollectionChangeSet_nativeGetRanges(JNIEnv *env, jclass, 
         case io_realm_internal_CollectionChangeSet_TYPE_MODIFICATION:
             return index_set_to_jlong_array(env, change_set.modifications_new);
         default:
+            REALM_UNREACHABLE();
             break;
     }
-
-    REALM_UNREACHABLE();
-    return nullptr;
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -116,10 +120,8 @@ Java_io_realm_internal_CollectionChangeSet_nativeGetIndices(JNIEnv *env, jclass,
         case io_realm_internal_CollectionChangeSet_TYPE_MODIFICATION:
             return index_set_to_indices_array(env, change_set.modifications_new);
         default:
+            REALM_UNREACHABLE();
             break;
     }
-
-    REALM_UNREACHABLE();
-    return nullptr;
 }
 

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -141,7 +141,7 @@ abstract class BaseRealm implements Closeable {
      * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      * @see io.realm.RealmChangeListener
      */
-    public <T extends BaseRealm> void removeChangeListener(RealmChangeListener<T> listener) {
+    protected <T extends BaseRealm> void removeListener(RealmChangeListener<T> listener) {
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }
@@ -177,7 +177,7 @@ abstract class BaseRealm implements Closeable {
      * @throws IllegalStateException if you try to remove listeners from a non-Looper Thread.
      * @see io.realm.RealmChangeListener
      */
-    public void removeAllChangeListeners() {
+    protected void removeAllListeners() {
         checkIfValid();
         sharedRealm.capabilities.checkCanDeliverNotification("removeListener cannot be called on current thread.");
         sharedRealm.realmNotifier.removeChangeListeners(this);

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -42,7 +42,7 @@ import rx.Observable;
  * @see Realm
  * @see RealmSchema
  */
-public class DynamicRealm extends BaseRealm {
+public class DynamicRealm extends BaseRealm implements RealmObservable<DynamicRealm> {
 
     private DynamicRealm(RealmConfiguration configuration) {
         super(configuration);
@@ -134,8 +134,25 @@ public class DynamicRealm extends BaseRealm {
      * @see #removeAllChangeListeners()
      * @see #waitForChange()
      */
+    @Override
     public void addChangeListener(RealmChangeListener<DynamicRealm> listener) {
         super.addListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeChangeListener(RealmChangeListener<DynamicRealm> listener) {
+        super.removeListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeAllChangeListeners() {
+        super.removeAllListeners();
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
@@ -31,14 +31,14 @@ public interface OrderedCollectionChangeSet {
      *
      * @return the indices array. A zero-sized array will be returned if no objects were deleted.
      */
-    long[] getDeletions();
+    int[] getDeletions();
 
     /**
      * The inserted indices in the new version of the collection.
      *
      * @return the indices array. A zero-sized array will be returned if no objects were inserted.
      */
-    long[] getInsertions();
+    int[] getInsertions();
 
     /**
      * The modified indices in the new version of the collection.
@@ -48,7 +48,7 @@ public interface OrderedCollectionChangeSet {
      *
      * @return the indices array. A zero-sized array will be returned if objects were modified.
      */
-    long[] getChanges();
+    int[] getChanges();
 
     /**
      * The deleted ranges of objects in the previous version of the collection.
@@ -78,12 +78,12 @@ public interface OrderedCollectionChangeSet {
         /**
          * The start index of this change range.
          */
-        public final long startIndex;
+        public final int startIndex;
 
         /**
          * How many elements are inside this range.
          */
-        public final long length;
+        public final int length;
 
         /**
          * Creates a {@link Range} with given start index and length.
@@ -91,7 +91,7 @@ public interface OrderedCollectionChangeSet {
          * @param startIndex the start index of this change range.
          * @param length how many elements are inside this range.
          */
-        public Range(long startIndex, long length) {
+        public Range(int startIndex, int length) {
             this.startIndex = startIndex;
             this.length = length;
         }

--- a/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+/**
+ * This interface describes the changes made to a collection during the last update.
+ * <p>
+ * {@link OrderedCollectionChangeSet} is passed to the {@link OrderedRealmCollectionChangeListener} which is registered
+ * by {@link RealmResults#addChangeListener(OrderedRealmCollectionChangeListener)}.
+ * <p>
+ * The change information is available in two formats: a simple array of row indices in the collection for each type of
+ * change, and an array of {@link Range}s.
+ */
+public interface OrderedCollectionChangeSet {
+    /**
+     * The indices of objects in the previous version of the collection which have been removed from this one.
+     *
+     * @return the indices array. A zero-sized array will be returned if no deletion in the change set.
+     */
+    long[] getDeletions();
+
+    /**
+     * The indices in the new version of the collection which were newly inserted.
+     *
+     * @return the indices array. A zero-sized array will be returned if no insertion in the change set.
+     */
+    long[] getInsertions();
+
+    /**
+     * The indices in the new version of the collection which were modified.
+     * <p>
+     * For {@link RealmResults}, this means that one or more of the properties of the object at that index were
+     * modified (or an object linked to by that object was modified).
+     *
+     * @return the indices array. A zero-sized array will be returned if no modification in the change set.
+     */
+    long[] getChanges();
+
+    /**
+     * The ranges of objects in the previous version of the collection which have been removed from this one.
+     *
+     * @return the {@link Range} array. A zero-sized array will be returned if no deletion in the change set.
+     */
+    Range[] getDeletionRanges();
+
+    /**
+     * The ranges of objects in the new version of the collection which were newly inserted.
+     *
+     * @return the {@link Range} array. A zero-sized array will be returned if no insertion in the change set.
+     */
+    Range[] getInsertionRanges();
+
+    /**
+     * The ranges of objects in the new version of the collection which were modified.
+     *
+     * @return the {@link Range} array. A zero-sized array will be returned if no modification in the change set.
+     */
+    Range[] getChangeRanges();
+
+    /**
+     *
+     */
+    class Range {
+        /**
+         * The start index of this change range.
+         */
+        public final long startIndex;
+
+        /**
+         * How many elements are inside this range.
+         */
+        public final long length;
+
+        /**
+         * Creates a {@link Range} with given start index and length.
+         *
+         * @param startIndex the start index of this change range.
+         * @param length how many elements are inside this range.
+         */
+        public Range(long startIndex, long length) {
+            this.startIndex = startIndex;
+            this.length = length;
+        }
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
@@ -23,51 +23,51 @@ package io.realm;
  * by {@link RealmResults#addChangeListener(OrderedRealmCollectionChangeListener)}.
  * <p>
  * The change information is available in two formats: a simple array of row indices in the collection for each type of
- * change, and an array of {@link Range}s.
+ * change, or an array of {@link Range}s.
  */
 public interface OrderedCollectionChangeSet {
     /**
-     * The indices of objects in the previous version of the collection which have been removed from this one.
+     * The deleted indices in the previous version of the collection.
      *
-     * @return the indices array. A zero-sized array will be returned if no deletion in the change set.
+     * @return the indices array. A zero-sized array will be returned if no objects were deleted.
      */
     long[] getDeletions();
 
     /**
-     * The indices in the new version of the collection which were newly inserted.
+     * The inserted indices in the new version of the collection.
      *
-     * @return the indices array. A zero-sized array will be returned if no insertion in the change set.
+     * @return the indices array. A zero-sized array will be returned if no objects were inserted.
      */
     long[] getInsertions();
 
     /**
-     * The indices in the new version of the collection which were modified.
+     * The modified indices in the new version of the collection.
      * <p>
-     * For {@link RealmResults}, this means that one or more of the properties of the object at that index were
+     * For {@link RealmResults}, this means that one or more of the properties of the object at the given index were
      * modified (or an object linked to by that object was modified).
      *
-     * @return the indices array. A zero-sized array will be returned if no modification in the change set.
+     * @return the indices array. A zero-sized array will be returned if objects were modified.
      */
     long[] getChanges();
 
     /**
-     * The ranges of objects in the previous version of the collection which have been removed from this one.
+     * The deleted ranges of objects in the previous version of the collection.
      *
-     * @return the {@link Range} array. A zero-sized array will be returned if no deletion in the change set.
+     * @return the {@link Range} array. A zero-sized array will be returned if no objects were deleted.
      */
     Range[] getDeletionRanges();
 
     /**
-     * The ranges of objects in the new version of the collection which were newly inserted.
+     * The inserted ranges of objects in the new version of the collection.
      *
-     * @return the {@link Range} array. A zero-sized array will be returned if no insertion in the change set.
+     * @return the {@link Range} array. A zero-sized array will be returned if no objects were inserted.
      */
     Range[] getInsertionRanges();
 
     /**
-     * The ranges of objects in the new version of the collection which were modified.
+     * The modified ranges of objects in the new version of the collection.
      *
-     * @return the {@link Range} array. A zero-sized array will be returned if no modification in the change set.
+     * @return the {@link Range} array. A zero-sized array will be returned if no objects were modified.
      */
     Range[] getChangeRanges();
 

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
@@ -25,7 +25,7 @@ package io.realm;
  * {@link OrderedRealmCollectionChangeListener}.
  * <p>
  *
- * @see {@link RealmResults#addChangeListener(OrderedRealmCollectionChangeListener)}.
+ * @see RealmResults#addChangeListener(OrderedRealmCollectionChangeListener)
  */
 public interface OrderedRealmCollectionChangeListener<T> {
 

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+/**
+ * {@link OrderedRealmCollectionChangeListener} can be registered with a {@link RealmResults} to receive a notification
+ * with a {@link OrderedCollectionChangeSet} to describe the details of what have been changed in the collection from
+ * last time.
+ * <p>
+ * Realm instances on a thread without an {@link android.os.Looper} cannot register a
+ * {@link OrderedRealmCollectionChangeListener}.
+ * <p>
+ *
+ * @see {@link RealmResults#addChangeListener(OrderedRealmCollectionChangeListener)}.
+ */
+public interface OrderedRealmCollectionChangeListener<T> {
+    /**
+     * This will be called when the async query finished at the first time or the collection gets changed.
+     *
+     * @param collection the collection this listener is registered to.
+     * @param changes {@code null} if the it is first time async query returns or information about which rows in the
+     * collection were added, removed or modified.
+     */
+    void onChange(T collection, OrderedCollectionChangeSet changes);
+}

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
@@ -28,8 +28,9 @@ package io.realm;
  * @see {@link RealmResults#addChangeListener(OrderedRealmCollectionChangeListener)}.
  */
 public interface OrderedRealmCollectionChangeListener<T> {
+
     /**
-     * This will be called when the async query finished at the first time or the collection gets changed.
+     * This will be called when the async query is finished the first time or the collection of objects has changed.
      *
      * @param collection the collection this listener is registered to.
      * @param changes {@code null} if the it is first time async query returns or information about which rows in the

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
@@ -33,8 +33,8 @@ public interface OrderedRealmCollectionChangeListener<T> {
      * This will be called when the async query is finished the first time or the collection of objects has changed.
      *
      * @param collection the collection this listener is registered to.
-     * @param changes {@code null} if the it is first time async query returns or information about which rows in the
-     * collection were added, removed or modified.
+     * @param changeSet object with information about which rows in the collection were added, removed or modified.
+     * {@code null} is returned the first time an async query is completed.
      */
-    void onChange(T collection, OrderedCollectionChangeSet changes);
+    void onChange(T collection, OrderedCollectionChangeSet changeSet);
 }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -124,7 +124,7 @@ import rx.Observable;
  * @see <a href="http://en.wikipedia.org/wiki/ACID">ACID</a>
  * @see <a href="https://github.com/realm/realm-java/tree/master/examples">Examples using Realm</a>
  */
-public class Realm extends BaseRealm {
+public class Realm extends BaseRealm implements RealmObservable<Realm> {
 
     public static final String DEFAULT_REALM_NAME = RealmConfiguration.DEFAULT_REALM_NAME;
 
@@ -1281,8 +1281,25 @@ public class Realm extends BaseRealm {
      * @see #removeChangeListener(RealmChangeListener)
      * @see #removeAllChangeListeners()
      */
+    @Override
     public void addChangeListener(RealmChangeListener<Realm> listener) {
         super.addListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeChangeListener(RealmChangeListener<Realm> listener) {
+        super.removeListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeAllChangeListeners() {
+        super.removeAllListeners();
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+/**
+ * A collection class implementing this interface is capable of reporting fine-grained notifications about how the
+ * collection is changed. It will report insertions, deletions and changes, but not _how_ an individual element changed.
+ * When a change is detected all registered listeners will be triggered.
+ * <p>
+ * This is commonly useful when updating UI elements, e.g {@code RecyclerView.Adapter} can provide nicer animations and
+ * work more effectively if it knows exactly which elements changed.
+ * @see RealmObservable for information about more coarse-grained notifications.
+ * @see <a href="https://realm.io/docs/java/latest/#adapters">Android Adapters<a>
+ */
+public interface RealmCollectionObservable<T, S extends OrderedRealmCollectionChangeListener>
+        extends RealmObservable<T> {
+    /**
+     * Adds a change listener to this RealmResults.
+     *
+     * @param listener the change listener to be notified.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalStateException if you try to add a listener from a non-Looper or
+     * {@link android.app.IntentService} thread.
+     */
+    void addChangeListener(S listener);
+
+    /**
+     * Removes the specified change listener.
+     *
+     * @param listener the change listener to be removed.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
+     * @see io.realm.RealmChangeListener
+     */
+    void removeChangeListener(S listener);
+}

--- a/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
@@ -18,8 +18,8 @@ package io.realm;
 
 /**
  * A collection class implementing this interface is capable of reporting fine-grained notifications about how the
- * collection is changed. It will report insertions, deletions and changes, but not _how_ an individual element changed.
- * When a change is detected all registered listeners will be triggered.
+ * collection is changed. It will report insertions, deletions and changes, but not <i>how</i> an individual element
+ * changed. When a change is detected all registered listeners will be triggered.
  * <p>
  * This is often useful when updating UI elements, e.g. {@code RecyclerView.Adapter} can provide nicer animations and
  * work more effectively if it knows exactly which elements changed.
@@ -29,7 +29,7 @@ package io.realm;
 public interface RealmCollectionObservable<T, S extends OrderedRealmCollectionChangeListener>
         extends RealmObservable<T> {
     /**
-     * Adds a change listener to this RealmResults.
+     * Adds a change listener to this {@link OrderedRealmCollection}.
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null}.

--- a/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
@@ -24,7 +24,7 @@ package io.realm;
  * This is often useful when updating UI elements, e.g. {@code RecyclerView.Adapter} can provide nicer animations and
  * work more effectively if it knows exactly which elements changed.
  * @see RealmObservable for information about more coarse-grained notifications.
- * @see <a href="https://realm.io/docs/java/latest/#adapters">Android Adapters<a>
+ * @see <a href="https://realm.io/docs/java/latest/#adapters">Android Adapters</a>
  */
 public interface RealmCollectionObservable<T, S extends OrderedRealmCollectionChangeListener>
         extends RealmObservable<T> {

--- a/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCollectionObservable.java
@@ -21,7 +21,7 @@ package io.realm;
  * collection is changed. It will report insertions, deletions and changes, but not _how_ an individual element changed.
  * When a change is detected all registered listeners will be triggered.
  * <p>
- * This is commonly useful when updating UI elements, e.g {@code RecyclerView.Adapter} can provide nicer animations and
+ * This is often useful when updating UI elements, e.g. {@code RecyclerView.Adapter} can provide nicer animations and
  * work more effectively if it knows exactly which elements changed.
  * @see RealmObservable for information about more coarse-grained notifications.
  * @see <a href="https://realm.io/docs/java/latest/#adapters">Android Adapters<a>

--- a/realm/realm-library/src/main/java/io/realm/RealmObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObservable.java
@@ -25,7 +25,8 @@ package io.realm;
  */
 public interface RealmObservable<T> {
     /**
-     * Adds a change listener to this {@link RealmResults}, {@link Realm}, {@link DynamicRealm} or {@link RealmObject}.
+     * Adds a change listener to this {@link RealmResults}, {@link RealmList}, {@link Realm}, {@link DynamicRealm} or
+     * {@link RealmObject}.
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null}.

--- a/realm/realm-library/src/main/java/io/realm/RealmObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObservable.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+/**
+ * A class implementing this interface is capable of reporting when the data stored by the class has changed. When that
+ * happens all registered {@link RealmChangeListener}'s will be triggered.
+ * <p>
+ * This class will only report that <i>something<i> changed, not what changed.
+ * @see RealmCollectionObservable for information about more fine-grained collection notifications.
+ */
+public interface RealmObservable<T> {
+    /**
+     * Adds a change listener to this {@link RealmResults}, {@link Realm}, {@link DynamicRealm} or {@link RealmObject}.
+     *
+     * @param listener the change listener to be notified.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalStateException if you try to add a listener from a non-Looper or
+     * {@link android.app.IntentService} thread.
+     */
+    void addChangeListener(RealmChangeListener<T> listener);
+
+    /**
+     * Removes the specified change listener.
+     *
+     * @param listener the change listener to be removed.
+     * @throws IllegalArgumentException if the change listener is {@code null}.
+     * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
+     * @see io.realm.RealmChangeListener
+     */
+    void removeChangeListener(RealmChangeListener<T> listener);
+
+    /**
+     * Removes all user-defined change listeners.
+     *
+     * @throws IllegalStateException if you try to remove listeners from a non-Looper Thread.
+     * @see io.realm.RealmChangeListener
+     */
+    void removeAllChangeListeners();
+}

--- a/realm/realm-library/src/main/java/io/realm/RealmObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObservable.java
@@ -20,7 +20,7 @@ package io.realm;
  * A class implementing this interface is capable of reporting when the data stored by the class have changed. When that
  * happens all registered {@link RealmChangeListener}'s will be triggered.
  * <p>
- * This class will only report that <i>something<i> changed, not what changed.
+ * This class will only report that <i>something</i> changed, not what changed.
  * @see RealmCollectionObservable for information about more fine-grained collection notifications.
  */
 public interface RealmObservable<T> {

--- a/realm/realm-library/src/main/java/io/realm/RealmObservable.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObservable.java
@@ -17,7 +17,7 @@
 package io.realm;
 
 /**
- * A class implementing this interface is capable of reporting when the data stored by the class has changed. When that
+ * A class implementing this interface is capable of reporting when the data stored by the class have changed. When that
  * happens all registered {@link RealmChangeListener}'s will be triggered.
  * <p>
  * This class will only report that <i>something<i> changed, not what changed.

--- a/realm/realm-library/src/main/java/io/realm/internal/Collection.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Collection.java
@@ -74,16 +74,16 @@ public class Collection implements NativeObject {
     }
 
     private static class Callback implements ObserverPairList.Callback<CollectionObserverPair> {
-        private final OrderedCollectionChangeSet changes;
+        private final OrderedCollectionChangeSet changeSet;
 
-        Callback(OrderedCollectionChangeSet changes) {
-            this.changes = changes;
+        Callback(OrderedCollectionChangeSet changeSet) {
+            this.changeSet = changeSet;
         }
 
         @Override
         public void onCalled(CollectionObserverPair pair, Object observer) {
             //noinspection unchecked
-            pair.onChange(observer, changes);
+            pair.onChange(observer, changeSet);
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/Collection.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Collection.java
@@ -20,6 +20,8 @@ import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.NoSuchElementException;
 
+import io.realm.OrderedCollectionChangeSet;
+import io.realm.OrderedRealmCollectionChangeListener;
 import io.realm.RealmChangeListener;
 
 /**
@@ -29,13 +31,59 @@ import io.realm.RealmChangeListener;
 @Keep
 public class Collection implements NativeObject {
 
-    private class CollectionObserverPair<T> extends ObserverPairList.ObserverPair<T, RealmChangeListener<T>> {
-        public CollectionObserverPair(T observer, RealmChangeListener<T> listener) {
+    private class CollectionObserverPair<T> extends ObserverPairList.ObserverPair<T, Object> {
+        public CollectionObserverPair(T observer, Object listener) {
             super(observer, listener);
         }
 
-        public void onChange(T observer) {
-            listener.onChange(observer);
+        public void onChange(T observer, OrderedCollectionChangeSet changes) {
+            if (listener instanceof OrderedRealmCollectionChangeListener) {
+                //noinspection unchecked
+                ((OrderedRealmCollectionChangeListener<T>)listener).onChange(observer, changes);
+            } else if (listener instanceof RealmChangeListener) {
+                //noinspection unchecked
+                ((RealmChangeListener<T>)listener).onChange(observer);
+            } else {
+                throw new RuntimeException("Unsupported listener type: " + listener);
+            }
+        }
+    }
+
+    private static class RealmChangeListenerWrapper<T> implements OrderedRealmCollectionChangeListener<T> {
+        private final RealmChangeListener<T> listener;
+
+        RealmChangeListenerWrapper(RealmChangeListener<T> listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onChange(T collection, OrderedCollectionChangeSet changes) {
+            listener.onChange(collection);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof RealmChangeListenerWrapper &&
+                    listener == ((RealmChangeListenerWrapper) obj).listener;
+        }
+
+        @Override
+        public int hashCode() {
+            return listener.hashCode();
+        }
+    }
+
+    private static class Callback implements ObserverPairList.Callback<CollectionObserverPair> {
+        private final OrderedCollectionChangeSet changes;
+
+        Callback(OrderedCollectionChangeSet changes) {
+            this.changes = changes;
+        }
+
+        @Override
+        public void onCalled(CollectionObserverPair pair, Object observer) {
+            //noinspection unchecked
+            pair.onChange(observer, changes);
         }
     }
 
@@ -208,14 +256,6 @@ public class Collection implements NativeObject {
     private boolean isSnapshot = false;
     private final ObserverPairList<CollectionObserverPair> observerPairs =
             new ObserverPairList<CollectionObserverPair>();
-    private static final ObserverPairList.Callback<CollectionObserverPair> onChangeCallback =
-            new ObserverPairList.Callback<CollectionObserverPair>() {
-                @Override
-                public void onCalled(CollectionObserverPair pair, Object observer) {
-                    //noinspection unchecked
-                    pair.onChange(observer);
-                }
-            };
 
     // Public for static checking in JNI
     @SuppressWarnings("WeakerAccess")
@@ -417,7 +457,7 @@ public class Collection implements NativeObject {
         return nativeDeleteLast(nativePtr);
     }
 
-    public <T> void addListener(T observer, RealmChangeListener<T> listener) {
+    public <T> void addListener(T observer, OrderedRealmCollectionChangeListener<T> listener) {
         if (observerPairs.isEmpty()) {
             nativeStartListening(nativePtr);
         }
@@ -425,12 +465,19 @@ public class Collection implements NativeObject {
         observerPairs.add(collectionObserverPair);
     }
 
-    public <T> void removeListener(T observer, RealmChangeListener<T> listener) {
-        CollectionObserverPair<T> collectionObserverPair = new CollectionObserverPair<T>(observer, listener);
-        observerPairs.remove(collectionObserverPair);
+    public <T> void addListener(T observer, RealmChangeListener<T> listener) {
+        addListener(observer, new RealmChangeListenerWrapper<T>(listener));
+    }
+
+    public <T> void removeListener(T observer, OrderedRealmCollectionChangeListener<T> listener) {
+        observerPairs.remove(observer, listener);
         if (observerPairs.isEmpty()) {
             nativeStopListening(nativePtr);
         }
+    }
+
+    public <T> void removeListener(T observer, RealmChangeListener<T> listener) {
+        removeListener(observer, new RealmChangeListenerWrapper<T>(listener));
     }
 
     public void removeAllListeners() {
@@ -444,15 +491,17 @@ public class Collection implements NativeObject {
 
     // Called by JNI
     @SuppressWarnings("unused")
-    private void notifyChangeListeners(boolean emptyChanges) {
-        if (emptyChanges && isLoaded()) {
+    private void notifyChangeListeners(long nativeChangeSetPtr) {
+        if (nativeChangeSetPtr == 0 && isLoaded()) {
             return;
         }
+        boolean wasLoaded = loaded;
         loaded = true;
-        // TODO: For the fine grained notification, remember to call the callback with empty change set if the
-        // isLoaded() returns false even when the change set is not empty. Since in that case, it is the first time
-        // the listener gets called to indicate async query returns.
-        observerPairs.foreach(onChangeCallback);
+        // Object Store compute the change set between the SharedGroup versions when the query created and the latest.
+        // So it is possible it deliver a non-empty change set for the first async query returns. In this case, we
+        // return an empty change set to user since it is considered as the first time async query returns.
+        observerPairs.foreach(new Callback(nativeChangeSetPtr == 0 || !wasLoaded ?
+                        null : new CollectionChangeSet(nativeChangeSetPtr)));
     }
 
     public Mode getMode() {
@@ -478,7 +527,7 @@ public class Collection implements NativeObject {
         if (loaded) {
             return;
         }
-        notifyChangeListeners(true);
+        notifyChangeListeners(0);
     }
 
     private static native long nativeGetFinalizerPtr();

--- a/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
@@ -21,7 +21,7 @@ import io.realm.OrderedCollectionChangeSet;
 /**
  * Implementation of {@link OrderedCollectionChangeSet}. This class holds a pointer to the Object Store's
  * CollectionChangeSet and read from it only when needed. Creating an Java object from JNI when the collection
- * notification arrives is avoided since we also support the collection listeners without a change set parameter,
+ * notification arrives, is avoided since we also support the collection listeners without a change set parameter,
  * parsing the change set may not be necessary all the time.
  */
 public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeObject {

--- a/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal;
+
+import io.realm.OrderedCollectionChangeSet;
+
+/**
+ * Implementation of {@link OrderedCollectionChangeSet}. This class holds a pointer to the Object Store's
+ * CollectionChangeSet and read from it only when needed. Creating an Java object from JNI when the collection
+ * notification arrives is avoided since we also support the collection listeners without a change set parameter,
+ * parsing the change set may not be necessary all the time.
+ */
+public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeObject {
+
+    // Used in JNI.
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_DELETION = 0;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_INSERTION = 1;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_MODIFICATION = 2;
+    // Max array length is VM dependent. This is a safe value.
+    // See http://stackoverflow.com/questions/3038392/do-java-arrays-have-a-maximum-size
+    @SuppressWarnings("WeakerAccess")
+    public static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
+
+    private static long finalizerPtr = nativeGetFinalizerPtr();
+    private final long nativePtr;
+
+    public CollectionChangeSet(long nativePtr) {
+        this.nativePtr = nativePtr;
+        Context.dummyContext.addReference(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long[] getDeletions() {
+        return nativeGetIndices(nativePtr, TYPE_DELETION);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long[] getInsertions() {
+        return nativeGetIndices(nativePtr, TYPE_INSERTION);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long[] getChanges()  {
+        return nativeGetIndices(nativePtr, TYPE_MODIFICATION);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Range[] getDeletionRanges() {
+        return longArrayToRangeArray(nativeGetRanges(nativePtr, TYPE_DELETION));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Range[] getInsertionRanges() {
+        return longArrayToRangeArray(nativeGetRanges(nativePtr, TYPE_INSERTION));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Range[] getChangeRanges() {
+        return longArrayToRangeArray(nativeGetRanges(nativePtr, TYPE_MODIFICATION));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getNativePtr() {
+        return nativePtr;
+    }
+
+    @Override
+    public long getNativeFinalizerPtr() {
+        return finalizerPtr;
+    }
+
+    // Convert long array returned by the nativeGetXxxRanges() to Range array.
+    private Range[] longArrayToRangeArray(long[] longArray) {
+        if (longArray == null) {
+            // Returns a size 0 array so we know the JNI gets called.
+            return new Range[0];
+        }
+
+        Range[] ranges = new Range[longArray.length / 2];
+        for (int i = 0; i < ranges.length; i++) {
+            ranges[i] = new Range(longArray[i * 2], longArray[i * 2 + 1]);
+        }
+        return ranges;
+    }
+
+    private native static long nativeGetFinalizerPtr();
+    // Returns the ranges as an long array. eg.: [startIndex1, length1, startIndex2, length2, ...]
+    private native static long[] nativeGetRanges(long nativePtr, int type);
+    // Returns the indices array.
+    private native static long[] nativeGetIndices(long nativePtr, int type);
+}

--- a/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
@@ -110,7 +110,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
     // Convert long array returned by the nativeGetXxxRanges() to Range array.
     private Range[] longArrayToRangeArray(long[] longArray) {
         if (longArray == null) {
-            // Returns a size 0 array so we know the JNI gets called.
+            // Returns a size 0 array so we know JNI gets called.
             return new Range[0];
         }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
@@ -35,7 +35,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
     public static final int TYPE_MODIFICATION = 2;
     // Max array length is VM dependent. This is a safe value.
     // See http://stackoverflow.com/questions/3038392/do-java-arrays-have-a-maximum-size
-    @SuppressWarnings("WeakerAccess")
+    @SuppressWarnings({"WeakerAccess", "unused"})
     public static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 
     private static long finalizerPtr = nativeGetFinalizerPtr();
@@ -50,7 +50,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
      * {@inheritDoc}
      */
     @Override
-    public long[] getDeletions() {
+    public int[] getDeletions() {
         return nativeGetIndices(nativePtr, TYPE_DELETION);
     }
 
@@ -58,7 +58,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
      * {@inheritDoc}
      */
     @Override
-    public long[] getInsertions() {
+    public int[] getInsertions() {
         return nativeGetIndices(nativePtr, TYPE_INSERTION);
     }
 
@@ -66,7 +66,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
      * {@inheritDoc}
      */
     @Override
-    public long[] getChanges()  {
+    public int[] getChanges()  {
         return nativeGetIndices(nativePtr, TYPE_MODIFICATION);
     }
 
@@ -108,7 +108,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
     }
 
     // Convert long array returned by the nativeGetXxxRanges() to Range array.
-    private Range[] longArrayToRangeArray(long[] longArray) {
+    private Range[] longArrayToRangeArray(int[] longArray) {
         if (longArray == null) {
             // Returns a size 0 array so we know JNI gets called.
             return new Range[0];
@@ -123,7 +123,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
 
     private native static long nativeGetFinalizerPtr();
     // Returns the ranges as an long array. eg.: [startIndex1, length1, startIndex2, length2, ...]
-    private native static long[] nativeGetRanges(long nativePtr, int type);
+    private native static int[] nativeGetRanges(long nativePtr, int type);
     // Returns the indices array.
-    private native static long[] nativeGetIndices(long nativePtr, int type);
+    private native static int[] nativeGetIndices(long nativePtr, int type);
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/Context.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Context.java
@@ -28,6 +28,8 @@ import java.lang.ref.ReferenceQueue;
 public class Context {
     private final static ReferenceQueue<NativeObject> referenceQueue = new ReferenceQueue<NativeObject>();
     private final static Thread finalizingThread = new Thread(new FinalizerRunnable(referenceQueue));
+    // Dummy context which will be used by native objects which's destructors are always thread safe.
+    final static Context dummyContext = new Context();
 
     static {
         finalizingThread.setName("RealmFinalizingDaemon");

--- a/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
@@ -32,19 +32,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @param <T> the type of {@link ObserverPair}.
  */
-public class ObserverPairList<T extends ObserverPairList.ObserverPair> {
+class ObserverPairList<T extends ObserverPairList.ObserverPair> {
 
     /**
      * @param <T> the type of observer.
      * @param <S> the type of listener.
      */
-    public abstract static class ObserverPair<T, S> {
-        protected final WeakReference<T> observerRef;
+    abstract static class ObserverPair<T, S> {
+        final WeakReference<T> observerRef;
         protected final S listener;
         // Should only be set by the outer class. To marked it as removed in case it is removed in foreach callback.
         boolean removed = false;
 
-        public ObserverPair(T observer, S listener) {
+        ObserverPair(T observer, S listener) {
             this.listener = listener;
             this.observerRef = new WeakReference<T>(observer);
         }
@@ -96,7 +96,7 @@ public class ObserverPairList<T extends ObserverPairList.ObserverPair> {
      *
      * @param callback to be executed on the pair.
      */
-    public void foreach(Callback<T> callback) {
+    void foreach(Callback<T> callback) {
         for (T pair : pairs) {
             if (cleared) {
                 break;
@@ -123,6 +123,7 @@ public class ObserverPairList<T extends ObserverPairList.ObserverPair> {
     public void add(T pair) {
         if (!pairs.contains(pair)) {
             pairs.add(pair);
+            pair.removed = false;
         }
         if (cleared) {
             cleared = false;
@@ -130,16 +131,16 @@ public class ObserverPairList<T extends ObserverPairList.ObserverPair> {
     }
 
     public <S, U> void remove(S observer, U listener) {
-        for (T it : pairs) {
-            if (observer == it.observerRef.get() && listener == it.listener) {
-                it.removed = true;
-                pairs.remove(it);
+        for (T pair : pairs) {
+            if (observer == pair.observerRef.get() && listener.equals(pair.listener)) {
+                pair.removed = true;
+                pairs.remove(pair);
                 break;
             }
         }
     }
 
-    public void removeByObserver(Object observer) {
+    void removeByObserver(Object observer) {
         for (T pair : pairs) {
             Object object = pair.observerRef.get();
             if (object == null || object == observer) {

--- a/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
@@ -49,8 +49,8 @@ public class ObserverPairList<T extends ObserverPairList.ObserverPair> {
             this.observerRef = new WeakReference<T>(observer);
         }
 
-        // The two pairs will be treated as the same only when the observers are the same and the listeners are the same
-        // as well.
+        // The two pairs will be treated as the same only when the observers are the same and the listeners equal to
+        // each other.
         @Override
         public boolean equals(Object obj) {
             if (this == obj) {
@@ -129,17 +129,21 @@ public class ObserverPairList<T extends ObserverPairList.ObserverPair> {
         }
     }
 
-    public void remove(T pair) {
-        pair.removed = true;
-        pairs.remove(pair);
+    public <S, U> void remove(S observer, U listener) {
+        for (T it : pairs) {
+            if (observer == it.observerRef.get() && listener == it.listener) {
+                it.removed = true;
+                pairs.remove(it);
+                break;
+            }
+        }
     }
 
     public void removeByObserver(Object observer) {
         for (T pair : pairs) {
             Object object = pair.observerRef.get();
-            if (object == null) {
-                pairs.remove(pair);
-            } else if (object == observer) {
+            if (object == null || object == observer) {
+                pair.removed = true;
                 pairs.remove(pair);
             }
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
@@ -49,8 +49,7 @@ class ObserverPairList<T extends ObserverPairList.ObserverPair> {
             this.observerRef = new WeakReference<T>(observer);
         }
 
-        // The two pairs will be treated as the same only when the observers are the same and the listeners equal to
-        // each other.
+        // The two pairs will be treated as the same only when the observers are the same and the listeners are equal.
         @Override
         public boolean equals(Object obj) {
             if (this == obj) {

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
@@ -127,8 +127,7 @@ public abstract class RealmNotifier implements Closeable {
     }
 
     public <E> void removeChangeListener(E observer, RealmChangeListener<E> realmChangeListener) {
-        RealmObserverPair observerPair = new RealmObserverPair<E>(observer, realmChangeListener);
-        realmObserverPairs.remove(observerPair);
+        realmObserverPairs.remove(observer, realmChangeListener);
     }
 
     public <E> void removeChangeListeners(E observer) {


### PR DESCRIPTION
- Add RealmObservable and RealmCollectionObservable interfaces.
- Enable detailed change information for RealmResults through
  OrderedCollectionChange interface.
- Fix a bug in the ObserverPairList which could cause the removed
  listener gets called if it was removed during previous listener
  iteration.

Fix #989

 - [ ] `RealmObject` should implement `RealmObservable`.