### PR TITLE
Fix documentation for directory() method in RealmConfiguration

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -429,7 +429,7 @@ public class RealmConfiguration {
         }
 
         /**
-         * Specifies the directory where the Realm file will be saved. The default value is {@code context.getFiles()}.
+         * Specifies the directory where the Realm file will be saved. The default value is {@code context.getFilesDir()}.
          * If the directory does not exist, it will be created.
          *
          * @param directory the directory to save the Realm file in. Directory must be writable.


### PR DESCRIPTION
There is no `context.getFiles()` method. The correct documentation for the `directory()` should read 

`The default value is {@code context.getFilesDir()}` instead of `The default value is {@code context.getFiles()}`