### PR TITLE
Proper RealmMigrationNeededException is now thrown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * Now `targetSdkVersion` is 25.
+* The proper `RealmMigrationNeededException` is now thrown instead of `IllegalArgumentException` if no migration is provided for a Realm that requires it.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Enhancements
 
 * Now `targetSdkVersion` is 25.
-* The proper `RealmMigrationNeededException` is now thrown instead of `IllegalArgumentException` if no migration is provided for a Realm that requires it.
+* The real `RealmMigrationNeededException` is now thrown instead of `IllegalArgumentException` if no migration is provided for a Realm that requires it.
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -391,7 +391,7 @@ public class RealmConfigurationTests {
             fail();
         } catch (RealmMigrationNeededException expected) {
             // And it should come with a cause.
-            assertNotNull(expected.getCause());
+            assertEquals("Realm on disk need to migrate from v0 to v42", expected.getMessage());
         }
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -1280,6 +1280,27 @@ public class RealmMigrationTests {
         realm.close();
     }
 
+    // Tests that if a migration is required and no migration block was provided, then the
+    // original RealmMigrationNeededException is thrown instead of IllegalArgumentException
+    @Test
+    public void migrationRequired_throwsOriginalException() {
+        RealmConfiguration config = configFactory.createConfigurationBuilder()
+                // .migration() No migration block provided, but one is required
+                .assetFile("default0.realm") // This Realm does not have the correct schema
+                .build();
+
+        Realm realm = null;
+        try {
+            realm = Realm.getInstance(config);
+            fail();
+        } catch (RealmMigrationNeededException ignored) {
+        } finally {
+            if (realm != null) {
+                realm.close();
+            }
+        }
+    }
+    
     // TODO Add unit tests for default nullability
     // TODO Add unit tests for default Indexing for Primary keys
 }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -269,7 +269,9 @@ public class Realm extends BaseRealm {
                 deleteRealm(configuration);
             } else {
                 try {
-                    migrateRealm(configuration, e);
+                    if (configuration.getMigration() != null) {
+                        migrateRealm(configuration, e);
+                    }
                 } catch (FileNotFoundException fileNotFoundException) {
                     // Should never happen.
                     throw new RealmFileException(RealmFileException.Kind.NOT_FOUND, fileNotFoundException);


### PR DESCRIPTION
@bmeike and others have run into this from time to time. But throwing the original exception makes much more sense when debugging. Apparently, we didn't have an issue tracking it.

