### PR TITLE
Fail Realm.migrateRealm() if a SyncConfiguration is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+* `Realm.migrateRealm(RealmConfiguration)` now fails correctly with an `IllegalArgumentException` if a `SyncConfiguration` is provided (#4075).
+
 ### Deprecated
 
 ### Internal

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
@@ -43,23 +43,6 @@ public class SyncedRealmMigrationTests {
 
     @Rule
     public final TestSyncConfigurationFactory configFactory = new TestSyncConfigurationFactory();
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
-    private Realm realm;
-    private Context context;
-
-    @Before
-    public void setup() {
-        context = InstrumentationRegistry.getInstrumentation().getContext();
-    }
-
-    @After
-    public void tearDown() {
-        if (realm != null) {
-            realm.close();
-        }
-    }
 
     @Test
     public void migrateRealm_syncConfigurationThrows() {

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.FileNotFoundException;
+
+import io.realm.rule.TestRealmConfigurationFactory;
+import io.realm.rule.TestSyncConfigurationFactory;
+import io.realm.util.SyncTestUtils;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Testing methods around migrations for Realms using a {@link SyncConfiguration}.
+ */
+@RunWith(AndroidJUnit4.class)
+public class SyncedRealmMigrationTests {
+
+    @Rule
+    public final TestSyncConfigurationFactory configFactory = new TestSyncConfigurationFactory();
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private Realm realm;
+    private Context context;
+
+    @Before
+    public void setup() {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+    }
+
+    @After
+    public void tearDown() {
+        if (realm != null) {
+            realm.close();
+        }
+    }
+
+    @Test
+    public void migrateRealm_syncConfigurationThrows() {
+        SyncConfiguration config = configFactory.createSyncConfigurationBuilder(SyncTestUtils.createTestUser(), "http://foo.com/auth").build();
+        try {
+            Realm.migrateRealm(config);
+            fail();
+        } catch (FileNotFoundException e) {
+            fail(e.toString());
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+}

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -586,6 +586,7 @@ abstract class BaseRealm implements Closeable {
      * @param callback callback for specific Realm type behaviors.
      * @param cause which triggers this migration.
      * @throws FileNotFoundException if the Realm file doesn't exist.
+     * @throws IllegalArgumentException if the provided configuration is a {@link SyncConfiguration}.
      */
     protected static void migrateRealm(final RealmConfiguration configuration, final RealmMigration migration,
                                        final MigrationCallback callback, final RealmMigrationNeededException cause)
@@ -595,7 +596,7 @@ abstract class BaseRealm implements Closeable {
             throw new IllegalArgumentException("RealmConfiguration must be provided");
         }
         if (configuration.isSyncConfiguration()) {
-            return;
+            throw new IllegalArgumentException("Manual migrations are not supported for synced Realms");
         }
         if (migration == null && configuration.getMigration() == null) {
             throw new RealmMigrationNeededException(configuration.getPath(), "RealmMigration must be provided", cause);


### PR DESCRIPTION
Fixes #4075 

I used `IllegalArgumentException` instead of `UnsupportedOperationException`, since the later should only really be used if the method fails for all input IMO.