### PR TITLE
Deprecate distinctXxx of RealmResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Breaking changes
 
-* `RealmResults.distinct()` returns a new `RealmResults` object instead of filtering on the original object (#2947).
 * `RealmResults` is auto-updated continuously. Any transaction on the current thread which may have an impact on the order or elements of the `RealmResults` will change the `RealmResults` immediately instead of change it in the next event loop. The standard `RealmResults.iterator()` will continue to work as normal, which means that you can still delete or modify elements without impacting the iterator. The same is not true for simple for-loops. In some cases a simple for-loop will not work (https://realm.io/docs/java/2.3.1/api/io/realm/OrderedRealmCollection.html#loops), and you must use the new createSnapshot() method.
+
+### Deprecated
+
+* `RealmResults.distinct()` and `RealmResults.distinctAsync()`. Use `RealmQuery.distinct()` and `RealmQuery.distinctAsync()` instead.
 
 ### Enhancements
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -16,7 +16,6 @@
 
 package io.realm;
 
-import android.os.Looper;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
@@ -31,8 +30,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -3023,6 +3020,7 @@ public class RealmQueryTests {
     }
 
     @Test
+    @RunTestInLooperThread
     public void distinctAsync_doesNotExist() {
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10;
@@ -3032,9 +3030,11 @@ public class RealmQueryTests {
             realm.where(AnnotationIndexTypes.class).distinctAsync("doesNotExist");
         } catch (IllegalArgumentException ignored) {
         }
+        looperThread.testComplete();
     }
 
     @Test
+    @RunTestInLooperThread
     public void distinctAsync_invalidTypes() {
         populateTestRealm(realm, TEST_DATA_SIZE);
 
@@ -3044,9 +3044,11 @@ public class RealmQueryTests {
             } catch (IllegalArgumentException ignored) {
             }
         }
+        looperThread.testComplete();
     }
 
     @Test
+    @RunTestInLooperThread
     public void distinctAsync_indexedLinkedFields() {
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10;
@@ -3059,9 +3061,11 @@ public class RealmQueryTests {
             } catch (IllegalArgumentException ignored) {
             }
         }
+        looperThread.testComplete();
     }
 
     @Test
+    @RunTestInLooperThread
     public void distinctAsync_notIndexedLinkedFields() {
         populateForDistinctInvalidTypesLinked(realm);
 
@@ -3069,6 +3073,7 @@ public class RealmQueryTests {
             realm.where(AllJavaTypes.class).distinctAsync(AllJavaTypes.FIELD_OBJECT + "." + AllJavaTypes.FIELD_BINARY);
         } catch (IllegalArgumentException ignored) {
         }
+        looperThread.testComplete();
     }
 
     @Test

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
@@ -52,6 +52,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isValid() {
         return collection.isValid();
     }
@@ -62,6 +63,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
      * @return {@code true}.
      * @see RealmCollection#isManaged()
      */
+    @Override
     public boolean isManaged() {
         return true;
     }
@@ -310,6 +312,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
     /**
      * {@inheritDoc}
      */
