### PR TITLE
Improve performance of publishToMavenLocal (installRealmJava) task

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -500,8 +500,10 @@ task deployCore(group: 'build setup', description: 'Deploy the latest version of
     }
 }
 
-publishToMavenLocal.dependsOn assemble
-preBuild.dependsOn deployCore
+project.afterEvaluate {
+    publishToMavenLocal.dependsOn assembleRelease
+    preBuild.dependsOn deployCore
+}
 
 if (project.hasProperty('dontCleanJniFiles')) {
     project.afterEvaluate {


### PR DESCRIPTION
now publishToMavenLocal in realm/realm-library/build.gradle depends on assembleRelease task insteadof assemble task in order to improve build time.

@realm/java 