### PR TITLE
RealmObject now uses the same interface methods for RealmObservable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecated
 
 * `RealmResults.removeChangeListeners()`. Use `RealmResults.removeAllChangeListeners()` instead.
+* `RealmObject.removeChangeListeners()`. Use `RealmObject.removeAllChangeListeners()` instead.
 
 ### Enhancements
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1661,7 +1661,7 @@ public class RealmObjectTests {
      */
     @Test
     @RunTestInLooperThread
-    public void removeChangeListeners() {
+    public void removeAllChangeListeners() {
         final Realm realm = looperThread.realm;
         realm.beginTransaction();
         Dog dog = realm.createObject(Dog.class);
@@ -1673,7 +1673,7 @@ public class RealmObjectTests {
                 assertTrue(false);
             }
         });
-        dog.removeChangeListeners();
+        dog.removeAllChangeListeners();
 
         realm.beginTransaction();
         Dog sameDog = realm.where(Dog.class).equalTo(Dog.FIELD_AGE, 13).findFirst();
@@ -1702,11 +1702,11 @@ public class RealmObjectTests {
 
     @Test
     @RunTestInLooperThread
-    public void removeChangeListeners_throwOnUnmanagedObject() {
+    public void removeAllChangeListeners_throwOnUnmanagedObject() {
         Dog dog = new Dog();
 
         try {
-            dog.removeChangeListeners();
+            dog.removeAllChangeListeners();
             fail("Failed to remove null listener.");
         } catch (IllegalArgumentException ignore) {
             looperThread.testComplete();

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -354,7 +354,6 @@ public abstract class RealmObject implements RealmModel {
         }
     }
 
-
     /**
      * Removes a previously registered listener.
      *
@@ -396,9 +395,31 @@ public abstract class RealmObject implements RealmModel {
 
     /**
      * Removes all registered listeners.
+     *
+     * @deprecated Use {@link #removeAllChangeListeners()} instead.
      */
+    @Deprecated
     public final void removeChangeListeners() {
         RealmObject.removeChangeListeners(this);
+    }
+
+    /**
+     * Removes all registered listeners.
+     */
+    public final void removeAllChangeListeners() {
+        RealmObject.removeAllChangeListeners(this);
+    }
+
+    /**
+     * Removes all registered listeners from the given RealmObject.
+     *
+     * @param object RealmObject to remove all listeners from.
+     * @throws IllegalArgumentException if object is {@code null} or isn't managed by Realm.
+     * @deprecated Use {@link RealmObject#removeAllChangeListeners(RealmModel)} instead.
+     */
+    @Deprecated
+    public static <E extends RealmModel> void removeChangeListeners(E object) {
+        removeAllChangeListeners(object);
     }
 
     /**
@@ -407,7 +428,7 @@ public abstract class RealmObject implements RealmModel {
      * @param object RealmObject to remove all listeners from.
      * @throws IllegalArgumentException if object is {@code null} or isn't managed by Realm.
      */
-    public static <E extends RealmModel> void removeChangeListeners(E object) {
+    public static <E extends RealmModel> void removeAllChangeListeners(E object) {
         if (object instanceof RealmObjectProxy) {
             RealmObjectProxy proxy = (RealmObjectProxy) object;
             BaseRealm realm = proxy.realmGet$proxyState().getRealm$realm();


### PR DESCRIPTION
This PR makes RealmObject have the same methods for controlling change listeners as `OrderedRealmCollection` but without implementing the interface.

Yes, it is extremely annoying, but so far any attempt to make it better have failed:

```
public abstract class Realm<E extends RealmObject> implements RealmModel, RealmObservable<E>
```

* Crashes the Java compiler because it cannot find `rx.Observable`. Which is extremely perplexing. Possible the class loader does something else than normal in this case. We cannot require everyone to include RxJava. Attempting to add RxJava as a provided dependency in the maven POM for the artifact did not solve the issue.

* Also Kotlin has stricter requirements for generics. Causing fun errors like `Projections are not allowed for immediate arguments of a supertype` and `type parameter bound for E in fun <E : RealmModel!> where(clazz: Class<E!>!): RealmQuery<E!>!
 is not satisfied: inferred type Person! is not a subtype of RealmModel!`.

According to http://stackoverflow.com/questions/41209902/projections-are-not-allowed-for-immediate-subtypes-of-a-supertype Kotlin apparently have stricter requirements for generics, so all Kotlin classes would have to specify it - always.

Some day we might decide that our change listeners are so prominent that specifying the generic argument provide more benefits than drawbacks, but I'm not convinced it is this day. Happy to hear arguments both ways though.




