### PR TITLE
minimize task dependency

### DIFF
--- a/realm/realm-annotations-processor/build.gradle
+++ b/realm/realm-annotations-processor/build.gradle
@@ -38,7 +38,7 @@ sourceSets {
 }
 
 compileJava.dependsOn generateVersionClass
-compileTestJava.dependsOn ':realm-library:assemble'
+compileTestJava.dependsOn ':realm-library:assembleBaseRelease'
 
 task ojoUpload() {
     dependsOn "artifactoryPublish"


### PR DESCRIPTION
UT in `realm/realm-annotations-processor` only uses classes.jar of `baseRelease`.
No need to depend on entire `assemble` task.

@realm/java 