### PR TITLE
Throw IllegalArgumentException if mixing TLS and non-TLS connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * Now `targetSdkVersion` is 25.
+* [ObjectServer] An `IllegalArgumentException` is now thrown if authentication and Realm urls use a mix of TLS and non-TLS protocols (#3710).
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
@@ -37,6 +37,7 @@ import io.realm.entities.AllJavaTypes;
 import io.realm.entities.StringOnly;
 import io.realm.rule.RunInLooperThread;
 import io.realm.rule.TestSyncConfigurationFactory;
+import io.realm.util.SyncTestUtils;
 
 import static io.realm.util.SyncTestUtils.createNamedTestUser;
 import static io.realm.util.SyncTestUtils.createTestUser;
@@ -213,6 +214,26 @@ public class SyncConfigurationTests {
         for (String url : urlPort.keySet()) {
             SyncConfiguration config = new SyncConfiguration.Builder(createTestUser(), url).build();
             assertEquals(urlPort.get(url).intValue(), config.getServerUrl().getPort());
+        }
+    }
+
+    // Checks that mixing 'http' and 'realms or 'https' and 'realm' throws.
+    @Test
+    public void serverUrl_mixedProtocolSecurity() {
+        SyncUser httpUser = SyncTestUtils.createTestUser("http://ros.realm.io/auth");
+        String realmsUrl = "realms://ros.realm.io/~/default";
+        try {
+            new SyncConfiguration.Builder(httpUser, realmsUrl);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        SyncUser httpsUser = SyncTestUtils.createTestUser("https://ros.realm.io/auth");
+        String realmUrl = "realm://ros.realm.io/~/default";
+        try {
+            new SyncConfiguration.Builder(httpsUser, realmUrl);
+            fail();
+        } catch (IllegalArgumentException ignored) {
         }
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -297,6 +297,20 @@ public class SyncConfiguration extends RealmConfiguration {
 
             validateAndSet(user);
             validateAndSet(url);
+            checkMixedProtocolSecurity();
+        }
+
+        // Check that either TLS is used for both Auth and Sync protocol or not at all.
+        private void checkMixedProtocolSecurity() {
+            String authProtocol = user.getAuthenticationUrl().getProtocol();
+            String syncProtocol = serverUrl.getScheme();
+
+            if ((authProtocol.equalsIgnoreCase("http") && syncProtocol.equalsIgnoreCase("realms"))
+                    || (authProtocol.equalsIgnoreCase("https") && syncProtocol.equalsIgnoreCase("realm"))) {
+                throw new IllegalArgumentException(String.format("Mixing TLS with non-TLS " +
+                        "connections are not allowed: %s vs. %s", user.getAuthenticationUrl(),
+                        serverUrl.toString()));
+            }
         }
 
         private void validateAndSet(SyncUser user) {


### PR DESCRIPTION
Fixes #3710 
