### PR TITLE
Add thread check to methods in RealmQuery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.3 (YY-MM-DD)
+
+### Bug fixes
+
+* Throws `IllegalStateException` instead of process crash when any of thread confined methods in `RealmQuery` is called from wrong thread (#4228).
+
 ## 2.3.2 (2017-02-27)
 
 ### Bug fixes

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -165,7 +165,6 @@ public class RealmQueryTests {
         IN_STRING,
         IN_STRING_WITH_CASE,
         IN_BYTE,
-        //IN_BYTE_ARRAY,
         IN_SHORT,
         IN_INTEGER,
         IN_LONG,
@@ -186,64 +185,34 @@ public class RealmQueryTests {
         NOT_EQUAL_TO_BOOLEAN,
         NOT_EQUAL_TO_DATE,
 
-        //GREATER_THAN_STRING,
-        //GREATER_THAN_STRING_WITH_CASE,
-        //GREATER_THAN_BYTE,
-        //GREATER_THAN_BYTE_ARRAY,
-        //GREATER_THAN_SHORT,
         GREATER_THAN_INTEGER,
         GREATER_THAN_LONG,
         GREATER_THAN_DOUBLE,
         GREATER_THAN_FLOAT,
-        //GREATER_THAN_BOOLEAN,
         GREATER_THAN_DATE,
 
-        //GREATER_THAN_OR_EQUAL_TO_STRING,
-        //GREATER_THAN_OR_EQUAL_TO_STRING_WITH_CASE,
-        //GREATER_THAN_OR_EQUAL_TO_BYTE,
-        //GREATER_THAN_OR_EQUAL_TO_BYTE_ARRAY,
-        //GREATER_THAN_OR_EQUAL_TO_SHORT,
         GREATER_THAN_OR_EQUAL_TO_INTEGER,
         GREATER_THAN_OR_EQUAL_TO_LONG,
         GREATER_THAN_OR_EQUAL_TO_DOUBLE,
         GREATER_THAN_OR_EQUAL_TO_FLOAT,
-        //GREATER_THAN_OR_EQUAL_TO_BOOLEAN,
         GREATER_THAN_OR_EQUAL_TO_DATE,
 
-        //LESS_THAN_STRING,
-        //LESS_THAN_STRING_WITH_CASE,
-        //LESS_THAN_BYTE,
-        //LESS_THAN_BYTE_ARRAY,
-        //LESS_THAN_SHORT,
         LESS_THAN_INTEGER,
         LESS_THAN_LONG,
         LESS_THAN_DOUBLE,
         LESS_THAN_FLOAT,
-        //LESS_THAN_BOOLEAN,
         LESS_THAN_DATE,
 
-        //LESS_THAN_OR_EQUAL_TO_STRING,
-        //LESS_THAN_OR_EQUAL_TO_STRING_WITH_CASE,
-        //LESS_THAN_OR_EQUAL_TO_BYTE,
-        //LESS_THAN_OR_EQUAL_TO_BYTE_ARRAY,
-        //LESS_THAN_OR_EQUAL_TO_SHORT,
         LESS_THAN_OR_EQUAL_TO_INTEGER,
         LESS_THAN_OR_EQUAL_TO_LONG,
         LESS_THAN_OR_EQUAL_TO_DOUBLE,
         LESS_THAN_OR_EQUAL_TO_FLOAT,
-        //LESS_THAN_OR_EQUAL_TO_BOOLEAN,
         LESS_THAN_OR_EQUAL_TO_DATE,
 
-        //BETWEEN_STRING,
-        //BETWEEN_STRING_WITH_CASE,
-        //BETWEEN_BYTE,
-        //BETWEEN_BYTE_ARRAY,
-        //BETWEEN_SHORT,
         BETWEEN_INTEGER,
         BETWEEN_LONG,
         BETWEEN_DOUBLE,
         BETWEEN_FLOAT,
-        //BETWEEN_BOOLEAN,
         BETWEEN_DATE,
 
         CONTAINS_STRING,
@@ -253,7 +222,7 @@ public class RealmQueryTests {
         BEGINS_WITH_STRING_WITH_CASE,
 
         ENDS_WITH_STRING,
-        WNDS_WITH_STRING_WITH_CASE,
+        ENDS_WITH_STRING_WITH_CASE,
 
         LIKE_STRING,
         LIKE_STRING_WITH_CASE,
@@ -369,7 +338,7 @@ public class RealmQueryTests {
             case BEGINS_WITH_STRING_WITH_CASE: query.beginsWith( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;
 
             case ENDS_WITH_STRING: query.endsWith(           AllJavaTypes.FIELD_STRING, "dummy value"); break;
-            case WNDS_WITH_STRING_WITH_CASE: query.endsWith( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;
+            case ENDS_WITH_STRING_WITH_CASE: query.endsWith( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;
 
             case LIKE_STRING: query.like(           AllJavaTypes.FIELD_STRING, "dummy value"); break;
             case LIKE_STRING_WITH_CASE: query.like( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -18,6 +18,7 @@ package io.realm;
 
 import android.os.Looper;
 import android.support.test.runner.AndroidJUnit4;
+import android.util.Pair;
 
 import org.junit.After;
 import org.junit.Before;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -35,6 +37,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
@@ -145,6 +148,449 @@ public class RealmQueryTests {
 
     private void populateNoPrimaryKeyNullTypesRows() {
         populateNoPrimaryKeyNullTypesRows(realm, TEST_NO_PRIMARY_KEY_NULL_TYPES_SIZE);
+    }
+
+    private static <F> Pair<F, String> pairOf(F first, String second) {
+        return new Pair<F, String>(first, second);
+    }
+
+    private enum ThreadConfinedQueryMethods {
+        EQUAL_TO_STRING,
+        EQUAL_TO_STRING_WITH_CASE,
+        EQUAL_TO_BYTE,
+        EQUAL_TO_BYTE_ARRAY,
+        EQUAL_TO_SHORT,
+        EQUAL_TO_INTEGER,
+        EQUAL_TO_LONG,
+        EQUAL_TO_DOUBLE,
+        EQUAL_TO_FLOAT,
+        EQUAL_TO_BOOLEAN,
+        EQUAL_TO_DATE,
+
+        IN_STRING,
+        IN_STRING_WITH_CASE,
+        IN_BYTE,
+        //IN_BYTE_ARRAY,
+        IN_SHORT,
+        IN_INTEGER,
+        IN_LONG,
+        IN_DOUBLE,
+        IN_FLOAT,
+        IN_BOOLEAN,
+        IN_DATE,
+
+        NOT_EQUAL_TO_STRING,
+        NOT_EQUAL_TO_STRING_WITH_CASE,
+        NOT_EQUAL_TO_BYTE,
+        NOT_EQUAL_TO_BYTE_ARRAY,
+        NOT_EQUAL_TO_SHORT,
+        NOT_EQUAL_TO_INTEGER,
+        NOT_EQUAL_TO_LONG,
+        NOT_EQUAL_TO_DOUBLE,
+        NOT_EQUAL_TO_FLOAT,
+        NOT_EQUAL_TO_BOOLEAN,
+        NOT_EQUAL_TO_DATE,
+
+        //GREATER_THAN_STRING,
+        //GREATER_THAN_STRING_WITH_CASE,
+        //GREATER_THAN_BYTE,
+        //GREATER_THAN_BYTE_ARRAY,
+        //GREATER_THAN_SHORT,
+        GREATER_THAN_INTEGER,
+        GREATER_THAN_LONG,
+        GREATER_THAN_DOUBLE,
+        GREATER_THAN_FLOAT,
+        //GREATER_THAN_BOOLEAN,
+        GREATER_THAN_DATE,
+
+        //GREATER_THAN_OR_EQUAL_TO_STRING,
+        //GREATER_THAN_OR_EQUAL_TO_STRING_WITH_CASE,
+        //GREATER_THAN_OR_EQUAL_TO_BYTE,
+        //GREATER_THAN_OR_EQUAL_TO_BYTE_ARRAY,
+        //GREATER_THAN_OR_EQUAL_TO_SHORT,
+        GREATER_THAN_OR_EQUAL_TO_INTEGER,
+        GREATER_THAN_OR_EQUAL_TO_LONG,
+        GREATER_THAN_OR_EQUAL_TO_DOUBLE,
+        GREATER_THAN_OR_EQUAL_TO_FLOAT,
+        //GREATER_THAN_OR_EQUAL_TO_BOOLEAN,
+        GREATER_THAN_OR_EQUAL_TO_DATE,
+
+        //LESS_THAN_STRING,
+        //LESS_THAN_STRING_WITH_CASE,
+        //LESS_THAN_BYTE,
+        //LESS_THAN_BYTE_ARRAY,
+        //LESS_THAN_SHORT,
+        LESS_THAN_INTEGER,
+        LESS_THAN_LONG,
+        LESS_THAN_DOUBLE,
+        LESS_THAN_FLOAT,
+        //LESS_THAN_BOOLEAN,
+        LESS_THAN_DATE,
+
+        //LESS_THAN_OR_EQUAL_TO_STRING,
+        //LESS_THAN_OR_EQUAL_TO_STRING_WITH_CASE,
+        //LESS_THAN_OR_EQUAL_TO_BYTE,
+        //LESS_THAN_OR_EQUAL_TO_BYTE_ARRAY,
+        //LESS_THAN_OR_EQUAL_TO_SHORT,
+        LESS_THAN_OR_EQUAL_TO_INTEGER,
+        LESS_THAN_OR_EQUAL_TO_LONG,
+        LESS_THAN_OR_EQUAL_TO_DOUBLE,
+        LESS_THAN_OR_EQUAL_TO_FLOAT,
+        //LESS_THAN_OR_EQUAL_TO_BOOLEAN,
+        LESS_THAN_OR_EQUAL_TO_DATE,
+
+        //BETWEEN_STRING,
+        //BETWEEN_STRING_WITH_CASE,
+        //BETWEEN_BYTE,
+        //BETWEEN_BYTE_ARRAY,
+        //BETWEEN_SHORT,
+        BETWEEN_INTEGER,
+        BETWEEN_LONG,
+        BETWEEN_DOUBLE,
+        BETWEEN_FLOAT,
+        //BETWEEN_BOOLEAN,
+        BETWEEN_DATE,
+
+        CONTAINS_STRING,
+        CONTAINS_STRING_WITH_CASE,
+
+        BEGINS_WITH_STRING,
+        BEGINS_WITH_STRING_WITH_CASE,
+
+        ENDS_WITH_STRING,
+        WNDS_WITH_STRING_WITH_CASE,
+
+        LIKE_STRING,
+        LIKE_STRING_WITH_CASE,
+
+        BEGIN_GROUP,
+        END_GROUP,
+        OR,
+        NOT,
+        IS_NULL,
+        IS_NOT_NULL,
+        IS_EMPTY,
+        IS_NOT_EMPTY,
+
+        IS_VALID,
+        DISTINCT,
+        DISTINCT_BY_MULTIPLE_FIELDS,
+        DISTINCT_ASYNC,
+        DISTINCT_ASYNC_BY_MULTIPLE_FIELDS,
+
+        SUM,
+        AVERAGE,
+        MIN,
+        MINIMUM_DATE,
+        MAX,
+        MAXIMUM_DATE,
+        COUNT,
+
+        FIND_ALL,
+        FIND_ALL_ASYNC,
+        FIND_ALL_SORTED,
+        FIND_ALL_SORTED_ASYNC,
+        FIND_ALL_SORTED_WITH_ORDER,
+        FIND_ALL_SORTED_ASYNC_WITH_ORDER,
+        FIND_ALL_SORTED_WITH_TWO_ORDERS,
+        FIND_ALL_SORTED_ASYNC_WITH_TWO_ORDERS,
+        FIND_ALL_SORTED_WITH_MANY_ORDERS,
+        FIND_ALL_SORTED_ASYNC_WITH_MANY_ORDERS,
+
+        FIND_FIRST,
+        FIND_FIRST_ASYNC,
+    }
+
+    private static void callThreadConfinedMethod(RealmQuery<?> query, ThreadConfinedQueryMethods method, String fieldName) {
+        switch (method) {
+            case EQUAL_TO_STRING: query.equalTo(fieldName, "dummy value"); break;
+            case EQUAL_TO_STRING_WITH_CASE: query.equalTo(fieldName, "dummy value", Case.INSENSITIVE); break;
+            case EQUAL_TO_BYTE: query.equalTo(fieldName, (byte) 1); break;
+            case EQUAL_TO_BYTE_ARRAY: query.equalTo(fieldName, new byte[] {0, 1, 2}); break;
+            case EQUAL_TO_SHORT: query.equalTo(fieldName, (short) 1); break;
+            case EQUAL_TO_INTEGER: query.equalTo(fieldName, 1); break;
+            case EQUAL_TO_LONG: query.equalTo(fieldName, 1L); break;
+            case EQUAL_TO_DOUBLE: query.equalTo(fieldName, 1D); break;
+            case EQUAL_TO_FLOAT: query.equalTo(fieldName, 1F); break;
+            case EQUAL_TO_BOOLEAN: query.equalTo(fieldName, true); break;
+            case EQUAL_TO_DATE: query.equalTo(fieldName, new Date(0L)); break;
+
+            case IN_STRING: query.in(fieldName, new String[] {"dummy value1", "dummy value2"}); break;
+            case IN_STRING_WITH_CASE: query.in(fieldName, new String[] {"dummy value1", "dummy value2"}, Case.INSENSITIVE); break;
+            case IN_BYTE: query.in(fieldName, new Byte[] {1, 2, 3}); break;
+            case IN_SHORT: query.in(fieldName, new Short[] {1, 2, 3}); break;
+            case IN_INTEGER: query.in(fieldName, new Integer[] {1, 2, 3}); break;
+            case IN_LONG: query.in(fieldName, new Long[] {1L, 2L, 3L}); break;
+            case IN_DOUBLE: query.in(fieldName, new Double[] {1D, 2D, 3D}); break;
+            case IN_FLOAT: query.in(fieldName, new Float[] {1F, 2F, 3F}); break;
+            case IN_BOOLEAN: query.in(fieldName, new Boolean[] {true, false}); break;
+            case IN_DATE: query.in(fieldName, new Date[] {new Date(0L)}); break;
+
+            case NOT_EQUAL_TO_STRING: query.notEqualTo(fieldName, "dummy value"); break;
+            case NOT_EQUAL_TO_STRING_WITH_CASE: query.notEqualTo(fieldName, "dummy value", Case.INSENSITIVE); break;
+            case NOT_EQUAL_TO_BYTE: query.notEqualTo(fieldName, (byte) 1); break;
+            case NOT_EQUAL_TO_BYTE_ARRAY: query.notEqualTo(fieldName, new byte[] {1,2,3}); break;
+            case NOT_EQUAL_TO_SHORT: query.notEqualTo(fieldName, (short) 1); break;
+            case NOT_EQUAL_TO_INTEGER: query.notEqualTo(fieldName, 1); break;
+            case NOT_EQUAL_TO_LONG: query.notEqualTo(fieldName, 1L); break;
+            case NOT_EQUAL_TO_DOUBLE: query.notEqualTo(fieldName, 1D); break;
+            case NOT_EQUAL_TO_FLOAT: query.notEqualTo(fieldName, 1F); break;
+            case NOT_EQUAL_TO_BOOLEAN: query.notEqualTo(fieldName, true); break;
+            case NOT_EQUAL_TO_DATE: query.notEqualTo(fieldName, new Date(0L)); break;
+
+            case GREATER_THAN_INTEGER: query.greaterThan(fieldName, 1); break;
+            case GREATER_THAN_LONG: query.greaterThan(fieldName, 1L); break;
+            case GREATER_THAN_DOUBLE: query.greaterThan(fieldName, 1D); break;
+            case GREATER_THAN_FLOAT: query.greaterThan(fieldName, 1F); break;
+            case GREATER_THAN_DATE: query.greaterThan(fieldName, new Date(0L)); break;
+
+            case GREATER_THAN_OR_EQUAL_TO_INTEGER: query.greaterThanOrEqualTo(fieldName, 1); break;
+            case GREATER_THAN_OR_EQUAL_TO_LONG: query.greaterThanOrEqualTo(fieldName, 1L); break;
+            case GREATER_THAN_OR_EQUAL_TO_DOUBLE: query.greaterThanOrEqualTo(fieldName, 1D); break;
+            case GREATER_THAN_OR_EQUAL_TO_FLOAT: query.greaterThanOrEqualTo(fieldName, 1F); break;
+            case GREATER_THAN_OR_EQUAL_TO_DATE: query.greaterThanOrEqualTo(fieldName, new Date(0L)); break;
+
+            case LESS_THAN_INTEGER: query.lessThan(fieldName, 1); break;
+            case LESS_THAN_LONG: query.lessThan(fieldName, 1L); break;
+            case LESS_THAN_DOUBLE: query.lessThan(fieldName, 1D); break;
+            case LESS_THAN_FLOAT: query.lessThan(fieldName, 1F); break;
+            case LESS_THAN_DATE: query.lessThan(fieldName, new Date(0L)); break;
+
+            case LESS_THAN_OR_EQUAL_TO_INTEGER: query.lessThanOrEqualTo(fieldName, 1); break;
+            case LESS_THAN_OR_EQUAL_TO_LONG: query.lessThanOrEqualTo(fieldName, 1L); break;
+            case LESS_THAN_OR_EQUAL_TO_DOUBLE: query.lessThanOrEqualTo(fieldName, 1D); break;
+            case LESS_THAN_OR_EQUAL_TO_FLOAT: query.lessThanOrEqualTo(fieldName, 1F); break;
+            case LESS_THAN_OR_EQUAL_TO_DATE: query.lessThanOrEqualTo(fieldName, new Date(0L)); break;
+
+            case BETWEEN_INTEGER: query.between(fieldName, 1, 100); break;
+            case BETWEEN_LONG: query.between(fieldName, 1L, 100L); break;
+            case BETWEEN_DOUBLE: query.between(fieldName, 1D, 100D); break;
+            case BETWEEN_FLOAT: query.between(fieldName, 1F, 100F); break;
+            case BETWEEN_DATE: query.between(fieldName, new Date(0L), new Date(10000L)); break;
+
+            case CONTAINS_STRING: query.contains(fieldName, "dummy value"); break;
+            case CONTAINS_STRING_WITH_CASE: query.contains(fieldName, "dummy value", Case.INSENSITIVE); break;
+
+            case BEGINS_WITH_STRING: query.beginsWith(fieldName, "dummy value"); break;
+            case BEGINS_WITH_STRING_WITH_CASE: query.beginsWith(fieldName, "dummy value", Case.INSENSITIVE); break;
+
+            case ENDS_WITH_STRING: query.endsWith(fieldName, "dummy value"); break;
+            case WNDS_WITH_STRING_WITH_CASE: query.endsWith(fieldName, "dummy value", Case.INSENSITIVE); break;
+
+            case LIKE_STRING: query.like(fieldName, "dummy value"); break;
+            case LIKE_STRING_WITH_CASE: query.like(fieldName, "dummy value", Case.INSENSITIVE); break;
+
+            case BEGIN_GROUP: query.beginGroup(); break;
+            case END_GROUP: query.endGroup(); break;
+            case OR: query.or(); break;
+            case NOT: query.not(); break;
+            case IS_NULL: query.isNull(fieldName); break;
+            case IS_NOT_NULL: query.isNotNull(fieldName); break;
+            case IS_EMPTY: query.isEmpty(fieldName); break;
+            case IS_NOT_EMPTY: query.isNotEmpty(fieldName); break;
+
+            case IS_VALID: query.isValid(); break;
+            case DISTINCT: query.distinct(fieldName); break;
+            case DISTINCT_BY_MULTIPLE_FIELDS: query.distinct(fieldName, AllJavaTypes.FIELD_ID); break;
+            case DISTINCT_ASYNC: query.distinctAsync(fieldName); break;
+
+            case SUM: query.sum(fieldName); break;
+            case AVERAGE: query.average(fieldName); break;
+            case MIN: query.min(fieldName); break;
+            case MINIMUM_DATE: query.minimumDate(fieldName); break;
+            case MAX: query.max(fieldName); break;
+            case MAXIMUM_DATE: query.maximumDate(fieldName); break;
+            case COUNT: query.count(); break;
+
+            case FIND_ALL: query.findAll(); break;
+            case FIND_ALL_ASYNC: query.findAllAsync(); break;
+            case FIND_ALL_SORTED: query.findAllSorted(fieldName); break;
+            case FIND_ALL_SORTED_ASYNC: query.findAllSortedAsync(fieldName); break;
+            case FIND_ALL_SORTED_WITH_ORDER: query.findAllSorted(fieldName, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_ASYNC_WITH_ORDER: query.findAllSortedAsync(fieldName, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_WITH_TWO_ORDERS: query.findAllSorted(fieldName, Sort.DESCENDING, AllJavaTypes.FIELD_ID, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_ASYNC_WITH_TWO_ORDERS: query.findAllSortedAsync(fieldName, Sort.DESCENDING, AllJavaTypes.FIELD_ID, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_WITH_MANY_ORDERS: query.findAllSorted(new String[] {fieldName, AllJavaTypes.FIELD_ID}, new Sort[] {Sort.DESCENDING, Sort.DESCENDING}); break;
+            case FIND_ALL_SORTED_ASYNC_WITH_MANY_ORDERS: query.findAllSortedAsync(new String[] {fieldName, AllJavaTypes.FIELD_ID}, new Sort[] {Sort.DESCENDING, Sort.DESCENDING}); break;
+
+            case FIND_FIRST: query.findFirst(); break;
+            case FIND_FIRST_ASYNC: query.findFirstAsync(); break;
+
+            default:
+                throw new AssertionError("missing case for " + method);
+        }
+    }
+
+    @Test
+    public void callThreadConfinedMethodsFromWrongThread() throws Throwable {
+        final List<Pair<ThreadConfinedQueryMethods, String>> methodParams = Arrays.asList(
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_BYTE, AllJavaTypes.FIELD_BYTE),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_BYTE_ARRAY, AllJavaTypes.FIELD_BINARY),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_SHORT, AllJavaTypes.FIELD_SHORT),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_INTEGER, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_BOOLEAN, AllJavaTypes.FIELD_BOOLEAN),
+                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.IN_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.IN_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.IN_BYTE, AllJavaTypes.FIELD_BYTE),
+                pairOf(ThreadConfinedQueryMethods.IN_SHORT, AllJavaTypes.FIELD_SHORT),
+                pairOf(ThreadConfinedQueryMethods.IN_INTEGER, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.IN_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.IN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.IN_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.IN_BOOLEAN, AllJavaTypes.FIELD_BOOLEAN),
+                pairOf(ThreadConfinedQueryMethods.IN_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_BYTE, AllJavaTypes.FIELD_BYTE),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_BYTE_ARRAY, AllJavaTypes.FIELD_BINARY),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_SHORT, AllJavaTypes.FIELD_SHORT),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_INTEGER, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_BOOLEAN, AllJavaTypes.FIELD_BOOLEAN),
+                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_INTEGER, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_INTEGER, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_INTEGER, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_INTEGER, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.BETWEEN_INTEGER, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.BETWEEN_LONG, AllJavaTypes.FIELD_LONG),
+                pairOf(ThreadConfinedQueryMethods.BETWEEN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
+                pairOf(ThreadConfinedQueryMethods.BETWEEN_FLOAT, AllJavaTypes.FIELD_FLOAT),
+                pairOf(ThreadConfinedQueryMethods.BETWEEN_DATE, AllJavaTypes.FIELD_DATE),
+
+                pairOf(ThreadConfinedQueryMethods.CONTAINS_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.CONTAINS_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
+
+                pairOf(ThreadConfinedQueryMethods.BEGINS_WITH_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.BEGINS_WITH_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
+
+                pairOf(ThreadConfinedQueryMethods.ENDS_WITH_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.WNDS_WITH_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
+
+                pairOf(ThreadConfinedQueryMethods.LIKE_STRING, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.LIKE_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
+
+                pairOf(ThreadConfinedQueryMethods.BEGIN_GROUP, null),
+                pairOf(ThreadConfinedQueryMethods.END_GROUP, null),
+                pairOf(ThreadConfinedQueryMethods.OR, null),
+                pairOf(ThreadConfinedQueryMethods.NOT, null),
+                pairOf(ThreadConfinedQueryMethods.IS_NULL, AllJavaTypes.FIELD_DATE),
+                pairOf(ThreadConfinedQueryMethods.IS_NOT_NULL, AllJavaTypes.FIELD_DATE),
+                pairOf(ThreadConfinedQueryMethods.IS_EMPTY, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.IS_NOT_EMPTY, AllJavaTypes.FIELD_STRING),
+
+                pairOf(ThreadConfinedQueryMethods.IS_VALID, null),
+                pairOf(ThreadConfinedQueryMethods.DISTINCT, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.DISTINCT_BY_MULTIPLE_FIELDS, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.DISTINCT_ASYNC, AllJavaTypes.FIELD_STRING),
+
+                pairOf(ThreadConfinedQueryMethods.SUM, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.AVERAGE, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.MIN, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.MINIMUM_DATE, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.MAX, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.MAXIMUM_DATE, AllJavaTypes.FIELD_INT),
+                pairOf(ThreadConfinedQueryMethods.COUNT, null),
+
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL, null),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_ASYNC, null),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_WITH_ORDER, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC_WITH_ORDER, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_WITH_TWO_ORDERS, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC_WITH_TWO_ORDERS, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_WITH_MANY_ORDERS, AllJavaTypes.FIELD_STRING),
+                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC_WITH_MANY_ORDERS, AllJavaTypes.FIELD_STRING),
+
+                pairOf(ThreadConfinedQueryMethods.FIND_FIRST, null),
+                pairOf(ThreadConfinedQueryMethods.FIND_FIRST_ASYNC, null)
+        );
+
+        if (ThreadConfinedQueryMethods.values().length != methodParams.size()) {
+            throw new RuntimeException("missing some entries in 'methodParams'.");
+        }
+
+        final RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class);
+
+        final AtomicReference<Throwable> throwableFromThread = new AtomicReference<Throwable>();
+        final CountDownLatch testFinished = new CountDownLatch(1);
+
+        final String expectedMessage;
+        //noinspection TryWithIdenticalCatches
+        try {
+            final Field expectedMessageField = BaseRealm.class.getDeclaredField("INCORRECT_THREAD_MESSAGE");
+            expectedMessageField.setAccessible(true);
+            expectedMessage = (String) expectedMessageField.get(null);
+        } catch (NoSuchFieldException e) {
+            throw new AssertionError(e);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+
+        final Thread thread = new Thread("addingQueryParamFromWrongThread") {
+            @Override
+            public void run() {
+                try {
+                    for (Pair<ThreadConfinedQueryMethods, String> methodParam : methodParams) {
+                        ThreadConfinedQueryMethods queryMethod = methodParam.first;
+                        String fieldName = methodParam.second;
+                        try {
+                            callThreadConfinedMethod(query, queryMethod, fieldName);
+                            fail("IllegalStateException must be thrown.");
+                        } catch (Throwable e) {
+                            if (e instanceof IllegalStateException && expectedMessage.equals(e.getMessage())) {
+                                // expected exception
+                                continue;
+                            }
+                            throwableFromThread.set(e);
+                            return;
+                        }
+                    }
+                } finally {
+                    testFinished.countDown();
+                }
+            }
+        };
+        thread.start();
+
+        TestHelper.awaitOrFail(testFinished);
+        final Throwable throwable = throwableFromThread.get();
+        if (throwable != null) {
+            throw throwable;
+        }
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -18,7 +18,6 @@ package io.realm;
 
 import android.os.Looper;
 import android.support.test.runner.AndroidJUnit4;
-import android.util.Pair;
 
 import org.junit.After;
 import org.junit.Before;
@@ -150,11 +149,7 @@ public class RealmQueryTests {
         populateNoPrimaryKeyNullTypesRows(realm, TEST_NO_PRIMARY_KEY_NULL_TYPES_SIZE);
     }
 
-    private static <F> Pair<F, String> pairOf(F first, String second) {
-        return new Pair<F, String>(first, second);
-    }
-
-    private enum ThreadConfinedQueryMethods {
+    private enum ThreadConfinedMethods {
         EQUAL_TO_STRING,
         EQUAL_TO_STRING_WITH_CASE,
         EQUAL_TO_BYTE,
@@ -276,7 +271,6 @@ public class RealmQueryTests {
         DISTINCT,
         DISTINCT_BY_MULTIPLE_FIELDS,
         DISTINCT_ASYNC,
-        DISTINCT_ASYNC_BY_MULTIPLE_FIELDS,
 
         SUM,
         AVERAGE,
@@ -301,117 +295,117 @@ public class RealmQueryTests {
         FIND_FIRST_ASYNC,
     }
 
-    private static void callThreadConfinedMethod(RealmQuery<?> query, ThreadConfinedQueryMethods method, String fieldName) {
+    private static void callThreadConfinedMethod(RealmQuery<?> query, ThreadConfinedMethods method) {
         switch (method) {
-            case EQUAL_TO_STRING: query.equalTo(fieldName, "dummy value"); break;
-            case EQUAL_TO_STRING_WITH_CASE: query.equalTo(fieldName, "dummy value", Case.INSENSITIVE); break;
-            case EQUAL_TO_BYTE: query.equalTo(fieldName, (byte) 1); break;
-            case EQUAL_TO_BYTE_ARRAY: query.equalTo(fieldName, new byte[] {0, 1, 2}); break;
-            case EQUAL_TO_SHORT: query.equalTo(fieldName, (short) 1); break;
-            case EQUAL_TO_INTEGER: query.equalTo(fieldName, 1); break;
-            case EQUAL_TO_LONG: query.equalTo(fieldName, 1L); break;
-            case EQUAL_TO_DOUBLE: query.equalTo(fieldName, 1D); break;
-            case EQUAL_TO_FLOAT: query.equalTo(fieldName, 1F); break;
-            case EQUAL_TO_BOOLEAN: query.equalTo(fieldName, true); break;
-            case EQUAL_TO_DATE: query.equalTo(fieldName, new Date(0L)); break;
+            case EQUAL_TO_STRING: query.equalTo(           AllJavaTypes.FIELD_STRING,  "dummy value"); break;
+            case EQUAL_TO_STRING_WITH_CASE: query.equalTo( AllJavaTypes.FIELD_STRING,  "dummy value", Case.INSENSITIVE); break;
+            case EQUAL_TO_BYTE: query.equalTo(             AllJavaTypes.FIELD_BYTE,    (byte) 1); break;
+            case EQUAL_TO_BYTE_ARRAY: query.equalTo(       AllJavaTypes.FIELD_BINARY,  new byte[] {0, 1, 2}); break;
+            case EQUAL_TO_SHORT: query.equalTo(            AllJavaTypes.FIELD_SHORT,   (short) 1); break;
+            case EQUAL_TO_INTEGER: query.equalTo(          AllJavaTypes.FIELD_INT,     1); break;
+            case EQUAL_TO_LONG: query.equalTo(             AllJavaTypes.FIELD_LONG,    1L); break;
+            case EQUAL_TO_DOUBLE: query.equalTo(           AllJavaTypes.FIELD_DOUBLE,  1D); break;
+            case EQUAL_TO_FLOAT: query.equalTo(            AllJavaTypes.FIELD_FLOAT,   1F); break;
+            case EQUAL_TO_BOOLEAN: query.equalTo(          AllJavaTypes.FIELD_BOOLEAN, true); break;
+            case EQUAL_TO_DATE: query.equalTo(             AllJavaTypes.FIELD_DATE,    new Date(0L)); break;
 
-            case IN_STRING: query.in(fieldName, new String[] {"dummy value1", "dummy value2"}); break;
-            case IN_STRING_WITH_CASE: query.in(fieldName, new String[] {"dummy value1", "dummy value2"}, Case.INSENSITIVE); break;
-            case IN_BYTE: query.in(fieldName, new Byte[] {1, 2, 3}); break;
-            case IN_SHORT: query.in(fieldName, new Short[] {1, 2, 3}); break;
-            case IN_INTEGER: query.in(fieldName, new Integer[] {1, 2, 3}); break;
-            case IN_LONG: query.in(fieldName, new Long[] {1L, 2L, 3L}); break;
-            case IN_DOUBLE: query.in(fieldName, new Double[] {1D, 2D, 3D}); break;
-            case IN_FLOAT: query.in(fieldName, new Float[] {1F, 2F, 3F}); break;
-            case IN_BOOLEAN: query.in(fieldName, new Boolean[] {true, false}); break;
-            case IN_DATE: query.in(fieldName, new Date[] {new Date(0L)}); break;
+            case IN_STRING: query.in(           AllJavaTypes.FIELD_STRING,  new String[] {"dummy value1", "dummy value2"}); break;
+            case IN_STRING_WITH_CASE: query.in( AllJavaTypes.FIELD_STRING,  new String[] {"dummy value1", "dummy value2"}, Case.INSENSITIVE); break;
+            case IN_BYTE: query.in(             AllJavaTypes.FIELD_BYTE,    new Byte[] {1, 2, 3}); break;
+            case IN_SHORT: query.in(            AllJavaTypes.FIELD_SHORT,   new Short[] {1, 2, 3}); break;
+            case IN_INTEGER: query.in(          AllJavaTypes.FIELD_INT,     new Integer[] {1, 2, 3}); break;
+            case IN_LONG: query.in(             AllJavaTypes.FIELD_LONG,    new Long[] {1L, 2L, 3L}); break;
+            case IN_DOUBLE: query.in(           AllJavaTypes.FIELD_DOUBLE,  new Double[] {1D, 2D, 3D}); break;
+            case IN_FLOAT: query.in(            AllJavaTypes.FIELD_FLOAT,   new Float[] {1F, 2F, 3F}); break;
+            case IN_BOOLEAN: query.in(          AllJavaTypes.FIELD_BOOLEAN, new Boolean[] {true, false}); break;
+            case IN_DATE: query.in(             AllJavaTypes.FIELD_DATE,    new Date[] {new Date(0L)}); break;
 
-            case NOT_EQUAL_TO_STRING: query.notEqualTo(fieldName, "dummy value"); break;
-            case NOT_EQUAL_TO_STRING_WITH_CASE: query.notEqualTo(fieldName, "dummy value", Case.INSENSITIVE); break;
-            case NOT_EQUAL_TO_BYTE: query.notEqualTo(fieldName, (byte) 1); break;
-            case NOT_EQUAL_TO_BYTE_ARRAY: query.notEqualTo(fieldName, new byte[] {1,2,3}); break;
-            case NOT_EQUAL_TO_SHORT: query.notEqualTo(fieldName, (short) 1); break;
-            case NOT_EQUAL_TO_INTEGER: query.notEqualTo(fieldName, 1); break;
-            case NOT_EQUAL_TO_LONG: query.notEqualTo(fieldName, 1L); break;
-            case NOT_EQUAL_TO_DOUBLE: query.notEqualTo(fieldName, 1D); break;
-            case NOT_EQUAL_TO_FLOAT: query.notEqualTo(fieldName, 1F); break;
-            case NOT_EQUAL_TO_BOOLEAN: query.notEqualTo(fieldName, true); break;
-            case NOT_EQUAL_TO_DATE: query.notEqualTo(fieldName, new Date(0L)); break;
+            case NOT_EQUAL_TO_STRING: query.notEqualTo(           AllJavaTypes.FIELD_STRING,  "dummy value"); break;
+            case NOT_EQUAL_TO_STRING_WITH_CASE: query.notEqualTo( AllJavaTypes.FIELD_STRING,  "dummy value", Case.INSENSITIVE); break;
+            case NOT_EQUAL_TO_BYTE: query.notEqualTo(             AllJavaTypes.FIELD_BYTE,    (byte) 1); break;
+            case NOT_EQUAL_TO_BYTE_ARRAY: query.notEqualTo(       AllJavaTypes.FIELD_BINARY,  new byte[] {1,2,3}); break;
+            case NOT_EQUAL_TO_SHORT: query.notEqualTo(            AllJavaTypes.FIELD_SHORT,   (short) 1); break;
+            case NOT_EQUAL_TO_INTEGER: query.notEqualTo(          AllJavaTypes.FIELD_INT,     1); break;
+            case NOT_EQUAL_TO_LONG: query.notEqualTo(             AllJavaTypes.FIELD_LONG,    1L); break;
+            case NOT_EQUAL_TO_DOUBLE: query.notEqualTo(           AllJavaTypes.FIELD_DOUBLE,  1D); break;
+            case NOT_EQUAL_TO_FLOAT: query.notEqualTo(            AllJavaTypes.FIELD_FLOAT,   1F); break;
+            case NOT_EQUAL_TO_BOOLEAN: query.notEqualTo(          AllJavaTypes.FIELD_BOOLEAN, true); break;
+            case NOT_EQUAL_TO_DATE: query.notEqualTo(             AllJavaTypes.FIELD_DATE,    new Date(0L)); break;
 
-            case GREATER_THAN_INTEGER: query.greaterThan(fieldName, 1); break;
-            case GREATER_THAN_LONG: query.greaterThan(fieldName, 1L); break;
-            case GREATER_THAN_DOUBLE: query.greaterThan(fieldName, 1D); break;
-            case GREATER_THAN_FLOAT: query.greaterThan(fieldName, 1F); break;
-            case GREATER_THAN_DATE: query.greaterThan(fieldName, new Date(0L)); break;
+            case GREATER_THAN_INTEGER: query.greaterThan( AllJavaTypes.FIELD_INT,    1); break;
+            case GREATER_THAN_LONG: query.greaterThan(    AllJavaTypes.FIELD_LONG,   1L); break;
+            case GREATER_THAN_DOUBLE: query.greaterThan(  AllJavaTypes.FIELD_DOUBLE, 1D); break;
+            case GREATER_THAN_FLOAT: query.greaterThan(   AllJavaTypes.FIELD_FLOAT,  1F); break;
+            case GREATER_THAN_DATE: query.greaterThan(    AllJavaTypes.FIELD_DATE,   new Date(0L)); break;
 
-            case GREATER_THAN_OR_EQUAL_TO_INTEGER: query.greaterThanOrEqualTo(fieldName, 1); break;
-            case GREATER_THAN_OR_EQUAL_TO_LONG: query.greaterThanOrEqualTo(fieldName, 1L); break;
-            case GREATER_THAN_OR_EQUAL_TO_DOUBLE: query.greaterThanOrEqualTo(fieldName, 1D); break;
-            case GREATER_THAN_OR_EQUAL_TO_FLOAT: query.greaterThanOrEqualTo(fieldName, 1F); break;
-            case GREATER_THAN_OR_EQUAL_TO_DATE: query.greaterThanOrEqualTo(fieldName, new Date(0L)); break;
+            case GREATER_THAN_OR_EQUAL_TO_INTEGER: query.greaterThanOrEqualTo( AllJavaTypes.FIELD_INT,    1); break;
+            case GREATER_THAN_OR_EQUAL_TO_LONG: query.greaterThanOrEqualTo(    AllJavaTypes.FIELD_LONG,   1L); break;
+            case GREATER_THAN_OR_EQUAL_TO_DOUBLE: query.greaterThanOrEqualTo(  AllJavaTypes.FIELD_DOUBLE, 1D); break;
+            case GREATER_THAN_OR_EQUAL_TO_FLOAT: query.greaterThanOrEqualTo(   AllJavaTypes.FIELD_FLOAT,  1F); break;
+            case GREATER_THAN_OR_EQUAL_TO_DATE: query.greaterThanOrEqualTo(    AllJavaTypes.FIELD_DATE,   new Date(0L)); break;
 
-            case LESS_THAN_INTEGER: query.lessThan(fieldName, 1); break;
-            case LESS_THAN_LONG: query.lessThan(fieldName, 1L); break;
-            case LESS_THAN_DOUBLE: query.lessThan(fieldName, 1D); break;
-            case LESS_THAN_FLOAT: query.lessThan(fieldName, 1F); break;
-            case LESS_THAN_DATE: query.lessThan(fieldName, new Date(0L)); break;
+            case LESS_THAN_INTEGER: query.lessThan( AllJavaTypes.FIELD_INT,    1); break;
+            case LESS_THAN_LONG: query.lessThan(    AllJavaTypes.FIELD_LONG,   1L); break;
+            case LESS_THAN_DOUBLE: query.lessThan(  AllJavaTypes.FIELD_DOUBLE, 1D); break;
+            case LESS_THAN_FLOAT: query.lessThan(   AllJavaTypes.FIELD_FLOAT,  1F); break;
+            case LESS_THAN_DATE: query.lessThan(    AllJavaTypes.FIELD_DATE,   new Date(0L)); break;
 
-            case LESS_THAN_OR_EQUAL_TO_INTEGER: query.lessThanOrEqualTo(fieldName, 1); break;
-            case LESS_THAN_OR_EQUAL_TO_LONG: query.lessThanOrEqualTo(fieldName, 1L); break;
-            case LESS_THAN_OR_EQUAL_TO_DOUBLE: query.lessThanOrEqualTo(fieldName, 1D); break;
-            case LESS_THAN_OR_EQUAL_TO_FLOAT: query.lessThanOrEqualTo(fieldName, 1F); break;
-            case LESS_THAN_OR_EQUAL_TO_DATE: query.lessThanOrEqualTo(fieldName, new Date(0L)); break;
+            case LESS_THAN_OR_EQUAL_TO_INTEGER: query.lessThanOrEqualTo( AllJavaTypes.FIELD_INT,    1); break;
+            case LESS_THAN_OR_EQUAL_TO_LONG: query.lessThanOrEqualTo(    AllJavaTypes.FIELD_LONG,   1L); break;
+            case LESS_THAN_OR_EQUAL_TO_DOUBLE: query.lessThanOrEqualTo(  AllJavaTypes.FIELD_DOUBLE, 1D); break;
+            case LESS_THAN_OR_EQUAL_TO_FLOAT: query.lessThanOrEqualTo(   AllJavaTypes.FIELD_FLOAT,  1F); break;
+            case LESS_THAN_OR_EQUAL_TO_DATE: query.lessThanOrEqualTo(    AllJavaTypes.FIELD_DATE,   new Date(0L)); break;
 
-            case BETWEEN_INTEGER: query.between(fieldName, 1, 100); break;
-            case BETWEEN_LONG: query.between(fieldName, 1L, 100L); break;
-            case BETWEEN_DOUBLE: query.between(fieldName, 1D, 100D); break;
-            case BETWEEN_FLOAT: query.between(fieldName, 1F, 100F); break;
-            case BETWEEN_DATE: query.between(fieldName, new Date(0L), new Date(10000L)); break;
+            case BETWEEN_INTEGER: query.between( AllJavaTypes.FIELD_INT,    1, 100); break;
+            case BETWEEN_LONG: query.between(    AllJavaTypes.FIELD_LONG,   1L, 100L); break;
+            case BETWEEN_DOUBLE: query.between(  AllJavaTypes.FIELD_DOUBLE, 1D, 100D); break;
+            case BETWEEN_FLOAT: query.between(   AllJavaTypes.FIELD_FLOAT,  1F, 100F); break;
+            case BETWEEN_DATE: query.between(    AllJavaTypes.FIELD_DATE,   new Date(0L), new Date(10000L)); break;
 
-            case CONTAINS_STRING: query.contains(fieldName, "dummy value"); break;
-            case CONTAINS_STRING_WITH_CASE: query.contains(fieldName, "dummy value", Case.INSENSITIVE); break;
+            case CONTAINS_STRING: query.contains(           AllJavaTypes.FIELD_STRING, "dummy value"); break;
+            case CONTAINS_STRING_WITH_CASE: query.contains( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;
 
-            case BEGINS_WITH_STRING: query.beginsWith(fieldName, "dummy value"); break;
-            case BEGINS_WITH_STRING_WITH_CASE: query.beginsWith(fieldName, "dummy value", Case.INSENSITIVE); break;
+            case BEGINS_WITH_STRING: query.beginsWith(           AllJavaTypes.FIELD_STRING, "dummy value"); break;
+            case BEGINS_WITH_STRING_WITH_CASE: query.beginsWith( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;
 
-            case ENDS_WITH_STRING: query.endsWith(fieldName, "dummy value"); break;
-            case WNDS_WITH_STRING_WITH_CASE: query.endsWith(fieldName, "dummy value", Case.INSENSITIVE); break;
+            case ENDS_WITH_STRING: query.endsWith(           AllJavaTypes.FIELD_STRING, "dummy value"); break;
+            case WNDS_WITH_STRING_WITH_CASE: query.endsWith( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;
 
-            case LIKE_STRING: query.like(fieldName, "dummy value"); break;
-            case LIKE_STRING_WITH_CASE: query.like(fieldName, "dummy value", Case.INSENSITIVE); break;
+            case LIKE_STRING: query.like(           AllJavaTypes.FIELD_STRING, "dummy value"); break;
+            case LIKE_STRING_WITH_CASE: query.like( AllJavaTypes.FIELD_STRING, "dummy value", Case.INSENSITIVE); break;
 
             case BEGIN_GROUP: query.beginGroup(); break;
             case END_GROUP: query.endGroup(); break;
             case OR: query.or(); break;
             case NOT: query.not(); break;
-            case IS_NULL: query.isNull(fieldName); break;
-            case IS_NOT_NULL: query.isNotNull(fieldName); break;
-            case IS_EMPTY: query.isEmpty(fieldName); break;
-            case IS_NOT_EMPTY: query.isNotEmpty(fieldName); break;
+            case IS_NULL: query.isNull(          AllJavaTypes.FIELD_DATE); break;
+            case IS_NOT_NULL: query.isNotNull(   AllJavaTypes.FIELD_DATE); break;
+            case IS_EMPTY: query.isEmpty(        AllJavaTypes.FIELD_STRING); break;
+            case IS_NOT_EMPTY: query.isNotEmpty( AllJavaTypes.FIELD_STRING); break;
 
             case IS_VALID: query.isValid(); break;
-            case DISTINCT: query.distinct(fieldName); break;
-            case DISTINCT_BY_MULTIPLE_FIELDS: query.distinct(fieldName, AllJavaTypes.FIELD_ID); break;
-            case DISTINCT_ASYNC: query.distinctAsync(fieldName); break;
+            case DISTINCT: query.distinct(                    AllJavaTypes.FIELD_STRING); break;
+            case DISTINCT_BY_MULTIPLE_FIELDS: query.distinct( AllJavaTypes.FIELD_STRING, AllJavaTypes.FIELD_ID); break;
+            case DISTINCT_ASYNC: query.distinctAsync(         AllJavaTypes.FIELD_STRING); break;
 
-            case SUM: query.sum(fieldName); break;
-            case AVERAGE: query.average(fieldName); break;
-            case MIN: query.min(fieldName); break;
-            case MINIMUM_DATE: query.minimumDate(fieldName); break;
-            case MAX: query.max(fieldName); break;
-            case MAXIMUM_DATE: query.maximumDate(fieldName); break;
+            case SUM: query.sum(                  AllJavaTypes.FIELD_INT); break;
+            case AVERAGE: query.average(          AllJavaTypes.FIELD_INT); break;
+            case MIN: query.min(                  AllJavaTypes.FIELD_INT); break;
+            case MINIMUM_DATE: query.minimumDate( AllJavaTypes.FIELD_INT); break;
+            case MAX: query.max(                  AllJavaTypes.FIELD_INT); break;
+            case MAXIMUM_DATE: query.maximumDate( AllJavaTypes.FIELD_INT); break;
             case COUNT: query.count(); break;
 
             case FIND_ALL: query.findAll(); break;
             case FIND_ALL_ASYNC: query.findAllAsync(); break;
-            case FIND_ALL_SORTED: query.findAllSorted(fieldName); break;
-            case FIND_ALL_SORTED_ASYNC: query.findAllSortedAsync(fieldName); break;
-            case FIND_ALL_SORTED_WITH_ORDER: query.findAllSorted(fieldName, Sort.DESCENDING); break;
-            case FIND_ALL_SORTED_ASYNC_WITH_ORDER: query.findAllSortedAsync(fieldName, Sort.DESCENDING); break;
-            case FIND_ALL_SORTED_WITH_TWO_ORDERS: query.findAllSorted(fieldName, Sort.DESCENDING, AllJavaTypes.FIELD_ID, Sort.DESCENDING); break;
-            case FIND_ALL_SORTED_ASYNC_WITH_TWO_ORDERS: query.findAllSortedAsync(fieldName, Sort.DESCENDING, AllJavaTypes.FIELD_ID, Sort.DESCENDING); break;
-            case FIND_ALL_SORTED_WITH_MANY_ORDERS: query.findAllSorted(new String[] {fieldName, AllJavaTypes.FIELD_ID}, new Sort[] {Sort.DESCENDING, Sort.DESCENDING}); break;
-            case FIND_ALL_SORTED_ASYNC_WITH_MANY_ORDERS: query.findAllSortedAsync(new String[] {fieldName, AllJavaTypes.FIELD_ID}, new Sort[] {Sort.DESCENDING, Sort.DESCENDING}); break;
+            case FIND_ALL_SORTED: query.findAllSorted(                             AllJavaTypes.FIELD_STRING); break;
+            case FIND_ALL_SORTED_ASYNC: query.findAllSortedAsync(                  AllJavaTypes.FIELD_STRING); break;
+            case FIND_ALL_SORTED_WITH_ORDER: query.findAllSorted(                  AllJavaTypes.FIELD_STRING, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_ASYNC_WITH_ORDER: query.findAllSortedAsync(       AllJavaTypes.FIELD_STRING, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_WITH_TWO_ORDERS: query.findAllSorted(             AllJavaTypes.FIELD_STRING, Sort.DESCENDING, AllJavaTypes.FIELD_ID, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_ASYNC_WITH_TWO_ORDERS: query.findAllSortedAsync(  AllJavaTypes.FIELD_STRING, Sort.DESCENDING, AllJavaTypes.FIELD_ID, Sort.DESCENDING); break;
+            case FIND_ALL_SORTED_WITH_MANY_ORDERS: query.findAllSorted(            new String[] {AllJavaTypes.FIELD_STRING, AllJavaTypes.FIELD_ID}, new Sort[] {Sort.DESCENDING, Sort.DESCENDING}); break;
+            case FIND_ALL_SORTED_ASYNC_WITH_MANY_ORDERS: query.findAllSortedAsync( new String[] {AllJavaTypes.FIELD_STRING, AllJavaTypes.FIELD_ID}, new Sort[] {Sort.DESCENDING, Sort.DESCENDING}); break;
 
             case FIND_FIRST: query.findFirst(); break;
             case FIND_FIRST_ASYNC: query.findFirstAsync(); break;
@@ -423,126 +417,6 @@ public class RealmQueryTests {
 
     @Test
     public void callThreadConfinedMethodsFromWrongThread() throws Throwable {
-        final List<Pair<ThreadConfinedQueryMethods, String>> methodParams = Arrays.asList(
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_BYTE, AllJavaTypes.FIELD_BYTE),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_BYTE_ARRAY, AllJavaTypes.FIELD_BINARY),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_SHORT, AllJavaTypes.FIELD_SHORT),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_INTEGER, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_BOOLEAN, AllJavaTypes.FIELD_BOOLEAN),
-                pairOf(ThreadConfinedQueryMethods.EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.IN_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.IN_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.IN_BYTE, AllJavaTypes.FIELD_BYTE),
-                pairOf(ThreadConfinedQueryMethods.IN_SHORT, AllJavaTypes.FIELD_SHORT),
-                pairOf(ThreadConfinedQueryMethods.IN_INTEGER, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.IN_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.IN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.IN_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.IN_BOOLEAN, AllJavaTypes.FIELD_BOOLEAN),
-                pairOf(ThreadConfinedQueryMethods.IN_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_BYTE, AllJavaTypes.FIELD_BYTE),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_BYTE_ARRAY, AllJavaTypes.FIELD_BINARY),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_SHORT, AllJavaTypes.FIELD_SHORT),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_INTEGER, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_BOOLEAN, AllJavaTypes.FIELD_BOOLEAN),
-                pairOf(ThreadConfinedQueryMethods.NOT_EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_INTEGER, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_INTEGER, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.GREATER_THAN_OR_EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_INTEGER, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_INTEGER, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.LESS_THAN_OR_EQUAL_TO_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.BETWEEN_INTEGER, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.BETWEEN_LONG, AllJavaTypes.FIELD_LONG),
-                pairOf(ThreadConfinedQueryMethods.BETWEEN_DOUBLE, AllJavaTypes.FIELD_DOUBLE),
-                pairOf(ThreadConfinedQueryMethods.BETWEEN_FLOAT, AllJavaTypes.FIELD_FLOAT),
-                pairOf(ThreadConfinedQueryMethods.BETWEEN_DATE, AllJavaTypes.FIELD_DATE),
-
-                pairOf(ThreadConfinedQueryMethods.CONTAINS_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.CONTAINS_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
-
-                pairOf(ThreadConfinedQueryMethods.BEGINS_WITH_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.BEGINS_WITH_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
-
-                pairOf(ThreadConfinedQueryMethods.ENDS_WITH_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.WNDS_WITH_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
-
-                pairOf(ThreadConfinedQueryMethods.LIKE_STRING, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.LIKE_STRING_WITH_CASE, AllJavaTypes.FIELD_STRING),
-
-                pairOf(ThreadConfinedQueryMethods.BEGIN_GROUP, null),
-                pairOf(ThreadConfinedQueryMethods.END_GROUP, null),
-                pairOf(ThreadConfinedQueryMethods.OR, null),
-                pairOf(ThreadConfinedQueryMethods.NOT, null),
-                pairOf(ThreadConfinedQueryMethods.IS_NULL, AllJavaTypes.FIELD_DATE),
-                pairOf(ThreadConfinedQueryMethods.IS_NOT_NULL, AllJavaTypes.FIELD_DATE),
-                pairOf(ThreadConfinedQueryMethods.IS_EMPTY, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.IS_NOT_EMPTY, AllJavaTypes.FIELD_STRING),
-
-                pairOf(ThreadConfinedQueryMethods.IS_VALID, null),
-                pairOf(ThreadConfinedQueryMethods.DISTINCT, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.DISTINCT_BY_MULTIPLE_FIELDS, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.DISTINCT_ASYNC, AllJavaTypes.FIELD_STRING),
-
-                pairOf(ThreadConfinedQueryMethods.SUM, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.AVERAGE, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.MIN, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.MINIMUM_DATE, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.MAX, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.MAXIMUM_DATE, AllJavaTypes.FIELD_INT),
-                pairOf(ThreadConfinedQueryMethods.COUNT, null),
-
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL, null),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_ASYNC, null),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_WITH_ORDER, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC_WITH_ORDER, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_WITH_TWO_ORDERS, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC_WITH_TWO_ORDERS, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_WITH_MANY_ORDERS, AllJavaTypes.FIELD_STRING),
-                pairOf(ThreadConfinedQueryMethods.FIND_ALL_SORTED_ASYNC_WITH_MANY_ORDERS, AllJavaTypes.FIELD_STRING),
-
-                pairOf(ThreadConfinedQueryMethods.FIND_FIRST, null),
-                pairOf(ThreadConfinedQueryMethods.FIND_FIRST_ASYNC, null)
-        );
-
-        if (ThreadConfinedQueryMethods.values().length != methodParams.size()) {
-            throw new RuntimeException("missing some entries in 'methodParams'.");
-        }
-
         final RealmQuery<AllJavaTypes> query = realm.where(AllJavaTypes.class);
 
         final AtomicReference<Throwable> throwableFromThread = new AtomicReference<Throwable>();
@@ -560,15 +434,13 @@ public class RealmQueryTests {
             throw new AssertionError(e);
         }
 
-        final Thread thread = new Thread("addingQueryParamFromWrongThread") {
+        final Thread thread = new Thread("callThreadConfinedMethodsFromWrongThread") {
             @Override
             public void run() {
                 try {
-                    for (Pair<ThreadConfinedQueryMethods, String> methodParam : methodParams) {
-                        ThreadConfinedQueryMethods queryMethod = methodParam.first;
-                        String fieldName = methodParam.second;
+                    for (ThreadConfinedMethods method : ThreadConfinedMethods.values()) {
                         try {
-                            callThreadConfinedMethod(query, queryMethod, fieldName);
+                            callThreadConfinedMethod(query, method);
                             fail("IllegalStateException must be thrown.");
                         } catch (Throwable e) {
                             if (e instanceof IllegalStateException && expectedMessage.equals(e.getMessage())) {

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -241,8 +241,6 @@ public class RealmQuery<E extends RealmModel> {
         return this;
     }
 
-    // Equal
-
     /**
      * Equal-to comparison.
      *
@@ -484,8 +482,6 @@ public class RealmQuery<E extends RealmModel> {
         return this;
     }
 
-    // In
-
     /**
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
@@ -697,8 +693,6 @@ public class RealmQuery<E extends RealmModel> {
         }
         return endGroupWithoutThreadValidation();
     }
-
-    // Not Equal
 
     /**
      * Not-equal-to comparison.
@@ -912,8 +906,6 @@ public class RealmQuery<E extends RealmModel> {
         return this;
     }
 
-    // Greater Than
-
     /**
      * Greater-than comparison.
      *
@@ -993,8 +985,6 @@ public class RealmQuery<E extends RealmModel> {
         this.query.greaterThan(columnIndices, value);
         return this;
     }
-
-    // Greater Than Or Equal To
 
     /**
      * Greater-than-or-equal-to comparison.
@@ -1076,8 +1066,6 @@ public class RealmQuery<E extends RealmModel> {
         return this;
     }
 
-    // Less Than
-
     /**
      * Less-than comparison.
      *
@@ -1158,8 +1146,6 @@ public class RealmQuery<E extends RealmModel> {
         return this;
     }
 
-    // Less Than Or Equal To
-
     /**
      * Less-than-or-equal-to comparison.
      *
@@ -1239,8 +1225,6 @@ public class RealmQuery<E extends RealmModel> {
         this.query.lessThanOrEqual(columnIndices, value);
         return this;
     }
-
-    // Between
 
     /**
      * Between condition.
@@ -1328,8 +1312,6 @@ public class RealmQuery<E extends RealmModel> {
     }
 
 
-    // Contains
-
     /**
      * Condition that value of field contains the specified substring.
      *
@@ -1358,8 +1340,6 @@ public class RealmQuery<E extends RealmModel> {
         this.query.contains(columnIndices, value, casing);
         return this;
     }
-
-    // Begins With
 
     /**
      * Condition that the value of field begins with the specified string.
@@ -1390,8 +1370,6 @@ public class RealmQuery<E extends RealmModel> {
         return this;
     }
 
-    // Ends With
-
     /**
      * Condition that the value of field ends with the specified string.
      *
@@ -1420,8 +1398,6 @@ public class RealmQuery<E extends RealmModel> {
         this.query.endsWith(columnIndices, value, casing);
         return this;
     }
-
-    // Like
 
     /**
      * Condition that the value of field matches with the specified substring, with wildcards:
@@ -1460,8 +1436,6 @@ public class RealmQuery<E extends RealmModel> {
         return this;
     }
 
-
-    // Grouping
 
     /**
      * Begin grouping of conditions ("left parenthesis"). A group must be closed with a call to {@code endGroup()}.
@@ -1737,10 +1711,6 @@ public class RealmQuery<E extends RealmModel> {
         return columnIndexes;
     }
 
-    // Aggregates
-
-    // Sum
-
     /**
      * Calculates the sum of a given field.
      *
@@ -1766,8 +1736,6 @@ public class RealmQuery<E extends RealmModel> {
         }
     }
 
-    // Average
-
     /**
      * Returns the average of a given field.
      *
@@ -1792,8 +1760,6 @@ public class RealmQuery<E extends RealmModel> {
                 throw new IllegalArgumentException(String.format(TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
-
-    // Min
 
     /**
      * Finds the minimum value of a field.
@@ -1835,8 +1801,6 @@ public class RealmQuery<E extends RealmModel> {
         long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         return this.query.minimumDate(columnIndex);
     }
-
-    // Max
 
     /**
      * Finds the maximum value of a field.

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -191,11 +191,9 @@ public class RealmQuery<E extends RealmModel> {
      * @return {@code true} if still valid to use, {@code false} otherwise.
      */
     public boolean isValid() {
-        if (realm == null || realm.isClosed()) {
+        if (realm == null || realm.isClosed() /* this includes thread checking */) {
             return false;
         }
-
-        realm.checkIfValid();
 
         if (linkView != null) {
             return linkView.isAttached();

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -195,6 +195,8 @@ public class RealmQuery<E extends RealmModel> {
             return false;
         }
 
+        realm.checkIfValid();
+
         if (linkView != null) {
             return linkView.isAttached();
         }
@@ -214,6 +216,8 @@ public class RealmQuery<E extends RealmModel> {
      * @see Required for further infomation.
      */
     public RealmQuery<E> isNull(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName);
 
         // Checks that fieldName has the correct type is done in C++.
@@ -230,6 +234,8 @@ public class RealmQuery<E extends RealmModel> {
      * @see Required for further infomation.
      */
     public RealmQuery<E> isNotNull(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName);
 
         // Checks that fieldName has the correct type is done in C++.
@@ -261,6 +267,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, String value, Case casing) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value, casing);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, String value, Case casing) {
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
         this.query.equalTo(columnIndices, value, casing);
         return this;
@@ -275,6 +287,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Byte value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Byte value) {
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -293,6 +311,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, byte[] value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.BINARY);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -311,6 +331,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Short value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Short value) {
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -329,6 +355,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Integer value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Integer value) {
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -347,6 +379,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Long value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Long value) {
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -355,6 +393,7 @@ public class RealmQuery<E extends RealmModel> {
         }
         return this;
     }
+
     /**
      * Equal-to comparison.
      *
@@ -364,6 +403,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Double value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Double value) {
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -382,6 +427,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Float value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Float value) {
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -400,6 +451,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Boolean value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Boolean value) {
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.BOOLEAN);
         if (value == null) {
             this.query.isNull(columnIndices);
@@ -418,6 +475,12 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> equalTo(String fieldName, Date value) {
+        realm.checkIfValid();
+
+        return equalToWithoutThreadValidation(fieldName, value);
+    }
+
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Date value) {
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         this.query.equalTo(columnIndices, value);
         return this;
@@ -449,14 +512,16 @@ public class RealmQuery<E extends RealmModel> {
      * empty.
      */
     public RealmQuery<E> in(String fieldName, String[] values, Case casing) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0], casing);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0], casing);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i], casing);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i], casing);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -469,14 +534,16 @@ public class RealmQuery<E extends RealmModel> {
      * empty.
      */
     public RealmQuery<E> in(String fieldName, Byte[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -489,14 +556,16 @@ public class RealmQuery<E extends RealmModel> {
      * empty.
      */
     public RealmQuery<E> in(String fieldName, Short[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -509,14 +578,16 @@ public class RealmQuery<E extends RealmModel> {
      * or empty.
      */
     public RealmQuery<E> in(String fieldName, Integer[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -529,14 +600,16 @@ public class RealmQuery<E extends RealmModel> {
      * empty.
      */
     public RealmQuery<E> in(String fieldName, Long[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -549,14 +622,16 @@ public class RealmQuery<E extends RealmModel> {
      * empty.
      */
     public RealmQuery<E> in(String fieldName, Double[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -569,14 +644,16 @@ public class RealmQuery<E extends RealmModel> {
      * empty.
      */
     public RealmQuery<E> in(String fieldName, Float[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -589,14 +666,16 @@ public class RealmQuery<E extends RealmModel> {
      * or empty.
      */
     public RealmQuery<E> in(String fieldName, Boolean[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -609,14 +688,16 @@ public class RealmQuery<E extends RealmModel> {
      * empty.
      */
     public RealmQuery<E> in(String fieldName, Date[] values) {
+        realm.checkIfValid();
+
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
-        beginGroup().equalTo(fieldName, values[0]);
+        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
         for (int i = 1; i < values.length; i++) {
-            or().equalTo(fieldName, values[i]);
+            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
         }
-        return endGroup();
+        return endGroupWithoutThreadValidation();
     }
 
     // Not Equal
@@ -643,6 +724,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, String value, Case casing) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
         if (columnIndices.length > 1 && !casing.getValue()) {
             throw new IllegalArgumentException("Link queries cannot be case insensitive - coming soon.");
@@ -660,6 +743,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Byte value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -678,6 +763,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, byte[] value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.BINARY);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -696,6 +783,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Short value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -714,6 +803,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Integer value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -732,6 +823,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Long value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -750,6 +843,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Double value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -768,6 +863,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Float value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -786,6 +883,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Boolean value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.BOOLEAN);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -804,6 +903,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> notEqualTo(String fieldName, Date value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         if (value == null) {
             this.query.isNotNull(columnIndices);
@@ -824,6 +925,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThan(String fieldName, int value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.greaterThan(columnIndices, value);
         return this;
@@ -838,6 +941,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThan(String fieldName, long value) {
+        realm.checkIfValid();
+
         long[] columnIndices = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.greaterThan(columnIndices, value);
         return this;
@@ -852,6 +957,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThan(String fieldName, double value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         this.query.greaterThan(columnIndices, value);
         return this;
@@ -866,6 +973,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThan(String fieldName, float value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         this.query.greaterThan(columnIndices, value);
         return this;
@@ -880,10 +989,14 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThan(String fieldName, Date value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         this.query.greaterThan(columnIndices, value);
         return this;
     }
+
+    // Greater Than Or Equal To
 
     /**
      * Greater-than-or-equal-to comparison.
@@ -894,6 +1007,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThanOrEqualTo(String fieldName, int value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.greaterThanOrEqual(columnIndices, value);
         return this;
@@ -908,6 +1023,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThanOrEqualTo(String fieldName, long value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.greaterThanOrEqual(columnIndices, value);
         return this;
@@ -922,6 +1039,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThanOrEqualTo(String fieldName, double value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         this.query.greaterThanOrEqual(columnIndices, value);
         return this;
@@ -936,6 +1055,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type
      */
     public RealmQuery<E> greaterThanOrEqualTo(String fieldName, float value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         this.query.greaterThanOrEqual(columnIndices, value);
         return this;
@@ -950,6 +1071,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> greaterThanOrEqualTo(String fieldName, Date value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         this.query.greaterThanOrEqual(columnIndices, value);
         return this;
@@ -966,6 +1089,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThan(String fieldName, int value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.lessThan(columnIndices, value);
         return this;
@@ -980,6 +1105,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThan(String fieldName, long value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.lessThan(columnIndices, value);
         return this;
@@ -994,6 +1121,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThan(String fieldName, double value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         this.query.lessThan(columnIndices, value);
         return this;
@@ -1008,6 +1137,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThan(String fieldName, float value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         this.query.lessThan(columnIndices, value);
         return this;
@@ -1022,10 +1153,14 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThan(String fieldName, Date value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         this.query.lessThan(columnIndices, value);
         return this;
     }
+
+    // Less Than Or Equal To
 
     /**
      * Less-than-or-equal-to comparison.
@@ -1036,6 +1171,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThanOrEqualTo(String fieldName, int value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.lessThanOrEqual(columnIndices, value);
         return this;
@@ -1050,6 +1187,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThanOrEqualTo(String fieldName, long value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.lessThanOrEqual(columnIndices, value);
         return this;
@@ -1064,6 +1203,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThanOrEqualTo(String fieldName, double value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         this.query.lessThanOrEqual(columnIndices, value);
         return this;
@@ -1078,6 +1219,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThanOrEqualTo(String fieldName, float value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         this.query.lessThanOrEqual(columnIndices, value);
         return this;
@@ -1092,6 +1235,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> lessThanOrEqualTo(String fieldName, Date value) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         this.query.lessThanOrEqual(columnIndices, value);
         return this;
@@ -1109,6 +1254,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> between(String fieldName, int from, int to) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.between(columnIndices, from, to);
         return this;
@@ -1124,6 +1271,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> between(String fieldName, long from, long to) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         this.query.between(columnIndices, from, to);
         return this;
@@ -1139,6 +1288,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> between(String fieldName, double from, double to) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         this.query.between(columnIndices, from, to);
         return this;
@@ -1154,6 +1305,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> between(String fieldName, float from, float to) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         this.query.between(columnIndices, from, to);
         return this;
@@ -1169,6 +1322,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> between(String fieldName, Date from, Date to) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         this.query.between(columnIndices, from, to);
         return this;
@@ -1199,10 +1354,14 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> contains(String fieldName, String value, Case casing) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
         this.query.contains(columnIndices, value, casing);
         return this;
     }
+
+    // Begins With
 
     /**
      * Condition that the value of field begins with the specified string.
@@ -1226,10 +1385,14 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> beginsWith(String fieldName, String value, Case casing) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
         this.query.beginsWith(columnIndices, value, casing);
         return this;
     }
+
+    // Ends With
 
     /**
      * Condition that the value of field ends with the specified string.
@@ -1253,6 +1416,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> endsWith(String fieldName, String value, Case casing) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
         this.query.endsWith(columnIndices, value, casing);
         return this;
@@ -1290,6 +1455,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
     public RealmQuery<E> like(String fieldName, String value, Case casing) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
         this.query.like(columnIndices, value, casing);
         return this;
@@ -1305,6 +1472,12 @@ public class RealmQuery<E extends RealmModel> {
      * @see #endGroup()
      */
     public RealmQuery<E> beginGroup() {
+        realm.checkIfValid();
+
+        return beginGroupWithoutThreadValidation();
+    }
+
+    private RealmQuery<E> beginGroupWithoutThreadValidation() {
         this.query.group();
         return this;
     }
@@ -1316,6 +1489,12 @@ public class RealmQuery<E extends RealmModel> {
      * @see #beginGroup()
      */
     public RealmQuery<E> endGroup() {
+        realm.checkIfValid();
+
+        return endGroupWithoutThreadValidation();
+    }
+
+    private RealmQuery<E> endGroupWithoutThreadValidation() {
         this.query.endGroup();
         return this;
     }
@@ -1326,6 +1505,12 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      */
     public RealmQuery<E> or() {
+        realm.checkIfValid();
+
+        return orWithoutThreadValidation();
+    }
+
+    private RealmQuery<E> orWithoutThreadValidation() {
         this.query.or();
         return this;
     }
@@ -1336,6 +1521,8 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      */
     public RealmQuery<E> not() {
+        realm.checkIfValid();
+
         this.query.not();
         return this;
     }
@@ -1349,6 +1536,8 @@ public class RealmQuery<E extends RealmModel> {
      * String or byte array.
      */
     public RealmQuery<E> isEmpty(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING, RealmFieldType.BINARY, RealmFieldType.LIST);
         this.query.isEmpty(columnIndices);
         return this;
@@ -1363,6 +1552,8 @@ public class RealmQuery<E extends RealmModel> {
      * String or byte array.
      */
     public RealmQuery<E> isNotEmpty(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndices[] = schema.getColumnIndices(fieldName, RealmFieldType.STRING, RealmFieldType.BINARY, RealmFieldType.LIST);
         this.query.isNotEmpty(columnIndices);
         return this;
@@ -1379,6 +1570,8 @@ public class RealmQuery<E extends RealmModel> {
      * is not indexed, or points to linked fields.
      */
     public RealmResults<E> distinct(String fieldName) {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         long columnIndex = getAndValidateDistinctColumnIndex(fieldName, this.table.getTable());
         TableView tableView = this.query.findAll();
@@ -1407,6 +1600,8 @@ public class RealmQuery<E extends RealmModel> {
      * is not indexed, or points to linked fields.
      */
     public RealmResults<E> distinctAsync(String fieldName) {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         final long columnIndex = getAndValidateDistinctColumnIndex(fieldName, this.table.getTable());
         final WeakReference<RealmNotifier> weakNotifier = getWeakReferenceNotifier();
@@ -1511,6 +1706,8 @@ public class RealmQuery<E extends RealmModel> {
      * is an unsupported type, or points to a linked field.
      */
     public RealmResults<E> distinct(String firstFieldName, String... remainingFieldNames) {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         List<Long> columnIndexes = getValidatedColumIndexes(this.table.getTable(), firstFieldName, remainingFieldNames);
         TableView tableView = this.query.findAll();
@@ -1556,6 +1753,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if the field is not a number type.
      */
     public Number sum(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
@@ -1581,6 +1780,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.IllegalArgumentException if the field is not a number type.
      */
     public double average(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
@@ -1607,6 +1808,7 @@ public class RealmQuery<E extends RealmModel> {
      */
     public Number min(String fieldName) {
         realm.checkIfValid();
+
         long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
@@ -1630,6 +1832,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.UnsupportedOperationException if the query is not valid ("syntax error").
      */
     public Date minimumDate(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         return this.query.minimumDate(columnIndex);
     }
@@ -1647,6 +1851,7 @@ public class RealmQuery<E extends RealmModel> {
      */
     public Number max(String fieldName) {
         realm.checkIfValid();
+
         long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         switch (table.getColumnType(columnIndex)) {
             case INTEGER:
@@ -1670,6 +1875,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.UnsupportedOperationException if the query is not valid ("syntax error").
      */
     public Date maximumDate(String fieldName) {
+        realm.checkIfValid();
+
         long columnIndex = schema.getAndCheckFieldIndex(fieldName);
         return this.query.maximumDate(columnIndex);
     }
@@ -1681,6 +1888,8 @@ public class RealmQuery<E extends RealmModel> {
      * @throws java.lang.UnsupportedOperationException if the query is not valid ("syntax error").
      */
     public long count() {
+        realm.checkIfValid();
+
         return this.query.count();
     }
 
@@ -1693,6 +1902,8 @@ public class RealmQuery<E extends RealmModel> {
      */
     @SuppressWarnings("unchecked")
     public RealmResults<E> findAll() {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         RealmResults<E> realmResults;
         if (isDynamicQuery()) {
@@ -1712,6 +1923,8 @@ public class RealmQuery<E extends RealmModel> {
      * @see io.realm.RealmResults
      */
     public RealmResults<E> findAllAsync() {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         final WeakReference<RealmNotifier> weakNotifier = getWeakReferenceNotifier();
 
@@ -1801,6 +2014,8 @@ public class RealmQuery<E extends RealmModel> {
      */
     @SuppressWarnings("unchecked")
     public RealmResults<E> findAllSorted(String fieldName, Sort sortOrder) {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         TableView tableView = query.findAll();
         long columnIndex = getColumnIndexForSort(fieldName);
@@ -1825,6 +2040,8 @@ public class RealmQuery<E extends RealmModel> {
      * {@link RealmObject} or a child {@link RealmList}.
      */
     public RealmResults<E> findAllSortedAsync(final String fieldName, final Sort sortOrder) {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         long columnIndex = getColumnIndexForSort(fieldName);
 
@@ -1945,6 +2162,8 @@ public class RealmQuery<E extends RealmModel> {
      */
     @SuppressWarnings("unchecked")
     public RealmResults<E> findAllSorted(String fieldNames[], Sort sortOrders[]) {
+        realm.checkIfValid();
+
         checkSortParameters(fieldNames, sortOrders);
 
         if (fieldNames.length == 1 && sortOrders.length == 1) {
@@ -1986,6 +2205,8 @@ public class RealmQuery<E extends RealmModel> {
      * {@link RealmObject} or a child {@link RealmList}.
      */
     public RealmResults<E> findAllSortedAsync(String fieldNames[], final Sort[] sortOrders) {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         checkSortParameters(fieldNames, sortOrders);
 
@@ -2112,6 +2333,8 @@ public class RealmQuery<E extends RealmModel> {
      * @see io.realm.RealmObject
      */
     public E findFirst() {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         long tableRowIndex = getSourceRowIndexForFirstObject();
         if (tableRowIndex >= 0) {
@@ -2134,6 +2357,8 @@ public class RealmQuery<E extends RealmModel> {
      * {@code false}.
      */
     public E findFirstAsync() {
+        realm.checkIfValid();
+
         checkQueryIsNotReused();
         final WeakReference<RealmNotifier> weakNotifier = getWeakReferenceNotifier();
 


### PR DESCRIPTION
Throw IllegalStateException instead of process crash when any of thread confined methods in RealmQuery is called from wrong thread.

fixes #4228 

@realm/java 