+    @Override
     public Number min(String fieldName) {
         realm.checkIfValid();
         long columnIndex = getColumnIndexForSort(fieldName);
@@ -319,6 +322,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
     /**
      * {@inheritDoc}
      */
+    @Override
     public Date minDate(String fieldName) {
         realm.checkIfValid();
         long columnIndex = getColumnIndexForSort(fieldName);
@@ -328,6 +332,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
     /**
      * {@inheritDoc}
      */
+    @Override
     public Number max(String fieldName) {
         realm.checkIfValid();
         long columnIndex = getColumnIndexForSort(fieldName);
@@ -344,6 +349,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
      * {@code null} values are ignored.
      * @throws IllegalArgumentException if fieldName is not a Date field.
      */
+    @Override
     public Date maxDate(String fieldName) {
         realm.checkIfValid();
         long columnIndex = getColumnIndexForSort(fieldName);
@@ -354,6 +360,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
     /**
      * {@inheritDoc}
      */
+    @Override
     public Number sum(String fieldName) {
         realm.checkIfValid();
         long columnIndex = getColumnIndexForSort(fieldName);
@@ -363,61 +370,13 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
     /**
      * {@inheritDoc}
      */
+    @Override
     public double average(String fieldName) {
         realm.checkIfValid();
         long columnIndex = getColumnIndexForSort(fieldName);
 
         Number avg = collection.aggregateNumber(Collection.Aggregate.AVERAGE, columnIndex);
         return avg.doubleValue();
-    }
-
-    /**
-     * Returns a distinct set of objects of a specific class. If the result is sorted, the first
-     * object will be returned in case of multiple occurrences, otherwise it is undefined which
-     * object is returned.
-     *
-     * @param fieldName the field name.
-     * @return a new non-null {@link RealmResults} containing the distinct objects.
-     * @throws IllegalArgumentException if a field is null, does not exist, is an unsupported type,
-     * is not indexed, or points to linked fields.
-     */
-    public RealmResults<E> distinct(String fieldName) {
-        SortDescriptor distinctDescriptor = SortDescriptor.getInstanceForDistinct(collection.getTable(), fieldName);
-        Collection distinctCollection = collection.distinct(distinctDescriptor);
-        return createLoadedResults(distinctCollection);
-    }
-
-    /**
-     * Asynchronously returns a distinct set of objects of a specific class. If the result is
-     * sorted, the first object will be returned in case of multiple occurrences, otherwise it is
-     * undefined which object is returned.
-     *
-     * @param fieldName the field name.
-     * @return immediately a {@link RealmResults}. Users need to register a listener
-     * {@link io.realm.RealmResults#addChangeListener(RealmChangeListener)} to be notified when the
-     * query completes.
-     * @throws IllegalArgumentException if a field is null, does not exist, is an unsupported type,
-     * is not indexed, or points to linked fields.
-     */
-    public RealmResults<E> distinctAsync(String fieldName) {
-        realm.sharedRealm.capabilities.checkCanDeliverNotification(RealmQuery.ASYNC_QUERY_WRONG_THREAD_MESSAGE);
-        return where().distinctAsync(fieldName);
-    }
-
-    /**
-     * Returns a distinct set of objects from a specific class. When multiple distinct fields are
-     * given, all unique combinations of values in the fields will be returned. In case of multiple
-     * matches, it is undefined which object is returned. Unless the result is sorted, then the
-     * first object will be returned.
-     *
-     * @param firstFieldName first field name to use when finding distinct objects.
-     * @param remainingFieldNames remaining field names when determining all unique combinations of field values.
-     * @return a non-null {@link RealmResults} containing the distinct objects.
-     * @throws IllegalArgumentException if field names is empty or {@code null}, does not exist,
-     * is an unsupported type, or points to a linked field.
-     */
-    public RealmResults<E> distinct(String firstFieldName, String... remainingFieldNames) {
-        return where().distinct(firstFieldName, remainingFieldNames);
     }
 
     // Deleting
@@ -590,7 +549,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
         }
     }
 
-    private RealmResults<E> createLoadedResults(Collection newCollection) {
+    RealmResults<E> createLoadedResults(Collection newCollection) {
         RealmResults<E> results;
         if (className != null) {
             results = new RealmResults<E>(realm, newCollection, className);

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1383,6 +1383,7 @@ public class RealmQuery<E extends RealmModel> {
      * is not indexed, or points to linked fields.
      */
     public RealmResults<E> distinctAsync(String fieldName) {
+        realm.sharedRealm.capabilities.checkCanDeliverNotification(ASYNC_QUERY_WRONG_THREAD_MESSAGE);
         SortDescriptor distinctDescriptor = SortDescriptor.getInstanceForDistinct(query.getTable(), fieldName);
         return createRealmResults(query, null, distinctDescriptor, false);
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -198,4 +198,53 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
             throw new UnsupportedOperationException(realm.getClass() + " does not support RxJava.");
         }
     }
+
+    /**
+     * Returns a distinct set of objects of a specific class. If the result is sorted, the first
+     * object will be returned in case of multiple occurrences, otherwise it is undefined which
+     * object is returned.
+     *
+     * @param fieldName the field name.
+     * @return a new non-null {@link RealmResults} containing the distinct objects.
+     * @throws IllegalArgumentException if a field is null, does not exist, is an unsupported type,
+     * is not indexed, or points to linked fields.
+     */
+    public RealmResults<E> distinct(String fieldName) {
+        SortDescriptor distinctDescriptor = SortDescriptor.getInstanceForDistinct(collection.getTable(), fieldName);
+        Collection distinctCollection = collection.distinct(distinctDescriptor);
+        return createLoadedResults(distinctCollection);
+    }
+
+    /**
+     * Asynchronously returns a distinct set of objects of a specific class. If the result is
+     * sorted, the first object will be returned in case of multiple occurrences, otherwise it is
+     * undefined which object is returned.
+     *
+     * @param fieldName the field name.
+     * @return immediately a {@link RealmResults}. Users need to register a listener
+     * {@link io.realm.RealmResults#addChangeListener(RealmChangeListener)} to be notified when the
+     * query completes.
+     * @throws IllegalArgumentException if a field is null, does not exist, is an unsupported type,
+     * is not indexed, or points to linked fields.
+     */
+    public RealmResults<E> distinctAsync(String fieldName) {
+        realm.sharedRealm.capabilities.checkCanDeliverNotification(RealmQuery.ASYNC_QUERY_WRONG_THREAD_MESSAGE);
+        return where().distinctAsync(fieldName);
+    }
+
+    /**
+     * Returns a distinct set of objects from a specific class. When multiple distinct fields are
+     * given, all unique combinations of values in the fields will be returned. In case of multiple
+     * matches, it is undefined which object is returned. Unless the result is sorted, then the
+     * first object will be returned.
+     *
+     * @param firstFieldName first field name to use when finding distinct objects.
+     * @param remainingFieldNames remaining field names when determining all unique combinations of field values.
+     * @return a non-null {@link RealmResults} containing the distinct objects.
+     * @throws IllegalArgumentException if field names is empty or {@code null}, does not exist,
+     * is an unsupported type, or points to a linked field.
+     */
+    public RealmResults<E> distinct(String firstFieldName, String... remainingFieldNames) {
+        return where().distinct(firstFieldName, remainingFieldNames);
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -208,6 +208,7 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
      * @deprecated use {@link RealmQuery#distinct(String)} on the return value of {@link #where()} instead. This will
      * be removed in coming 3.x.x minor releases.
      */
+    @Deprecated
     public RealmResults<E> distinct(String fieldName) {
         SortDescriptor distinctDescriptor = SortDescriptor.getInstanceForDistinct(collection.getTable(), fieldName);
         Collection distinctCollection = collection.distinct(distinctDescriptor);
@@ -218,6 +219,7 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
      * @deprecated use {@link RealmQuery#distinctAsync(String)} on the return value of {@link #where()} instead. This
      * will be removed in coming 3.x.x minor releases.
      */
+    @Deprecated
     public RealmResults<E> distinctAsync(String fieldName) {
         return where().distinctAsync(fieldName);
     }
@@ -226,6 +228,7 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
      * @deprecated use {@link RealmQuery#distinct(String, String...)} on the return value of {@link #where()} instead.
      * This will be removed in coming 3.x.x minor releases.
      */
+    @Deprecated
     public RealmResults<E> distinct(String firstFieldName, String... remainingFieldNames) {
         return where().distinct(firstFieldName, remainingFieldNames);
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -200,14 +200,8 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
     }
 
     /**
-     * Returns a distinct set of objects of a specific class. If the result is sorted, the first
-     * object will be returned in case of multiple occurrences, otherwise it is undefined which
-     * object is returned.
-     *
-     * @param fieldName the field name.
-     * @return a new non-null {@link RealmResults} containing the distinct objects.
-     * @throws IllegalArgumentException if a field is null, does not exist, is an unsupported type,
-     * is not indexed, or points to linked fields.
+     * @deprecated use {@link RealmQuery#distinct(String)} on the return value of {@link #where()} instead. This will
+     * be removed in coming 3.x.x minor releases.
      */
     public RealmResults<E> distinct(String fieldName) {
         SortDescriptor distinctDescriptor = SortDescriptor.getInstanceForDistinct(collection.getTable(), fieldName);
@@ -216,33 +210,16 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
     }
 
     /**
-     * Asynchronously returns a distinct set of objects of a specific class. If the result is
-     * sorted, the first object will be returned in case of multiple occurrences, otherwise it is
-     * undefined which object is returned.
-     *
-     * @param fieldName the field name.
-     * @return immediately a {@link RealmResults}. Users need to register a listener
-     * {@link io.realm.RealmResults#addChangeListener(RealmChangeListener)} to be notified when the
-     * query completes.
-     * @throws IllegalArgumentException if a field is null, does not exist, is an unsupported type,
-     * is not indexed, or points to linked fields.
+     * @deprecated use {@link RealmQuery#distinctAsync(String)} on the return value of {@link #where()} instead. This
+     * will be removed in coming 3.x.x minor releases.
      */
     public RealmResults<E> distinctAsync(String fieldName) {
-        realm.sharedRealm.capabilities.checkCanDeliverNotification(RealmQuery.ASYNC_QUERY_WRONG_THREAD_MESSAGE);
         return where().distinctAsync(fieldName);
     }
 
     /**
-     * Returns a distinct set of objects from a specific class. When multiple distinct fields are
-     * given, all unique combinations of values in the fields will be returned. In case of multiple
-     * matches, it is undefined which object is returned. Unless the result is sorted, then the
-     * first object will be returned.
-     *
-     * @param firstFieldName first field name to use when finding distinct objects.
-     * @param remainingFieldNames remaining field names when determining all unique combinations of field values.
-     * @return a non-null {@link RealmResults} containing the distinct objects.
-     * @throws IllegalArgumentException if field names is empty or {@code null}, does not exist,
-     * is an unsupported type, or points to a linked field.
+     * @deprecated use {@link RealmQuery#distinct(String, String...)} on the return value of {@link #where()} instead.
+     * This will be removed in coming 3.x.x minor releases.
      */
     public RealmResults<E> distinct(String firstFieldName, String... remainingFieldNames) {
         return where().distinct(firstFieldName, remainingFieldNames);

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -20,6 +20,7 @@ package io.realm;
 import android.os.Looper;
 
 import io.realm.internal.Collection;
+import io.realm.internal.SortDescriptor;
 import rx.Observable;
 
 /**


### PR DESCRIPTION
Those methods should only exist in the RealmResults. And maybe those
should be deprecated since all they are doing is distinct on the
where().
And annotate methods with @Override in the OrderedRealmCollectionImpl.