### PR TITLE
Deleted RealmObjects are now emitted as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `RealmResults.distinct()` returns a new `RealmResults` object instead of filtering on the original object (#2947).
 * `RealmResults` is auto-updated continuously. Any transaction on the current thread which may have an impact on the order or elements of the `RealmResults` will change the `RealmResults` immediately instead of change it in the next event loop. The standard `RealmResults.iterator()` will continue to work as normal, which means that you can still delete or modify elements without impacting the iterator. The same is not true for simple for-loops. In some cases a simple for-loop will not work (https://realm.io/docs/java/3.0.0/api/io/realm/OrderedRealmCollection.html#loops), and you must use the new createSnapshot() method.
+* `RealmChangeListener` on `RealmObject` will now also be triggered when the object is deleted. Use `RealmObject.isValid()` to check this state(#3138).
+* `RealmObject.asObservable()` will now emit the object when it is deleted. Use `RealmObject.isValid()` to check this state (#3138).
 
 ### Deprecated
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1605,6 +1605,27 @@ public class RealmObjectTests {
 
     @Test
     @RunTestInLooperThread
+    public void changeListener_triggeredWhenObjectIsdeleted() {
+        final Realm realm = looperThread.realm;
+        realm.beginTransaction();
+        AllTypes obj = realm.createObject(AllTypes.class);
+        realm.commitTransaction();
+
+        obj.addChangeListener(new RealmChangeListener<AllTypes>() {
+            @Override
+            public void onChange(AllTypes obj) {
+                assertFalse(obj.isValid());
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        obj.deleteFromRealm();
+        realm.commitTransaction();
+    }
+
+    @Test
+    @RunTestInLooperThread
     public void addChangeListener_throwOnUnmanagedObject() {
         Dog dog = new Dog();
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
@@ -31,10 +31,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import dk.ilios.spanner.All;
 import io.realm.entities.AllTypes;
 import io.realm.entities.CyclicType;
-import io.realm.log.RealmLog;
 import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;


### PR DESCRIPTION
Fixes #3138 

It appears that moving to the Object Store notifications accidentally fixed https://github.com/realm/realm-java/issues/3138 for us. Yay.

I just added the unit tests to verify + changelog.