### PR TITLE
Expose bug with default constructors

### DIFF
--- a/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/BytecodeModifier.groovy
@@ -85,11 +85,12 @@ class BytecodeModifier {
         clazz.addInterface(proxyInterface)
     }
 
-    public static void callInjectObjectContextFromDefaultConstructor(CtClass clazz) {
-        def defaultConstructor = clazz.getDeclaredConstructor()
-        defaultConstructor.insertBeforeBody('if ($0 instanceof io.realm.internal.RealmObjectProxy) {' +
-                ' ((io.realm.internal.RealmObjectProxy) $0).realm$injectObjectContext();' +
-                ' }')
+    public static void callInjectObjectContextFromConstructors(CtClass clazz) {
+        clazz.getConstructors().each {
+            it.insertBeforeBody('if ($0 instanceof io.realm.internal.RealmObjectProxy) {' +
+                    ' ((io.realm.internal.RealmObjectProxy) $0).realm$injectObjectContext();' +
+                    ' }')
+        }
     }
 
     /**

--- a/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
@@ -26,7 +26,6 @@ import io.realm.annotations.Ignore
 import io.realm.annotations.RealmClass
 import javassist.ClassPool
 import javassist.CtClass
-import javassist.LoaderClassPath
 import org.gradle.api.Project
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -131,7 +130,7 @@ class RealmTransformer extends Transform {
         inputModelClasses.each {
             BytecodeModifier.addRealmAccessors(it)
             BytecodeModifier.addRealmProxyInterface(it, classPool)
-            BytecodeModifier.callInjectObjectContextFromDefaultConstructor(it)
+            BytecodeModifier.callInjectObjectContextFromConstructors(it)
         }
 
         // Use accessors instead of direct field access

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -481,6 +481,9 @@ public class RealmProxyClassGenerator {
                 EnumSet.of(Modifier.PUBLIC) // Modifiers
                 ); // Argument type & argument name
 
+        writer.beginControlFlow("if (this.proxyState != null)");
+        writer.emitStatement("return");
+        writer.endControlFlow();
         writer.emitStatement("final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get()");
         writer.emitStatement("this.columnInfo = (%1$s) context.getColumnInfo()", columnInfoClassName());
         writer.emitStatement("this.proxyState = new ProxyState<%1$s>(%1$s.class, this)", qualifiedClassName);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -115,6 +115,9 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
     @Override
     public void realm$injectObjectContext() {
+        if (this.proxyState != null) {
+            return;
+        }
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (AllTypesColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState<some.test.AllTypes>(some.test.AllTypes.class, this);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -89,6 +89,9 @@ public class BooleansRealmProxy extends some.test.Booleans
 
     @Override
     public void realm$injectObjectContext() {
+        if (this.proxyState != null) {
+            return;
+        }
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (BooleansColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState<some.test.Booleans>(some.test.Booleans.class, this);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -174,6 +174,9 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     @Override
     public void realm$injectObjectContext() {
+        if (this.proxyState != null) {
+            return;
+        }
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (NullTypesColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState<some.test.NullTypes>(some.test.NullTypes.class, this);

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -79,6 +79,9 @@ public class SimpleRealmProxy extends some.test.Simple
 
     @Override
     public void realm$injectObjectContext() {
+        if (this.proxyState != null) {
+            return;
+        }
         final BaseRealm.RealmObjectContext context = BaseRealm.objectContext.get();
         this.columnInfo = (SimpleColumnInfo) context.getColumnInfo();
         this.proxyState = new ProxyState<some.test.Simple>(some.test.Simple.class, this);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -67,6 +67,7 @@ import io.realm.entities.Cat;
 import io.realm.entities.CyclicType;
 import io.realm.entities.CyclicTypePrimaryKey;
 import io.realm.entities.DefaultValueConstructor;
+import io.realm.entities.DefaultValueFromOtherConstructor;
 import io.realm.entities.DefaultValueOfField;
 import io.realm.entities.DefaultValueOverwriteNullLink;
 import io.realm.entities.DefaultValueSetter;
@@ -2423,6 +2424,15 @@ public class RealmTests {
         testOneObjectFound(realm, DefaultValueSetter.class,
                 DefaultValueSetter.FIELD_LIST+ "." + RandomPrimaryKey.FIELD_INT,
                         RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1);
+    }
+
+    @Test
+    public void createObject_defaultValueFromOtherConstructor() {
+        realm.beginTransaction();
+        DefaultValueFromOtherConstructor obj = realm.createObject(DefaultValueFromOtherConstructor.class);
+        realm.commitTransaction();
+
+        assertEquals(42, obj.getFieldLong());
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueFromOtherConstructor.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueFromOtherConstructor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import java.util.Date;
+import java.util.UUID;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.PrimaryKey;
+
+public class DefaultValueFromOtherConstructor extends RealmObject {
+
+    public static final String CLASS_NAME = "DefaultValueOfField";
+    public static String FIELD_LONG = "fieldLong";
+
+    private long fieldLong;
+
+    public DefaultValueFromOtherConstructor() {
+        this(42);
+    }
+
+    public DefaultValueFromOtherConstructor(long fieldLong) {
+        this.fieldLong = fieldLong;
+    }
+
+    public long getFieldLong() {
+        return fieldLong;
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueFromOtherConstructor.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueFromOtherConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Realm Inc.
+ * Copyright 2017 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,7 @@
 
 package io.realm.entities;
 
-import java.util.Date;
-import java.util.UUID;
-
-import io.realm.RealmList;
 import io.realm.RealmObject;
-import io.realm.annotations.Ignore;
-import io.realm.annotations.PrimaryKey;
 
 public class DefaultValueFromOtherConstructor extends RealmObject {
 


### PR DESCRIPTION
Apparently the recent change to getters/setters (https://github.com/realm/realm-java/pull/4206)  caused a regression not caught by our unit tests, but it was revealed by our Kotlin example (we should really re-enable checking those again).

/cc @zaki50 
