### PR TITLE
Remove unnecessary 'super's

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -147,7 +147,7 @@ public class DynamicRealm extends BaseRealm {
      * @see io.realm.RealmChangeListener
      */
     public void removeChangeListener(RealmChangeListener<DynamicRealm> listener) {
-        super.removeListener(listener);
+        removeListener(listener);
     }
 
     /**
@@ -157,7 +157,7 @@ public class DynamicRealm extends BaseRealm {
      * @see io.realm.RealmChangeListener
      */
     public void removeAllChangeListeners() {
-        super.removeAllListeners();
+        removeAllListeners();
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -47,7 +47,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
 import io.realm.exceptions.RealmMigrationNeededException;
-import io.realm.internal.Capabilities;
 import io.realm.internal.ColumnIndices;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.ObjectServerFacade;
@@ -1294,7 +1293,7 @@ public class Realm extends BaseRealm {
      * @see io.realm.RealmChangeListener
      */
     public void removeChangeListener(RealmChangeListener<Realm> listener) {
-        super.removeListener(listener);
+        removeListener(listener);
     }
 
     /**
@@ -1304,7 +1303,7 @@ public class Realm extends BaseRealm {
      * @see io.realm.RealmChangeListener
      */
     public void removeAllChangeListeners() {
-        super.removeAllListeners();
+        removeAllListeners();
     }
 
     /**


### PR DESCRIPTION
Since this.removeListener and this.removeAllListeners does not exist,
super.removeListener and super.removeAllListeners are not necessary.
Just use removeListener and removeAllListeners instead.

Please merge #4247 before this PR.