### PR TITLE
Use `clang-format` to format C++ code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Realm welcomes all contributions! The only requirement we have is that, like man
 
 While we havn't described our code style yet, please just follow the existing style you see in the files you change.
 
+For source code written in C++, we format it using `clang-format`. You can use the [plugin](https://plugins.jetbrains.com/plugin/8396-clangformatij): mark the entire file and right-click to execute `clang-format` before committing any changes. Of course, if you don't use Android Studio to edit C++ code, run `clang-format` on the command-line.
+
 ### Unit Tests
 
 All PR's must be accompanied by related unit tests. All bug fixes must have a unit test proving that the bug is fixed.

--- a/realm/realm-library/src/main/cpp/.clang-format
+++ b/realm/realm-library/src/main/cpp/.clang-format
@@ -1,0 +1,89 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     118
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/realm/realm-library/src/main/cpp/io_realm_Property.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_Property.cpp
@@ -25,18 +25,18 @@
 
 using namespace realm;
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2IZZZ(JNIEnv *env, jclass, jstring name_,
-                                                                     jint type, jboolean is_primary, jboolean is_indexed,
-                                                                     jboolean is_nullable) {
+JNIEXPORT jlong JNICALL Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2IZZZ(
+    JNIEnv* env, jclass, jstring name_, jint type, jboolean is_primary, jboolean is_indexed, jboolean is_nullable)
+{
     TR_ENTER()
     try {
         JStringAccessor str(env, name_);
         PropertyType p_type = static_cast<PropertyType>(static_cast<int>(type));
-        std::unique_ptr<Property> property(new Property(str, p_type, "", "", to_bool(is_primary), to_bool(is_indexed), to_bool(is_nullable)));
+        std::unique_ptr<Property> property(
+            new Property(str, p_type, "", "", to_bool(is_primary), to_bool(is_indexed), to_bool(is_nullable)));
         if (to_bool(is_indexed) && !property->is_indexable()) {
             throw std::invalid_argument(
-                    "This field cannot be indexed - Only String/byte/short/int/long/boolean/Date fields are supported.");
+                "This field cannot be indexed - Only String/byte/short/int/long/boolean/Date fields are supported.");
         }
         if (to_bool(is_primary) && p_type != PropertyType::Int && p_type != PropertyType::String) {
             std::string typ = property->type_string();
@@ -48,10 +48,9 @@ Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2IZZZ(JNIEnv *env
     return 0;
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2ILjava_lang_String_2(JNIEnv *env, jclass,
-                                                                                     jstring name_, jint type,
-                                                                                     jstring linkedToName_) {
+JNIEXPORT jlong JNICALL Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2ILjava_lang_String_2(
+    JNIEnv* env, jclass, jstring name_, jint type, jstring linkedToName_)
+{
     TR_ENTER()
     try {
         JStringAccessor name(env, name_);
@@ -65,11 +64,11 @@ Java_io_realm_Property_nativeCreateProperty__Ljava_lang_String_2ILjava_lang_Stri
     return 0;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_Property_nativeClose(JNIEnv *env, jclass, jlong property_ptr) {
+JNIEXPORT void JNICALL Java_io_realm_Property_nativeClose(JNIEnv* env, jclass, jlong property_ptr)
+{
     TR_ENTER_PTR(property_ptr)
     try {
-        Property *property = reinterpret_cast<Property *>(property_ptr);
+        Property* property = reinterpret_cast<Property*>(property_ptr);
         delete property;
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
@@ -25,54 +25,55 @@ using namespace realm;
 
 static const char* ERR_COULD_NOT_ALLOCATE_MEMORY = "Could not allocate memory to return all users.";
 
-static jstring
-to_user_string_or_null (JNIEnv *env, const std::shared_ptr<SyncUser>& user)
+static jstring to_user_string_or_null(JNIEnv* env, const std::shared_ptr<SyncUser>& user)
 {
     if (user) {
         return to_jstring(env, user->refresh_token().data());
-    } else {
+    }
+    else {
         return nullptr;
     }
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_realm_RealmFileUserStore_nativeGetCurrentUser (JNIEnv *env, jclass)
+JNIEXPORT jstring JNICALL Java_io_realm_RealmFileUserStore_nativeGetCurrentUser(JNIEnv* env, jclass)
 {
     TR_ENTER()
     try {
         const std::shared_ptr<SyncUser>& user = SyncManager::shared().get_current_user();
         return to_user_string_or_null(env, user);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return nullptr;
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_realm_RealmFileUserStore_nativeGetUser (JNIEnv *env, jclass, jstring identity)
+JNIEXPORT jstring JNICALL Java_io_realm_RealmFileUserStore_nativeGetUser(JNIEnv* env, jclass, jstring identity)
 {
     TR_ENTER()
     try {
         JStringAccessor id(env, identity); // throws
         const std::shared_ptr<SyncUser>& user = SyncManager::shared().get_existing_logged_in_user(id);
         return to_user_string_or_null(env, user);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return nullptr;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_RealmFileUserStore_nativeUpdateOrCreateUser (JNIEnv *env, jclass, jstring identity, jstring jsonToken, jstring url)
+JNIEXPORT void JNICALL Java_io_realm_RealmFileUserStore_nativeUpdateOrCreateUser(JNIEnv* env, jclass,
+                                                                                 jstring identity, jstring jsonToken,
+                                                                                 jstring url)
 {
     TR_ENTER()
     try {
-        JStringAccessor user_identity(env, identity); // throws
+        JStringAccessor user_identity(env, identity);    // throws
         JStringAccessor user_json_token(env, jsonToken); // throws
-        JStringAccessor auth_url(env, url); // throws
+        JStringAccessor auth_url(env, url);              // throws
 
         SyncManager::shared().get_user(user_identity, user_json_token, std::string(auth_url));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_RealmFileUserStore_nativeLogoutUser (JNIEnv *env, jclass, jstring identity)
+JNIEXPORT void JNICALL Java_io_realm_RealmFileUserStore_nativeLogoutUser(JNIEnv* env, jclass, jstring identity)
 {
     TR_ENTER()
     try {
@@ -81,12 +82,12 @@ Java_io_realm_RealmFileUserStore_nativeLogoutUser (JNIEnv *env, jclass, jstring 
         if (user) {
             user->log_out();
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT jobjectArray JNICALL
-Java_io_realm_RealmFileUserStore_nativeGetAllUsers (JNIEnv *env, jclass)
+JNIEXPORT jobjectArray JNICALL Java_io_realm_RealmFileUserStore_nativeGetAllUsers(JNIEnv* env, jclass)
 {
     TR_ENTER()
     std::vector<std::shared_ptr<SyncUser>> all_users = SyncManager::shared().all_logged_in_users();
@@ -106,10 +107,8 @@ Java_io_realm_RealmFileUserStore_nativeGetAllUsers (JNIEnv *env, jclass)
     return nullptr;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_RealmFileUserStore_nativeResetForTesting (JNIEnv *, jclass)
+JNIEXPORT void JNICALL Java_io_realm_RealmFileUserStore_nativeResetForTesting(JNIEnv*, jclass)
 {
     TR_ENTER();
     SyncManager::shared().reset_for_testing();
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_RealmObjectSchema.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmObjectSchema.cpp
@@ -23,12 +23,13 @@
 #include "util.hpp"
 using namespace realm;
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_RealmObjectSchema_nativeCreateRealmObjectSchema(JNIEnv *env, jclass, jstring className_) {
+JNIEXPORT jlong JNICALL Java_io_realm_RealmObjectSchema_nativeCreateRealmObjectSchema(JNIEnv* env, jclass,
+                                                                                      jstring className_)
+{
     TR_ENTER()
     try {
         JStringAccessor name(env, className_);
-        ObjectSchema *object_schema = new ObjectSchema();
+        ObjectSchema* object_schema = new ObjectSchema();
         object_schema->name = name;
         return reinterpret_cast<jlong>(object_schema);
     }
@@ -36,8 +37,8 @@ Java_io_realm_RealmObjectSchema_nativeCreateRealmObjectSchema(JNIEnv *env, jclas
     return 0;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_RealmObjectSchema_nativeClose(JNIEnv *env, jclass, jlong native_ptr) {
+JNIEXPORT void JNICALL Java_io_realm_RealmObjectSchema_nativeClose(JNIEnv* env, jclass, jlong native_ptr)
+{
     TR_ENTER_PTR(native_ptr)
     try {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(native_ptr);
@@ -47,8 +48,9 @@ Java_io_realm_RealmObjectSchema_nativeClose(JNIEnv *env, jclass, jlong native_pt
 }
 
 
-JNIEXPORT void JNICALL
-Java_io_realm_RealmObjectSchema_nativeAddProperty(JNIEnv *env, jclass, jlong native_ptr, jlong property_ptr) {
+JNIEXPORT void JNICALL Java_io_realm_RealmObjectSchema_nativeAddProperty(JNIEnv* env, jclass, jlong native_ptr,
+                                                                         jlong property_ptr)
+{
     TR_ENTER_PTR(native_ptr)
     try {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(native_ptr);
@@ -61,8 +63,8 @@ Java_io_realm_RealmObjectSchema_nativeAddProperty(JNIEnv *env, jclass, jlong nat
     CATCH_STD()
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_realm_RealmObjectSchema_nativeGetClassName(JNIEnv *env, jclass, jlong nativePtr) {
+JNIEXPORT jstring JNICALL Java_io_realm_RealmObjectSchema_nativeGetClassName(JNIEnv* env, jclass, jlong nativePtr)
+{
     TR_ENTER_PTR(nativePtr)
     try {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(nativePtr);
@@ -74,8 +76,8 @@ Java_io_realm_RealmObjectSchema_nativeGetClassName(JNIEnv *env, jclass, jlong na
     return NULL;
 }
 
-JNIEXPORT jlongArray JNICALL
-Java_io_realm_RealmObjectSchema_nativeGetProperties(JNIEnv *env, jclass, jlong nativePtr) {
+JNIEXPORT jlongArray JNICALL Java_io_realm_RealmObjectSchema_nativeGetProperties(JNIEnv* env, jclass, jlong nativePtr)
+{
     TR_ENTER_PTR(nativePtr)
     try {
         ObjectSchema* object_schema = reinterpret_cast<ObjectSchema*>(nativePtr);
@@ -98,4 +100,3 @@ Java_io_realm_RealmObjectSchema_nativeGetProperties(JNIEnv *env, jclass, jlong n
 
     return NULL;
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_RealmObjectSchema.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmObjectSchema.cpp
@@ -73,7 +73,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_RealmObjectSchema_nativeGetClassName(JNI
     }
     CATCH_STD()
 
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jlongArray JNICALL Java_io_realm_RealmObjectSchema_nativeGetProperties(JNIEnv* env, jclass, jlong nativePtr)
@@ -98,5 +98,5 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_RealmObjectSchema_nativeGetProperties
     }
     CATCH_STD()
 
-    return NULL;
+    return nullptr;
 }

--- a/realm/realm-library/src/main/cpp/io_realm_RealmSchema.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmSchema.cpp
@@ -25,8 +25,9 @@
 using namespace realm;
 
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_RealmSchema_nativeCreateFromList(JNIEnv *env, jclass, jlongArray objectSchemaPtrs_) {
+JNIEXPORT jlong JNICALL Java_io_realm_RealmSchema_nativeCreateFromList(JNIEnv* env, jclass,
+                                                                       jlongArray objectSchemaPtrs_)
+{
     TR_ENTER()
     try {
         std::vector<ObjectSchema> object_schemas;
@@ -35,22 +36,22 @@ Java_io_realm_RealmSchema_nativeCreateFromList(JNIEnv *env, jclass, jlongArray o
             ObjectSchema object_schema = *reinterpret_cast<ObjectSchema*>(array[i]);
             object_schemas.push_back(std::move(object_schema));
         }
-        auto *schema = new Schema(object_schemas);
+        auto* schema = new Schema(object_schemas);
         return reinterpret_cast<jlong>(schema);
     }
     CATCH_STD()
     return 0;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_RealmSchema_nativeClose(JNIEnv*, jclass, jlong nativePtr) {
+JNIEXPORT void JNICALL Java_io_realm_RealmSchema_nativeClose(JNIEnv*, jclass, jlong nativePtr)
+{
     TR_ENTER_PTR(nativePtr)
     Schema* schema = reinterpret_cast<Schema*>(nativePtr);
     delete schema;
 }
 
-JNIEXPORT jlongArray JNICALL
-Java_io_realm_RealmSchema_nativeGetAll(JNIEnv *env, jclass, jlong nativePtr) {
+JNIEXPORT jlongArray JNICALL Java_io_realm_RealmSchema_nativeGetAll(JNIEnv* env, jclass, jlong nativePtr)
+{
     TR_ENTER_PTR(nativePtr)
     try {
         Schema* schema = reinterpret_cast<Schema*>(nativePtr);
@@ -72,4 +73,3 @@ Java_io_realm_RealmSchema_nativeGetAll(JNIEnv *env, jclass, jlong nativePtr) {
     CATCH_STD()
     return NULL;
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_RealmSchema.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmSchema.cpp
@@ -71,5 +71,5 @@ JNIEXPORT jlongArray JNICALL Java_io_realm_RealmSchema_nativeGetAll(JNIEnv* env,
         return native_ptr_array;
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }

--- a/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
@@ -44,8 +44,9 @@ std::unique_ptr<Client> sync_client;
 JNIEXPORT void JNICALL Java_io_realm_SyncManager_nativeInitializeSyncClient(JNIEnv* env, jclass)
 {
     TR_ENTER()
-    if (sync_client)
+    if (sync_client) {
         return;
+    }
 
     try {
         sync::Client::Config config;

--- a/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
@@ -41,34 +41,35 @@ using namespace realm::jni_util;
 
 std::unique_ptr<Client> sync_client;
 
-JNIEXPORT void JNICALL Java_io_realm_SyncManager_nativeInitializeSyncClient
-    (JNIEnv *env, jclass)
+JNIEXPORT void JNICALL Java_io_realm_SyncManager_nativeInitializeSyncClient(JNIEnv* env, jclass)
 {
     TR_ENTER()
-    if (sync_client) return;
+    if (sync_client)
+        return;
 
     try {
         sync::Client::Config config;
         config.logger = &CoreLoggerBridge::shared();
         sync_client = std::make_unique<Client>(std::move(config)); // Throws
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 // Create the thread from java side to avoid some strange errors when native throws.
-JNIEXPORT void JNICALL
-Java_io_realm_SyncManager_nativeRunClient(JNIEnv *env, jclass)
+JNIEXPORT void JNICALL Java_io_realm_SyncManager_nativeRunClient(JNIEnv* env, jclass)
 {
     try {
         sync_client->run();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_SyncManager_nativeConfigureMetaDataSystem(JNIEnv *env, jclass,
-                                                        jstring baseFile) {
+JNIEXPORT void JNICALL Java_io_realm_SyncManager_nativeConfigureMetaDataSystem(JNIEnv* env, jclass, jstring baseFile)
+{
     TR_ENTER()
     try {
         JStringAccessor base_file_path(env, baseFile); // throws
         SyncManager::shared().configure_file_system(base_file_path, SyncManager::MetadataMode::NoEncryption);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CheckedRow.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CheckedRow.cpp
@@ -24,8 +24,9 @@ using namespace realm;
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnCount(JNIEnv* env, jobject obj,
                                                                                jlong nativeRowPtr)
 {
-    if (!ROW(nativeRowPtr)->is_attached())
+    if (!ROW(nativeRowPtr)->is_attached()) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetColumnCount(env, obj, nativeRowPtr);
 }
@@ -33,8 +34,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnCount(J
 JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnName(JNIEnv* env, jobject obj,
                                                                                 jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex))
+    if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex)) {
         return NULL;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetColumnName(env, obj, nativeRowPtr, columnIndex);
 }
@@ -59,8 +61,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnIndex(J
 JNIEXPORT jint JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnType(JNIEnv* env, jobject obj,
                                                                              jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex))
+    if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetColumnType(env, obj, nativeRowPtr, columnIndex);
 }
@@ -68,8 +71,9 @@ JNIEXPORT jint JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnType(JNI
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLong(JNIEnv* env, jobject obj, jlong nativeRowPtr,
                                                                         jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetLong(env, obj, nativeRowPtr, columnIndex);
 }
@@ -77,8 +81,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLong(JNIEnv* 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeGetBoolean(JNIEnv* env, jobject obj,
                                                                               jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetBoolean(env, obj, nativeRowPtr, columnIndex);
 }
@@ -86,8 +91,9 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeGetBoolean(JN
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_CheckedRow_nativeGetFloat(JNIEnv* env, jobject obj,
                                                                           jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetFloat(env, obj, nativeRowPtr, columnIndex);
 }
@@ -95,8 +101,9 @@ JNIEXPORT jfloat JNICALL Java_io_realm_internal_CheckedRow_nativeGetFloat(JNIEnv
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_CheckedRow_nativeGetDouble(JNIEnv* env, jobject obj,
                                                                             jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetDouble(env, obj, nativeRowPtr, columnIndex);
 }
@@ -104,8 +111,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_CheckedRow_nativeGetDouble(JNIE
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetTimestamp(JNIEnv* env, jobject obj,
                                                                              jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetTimestamp(env, obj, nativeRowPtr, columnIndex);
 }
@@ -113,8 +121,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetTimestamp(JNI
 JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetString(JNIEnv* env, jobject obj,
                                                                             jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetString(env, obj, nativeRowPtr, columnIndex);
 }
@@ -123,8 +132,9 @@ JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_CheckedRow_nativeGetByteArra
                                                                                   jlong nativeRowPtr,
                                                                                   jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetByteArray(env, obj, nativeRowPtr, columnIndex);
 }
@@ -132,8 +142,9 @@ JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_CheckedRow_nativeGetByteArra
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLink(JNIEnv* env, jobject obj, jlong nativeRowPtr,
                                                                         jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetLink(env, obj, nativeRowPtr, columnIndex);
 }
@@ -141,8 +152,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLink(JNIEnv* 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeIsNullLink(JNIEnv* env, jobject obj,
                                                                               jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeIsNullLink(env, obj, nativeRowPtr, columnIndex);
 }
@@ -150,8 +162,9 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeIsNullLink(JN
 JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLinkView(JNIEnv* env, jobject obj,
                                                                             jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_LinkList))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_LinkList)) {
         return 0;
+    }
 
     return Java_io_realm_internal_UncheckedRow_nativeGetLinkView(env, obj, nativeRowPtr, columnIndex);
 }
@@ -159,8 +172,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLinkView(JNIE
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLong(JNIEnv* env, jobject obj, jlong nativeRowPtr,
                                                                        jlong columnIndex, jlong value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetLong(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -169,8 +183,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetBoolean(JNIEnv
                                                                           jlong nativeRowPtr, jlong columnIndex,
                                                                           jboolean value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetBoolean(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -178,8 +193,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetBoolean(JNIEnv
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetFloat(JNIEnv* env, jobject obj, jlong nativeRowPtr,
                                                                         jlong columnIndex, jfloat value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetFloat(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -187,8 +203,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetFloat(JNIEnv* 
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetDouble(JNIEnv* env, jobject obj, jlong nativeRowPtr,
                                                                          jlong columnIndex, jdouble value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetDouble(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -197,8 +214,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetTimestamp(JNIE
                                                                             jlong nativeRowPtr, jlong columnIndex,
                                                                             jlong value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetTimestamp(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -206,8 +224,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetTimestamp(JNIE
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetString(JNIEnv* env, jobject obj, jlong nativeRowPtr,
                                                                          jlong columnIndex, jstring value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetString(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -216,8 +235,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetByteArray(JNIE
                                                                             jlong nativeRowPtr, jlong columnIndex,
                                                                             jbyteArray value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetByteArray(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -225,8 +245,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetByteArray(JNIE
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLink(JNIEnv* env, jobject obj, jlong nativeRowPtr,
                                                                        jlong columnIndex, jlong value)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeSetLink(env, obj, nativeRowPtr, columnIndex, value);
 }
@@ -234,8 +255,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLink(JNIEnv* e
 JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeNullifyLink(JNIEnv* env, jobject obj,
                                                                            jlong nativeRowPtr, jlong columnIndex)
 {
-    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
+    if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link)) {
         return;
+    }
 
     Java_io_realm_internal_UncheckedRow_nativeNullifyLink(env, obj, nativeRowPtr, columnIndex);
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CheckedRow.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CheckedRow.cpp
@@ -21,8 +21,8 @@
 
 using namespace realm;
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnCount
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnCount(JNIEnv* env, jobject obj,
+                                                                               jlong nativeRowPtr)
 {
     if (!ROW(nativeRowPtr)->is_attached())
         return 0;
@@ -30,8 +30,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnCount
     return Java_io_realm_internal_UncheckedRow_nativeGetColumnCount(env, obj, nativeRowPtr);
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnName
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnName(JNIEnv* env, jobject obj,
+                                                                                jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex))
         return NULL;
@@ -39,8 +39,8 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnName
     return Java_io_realm_internal_UncheckedRow_nativeGetColumnName(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnIndex
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jstring columnName)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnIndex(JNIEnv* env, jobject obj,
+                                                                               jlong nativeRowPtr, jstring columnName)
 {
     if (!ROW(nativeRowPtr)->is_attached())
         return 0;
@@ -56,8 +56,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnIndex
     }
 }
 
-JNIEXPORT jint JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnType
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jint JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnType(JNIEnv* env, jobject obj,
+                                                                             jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_VALID(env, ROW(nativeRowPtr), columnIndex))
         return 0;
@@ -65,8 +65,8 @@ JNIEXPORT jint JNICALL Java_io_realm_internal_CheckedRow_nativeGetColumnType
     return Java_io_realm_internal_UncheckedRow_nativeGetColumnType(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLong
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLong(JNIEnv* env, jobject obj, jlong nativeRowPtr,
+                                                                        jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int))
         return 0;
@@ -74,8 +74,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLong
     return Java_io_realm_internal_UncheckedRow_nativeGetLong(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeGetBoolean
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeGetBoolean(JNIEnv* env, jobject obj,
+                                                                              jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool))
         return 0;
@@ -83,8 +83,8 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeGetBoolean
     return Java_io_realm_internal_UncheckedRow_nativeGetBoolean(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jfloat JNICALL Java_io_realm_internal_CheckedRow_nativeGetFloat
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jfloat JNICALL Java_io_realm_internal_CheckedRow_nativeGetFloat(JNIEnv* env, jobject obj,
+                                                                          jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float))
         return 0;
@@ -92,8 +92,8 @@ JNIEXPORT jfloat JNICALL Java_io_realm_internal_CheckedRow_nativeGetFloat
     return Java_io_realm_internal_UncheckedRow_nativeGetFloat(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_CheckedRow_nativeGetDouble
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_CheckedRow_nativeGetDouble(JNIEnv* env, jobject obj,
+                                                                            jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double))
         return 0;
@@ -101,8 +101,8 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_CheckedRow_nativeGetDouble
     return Java_io_realm_internal_UncheckedRow_nativeGetDouble(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetTimestamp
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetTimestamp(JNIEnv* env, jobject obj,
+                                                                             jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp))
         return 0;
@@ -110,8 +110,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetTimestamp
     return Java_io_realm_internal_UncheckedRow_nativeGetTimestamp(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetString
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetString(JNIEnv* env, jobject obj,
+                                                                            jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String))
         return 0;
@@ -119,8 +119,9 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_CheckedRow_nativeGetString
     return Java_io_realm_internal_UncheckedRow_nativeGetString(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_CheckedRow_nativeGetByteArray
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_CheckedRow_nativeGetByteArray(JNIEnv* env, jobject obj,
+                                                                                  jlong nativeRowPtr,
+                                                                                  jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary))
         return 0;
@@ -128,8 +129,8 @@ JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_CheckedRow_nativeGetByteArra
     return Java_io_realm_internal_UncheckedRow_nativeGetByteArray(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLink
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLink(JNIEnv* env, jobject obj, jlong nativeRowPtr,
+                                                                        jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
         return 0;
@@ -137,8 +138,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLink
     return Java_io_realm_internal_UncheckedRow_nativeGetLink(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeIsNullLink
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeIsNullLink(JNIEnv* env, jobject obj,
+                                                                              jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
         return 0;
@@ -146,8 +147,8 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_CheckedRow_nativeIsNullLink
     return Java_io_realm_internal_UncheckedRow_nativeIsNullLink(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLinkView
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLinkView(JNIEnv* env, jobject obj,
+                                                                            jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_LinkList))
         return 0;
@@ -155,8 +156,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_CheckedRow_nativeGetLinkView
     return Java_io_realm_internal_UncheckedRow_nativeGetLinkView(env, obj, nativeRowPtr, columnIndex);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLong
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLong(JNIEnv* env, jobject obj, jlong nativeRowPtr,
+                                                                       jlong columnIndex, jlong value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Int))
         return;
@@ -164,8 +165,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLong
     Java_io_realm_internal_UncheckedRow_nativeSetLong(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetBoolean
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jboolean value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetBoolean(JNIEnv* env, jobject obj,
+                                                                          jlong nativeRowPtr, jlong columnIndex,
+                                                                          jboolean value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Bool))
         return;
@@ -173,8 +175,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetBoolean
     Java_io_realm_internal_UncheckedRow_nativeSetBoolean(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetFloat
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jfloat value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetFloat(JNIEnv* env, jobject obj, jlong nativeRowPtr,
+                                                                        jlong columnIndex, jfloat value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Float))
         return;
@@ -182,8 +184,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetFloat
     Java_io_realm_internal_UncheckedRow_nativeSetFloat(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetDouble
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jdouble value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetDouble(JNIEnv* env, jobject obj, jlong nativeRowPtr,
+                                                                         jlong columnIndex, jdouble value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Double))
         return;
@@ -191,8 +193,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetDouble
     Java_io_realm_internal_UncheckedRow_nativeSetDouble(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetTimestamp
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetTimestamp(JNIEnv* env, jobject obj,
+                                                                            jlong nativeRowPtr, jlong columnIndex,
+                                                                            jlong value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Timestamp))
         return;
@@ -200,8 +203,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetTimestamp
     Java_io_realm_internal_UncheckedRow_nativeSetTimestamp(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetString
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jstring value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetString(JNIEnv* env, jobject obj, jlong nativeRowPtr,
+                                                                         jlong columnIndex, jstring value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_String))
         return;
@@ -209,8 +212,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetString
     Java_io_realm_internal_UncheckedRow_nativeSetString(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetByteArray
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jbyteArray value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetByteArray(JNIEnv* env, jobject obj,
+                                                                            jlong nativeRowPtr, jlong columnIndex,
+                                                                            jbyteArray value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Binary))
         return;
@@ -218,8 +222,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetByteArray
     Java_io_realm_internal_UncheckedRow_nativeSetByteArray(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLink
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLink(JNIEnv* env, jobject obj, jlong nativeRowPtr,
+                                                                       jlong columnIndex, jlong value)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
         return;
@@ -227,8 +231,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeSetLink
     Java_io_realm_internal_UncheckedRow_nativeSetLink(env, obj, nativeRowPtr, columnIndex, value);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeNullifyLink
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_CheckedRow_nativeNullifyLink(JNIEnv* env, jobject obj,
+                                                                           jlong nativeRowPtr, jlong columnIndex)
 {
     if (!ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ROW(nativeRowPtr), columnIndex, type_Link))
         return;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Collection.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Collection.cpp
@@ -38,7 +38,11 @@ struct ResultsWrapper {
     Results m_results;
 
     ResultsWrapper(Results& results)
-    : m_collection_weak_ref(), m_notification_token(), m_results(std::move(results)) {}
+        : m_collection_weak_ref()
+        , m_notification_token()
+        , m_results(std::move(results))
+    {
+    }
 
     ResultsWrapper(ResultsWrapper&&) = delete;
     ResultsWrapper& operator=(ResultsWrapper&&) = delete;
@@ -46,7 +50,9 @@ struct ResultsWrapper {
     ResultsWrapper(ResultsWrapper const&) = delete;
     ResultsWrapper& operator=(ResultsWrapper const&) = delete;
 
-    ~ResultsWrapper() {}
+    ~ResultsWrapper()
+    {
+    }
 };
 
 static void finalize_results(jlong ptr);
@@ -57,9 +63,10 @@ static void finalize_results(jlong ptr)
     delete reinterpret_cast<ResultsWrapper*>(ptr);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeCreateResults(JNIEnv* env, jclass, jlong shared_realm_ptr, jlong query_ptr,
-        jobject sort_desc, jobject distinct_desc)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeCreateResults(JNIEnv* env, jclass,
+                                                                              jlong shared_realm_ptr, jlong query_ptr,
+                                                                              jobject sort_desc,
+                                                                              jobject distinct_desc)
 {
     TR_ENTER()
     try {
@@ -69,35 +76,35 @@ Java_io_realm_internal_Collection_nativeCreateResults(JNIEnv* env, jclass, jlong
         }
 
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        Results results(shared_realm, *query,
-                        SortDescriptor(JavaSortDescriptor(env, sort_desc)),
+        Results results(shared_realm, *query, SortDescriptor(JavaSortDescriptor(env, sort_desc)),
                         SortDescriptor(JavaSortDescriptor(env, distinct_desc)));
         auto wrapper = new ResultsWrapper(results);
 
         return reinterpret_cast<jlong>(wrapper);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeCreateResultsFromLinkView(JNIEnv* env, jclass, jlong shared_realm_ptr,
-                                                                  jlong link_view_ptr, jobject sort_desc)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeCreateResultsFromLinkView(JNIEnv* env, jclass,
+                                                                                          jlong shared_realm_ptr,
+                                                                                          jlong link_view_ptr,
+                                                                                          jobject sort_desc)
 {
     TR_ENTER()
     try {
         auto link_view_ref = reinterpret_cast<LinkViewRef*>(link_view_ptr);
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        Results results(shared_realm, *link_view_ref, util::none,
-                        SortDescriptor(JavaSortDescriptor(env, sort_desc)));
+        Results results(shared_realm, *link_view_ref, util::none, SortDescriptor(JavaSortDescriptor(env, sort_desc)));
         auto wrapper = new ResultsWrapper(results);
 
         return reinterpret_cast<jlong>(wrapper);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeCreateSnapshot(JNIEnv* env, jclass, jlong native_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeCreateSnapshot(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr);
     try {
@@ -105,12 +112,13 @@ Java_io_realm_internal_Collection_nativeCreateSnapshot(JNIEnv* env, jclass, jlon
         auto snapshot_results = wrapper->m_results.snapshot();
         auto snapshot_wrapper = new ResultsWrapper(snapshot_results);
         return reinterpret_cast<jlong>(snapshot_wrapper);
-    } CATCH_STD();
+    }
+    CATCH_STD();
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_Collection_nativeContains(JNIEnv *env, jclass, jlong native_ptr, jlong native_row_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Collection_nativeContains(JNIEnv* env, jclass, jlong native_ptr,
+                                                                            jlong native_row_ptr)
 {
     TR_ENTER_PTR(native_ptr);
     try {
@@ -118,24 +126,25 @@ Java_io_realm_internal_Collection_nativeContains(JNIEnv *env, jclass, jlong nati
         auto row = reinterpret_cast<Row*>(native_row_ptr);
         size_t index = wrapper->m_results.index_of(*row);
         return to_jbool(index != not_found);
-    } CATCH_STD();
+    }
+    CATCH_STD();
     return JNI_FALSE;
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeGetRow(JNIEnv *env, jclass, jlong native_ptr, jint index)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeGetRow(JNIEnv* env, jclass, jlong native_ptr,
+                                                                       jint index)
 {
     TR_ENTER_PTR(native_ptr)
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
         auto row = wrapper->m_results.get(static_cast<size_t>(index));
         return reinterpret_cast<jlong>(new Row(std::move(row)));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeFirstRow(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeFirstRow(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
@@ -144,13 +153,12 @@ Java_io_realm_internal_Collection_nativeFirstRow(JNIEnv *env, jclass, jlong nati
         if (optional_row) {
             return reinterpret_cast<jlong>(new Row(std::move(optional_row.value())));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
-
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeLastRow(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeLastRow(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
@@ -159,34 +167,34 @@ Java_io_realm_internal_Collection_nativeLastRow(JNIEnv *env, jclass, jlong nativ
         if (optional_row) {
             return reinterpret_cast<jlong>(new Row(std::move(optional_row.value())));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_Collection_nativeClear(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_Collection_nativeClear(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
         wrapper->m_results.clear();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeSize(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeSize(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
         return static_cast<jlong>(wrapper->m_results.size());
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jobject JNICALL
-Java_io_realm_internal_Collection_nativeAggregate(JNIEnv *env, jclass, jlong native_ptr, jlong column_index,
-        jbyte agg_func)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_Collection_nativeAggregate(JNIEnv* env, jclass, jlong native_ptr,
+                                                                            jlong column_index, jbyte agg_func)
 {
     TR_ENTER_PTR(native_ptr)
     try {
@@ -231,35 +239,39 @@ Java_io_realm_internal_Collection_nativeAggregate(JNIEnv *env, jclass, jlong nat
             default:
                 throw std::invalid_argument("Excepted numeric type");
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return static_cast<jobject>(nullptr);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeSort(JNIEnv *env, jclass, jlong native_ptr, jobject sort_desc)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeSort(JNIEnv* env, jclass, jlong native_ptr,
+                                                                     jobject sort_desc)
 {
     TR_ENTER_PTR(native_ptr)
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
         auto sorted_result = wrapper->m_results.sort(JavaSortDescriptor(env, sort_desc));
         return reinterpret_cast<jlong>(new ResultsWrapper(sorted_result));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeDistinct(JNIEnv *env, jclass, jlong native_ptr, jobject distinct_desc) {
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeDistinct(JNIEnv* env, jclass, jlong native_ptr,
+                                                                         jobject distinct_desc)
+{
     TR_ENTER_PTR(native_ptr)
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
         auto distinct_result = wrapper->m_results.distinct(JavaSortDescriptor(env, distinct_desc));
         return reinterpret_cast<jlong>(new ResultsWrapper(distinct_result));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_Collection_nativeStartListening(JNIEnv* env, jobject instance, jlong native_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_Collection_nativeStartListening(JNIEnv* env, jobject instance,
+                                                                              jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
 
@@ -273,62 +285,65 @@ Java_io_realm_internal_Collection_nativeStartListening(JNIEnv* env, jobject inst
 
         auto cb = [=](CollectionChangeSet const& changes, std::exception_ptr err) {
             // OS will call all notifiers' callback in one run, so check the Java exception first!!
-            if (env->ExceptionCheck()) return;
+            if (env->ExceptionCheck())
+                return;
 
             if (err) {
                 try {
                     std::rethrow_exception(err);
-                } catch(const std::exception& e) {
+                }
+                catch (const std::exception& e) {
                     realm::jni_util::Log::e("Caught exception in collection change callback %1", e.what());
                     return;
                 }
             }
 
-            wrapper->m_collection_weak_ref.call_with_local_ref(env, [&] (JNIEnv* local_env, jobject collection_obj) {
-                local_env->CallVoidMethod(collection_obj, notify_change_listeners,
-                                          reinterpret_cast<jlong>(changes.empty() ? 0 : new CollectionChangeSet(changes)));
+            wrapper->m_collection_weak_ref.call_with_local_ref(env, [&](JNIEnv* local_env, jobject collection_obj) {
+                local_env->CallVoidMethod(
+                    collection_obj, notify_change_listeners,
+                    reinterpret_cast<jlong>(changes.empty() ? 0 : new CollectionChangeSet(changes)));
             });
         };
 
-        wrapper->m_notification_token =  wrapper->m_results.add_notification_callback(cb);
-    } CATCH_STD()
+        wrapper->m_notification_token = wrapper->m_results.add_notification_callback(cb);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_Collection_nativeStopListening(JNIEnv *env, jobject, jlong native_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_Collection_nativeStopListening(JNIEnv* env, jobject, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
 
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
         wrapper->m_notification_token = {};
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeGetFinalizerPtr(JNIEnv *, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeGetFinalizerPtr(JNIEnv*, jclass)
 {
     TR_ENTER()
     return reinterpret_cast<jlong>(&finalize_results);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeWhere(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeWhere(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
 
         auto table_view = wrapper->m_results.get_tableview();
-        Query *query = new Query(table_view.get_parent(),
-                                 std::unique_ptr<TableViewBase>(new TableView(std::move(table_view))));
+        Query* query =
+            new Query(table_view.get_parent(), std::unique_ptr<TableViewBase>(new TableView(std::move(table_view))));
         return reinterpret_cast<jlong>(query);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeIndexOf(JNIEnv *env, jclass, jlong native_ptr, jlong row_native_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeIndexOf(JNIEnv* env, jclass, jlong native_ptr,
+                                                                        jlong row_native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
@@ -336,13 +351,14 @@ Java_io_realm_internal_Collection_nativeIndexOf(JNIEnv *env, jclass, jlong nativ
         auto row = reinterpret_cast<Row*>(row_native_ptr);
 
         return static_cast<jlong>(wrapper->m_results.index_of(*row));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return npos;
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_Collection_nativeIndexOfBySourceRowIndex(JNIEnv *env, jclass, jlong native_ptr,
-                                                                jlong source_row_index)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Collection_nativeIndexOfBySourceRowIndex(JNIEnv* env, jclass,
+                                                                                        jlong native_ptr,
+                                                                                        jlong source_row_index)
 {
     TR_ENTER_PTR(native_ptr)
     try {
@@ -350,13 +366,12 @@ Java_io_realm_internal_Collection_nativeIndexOfBySourceRowIndex(JNIEnv *env, jcl
         auto index = static_cast<size_t>(source_row_index);
 
         return static_cast<jlong>(wrapper->m_results.index_of(index));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return npos;
-
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_Collection_nativeDeleteLast(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Collection_nativeDeleteLast(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
@@ -366,12 +381,12 @@ Java_io_realm_internal_Collection_nativeDeleteLast(JNIEnv *env, jclass, jlong na
             row->move_last_over();
             return JNI_TRUE;
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return JNI_FALSE;
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_Collection_nativeDeleteFirst(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Collection_nativeDeleteFirst(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
 
@@ -382,12 +397,13 @@ Java_io_realm_internal_Collection_nativeDeleteFirst(JNIEnv *env, jclass, jlong n
             row->move_last_over();
             return JNI_TRUE;
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return JNI_FALSE;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_Collection_nativeDelete(JNIEnv *env, jclass, jlong native_ptr, jlong index)
+JNIEXPORT void JNICALL Java_io_realm_internal_Collection_nativeDelete(JNIEnv* env, jclass, jlong native_ptr,
+                                                                      jlong index)
 {
     TR_ENTER_PTR(native_ptr)
 
@@ -397,22 +413,22 @@ Java_io_realm_internal_Collection_nativeDelete(JNIEnv *env, jclass, jlong native
         if (row.is_attached()) {
             row.move_last_over();
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_Collection_nativeIsValid(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Collection_nativeIsValid(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
         return wrapper->m_results.is_valid();
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return JNI_FALSE;
 }
 
-JNIEXPORT jbyte JNICALL
-Java_io_realm_internal_Collection_nativeGetMode(JNIEnv *env, jclass, jlong native_ptr)
+JNIEXPORT jbyte JNICALL Java_io_realm_internal_Collection_nativeGetMode(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr)
     try {
@@ -429,7 +445,7 @@ Java_io_realm_internal_Collection_nativeGetMode(JNIEnv *env, jclass, jlong nativ
             case Results::Mode::TableView:
                 return io_realm_internal_Collection_MODE_TABLEVIEW;
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return -1; // Invalid mode value
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
@@ -46,9 +46,9 @@ static jintArray index_set_to_jint_array(JNIEnv* env, const IndexSet& index_set)
 
     if (ranges_vector.size() > io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH) {
         std::ostringstream error_msg;
-        error_msg << "There are too many ranges changed in this change set. They cannot fit into an array." <<
-            " ranges_vector's size: " << ranges_vector.size() <<
-            " Java array's max size: " << io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH << ".";
+        error_msg << "There are too many ranges changed in this change set. They cannot fit into an array."
+                  << " ranges_vector's size: " << ranges_vector.size()
+                  << " Java array's max size: " << io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH << ".";
         ThrowException(env, IllegalState, error_msg.str());
         return nullptr;
     }
@@ -69,9 +69,9 @@ static jintArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_s
     }
     if (indices_vector.size() > io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH) {
         std::ostringstream error_msg;
-        error_msg << "There are too many indices in this change set. They cannot fit into an array." <<
-            " indices_vector's size: " << indices_vector.size() <<
-            " Java array's max size: " << io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH << ".";
+        error_msg << "There are too many indices in this change set. They cannot fit into an array."
+                  << " indices_vector's size: " << indices_vector.size()
+                  << " Java array's max size: " << io_realm_internal_CollectionChangeSet_MAX_ARRAY_LENGTH << ".";
         ThrowException(env, IllegalState, error_msg.str());
         return nullptr;
     }
@@ -80,15 +80,14 @@ static jintArray index_set_to_indices_array(JNIEnv* env, const IndexSet& index_s
     return jint_array;
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_CollectionChangeSet_nativeGetFinalizerPtr(JNIEnv*, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_CollectionChangeSet_nativeGetFinalizerPtr(JNIEnv*, jclass)
 {
     TR_ENTER()
     return reinterpret_cast<jlong>(&finalize_changeset);
 }
 
-JNIEXPORT jintArray JNICALL
-Java_io_realm_internal_CollectionChangeSet_nativeGetRanges(JNIEnv *env, jclass, jlong native_ptr, jint type)
+JNIEXPORT jintArray JNICALL Java_io_realm_internal_CollectionChangeSet_nativeGetRanges(JNIEnv* env, jclass,
+                                                                                       jlong native_ptr, jint type)
 {
     TR_ENTER_PTR(native_ptr)
     // no throws
@@ -106,8 +105,8 @@ Java_io_realm_internal_CollectionChangeSet_nativeGetRanges(JNIEnv *env, jclass, 
     }
 }
 
-JNIEXPORT jintArray JNICALL
-Java_io_realm_internal_CollectionChangeSet_nativeGetIndices(JNIEnv *env, jclass, jlong native_ptr, jint type)
+JNIEXPORT jintArray JNICALL Java_io_realm_internal_CollectionChangeSet_nativeGetIndices(JNIEnv* env, jclass,
+                                                                                        jlong native_ptr, jint type)
 {
     TR_ENTER_PTR(native_ptr)
     // no throws
@@ -124,4 +123,3 @@ Java_io_realm_internal_CollectionChangeSet_nativeGetIndices(JNIEnv *env, jclass,
             break;
     }
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_CollectionChangeSet.cpp
@@ -101,7 +101,6 @@ JNIEXPORT jintArray JNICALL Java_io_realm_internal_CollectionChangeSet_nativeGet
             return index_set_to_jint_array(env, change_set.modifications_new);
         default:
             REALM_UNREACHABLE();
-            break;
     }
 }
 
@@ -120,6 +119,5 @@ JNIEXPORT jintArray JNICALL Java_io_realm_internal_CollectionChangeSet_nativeGet
             return index_set_to_indices_array(env, change_set.modifications_new);
         default:
             REALM_UNREACHABLE();
-            break;
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_LinkView.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_LinkView.cpp
@@ -154,7 +154,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeSize(JNIEnv* env, 
     try {
         LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
-        return lvr->size();
+        return static_cast<jlong>(lvr->size());
     }
     CATCH_STD()
     return 0;
@@ -168,7 +168,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsEmpty(JNIEnv*
     try {
         LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
-        return lvr->is_empty();
+        return to_jbool(lvr->is_empty());
     }
     CATCH_STD()
     return 0;
@@ -194,7 +194,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsAttached(JNIE
     try {
         LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
-        return lvr->is_attached();
+        return to_jbool(lvr->is_attached());
     }
     CATCH_STD()
     return 0;
@@ -210,7 +210,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeFind(JNIEnv* env, 
         if (!ROW_INDEX_VALID(env, &lvr->get_target_table(), targetRowIndex)) {
             return -1;
         }
-        size_t ndx = lvr->find(targetRowIndex);
+        size_t ndx = lvr->find(static_cast<size_t>(targetRowIndex));
         return to_jlong_or_not_found(ndx);
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/cpp/io_realm_internal_LinkView.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_LinkView.cpp
@@ -21,204 +21,216 @@ using namespace realm;
 
 static void finalize_link_view(jlong ptr);
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetRow
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong pos)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetRow(JNIEnv* env, jobject, jlong nativeLinkViewPtr,
+                                                                     jlong pos)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
-    LinkViewRef *lv = LV(nativeLinkViewPtr);
+    LinkViewRef* lv = LV(nativeLinkViewPtr);
     if (!ROW_INDEX_VALID(env, *lv, pos)) {
         return -1;
     }
     try {
         LinkViewRef lvr = *lv;
-        Row* row = new Row( (*lvr)[ S(pos) ] );
+        Row* row = new Row((*lvr)[S(pos)]);
         return reinterpret_cast<jlong>(row);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetRowIndex
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong linkViewIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetRowIndex(JNIEnv* env, jobject,
+                                                                                jlong nativeLinkViewPtr,
+                                                                                jlong linkViewIndex)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
-    LinkViewRef *lv = LV(nativeLinkViewPtr);
+    LinkViewRef* lv = LV(nativeLinkViewPtr);
     if (!ROW_INDEX_VALID(env, *lv, linkViewIndex)) {
         return -1;
     }
     try {
         LinkViewRef lvr = *lv;
         return lvr->get(S(linkViewIndex)).get_index();
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeAdd
-  (JNIEnv* env, jclass, jlong nativeLinkViewPtr, jlong rowIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeAdd(JNIEnv* env, jclass, jlong nativeLinkViewPtr,
+                                                                 jlong rowIndex)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
-    LinkViewRef *lv = LV(nativeLinkViewPtr);
+    LinkViewRef* lv = LV(nativeLinkViewPtr);
     try {
         LinkViewRef lvr = *lv;
-        lvr->add( S(rowIndex) );
-    } CATCH_STD()
+        lvr->add(S(rowIndex));
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeInsert
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong pos, jlong rowIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeInsert(JNIEnv* env, jobject, jlong nativeLinkViewPtr,
+                                                                    jlong pos, jlong rowIndex)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
-    LinkViewRef *lv = LV(nativeLinkViewPtr);
+    LinkViewRef* lv = LV(nativeLinkViewPtr);
     try {
         LinkViewRef lvr = *lv;
-        lvr->insert( S(pos), S(rowIndex) );
-    } CATCH_STD()
+        lvr->insert(S(pos), S(rowIndex));
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeSet
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong pos, jlong rowIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeSet(JNIEnv* env, jobject, jlong nativeLinkViewPtr,
+                                                                 jlong pos, jlong rowIndex)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
-    LinkViewRef *lv = LV(nativeLinkViewPtr);
+    LinkViewRef* lv = LV(nativeLinkViewPtr);
     if (!ROW_INDEX_VALID(env, *lv, pos)) {
         return;
     }
     try {
         LinkViewRef lvr = *lv;
-        lvr->set( S(pos), S(rowIndex) );
-    } CATCH_STD()
+        lvr->set(S(pos), S(rowIndex));
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeMove
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong old_pos, jlong new_pos)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeMove(JNIEnv* env, jobject, jlong nativeLinkViewPtr,
+                                                                  jlong old_pos, jlong new_pos)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
-        LinkViewRef *lv = LV(nativeLinkViewPtr);
+        LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
         size_t size = lvr->size();
         if (old_pos < 0 || new_pos < 0 || size_t(old_pos) >= size || size_t(new_pos) >= size) {
-            ThrowException(env, IndexOutOfBounds,
-                "Indices must be within range [0, " + num_to_string(size) + "[. " +
-                "Yours were (" + num_to_string(old_pos) + "," + num_to_string(new_pos) + ")");
+            ThrowException(env, IndexOutOfBounds, "Indices must be within range [0, " + num_to_string(size) + "[. " +
+                                                      "Yours were (" + num_to_string(old_pos) + "," +
+                                                      num_to_string(new_pos) + ")");
             return;
         }
-        lvr->move( S(old_pos), S(new_pos) );
-    } CATCH_STD()
+        lvr->move(S(old_pos), S(new_pos));
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemove
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong pos)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemove(JNIEnv* env, jobject, jlong nativeLinkViewPtr,
+                                                                    jlong pos)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
-    LinkViewRef *lv = LV(nativeLinkViewPtr);
+    LinkViewRef* lv = LV(nativeLinkViewPtr);
     if (!ROW_INDEX_VALID(env, *lv, pos)) {
         return;
     }
     try {
         LinkViewRef lvr = *lv;
-        return lvr->remove( S(pos) );
-    } CATCH_STD()
+        return lvr->remove(S(pos));
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeClear
-  (JNIEnv* env, jclass, jlong nativeLinkViewPtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeClear(JNIEnv* env, jclass, jlong nativeLinkViewPtr)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
-        LinkViewRef *lv = LV(nativeLinkViewPtr);
+        LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
         return lvr->clear();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeSize
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeSize(JNIEnv* env, jobject, jlong nativeLinkViewPtr)
 {
-    
+
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
-        LinkViewRef *lv = LV(nativeLinkViewPtr);
+        LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
         return lvr->size();
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsEmpty
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsEmpty(JNIEnv* env, jobject,
+                                                                         jlong nativeLinkViewPtr)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
-        LinkViewRef *lv = LV(nativeLinkViewPtr);
+        LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
         return lvr->is_empty();
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeWhere
-  (JNIEnv *env, jobject, jlong nativeLinkViewPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeWhere(JNIEnv* env, jobject, jlong nativeLinkViewPtr)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
-        LinkViewRef *lv = LV(nativeLinkViewPtr);
+        LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
-        Query *queryPtr = new Query(lvr->get_target_table().where(LinkViewRef(lvr)));
+        Query* queryPtr = new Query(lvr->get_target_table().where(LinkViewRef(lvr)));
         return reinterpret_cast<jlong>(queryPtr);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsAttached
-  (JNIEnv *env, jobject, jlong nativeLinkViewPtr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_LinkView_nativeIsAttached(JNIEnv* env, jobject,
+                                                                            jlong nativeLinkViewPtr)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
-        LinkViewRef *lv = LV(nativeLinkViewPtr);
+        LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
         return lvr->is_attached();
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeFind
-  (JNIEnv *env, jobject, jlong nativeLinkViewPtr, jlong targetRowIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeFind(JNIEnv* env, jobject, jlong nativeLinkViewPtr,
+                                                                   jlong targetRowIndex)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
-        LinkViewRef *lv = LV(nativeLinkViewPtr);
+        LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
         if (!ROW_INDEX_VALID(env, &lvr->get_target_table(), targetRowIndex)) {
             return -1;
         }
         size_t ndx = lvr->find(targetRowIndex);
         return to_jlong_or_not_found(ndx);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return -1;
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveAllTargetRows
-  (JNIEnv *env, jobject, jlong nativeLinkViewPtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveAllTargetRows(JNIEnv* env, jobject,
+                                                                                 jlong nativeLinkViewPtr)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     try {
         LinkViewRef* lv = LV(nativeLinkViewPtr);
         LinkViewRef lvr = *lv;
         lvr->remove_all_target_rows();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetTable
-  (JNIEnv*, jobject, jlong nativeLinkViewPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetTable(JNIEnv*, jobject,
+                                                                             jlong nativeLinkViewPtr)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
 
@@ -230,8 +242,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetTargetTable
     return reinterpret_cast<jlong>(pTable);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveTargetRow
-  (JNIEnv* env, jobject, jlong nativeLinkViewPtr, jlong pos)
+JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveTargetRow(JNIEnv* env, jobject,
+                                                                             jlong nativeLinkViewPtr, jlong pos)
 {
     TR_ENTER_PTR(nativeLinkViewPtr)
     LinkViewRef* lv = LV(nativeLinkViewPtr);
@@ -240,8 +252,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_LinkView_nativeRemoveTargetRow
     }
     try {
         LinkViewRef lvr = *lv;
-        return lvr->remove_target_row( S(pos) );
-    } CATCH_STD()
+        return lvr->remove_target_row(S(pos));
+    }
+    CATCH_STD()
 }
 
 static void finalize_link_view(jlong ptr)
@@ -250,8 +263,7 @@ static void finalize_link_view(jlong ptr)
     LangBindHelper::unbind_linklist_ptr(*LV(ptr));
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetFinalizerPtr
-  (JNIEnv *, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_LinkView_nativeGetFinalizerPtr(JNIEnv*, jclass)
 {
     TR_ENTER()
     return reinterpret_cast<jlong>(&finalize_link_view);

--- a/realm/realm-library/src/main/cpp/io_realm_internal_NativeObjectReference.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_NativeObjectReference.cpp
@@ -18,8 +18,10 @@
 
 typedef void (*FinalizeFunc)(jlong);
 
-JNIEXPORT void JNICALL Java_io_realm_internal_NativeObjectReference_nativeCleanUp
-(JNIEnv *, jclass, jlong finalizer_ptr, jlong native_ptr) {
+JNIEXPORT void JNICALL Java_io_realm_internal_NativeObjectReference_nativeCleanUp(JNIEnv*, jclass,
+                                                                                  jlong finalizer_ptr,
+                                                                                  jlong native_ptr)
+{
     FinalizeFunc finalize_func = reinterpret_cast<FinalizeFunc>(finalizer_ptr);
     finalize_func(native_ptr);
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -36,40 +36,45 @@ using namespace realm;
 using namespace realm::_impl;
 
 static_assert(SchemaMode::Automatic ==
-                      static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_AUTOMATIC), "");
+                  static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_AUTOMATIC),
+              "");
 static_assert(SchemaMode::ReadOnly ==
-                      static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_READONLY), "");
+                  static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_READONLY),
+              "");
 static_assert(SchemaMode::ResetFile ==
-                      static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_RESET_FILE), "");
+                  static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_RESET_FILE),
+              "");
 static_assert(SchemaMode::Additive ==
-                      static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_ADDITIVE), "");
-static_assert(SchemaMode::Manual ==
-              static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_MANUAL), "");
+                  static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_ADDITIVE),
+              "");
+static_assert(SchemaMode::Manual == static_cast<SchemaMode>(io_realm_internal_SharedRealm_SCHEMA_MODE_VALUE_MANUAL),
+              "");
 
 static void finalize_shared_realm(jlong ptr);
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeInit(JNIEnv *env, jclass, jstring temporary_directory_path)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeInit(JNIEnv* env, jclass,
+                                                                     jstring temporary_directory_path)
 {
     TR_ENTER()
 
     try {
-        JStringAccessor path(env, temporary_directory_path); // throws
+        JStringAccessor path(env, temporary_directory_path);    // throws
         SharedGroupOptions::set_sys_tmp_dir(std::string(path)); // throws
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeCreateConfig(JNIEnv *env, jclass, jstring realm_path, jbyteArray key,
-        jbyte schema_mode, jboolean in_memory, jboolean cache, jlong /* schema_version */, jboolean disable_format_upgrade,
-        jboolean auto_change_notification, REALM_UNUSED jstring sync_server_url, jstring /*sync_user_token*/)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeCreateConfig(
+    JNIEnv* env, jclass, jstring realm_path, jbyteArray key, jbyte schema_mode, jboolean in_memory, jboolean cache,
+    jlong /* schema_version */, jboolean disable_format_upgrade, jboolean auto_change_notification,
+    REALM_UNUSED jstring sync_server_url, jstring /*sync_user_token*/)
 {
     TR_ENTER()
 
     try {
         JStringAccessor path(env, realm_path); // throws
         JniByteArray key_array(env, key);
-        Realm::Config *config = new Realm::Config();
+        Realm::Config* config = new Realm::Config();
         config->path = path;
         // config->schema_version = schema_version; TODO: Disabled until we remove version handling from Java
         config->encryption_key = key_array;
@@ -82,13 +87,13 @@ Java_io_realm_internal_SharedRealm_nativeCreateConfig(JNIEnv *env, jclass, jstri
             config->force_sync_history = true;
         }
         return reinterpret_cast<jlong>(config);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return static_cast<jlong>(NULL);
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeCloseConfig(JNIEnv*, jclass, jlong config_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeCloseConfig(JNIEnv*, jclass, jlong config_ptr)
 {
     TR_ENTER_PTR(config_ptr)
 
@@ -96,8 +101,8 @@ Java_io_realm_internal_SharedRealm_nativeCloseConfig(JNIEnv*, jclass, jlong conf
     delete config;
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeGetSharedRealm(JNIEnv *env, jclass, jlong config_ptr, jobject realm_notifier)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeGetSharedRealm(JNIEnv* env, jclass, jlong config_ptr,
+                                                                                jobject realm_notifier)
 {
     TR_ENTER_PTR(config_ptr)
 
@@ -106,12 +111,13 @@ Java_io_realm_internal_SharedRealm_nativeGetSharedRealm(JNIEnv *env, jclass, jlo
         auto shared_realm = Realm::get_shared_realm(*config);
         shared_realm->m_binding_context = JavaBindingContext::create(env, realm_notifier);
         return reinterpret_cast<jlong>(new SharedRealm(std::move(shared_realm)));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return static_cast<jlong>(NULL);
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeCloseSharedRealm(JNIEnv*, jclass, jlong shared_realm_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeCloseSharedRealm(JNIEnv*, jclass,
+                                                                                 jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -120,42 +126,45 @@ Java_io_realm_internal_SharedRealm_nativeCloseSharedRealm(JNIEnv*, jclass, jlong
     shared_realm->close();
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeBeginTransaction(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeBeginTransaction(JNIEnv* env, jclass,
+                                                                                 jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         shared_realm->begin_transaction();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeCommitTransaction(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeCommitTransaction(JNIEnv* env, jclass,
+                                                                                  jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         shared_realm->commit_transaction();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeCancelTransaction(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeCancelTransaction(JNIEnv* env, jclass,
+                                                                                  jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         shared_realm->cancel_transaction();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeIsInTransaction(JNIEnv*, jclass, jlong shared_realm_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeIsInTransaction(JNIEnv*, jclass,
+                                                                                    jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -163,34 +172,36 @@ Java_io_realm_internal_SharedRealm_nativeIsInTransaction(JNIEnv*, jclass, jlong 
     return static_cast<jboolean>(shared_realm->is_in_transaction());
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeReadGroup(JNIEnv *env, jclass , jlong shared_realm_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeReadGroup(JNIEnv* env, jclass,
+                                                                           jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         return reinterpret_cast<jlong>(&shared_realm->read_group());
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return static_cast<jlong>(NULL);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeGetVersion(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeGetVersion(JNIEnv* env, jclass,
+                                                                            jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         return static_cast<jlong>(ObjectStore::get_schema_version(shared_realm->read_group()));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return static_cast<jlong>(ObjectStore::NotVersioned);
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeSetVersion(JNIEnv *env, jclass, jlong shared_realm_ptr, jlong version)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeSetVersion(JNIEnv* env, jclass,
+                                                                           jlong shared_realm_ptr, jlong version)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -204,34 +215,36 @@ Java_io_realm_internal_SharedRealm_nativeSetVersion(JNIEnv *env, jclass, jlong s
         }
 
         ObjectStore::set_schema_version(shared_realm->read_group(), static_cast<uint64_t>(version));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeIsEmpty(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeIsEmpty(JNIEnv* env, jclass,
+                                                                            jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         return static_cast<jboolean>(ObjectStore::is_empty(shared_realm->read_group()));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return JNI_FALSE;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeRefresh(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeRefresh(JNIEnv* env, jclass, jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         shared_realm->refresh();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlongArray JNICALL
-Java_io_realm_internal_SharedRealm_nativeGetVersionID(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jlongArray JNICALL Java_io_realm_internal_SharedRealm_nativeGetVersionID(JNIEnv* env, jclass,
+                                                                                   jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -252,13 +265,13 @@ Java_io_realm_internal_SharedRealm_nativeGetVersionID(JNIEnv *env, jclass, jlong
         env->SetLongArrayRegion(version_data, 0, 2, version_array);
 
         return version_data;
-    } CATCH_STD ()
+    }
+    CATCH_STD()
 
     return NULL;
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeIsClosed(JNIEnv*, jclass, jlong shared_realm_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeIsClosed(JNIEnv*, jclass, jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -267,8 +280,8 @@ Java_io_realm_internal_SharedRealm_nativeIsClosed(JNIEnv*, jclass, jlong shared_
 }
 
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeGetTable(JNIEnv *env, jclass, jlong shared_realm_ptr, jstring table_name)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeGetTable(JNIEnv* env, jclass, jlong shared_realm_ptr,
+                                                                          jstring table_name)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -283,13 +296,14 @@ Java_io_realm_internal_SharedRealm_nativeGetTable(JNIEnv *env, jclass, jlong sha
         }
         Table* pTable = LangBindHelper::get_or_add_table(shared_realm->read_group(), name);
         return reinterpret_cast<jlong>(pTable);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return static_cast<jlong>(NULL);
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_realm_internal_SharedRealm_nativeGetTableName(JNIEnv *env, jclass, jlong shared_realm_ptr, jint index)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_SharedRealm_nativeGetTableName(JNIEnv* env, jclass,
+                                                                                jlong shared_realm_ptr, jint index)
 {
 
     TR_ENTER_PTR(shared_realm_ptr)
@@ -297,12 +311,14 @@ Java_io_realm_internal_SharedRealm_nativeGetTableName(JNIEnv *env, jclass, jlong
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         return to_jstring(env, shared_realm->read_group().get_table_name(static_cast<size_t>(index)));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeHasTable(JNIEnv *env, jclass, jlong shared_realm_ptr, jstring table_name)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeHasTable(JNIEnv* env, jclass,
+                                                                             jlong shared_realm_ptr,
+                                                                             jstring table_name)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -310,13 +326,15 @@ Java_io_realm_internal_SharedRealm_nativeHasTable(JNIEnv *env, jclass, jlong sha
     try {
         JStringAccessor name(env, table_name);
         return static_cast<jboolean>(shared_realm->read_group().has_table(name));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return JNI_FALSE;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeRenameTable(JNIEnv *env, jclass, jlong shared_realm_ptr,
-        jstring old_table_name, jstring new_table_name)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeRenameTable(JNIEnv* env, jclass,
+                                                                            jlong shared_realm_ptr,
+                                                                            jstring old_table_name,
+                                                                            jstring new_table_name)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -331,11 +349,13 @@ Java_io_realm_internal_SharedRealm_nativeRenameTable(JNIEnv *env, jclass, jlong 
         }
         JStringAccessor new_name(env, new_table_name);
         shared_realm->read_group().rename_table(old_name, new_name);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeRemoveTable(JNIEnv *env, jclass, jlong shared_realm_ptr, jstring table_name)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeRemoveTable(JNIEnv* env, jclass,
+                                                                            jlong shared_realm_ptr,
+                                                                            jstring table_name)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -349,25 +369,25 @@ Java_io_realm_internal_SharedRealm_nativeRemoveTable(JNIEnv *env, jclass, jlong 
             return;
         }
         shared_realm->read_group().remove_table(name);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeSize(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeSize(JNIEnv* env, jclass, jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         return static_cast<jlong>(shared_realm->read_group().size());
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return 0;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeWriteCopy(JNIEnv *env, jclass, jlong shared_realm_ptr, jstring path,
-        jbyteArray key)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeWriteCopy(JNIEnv* env, jclass, jlong shared_realm_ptr,
+                                                                          jstring path, jbyteArray key)
 {
     TR_ENTER_PTR(shared_realm_ptr);
 
@@ -376,11 +396,12 @@ Java_io_realm_internal_SharedRealm_nativeWriteCopy(JNIEnv *env, jclass, jlong sh
         JStringAccessor path_str(env, path);
         JniByteArray key_buffer(env, key);
         shared_realm->write_copy(path_str, key_buffer);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeWaitForChange(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeWaitForChange(JNIEnv* env, jclass,
+                                                                                  jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr);
 
@@ -388,13 +409,14 @@ Java_io_realm_internal_SharedRealm_nativeWaitForChange(JNIEnv *env, jclass, jlon
     try {
         using rf = realm::_impl::RealmFriend;
         return static_cast<jboolean>(rf::get_shared_group(*shared_realm).wait_for_change());
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return JNI_FALSE;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeStopWaitForChange(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeStopWaitForChange(JNIEnv* env, jclass,
+                                                                                  jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr);
 
@@ -402,24 +424,26 @@ Java_io_realm_internal_SharedRealm_nativeStopWaitForChange(JNIEnv *env, jclass, 
     try {
         using rf = realm::_impl::RealmFriend;
         rf::get_shared_group(*shared_realm).wait_for_change_release();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeCompact(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeCompact(JNIEnv* env, jclass,
+                                                                            jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr);
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         return static_cast<jboolean>(shared_realm->compact());
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return JNI_FALSE;
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeGetSnapshotVersion(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeGetSnapshotVersion(JNIEnv* env, jclass,
+                                                                                    jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
 
@@ -428,31 +452,34 @@ Java_io_realm_internal_SharedRealm_nativeGetSnapshotVersion(JNIEnv *env, jclass,
         using rf = realm::_impl::RealmFriend;
         auto& shared_group = rf::get_shared_group(*shared_realm);
         return LangBindHelper::get_version_of_latest_snapshot(shared_group);
-    } CATCH_STD ()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeUpdateSchema(JNIEnv *env, jclass, jlong shared_realm_ptr,
-                                                      jlong schema_ptr, jlong version) {
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeUpdateSchema(JNIEnv* env, jclass,
+                                                                             jlong shared_realm_ptr, jlong schema_ptr,
+                                                                             jlong version)
+{
     TR_ENTER_PTR(shared_realm_ptr)
     try {
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        auto *schema = reinterpret_cast<Schema*>(schema_ptr);
+        auto* schema = reinterpret_cast<Schema*>(schema_ptr);
         shared_realm->update_schema(*schema, static_cast<uint64_t>(version), nullptr, true);
     }
     CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeRequiresMigration(JNIEnv *env, jclass, jlong nativePtr,
-                                                           jlong nativeSchemaPtr) {
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeRequiresMigration(JNIEnv* env, jclass,
+                                                                                      jlong nativePtr,
+                                                                                      jlong nativeSchemaPtr)
+{
 
     TR_ENTER()
     try {
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(nativePtr));
-        auto *schema = reinterpret_cast<Schema*>(nativeSchemaPtr);
-        const std::vector<SchemaChange> &change_list = shared_realm->schema().compare(*schema);
+        auto* schema = reinterpret_cast<Schema*>(nativeSchemaPtr);
+        const std::vector<SchemaChange>& change_list = shared_realm->schema().compare(*schema);
         return static_cast<jboolean>(!change_list.empty());
     }
     CATCH_STD()
@@ -465,30 +492,32 @@ static void finalize_shared_realm(jlong ptr)
     delete reinterpret_cast<SharedRealm*>(ptr);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_SharedRealm_nativeGetFinalizerPtr(JNIEnv*, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeGetFinalizerPtr(JNIEnv*, jclass)
 {
     TR_ENTER()
     return reinterpret_cast<jlong>(&finalize_shared_realm);
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_SharedRealm_nativeSetAutoRefresh(JNIEnv *env, jclass, jlong shared_realm_ptr, jboolean enabled)
+JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeSetAutoRefresh(JNIEnv* env, jclass,
+                                                                               jlong shared_realm_ptr,
+                                                                               jboolean enabled)
 {
     TR_ENTER_PTR(shared_realm_ptr)
     try {
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
         shared_realm->set_auto_refresh(to_bool(enabled));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_SharedRealm_nativeIsAutoRefresh(JNIEnv *env, jclass, jlong shared_realm_ptr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeIsAutoRefresh(JNIEnv* env, jclass,
+                                                                                  jlong shared_realm_ptr)
 {
     TR_ENTER_PTR(shared_realm_ptr)
     try {
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
         return to_jbool(shared_realm->auto_refresh());
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return JNI_FALSE;
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -226,7 +226,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeIsEmpty(JNIE
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
-        return static_cast<jboolean>(ObjectStore::is_empty(shared_realm->read_group()));
+        return to_jbool(ObjectStore::is_empty(shared_realm->read_group()));
     }
     CATCH_STD()
     return JNI_FALSE;
@@ -408,7 +408,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeWaitForChang
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         using rf = realm::_impl::RealmFriend;
-        return static_cast<jboolean>(rf::get_shared_group(*shared_realm).wait_for_change());
+        return to_jbool(rf::get_shared_group(*shared_realm).wait_for_change());
     }
     CATCH_STD()
 
@@ -435,7 +435,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeCompact(JNIE
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
-        return static_cast<jboolean>(shared_realm->compact());
+        return to_jbool(shared_realm->compact());
     }
     CATCH_STD()
 
@@ -451,7 +451,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeGetSnapshotVers
     try {
         using rf = realm::_impl::RealmFriend;
         auto& shared_group = rf::get_shared_group(*shared_realm);
-        return LangBindHelper::get_version_of_latest_snapshot(shared_group);
+        return static_cast<jlong>(LangBindHelper::get_version_of_latest_snapshot(shared_group));
     }
     CATCH_STD()
     return 0;
@@ -480,7 +480,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeRequiresMigr
         auto shared_realm = *(reinterpret_cast<SharedRealm*>(nativePtr));
         auto* schema = reinterpret_cast<Schema*>(nativeSchemaPtr);
         const std::vector<SchemaChange>& change_list = shared_realm->schema().compare(*schema);
-        return static_cast<jboolean>(!change_list.empty());
+        return to_jbool(!change_list.empty());
     }
     CATCH_STD()
     return JNI_FALSE;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -1306,16 +1306,16 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstNull(JNIEnv*
 {
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex)) {
-        return to_jlong_or_not_found(-1);
+        return static_cast<jlong>(realm::not_found);
     }
     if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex)) {
-        return to_jlong_or_not_found(-1);
+        return static_cast<jlong>(realm::not_found);
     }
     try {
         return to_jlong_or_not_found(pTable->find_first_null(S(columnIndex)));
     }
     CATCH_STD()
-    return to_jlong_or_not_found(-1);
+    return static_cast<jlong>(realm::not_found);
 }
 
 // FindAll

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -25,15 +25,12 @@ using namespace realm;
 
 static void finalize_table(jlong ptr);
 
-inline static bool is_allowed_to_index(JNIEnv* env, DataType column_type) {
-    if (!(column_type == type_String ||
-                column_type == type_Int ||
-                column_type == type_Bool ||
-                column_type == type_Timestamp ||
-                column_type == type_OldDateTime)) {
-        ThrowException(env, IllegalArgument,
-                "This field cannot be indexed - "
-                "Only String/byte/short/int/long/boolean/Date fields are supported.");
+inline static bool is_allowed_to_index(JNIEnv* env, DataType column_type)
+{
+    if (!(column_type == type_String || column_type == type_Int || column_type == type_Bool ||
+          column_type == type_Timestamp || column_type == type_OldDateTime)) {
+        ThrowException(env, IllegalArgument, "This field cannot be indexed - "
+                                             "Only String/byte/short/int/long/boolean/Date fields are supported.");
         return false;
     }
     return true;
@@ -43,13 +40,14 @@ inline static bool is_allowed_to_index(JNIEnv* env, DataType column_type) {
 // A spec is shared on subtables that are not in Mixed columns.
 //
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumn
-  (JNIEnv *env, jobject, jlong nativeTablePtr, jint colType, jstring name, jboolean isNullable)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumn(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                     jint colType, jstring name, jboolean isNullable)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return 0;
     if (TBL(nativeTablePtr)->has_shared_type()) {
-        ThrowException(env, UnsupportedOperation, "Not allowed to add field in subtable. Use getSubtableSchema() on root table instead.");
+        ThrowException(env, UnsupportedOperation,
+                       "Not allowed to add field in subtable. Use getSubtableSchema() on root table instead.");
         return 0;
     }
     try {
@@ -58,36 +56,41 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumn
 
         DataType dataType = DataType(colType);
         if (is_column_nullable && dataType == type_LinkList) {
-             ThrowException(env, IllegalArgument, "List fields cannot be nullable.");
+            ThrowException(env, IllegalArgument, "List fields cannot be nullable.");
         }
         return TBL(nativeTablePtr)->add_column(dataType, name2, is_column_nullable);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumnLink
-  (JNIEnv* env, jobject, jlong nativeTablePtr, jint colType, jstring name, jlong targetTablePtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumnLink(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jint colType, jstring name,
+                                                                         jlong targetTablePtr)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
-            return 0;
-        if (TBL(nativeTablePtr)->has_shared_type()) {
-            ThrowException(env, UnsupportedOperation, "Not allowed to add field in subtable. Use getSubtableSchema() on root table instead.");
-            return 0;
-        }
-        if (!TBL(targetTablePtr)->is_group_level()) {
-            ThrowException(env, UnsupportedOperation, "Links can only be made to toplevel tables.");
-            return 0;
-        }
-        try {
-            JStringAccessor name2(env, name); // throws
-            return TBL(nativeTablePtr)->add_column_link(DataType(colType), name2, *TBL(targetTablePtr));
-        } CATCH_STD()
         return 0;
+    if (TBL(nativeTablePtr)->has_shared_type()) {
+        ThrowException(env, UnsupportedOperation,
+                       "Not allowed to add field in subtable. Use getSubtableSchema() on root table instead.");
+        return 0;
+    }
+    if (!TBL(targetTablePtr)->is_group_level()) {
+        ThrowException(env, UnsupportedOperation, "Links can only be made to toplevel tables.");
+        return 0;
+    }
+    try {
+        JStringAccessor name2(env, name); // throws
+        return TBL(nativeTablePtr)->add_column_link(DataType(colType), name2, *TBL(targetTablePtr));
+    }
+    CATCH_STD()
+    return 0;
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativePivot
-(JNIEnv *env, jobject, jlong dataTablePtr, jlong stringCol, jlong intCol, jint operation, jlong resultTablePtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativePivot(JNIEnv* env, jobject, jlong dataTablePtr,
+                                                                jlong stringCol, jlong intCol, jint operation,
+                                                                jlong resultTablePtr)
 {
     Table* dataTable = TBL(dataTablePtr);
     Table* resultTable = TBL(resultTablePtr);
@@ -115,42 +118,48 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativePivot
 
     try {
         dataTable->aggregate(S(stringCol), S(intCol), pivotOp, *resultTable);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveColumn
-  (JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveColumn(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
         return;
     if (TBL(nativeTablePtr)->has_shared_type()) {
-        ThrowException(env, UnsupportedOperation, "Not allowed to remove field in subtable. Use getSubtableSchema() on root table instead.");
+        ThrowException(env, UnsupportedOperation,
+                       "Not allowed to remove field in subtable. Use getSubtableSchema() on root table instead.");
         return;
     }
     try {
         TBL(nativeTablePtr)->remove_column(S(columnIndex));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRenameColumn
-  (JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex, jstring name)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRenameColumn(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jstring name)
 {
     if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
         return;
     if (TBL(nativeTablePtr)->has_shared_type()) {
-        ThrowException(env, UnsupportedOperation, "Not allowed to rename field in subtable. Use getSubtableSchema() on root table instead.");
+        ThrowException(env, UnsupportedOperation,
+                       "Not allowed to rename field in subtable. Use getSubtableSchema() on root table instead.");
         return;
     }
     try {
         JStringAccessor name2(env, name); // throws
         TBL(nativeTablePtr)->rename_column(S(columnIndex), name2);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsColumnNullable
-  (JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsColumnNullable(JNIEnv* env, jobject,
+                                                                               jlong nativeTablePtr,
+                                                                               jlong columnIndex)
 {
-    Table *table = TBL(nativeTablePtr);
+    Table* table = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, table, columnIndex)) {
         return false;
     }
@@ -164,7 +173,8 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsColumnNullable
 
 
 // General comments about the implementation of
-// Java_io_realm_internal_Table_nativeConvertColumnToNullable and Java_io_realm_internal_Table_nativeConvertColumnToNotNullable
+// Java_io_realm_internal_Table_nativeConvertColumnToNullable and
+// Java_io_realm_internal_Table_nativeConvertColumnToNotNullable
 //
 // 1. converting a (not-)nullable column is idempotent (and is implemented as a no-op)
 // 2. not all column types can be converted (cannot be (not-)nullable)
@@ -177,10 +187,11 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsColumnNullable
 // 5. search indexing must be preserved
 // 6. removing the original column and renaming the temporary column will make it look like original is being modified
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullable
-  (JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullable(JNIEnv* env, jobject,
+                                                                                  jlong nativeTablePtr,
+                                                                                  jlong columnIndex)
 {
-    Table *table = TBL(nativeTablePtr);
+    Table* table = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, table, columnIndex)) {
         return;
     }
@@ -196,9 +207,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullabl
 
         std::string column_name = table->get_column_name(column_index);
         DataType column_type = table->get_column_type(column_index);
-        if (column_type == type_Link ||
-            column_type == type_LinkList ||
-            column_type == type_Mixed ||
+        if (column_type == type_Link || column_type == type_LinkList || column_type == type_Mixed ||
             column_type == type_Table) {
             ThrowException(env, IllegalArgument, "Wrong type - cannot be converted to nullable.");
         }
@@ -221,7 +230,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullabl
 
         for (size_t i = 0; i < table->size(); ++i) {
             switch (column_type) {
-               case type_String: {
+                case type_String: {
                     // Payload copy is needed
                     StringData sd(table->get_string(column_index + 1, i));
                     table->set_string(column_index, i, sd);
@@ -265,13 +274,15 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullabl
         }
         table->remove_column(column_index + 1);
         table->rename_column(table->get_column_index(tmp_column_name), column_name);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNotNullable
-  (JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNotNullable(JNIEnv* env, jobject,
+                                                                                     jlong nativeTablePtr,
+                                                                                     jlong columnIndex)
 {
-    Table *table = TBL(nativeTablePtr);
+    Table* table = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, table, columnIndex)) {
         return;
     }
@@ -287,9 +298,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNotNull
 
         std::string column_name = table->get_column_name(column_index);
         DataType column_type = table->get_column_type(column_index);
-        if (column_type == type_Link ||
-            column_type == type_LinkList ||
-            column_type == type_Mixed ||
+        if (column_type == type_Link || column_type == type_LinkList || column_type == type_Mixed ||
             column_type == type_Table) {
             ThrowException(env, IllegalArgument, "Wrong type - cannot be converted to nullable.");
         }
@@ -391,176 +400,182 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNotNull
         }
         table->remove_column(column_index + 1);
         table->rename_column(table->get_column_index(tmp_column_name), column_name);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSize(
-    JNIEnv* env, jobject, jlong nativeTablePtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSize(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return 0;
-    return TBL(nativeTablePtr)->size();     // noexcept
+    return TBL(nativeTablePtr)->size(); // noexcept
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeClear(
-    JNIEnv* env, jobject, jlong nativeTablePtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeClear(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return;
     try {
         TBL(nativeTablePtr)->clear();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
 // -------------- Column information
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetColumnCount(
-    JNIEnv* env, jobject, jlong nativeTablePtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetColumnCount(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return 0;
     return TBL(nativeTablePtr)->get_column_count(); // noexcept
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetColumnName(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetColumnName(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                           jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
         return NULL;
     try {
-        return to_jstring(env, TBL(nativeTablePtr)->get_column_name( S(columnIndex)));
-    } CATCH_STD();
+        return to_jstring(env, TBL(nativeTablePtr)->get_column_name(S(columnIndex)));
+    }
+    CATCH_STD();
     return NULL;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetColumnIndex(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jstring columnName)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetColumnIndex(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                          jstring columnName)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return 0;
     try {
-        JStringAccessor columnName2(env, columnName); // throws
-        return to_jlong_or_not_found( TBL(nativeTablePtr)->get_column_index(columnName2) ); // noexcept
-    } CATCH_STD()
+        JStringAccessor columnName2(env, columnName);                                     // throws
+        return to_jlong_or_not_found(TBL(nativeTablePtr)->get_column_index(columnName2)); // noexcept
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jint JNICALL Java_io_realm_internal_Table_nativeGetColumnType(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jint JNICALL Java_io_realm_internal_Table_nativeGetColumnType(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                        jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
         return 0;
 
-    return static_cast<jint>( TBL(nativeTablePtr)->get_column_type( S(columnIndex)) ); // noexcept
+    return static_cast<jint>(TBL(nativeTablePtr)->get_column_type(S(columnIndex))); // noexcept
 }
 
 
 // ---------------- Row handling
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddEmptyRow(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong rows)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddEmptyRow(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                       jlong rows)
 {
     Table* pTable = TBL(nativeTablePtr);
     if (!TABLE_VALID(env, pTable))
         return 0;
-    if (pTable->get_column_count() < 1){
+    if (pTable->get_column_count() < 1) {
         ThrowException(env, IndexOutOfBounds, concat_stringdata("Table has no columns: ", pTable->get_name()));
         return 0;
     }
     try {
-        return static_cast<jlong>( pTable->add_empty_row( S(rows)) );
-    } CATCH_STD()
+        return static_cast<jlong>(pTable->add_empty_row(S(rows)));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemove(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong rowIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemove(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                 jlong rowIndex)
 {
     if (!TBL_AND_ROW_INDEX_VALID(env, TBL(nativeTablePtr), rowIndex))
         return;
     try {
         TBL(nativeTablePtr)->remove(S(rowIndex));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveLast(
-    JNIEnv* env, jobject, jlong nativeTablePtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveLast(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return;
     try {
         TBL(nativeTablePtr)->remove_last();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeMoveLastOver
-  (JNIEnv *env, jobject, jlong nativeTablePtr, jlong rowIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeMoveLastOver(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong rowIndex)
 {
     if (!TBL_AND_ROW_INDEX_VALID_OFFSET(env, TBL(nativeTablePtr), rowIndex, false))
         return;
     try {
         TBL(nativeTablePtr)->move_last_over(S(rowIndex));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 // ----------------- Get cell
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLong(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLong(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                   jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int))
         return 0;
-    return TBL(nativeTablePtr)->get_int( S(columnIndex), S(rowIndex));  // noexcept
+    return TBL(nativeTablePtr)->get_int(S(columnIndex), S(rowIndex)); // noexcept
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeGetBoolean(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeGetBoolean(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Bool))
         return false;
 
-    return TBL(nativeTablePtr)->get_bool( S(columnIndex), S(rowIndex));  // noexcept
+    return TBL(nativeTablePtr)->get_bool(S(columnIndex), S(rowIndex)); // noexcept
 }
 
-JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeGetFloat(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeGetFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                     jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Float))
         return 0;
 
-    return TBL(nativeTablePtr)->get_float( S(columnIndex), S(rowIndex));  // noexcept
+    return TBL(nativeTablePtr)->get_float(S(columnIndex), S(rowIndex)); // noexcept
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeGetDouble(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeGetDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Double))
         return 0;
 
-    return TBL(nativeTablePtr)->get_double( S(columnIndex), S(rowIndex));  // noexcept
+    return TBL(nativeTablePtr)->get_double(S(columnIndex), S(rowIndex)); // noexcept
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetTimestamp(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetTimestamp(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                        jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Timestamp))
         return 0;
     try {
-        return to_milliseconds(TBL(nativeTablePtr)->get_timestamp( S(columnIndex), S(rowIndex)));
-    } CATCH_STD()
+        return to_milliseconds(TBL(nativeTablePtr)->get_timestamp(S(columnIndex), S(rowIndex)));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetString(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetString(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String))
         return NULL;
     try {
-        return to_jstring(env, TBL(nativeTablePtr)->get_string( S(columnIndex), S(rowIndex)));
-    } CATCH_STD()
+        return to_jstring(env, TBL(nativeTablePtr)->get_string(S(columnIndex), S(rowIndex)));
+    }
+    CATCH_STD()
     return NULL;
 }
 
@@ -577,117 +592,132 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_Table_nativeGetByteBuffer(
 }
 */
 
-JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_Table_nativeGetByteArray(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_Table_nativeGetByteArray(JNIEnv* env, jobject,
+                                                                             jlong nativeTablePtr, jlong columnIndex,
+                                                                             jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Binary))
         return NULL;
 
-    return tbl_GetByteArray<Table>(env, nativeTablePtr, columnIndex, rowIndex);  // noexcept
+    return tbl_GetByteArray<Table>(env, nativeTablePtr, columnIndex, rowIndex); // noexcept
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLink
-  (JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLink(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                   jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
         return 0;
-    return TBL(nativeTablePtr)->get_link( S(columnIndex), S(rowIndex));  // noexcept
+    return TBL(nativeTablePtr)->get_link(S(columnIndex), S(rowIndex)); // noexcept
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLinkView
-        (JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLinkView(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_LinkList))
         return 0;
     try {
-        LinkViewRef* link_view_ptr = new LinkViewRef(TBL(nativeTablePtr)->get_linklist( S(columnIndex), S(rowIndex)));
+        LinkViewRef* link_view_ptr = new LinkViewRef(TBL(nativeTablePtr)->get_linklist(S(columnIndex), S(rowIndex)));
         return reinterpret_cast<jlong>(link_view_ptr);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLinkTarget
-  (JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLinkTarget(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex)
 {
     try {
-        Table* pTable = &(*TBL(nativeTablePtr)->get_link_target( S(columnIndex) ));
+        Table* pTable = &(*TBL(nativeTablePtr)->get_link_target(S(columnIndex)));
         LangBindHelper::bind_table_ptr(pTable);
         return (jlong)pTable;
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsNull
-        (JNIEnv*, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsNull(JNIEnv*, jobject, jlong nativeTablePtr,
+                                                                     jlong columnIndex, jlong rowIndex)
 {
-    return TBL(nativeTablePtr)->is_null( S(columnIndex), S(rowIndex)) ? JNI_TRUE : JNI_FALSE;  // noexcept
+    return TBL(nativeTablePtr)->is_null(S(columnIndex), S(rowIndex)) ? JNI_TRUE : JNI_FALSE; // noexcept
 }
 
 // ----------------- Set cell
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLink
-  (JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jlong targetRowIndex, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLink(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                  jlong columnIndex, jlong rowIndex,
+                                                                  jlong targetRowIndex, jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_INSERT_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
         return;
     try {
-        TBL(nativeTablePtr)->set_link( S(columnIndex), S(rowIndex), S(targetRowIndex), B(isDefault));
-    } CATCH_STD()
+        TBL(nativeTablePtr)->set_link(S(columnIndex), S(rowIndex), S(targetRowIndex), B(isDefault));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLong(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jlong value, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLong(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                  jlong columnIndex, jlong rowIndex, jlong value,
+                                                                  jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int))
         return;
     try {
-        TBL(nativeTablePtr)->set_int( S(columnIndex), S(rowIndex), value, B(isDefault));
-    } CATCH_STD()
+        TBL(nativeTablePtr)->set_int(S(columnIndex), S(rowIndex), value, B(isDefault));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_Table_nativeSetLongUnique(JNIEnv *env, jclass, jlong nativeTablePtr, jlong columnIndex,
-                                                 jlong rowIndex, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLongUnique(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                        jlong columnIndex, jlong rowIndex,
+                                                                        jlong value)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int))
         return;
     try {
-        TBL(nativeTablePtr)->set_int_unique( S(columnIndex), S(rowIndex), value);
-    } CATCH_STD()
+        TBL(nativeTablePtr)->set_int_unique(S(columnIndex), S(rowIndex), value);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetBoolean(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jboolean value, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetBoolean(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                     jlong columnIndex, jlong rowIndex,
+                                                                     jboolean value, jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Bool))
         return;
     try {
-        TBL(nativeTablePtr)->set_bool( S(columnIndex), S(rowIndex), B(value), B(isDefault));
-    } CATCH_STD()
+        TBL(nativeTablePtr)->set_bool(S(columnIndex), S(rowIndex), B(value), B(isDefault));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetFloat(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jfloat value, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetFloat(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                   jlong columnIndex, jlong rowIndex, jfloat value,
+                                                                   jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Float))
         return;
     try {
-        TBL(nativeTablePtr)->set_float( S(columnIndex), S(rowIndex), value, B(isDefault));
-    } CATCH_STD()
+        TBL(nativeTablePtr)->set_float(S(columnIndex), S(rowIndex), value, B(isDefault));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetDouble(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jdouble value, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetDouble(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                    jlong columnIndex, jlong rowIndex, jdouble value,
+                                                                    jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Double))
         return;
     try {
-        TBL(nativeTablePtr)->set_double( S(columnIndex), S(rowIndex), value, B(isDefault));
-    } CATCH_STD()
+        TBL(nativeTablePtr)->set_double(S(columnIndex), S(rowIndex), value, B(isDefault));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetString(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jstring value, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetString(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                    jlong columnIndex, jlong rowIndex, jstring value,
+                                                                    jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String))
         return;
@@ -698,13 +728,14 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetString(
             }
         }
         JStringAccessor value2(env, value); // throws
-        TBL(nativeTablePtr)->set_string( S(columnIndex), S(rowIndex), value2, B(isDefault));
-    } CATCH_STD()
+        TBL(nativeTablePtr)->set_string(S(columnIndex), S(rowIndex), value2, B(isDefault));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_Table_nativeSetStringUnique(JNIEnv *env, jclass, jlong nativeTablePtr, jlong columnIndex,
-                                                   jlong rowIndex, jstring value)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetStringUnique(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                          jlong columnIndex, jlong rowIndex,
+                                                                          jstring value)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String))
         return;
@@ -714,22 +745,26 @@ Java_io_realm_internal_Table_nativeSetStringUnique(JNIEnv *env, jclass, jlong na
                 return;
             }
             TBL(nativeTablePtr)->set_string_unique(S(columnIndex), S(rowIndex), null{});
-        } else {
+        }
+        else {
             JStringAccessor value2(env, value); // throws
             TBL(nativeTablePtr)->set_string_unique(S(columnIndex), S(rowIndex), value2);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetTimestamp(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jlong timestampValue, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetTimestamp(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jlong rowIndex,
+                                                                       jlong timestampValue, jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Timestamp))
         return;
     try {
-        TBL(nativeTablePtr)->set_timestamp( S(columnIndex), S(rowIndex), from_milliseconds(timestampValue),
-                                            B(isDefault));
-    } CATCH_STD()
+        TBL(nativeTablePtr)
+            ->set_timestamp(S(columnIndex), S(rowIndex), from_milliseconds(timestampValue), B(isDefault));
+    }
+    CATCH_STD()
 }
 
 /*
@@ -744,23 +779,26 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetByteBuffer(
 }
 */
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetByteArray(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jbyteArray dataArray, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetByteArray(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jlong rowIndex,
+                                                                       jbyteArray dataArray, jboolean isDefault)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Binary))
         return;
     try {
         if (dataArray == NULL && !TBL_AND_COL_NULLABLE(env, TBL(nativeTablePtr), columnIndex)) {
-                return;
+            return;
         }
 
         JniByteArray byteAccessor(env, dataArray);
         TBL(nativeTablePtr)->set_binary(S(columnIndex), S(rowIndex), byteAccessor, B(isDefault));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetNull(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex, jboolean isDefault)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetNull(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                  jlong columnIndex, jlong rowIndex,
+                                                                  jboolean isDefault)
 {
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
@@ -771,12 +809,12 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetNull(
         return;
     try {
         pTable->set_null(S(columnIndex), S(rowIndex), B(isDefault));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_Table_nativeSetNullUnique(JNIEnv *env, jclass, jlong nativeTablePtr, jlong columnIndex,
-                                                 jlong rowIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetNullUnique(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                        jlong columnIndex, jlong rowIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
@@ -787,68 +825,73 @@ Java_io_realm_internal_Table_nativeSetNullUnique(JNIEnv *env, jclass, jlong nati
         return;
     try {
         pTable->set_null_unique(S(columnIndex), S(rowIndex));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetRowPtr
-  (JNIEnv* env, jobject, jlong nativeTablePtr, jlong index)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetRowPtr(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                     jlong index)
 {
     try {
-        Row* row = new Row( (*TBL(nativeTablePtr))[ S(index) ] );
+        Row* row = new Row((*TBL(nativeTablePtr))[S(index)]);
         return reinterpret_cast<jlong>(row);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 //--------------------- Indexing methods:
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeAddSearchIndex(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeAddSearchIndex(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
         return;
 
-    DataType column_type = pTable->get_column_type (S(columnIndex));
+    DataType column_type = pTable->get_column_type(S(columnIndex));
     if (!is_allowed_to_index(env, column_type)) {
         return;
     }
 
     try {
-        pTable->add_search_index( S(columnIndex));
-    } CATCH_STD()
+        pTable->add_search_index(S(columnIndex));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveSearchIndex(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveSearchIndex(JNIEnv* env, jobject,
+                                                                            jlong nativeTablePtr, jlong columnIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
         return;
-    DataType column_type = pTable->get_column_type (S(columnIndex));
+    DataType column_type = pTable->get_column_type(S(columnIndex));
     if (!is_allowed_to_index(env, column_type)) {
         return;
     }
     try {
-        pTable->remove_search_index( S(columnIndex));
-    } CATCH_STD()
+        pTable->remove_search_index(S(columnIndex));
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeHasSearchIndex(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeHasSearchIndex(JNIEnv* env, jobject,
+                                                                             jlong nativeTablePtr, jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
         return false;
     try {
-        return TBL(nativeTablePtr)->has_search_index( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->has_search_index(S(columnIndex));
+    }
+    CATCH_STD()
     return false;
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsNullLink
-  (JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsNullLink(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
         return 0;
@@ -856,314 +899,340 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsNullLink
     return TBL(nativeTablePtr)->is_null_link(S(columnIndex), S(rowIndex));
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeNullifyLink
-  (JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeNullifyLink(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                      jlong columnIndex, jlong rowIndex)
 {
     if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
         return;
     try {
         TBL(nativeTablePtr)->nullify_link(S(columnIndex), S(rowIndex));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 //---------------------- Aggregate methods for integers
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSumInt(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSumInt(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                  jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
     try {
-        return TBL(nativeTablePtr)->sum_int( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->sum_int(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumInt(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumInt(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                      jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
     try {
-        return TBL(nativeTablePtr)->maximum_int( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->maximum_int(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumInt(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumInt(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                      jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
     try {
-        return TBL(nativeTablePtr)->minimum_int( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->minimum_int(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageInt(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageInt(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                        jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
     try {
-        return TBL(nativeTablePtr)->average_int( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->average_int(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
 //--------------------- Aggregate methods for float
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumFloat(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                      jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
         return 0;
     try {
-        return TBL(nativeTablePtr)->sum_float( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->sum_float(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMaximumFloat(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMaximumFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
         return 0;
     try {
-        return TBL(nativeTablePtr)->maximum_float( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->maximum_float(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMinimumFloat(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMinimumFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
         return 0;
     try {
-        return TBL(nativeTablePtr)->minimum_float( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->minimum_float(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageFloat(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                          jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
         return 0;
     try {
-        return TBL(nativeTablePtr)->average_float( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->average_float(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
 
 //--------------------- Aggregate methods for double
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumDouble(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
         return 0;
     try {
-        return TBL(nativeTablePtr)->sum_double( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->sum_double(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMaximumDouble(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMaximumDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                           jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
         return 0;
     try {
-        return TBL(nativeTablePtr)->maximum_double( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->maximum_double(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMinimumDouble(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMinimumDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                           jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
         return 0;
     try {
-        return TBL(nativeTablePtr)->minimum_double( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->minimum_double(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageDouble(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                           jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
         return 0;
     try {
-        return TBL(nativeTablePtr)->average_double( S(columnIndex));
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->average_double(S(columnIndex));
+    }
+    CATCH_STD()
     return 0;
 }
 
 
 //--------------------- Aggregate methods for date
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumTimestamp(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumTimestamp(JNIEnv* env, jobject,
+                                                                            jlong nativeTablePtr, jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp))
         return 0;
     try {
-        return to_milliseconds(TBL(nativeTablePtr)->maximum_timestamp( S(columnIndex)));
-    } CATCH_STD()
+        return to_milliseconds(TBL(nativeTablePtr)->maximum_timestamp(S(columnIndex)));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumTimestamp(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumTimestamp(JNIEnv* env, jobject,
+                                                                            jlong nativeTablePtr, jlong columnIndex)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp))
         return 0;
     try {
-        return to_milliseconds(TBL(nativeTablePtr)->minimum_timestamp( S(columnIndex)));
-    } CATCH_STD()
+        return to_milliseconds(TBL(nativeTablePtr)->minimum_timestamp(S(columnIndex)));
+    }
+    CATCH_STD()
     return 0;
 }
 
 //---------------------- Count
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountLong(
-    JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountLong(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                     jlong columnIndex, jlong value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
     try {
-        return TBL(nativeTablePtr)->count_int( S(columnIndex), value);
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->count_int(S(columnIndex), value);
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountFloat(
-    JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex, jfloat value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                      jlong columnIndex, jfloat value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
         return 0;
     try {
-        return TBL(nativeTablePtr)->count_float( S(columnIndex), value);
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->count_float(S(columnIndex), value);
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountDouble(
-    JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex, jdouble value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jdouble value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
         return 0;
     try {
-        return TBL(nativeTablePtr)->count_double( S(columnIndex), value);
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->count_double(S(columnIndex), value);
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountString(
-    JNIEnv *env, jobject, jlong nativeTablePtr, jlong columnIndex, jstring value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountString(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                       jlong columnIndex, jstring value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_String))
         return 0;
 
     try {
         JStringAccessor value2(env, value); // throws
-        return TBL(nativeTablePtr)->count_string( S(columnIndex), value2);
-    } CATCH_STD()
+        return TBL(nativeTablePtr)->count_string(S(columnIndex), value2);
+    }
+    CATCH_STD()
     return 0;
 }
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeWhere(
-    JNIEnv *env, jobject, jlong nativeTablePtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeWhere(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr)))
         return 0;
     try {
-        Query *queryPtr = new Query(TBL(nativeTablePtr)->where());
+        Query* queryPtr = new Query(TBL(nativeTablePtr)->where());
         return reinterpret_cast<jlong>(queryPtr);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 //----------------------- FindFirst
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstInt(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jlong value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstInt(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                        jlong columnIndex, jlong value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
     try {
-        return to_jlong_or_not_found( TBL(nativeTablePtr)->find_first_int( S(columnIndex), value) );
-    } CATCH_STD()
+        return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_int(S(columnIndex), value));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstBool(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jboolean value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstBool(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex, jboolean value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Bool))
         return 0;
     try {
-        return to_jlong_or_not_found( TBL(nativeTablePtr)->find_first_bool( S(columnIndex), value != 0 ? true : false) );
-    } CATCH_STD()
+        return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_bool(S(columnIndex), value != 0 ? true : false));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstFloat(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jfloat value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                          jlong columnIndex, jfloat value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
         return 0;
     try {
-        return to_jlong_or_not_found( TBL(nativeTablePtr)->find_first_float( S(columnIndex), value) );
-    } CATCH_STD()
+        return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_float(S(columnIndex), value));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstDouble(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jdouble value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                           jlong columnIndex, jdouble value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
         return 0;
     try {
-        return to_jlong_or_not_found( TBL(nativeTablePtr)->find_first_double( S(columnIndex), value) );
-    } CATCH_STD()
+        return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_double(S(columnIndex), value));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstTimestamp(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong dateTimeValue)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstTimestamp(JNIEnv* env, jobject,
+                                                                              jlong nativeTablePtr, jlong columnIndex,
+                                                                              jlong dateTimeValue)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp))
         return 0;
     try {
-        size_t res = TBL(nativeTablePtr)->find_first_timestamp( S(columnIndex), from_milliseconds(dateTimeValue));
+        size_t res = TBL(nativeTablePtr)->find_first_timestamp(S(columnIndex), from_milliseconds(dateTimeValue));
         return to_jlong_or_not_found(res);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstString(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex, jstring value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstString(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                           jlong columnIndex, jstring value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_String))
         return 0;
 
     try {
         JStringAccessor value2(env, value); // throws
-        return to_jlong_or_not_found( TBL(nativeTablePtr)->find_first_string( S(columnIndex), value2) );
-    } CATCH_STD()
+        return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_string(S(columnIndex), value2));
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstNull(
-    JNIEnv* env, jclass, jlong nativeTablePtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstNull(JNIEnv* env, jclass, jlong nativeTablePtr,
+                                                                         jlong columnIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
@@ -1171,14 +1240,13 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstNull(
     if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex))
         return jlong(-1);
     try {
-        return to_jlong_or_not_found( pTable->find_first_null( S(columnIndex) ) );
-    } CATCH_STD()
+        return to_jlong_or_not_found(pTable->find_first_null(S(columnIndex)));
+    }
+    CATCH_STD()
     return jlong(-1);
 }
 
 // FindAll
-
-
 
 
 // FIXME: reenable when find_first_timestamp() is implemented
@@ -1189,7 +1257,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindAllTimestamp(
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp))
         return 0;
     try {
-        TableView* pTableView = new TableView(TBL(nativeTablePtr)->find_all_timestamp(S(columnIndex), from_milliseconds(dateTimeValue)));
+        TableView* pTableView = new TableView(TBL(nativeTablePtr)->find_all_timestamp(S(columnIndex),
+from_milliseconds(dateTimeValue)));
         return reinterpret_cast<jlong>(pTableView);
     } CATCH_STD()
     return 0;
@@ -1197,10 +1266,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindAllTimestamp(
 */
 
 
-
 // experimental
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeLowerBoundInt(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeLowerBoundInt(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex, jlong value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
@@ -1208,14 +1276,15 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeLowerBoundInt(
     Table* pTable = TBL(nativeTablePtr);
     try {
         return pTable->lower_bound_int(S(columnIndex), S(value));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 
 // experimental
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeUpperBoundInt(
-    JNIEnv* env, jobject, jlong nativeTablePtr, jlong columnIndex, jlong value)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeUpperBoundInt(JNIEnv* env, jobject, jlong nativeTablePtr,
+                                                                         jlong columnIndex, jlong value)
 {
     if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
         return 0;
@@ -1223,14 +1292,17 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeUpperBoundInt(
     Table* pTable = TBL(nativeTablePtr);
     try {
         return pTable->upper_bound_int(S(columnIndex), S(value));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 //
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetSortedViewMulti(
-   JNIEnv *env, jobject, jlong nativeTablePtr, jlongArray columnIndices, jbooleanArray ascending)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetSortedViewMulti(JNIEnv* env, jobject,
+                                                                              jlong nativeTablePtr,
+                                                                              jlongArray columnIndices,
+                                                                              jbooleanArray ascending)
 {
     Table* pTable = TBL(nativeTablePtr);
 
@@ -1256,10 +1328,10 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetSortedViewMulti(
     std::vector<bool> ascendings(S(arr_len));
 
     for (int i = 0; i < arr_len; ++i) {
-        if (!TBL_AND_COL_INDEX_VALID(env, pTable, S(long_arr[i]) )) {
+        if (!TBL_AND_COL_INDEX_VALID(env, pTable, S(long_arr[i]))) {
             return 0;
         }
-        int colType = pTable->get_column_type( S(long_arr[i]) );
+        int colType = pTable->get_column_type(S(long_arr[i]));
         switch (colType) {
             case type_Int:
             case type_Bool:
@@ -1267,11 +1339,12 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetSortedViewMulti(
             case type_Double:
             case type_Float:
             case type_Timestamp:
-                indices[i] = std::vector<size_t> { S(long_arr[i]) };
+                indices[i] = std::vector<size_t>{S(long_arr[i])};
                 ascendings[i] = S(bool_arr[i]);
                 break;
             default:
-                ThrowException(env, IllegalArgument, "Sort is only support on String, Date, boolean, byte, short, int, long and their boxed variants.");
+                ThrowException(env, IllegalArgument, "Sort is only support on String, Date, boolean, byte, short, "
+                                                     "int, long and their boxed variants.");
                 return 0;
         }
     }
@@ -1279,25 +1352,25 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetSortedViewMulti(
     try {
         TableView* pTableView = new TableView(pTable->get_sorted_view(SortDescriptor(*pTable, indices, ascendings)));
         return reinterpret_cast<jlong>(pTableView);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetName(
-    JNIEnv *env, jobject, jlong nativeTablePtr)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetName(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     try {
         Table* table = TBL(nativeTablePtr);
         if (!TABLE_VALID(env, table))
             return NULL;
         return to_jstring(env, table->get_name());
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToJson(
-    JNIEnv *env, jobject, jlong nativeTablePtr)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToJson(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     Table* table = TBL(nativeTablePtr);
     if (!TABLE_VALID(env, table))
@@ -1310,23 +1383,24 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToJson(
         table->to_json(ss);
         const string str = ss.str();
         return to_jstring(env, str);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsValid(
-    JNIEnv*, jobject, jlong nativeTablePtr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsValid(JNIEnv*, jobject, jlong nativeTablePtr)
 {
     TR_ENTER_PTR(nativeTablePtr)
-    return TBL(nativeTablePtr)->is_attached();  // noexcept
+    return TBL(nativeTablePtr)->is_attached(); // noexcept
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_createNative(JNIEnv *env, jobject)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_createNative(JNIEnv* env, jobject)
 {
     TR_ENTER()
     try {
         return reinterpret_cast<jlong>(LangBindHelper::new_table());
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
@@ -1343,7 +1417,7 @@ static bool check_valid_primary_key_column(JNIEnv* env, Table* table, StringData
     DataType column_type = table->get_column_type(column_index);
     TableView results = table->get_sorted_view(column_index);
 
-    switch(column_type) {
+    switch (column_type) {
         case type_Int:
             if (results.size() > 1) {
                 int64_t val = results.get_int(column_index, 0);
@@ -1388,14 +1462,16 @@ static bool check_valid_primary_key_column(JNIEnv* env, Table* table, StringData
     }
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(
-    JNIEnv* env, jobject, jlong nativePrivateKeyTablePtr, jlong nativeTablePtr, jstring columnName)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(JNIEnv* env, jobject,
+                                                                         jlong nativePrivateKeyTablePtr,
+                                                                         jlong nativeTablePtr, jstring columnName)
 {
     try {
         Table* table = TBL(nativeTablePtr);
         Table* pk_table = TBL(nativePrivateKeyTablePtr);
         const std::string table_name(table->get_name().substr(TABLE_PREFIX.length())); // Remove "class_" prefix
-        size_t row_index = pk_table->find_first_string(io_realm_internal_Table_PRIMARY_KEY_CLASS_COLUMN_INDEX, table_name);
+        size_t row_index =
+            pk_table->find_first_string(io_realm_internal_Table_PRIMARY_KEY_CLASS_COLUMN_INDEX, table_name);
 
         if (columnName == NULL || env->GetStringLength(columnName) == 0) {
             // No primary key provided => remove previous set keys
@@ -1411,24 +1487,29 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(
                 // No primary key is currently set
                 if (check_valid_primary_key_column(env, table, new_primary_key_column_name)) {
                     row_index = pk_table->add_empty_row();
-                    pk_table->set_string_unique(io_realm_internal_Table_PRIMARY_KEY_CLASS_COLUMN_INDEX, row_index, table_name);
-                    pk_table->set_string(io_realm_internal_Table_PRIMARY_KEY_FIELD_COLUMN_INDEX, row_index, new_primary_key_column_name);
+                    pk_table->set_string_unique(io_realm_internal_Table_PRIMARY_KEY_CLASS_COLUMN_INDEX, row_index,
+                                                table_name);
+                    pk_table->set_string(io_realm_internal_Table_PRIMARY_KEY_FIELD_COLUMN_INDEX, row_index,
+                                         new_primary_key_column_name);
                 }
             }
             else {
                 // Primary key already exists
                 // We only wish to check for duplicate values if a column isn't already a primary key
-                StringData current_primary_key = pk_table->get_string(io_realm_internal_Table_PRIMARY_KEY_FIELD_COLUMN_INDEX, row_index);
+                StringData current_primary_key =
+                    pk_table->get_string(io_realm_internal_Table_PRIMARY_KEY_FIELD_COLUMN_INDEX, row_index);
                 if (new_primary_key_column_name != current_primary_key) {
                     if (check_valid_primary_key_column(env, table, new_primary_key_column_name)) {
-                        pk_table->set_string(io_realm_internal_Table_PRIMARY_KEY_FIELD_COLUMN_INDEX, row_index, new_primary_key_column_name);
+                        pk_table->set_string(io_realm_internal_Table_PRIMARY_KEY_FIELD_COLUMN_INDEX, row_index,
+                                             new_primary_key_column_name);
                     }
                 }
             }
 
             return jlong(primary_key_column_index);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
@@ -1451,8 +1532,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(
 
 // This methods converts the old (wrong) table format (string, integer) to the right (string,string) format and strips
 // any class names in the col[0] of their "class_" prefix
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeMigratePrimaryKeyTableIfNeeded
-    (JNIEnv*, jclass, jlong groupNativePtr, jlong privateKeyTableNativePtr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeMigratePrimaryKeyTableIfNeeded(
+    JNIEnv*, jclass, jlong groupNativePtr, jlong privateKeyTableNativePtr)
 {
     const size_t CLASS_COLUMN_INDEX = io_realm_internal_Table_PRIMARY_KEY_CLASS_COLUMN_INDEX;
     const size_t FIELD_COLUMN_INDEX = io_realm_internal_Table_PRIMARY_KEY_FIELD_COLUMN_INDEX;
@@ -1505,7 +1586,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeMigratePrimaryKeyT
 }
 
 JNIEXPORT jboolean JNICALL
-Java_io_realm_internal_Table_nativePrimaryKeyTableNeedsMigration(JNIEnv *, jclass, jlong primaryKeyTableNativePtr)
+Java_io_realm_internal_Table_nativePrimaryKeyTableNeedsMigration(JNIEnv*, jclass, jlong primaryKeyTableNativePtr)
 {
 
     const size_t CLASS_COLUMN_INDEX = io_realm_internal_Table_PRIMARY_KEY_CLASS_COLUMN_INDEX;
@@ -1533,15 +1614,14 @@ Java_io_realm_internal_Table_nativePrimaryKeyTableNeedsMigration(JNIEnv *, jclas
     return JNI_FALSE;
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeHasSameSchema
-  (JNIEnv*, jobject, jlong thisTablePtr, jlong otherTablePtr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeHasSameSchema(JNIEnv*, jobject, jlong thisTablePtr,
+                                                                            jlong otherTablePtr)
 {
     return *TBL(thisTablePtr)->get_descriptor() == *TBL(otherTablePtr)->get_descriptor();
 }
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeVersion(
-        JNIEnv* env, jobject, jlong nativeTablePtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeVersion(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     bool valid = (TBL(nativeTablePtr) != NULL);
     if (valid) {
@@ -1551,8 +1631,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeVersion(
         }
     }
     try {
-        return (jlong) TBL(nativeTablePtr)->get_version_counter();
-    } CATCH_STD()
+        return (jlong)TBL(nativeTablePtr)->get_version_counter();
+    }
+    CATCH_STD()
     return 0;
 }
 
@@ -1562,10 +1643,8 @@ static void finalize_table(jlong ptr)
     LangBindHelper::unbind_table_ptr(TBL(ptr));
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetFinalizerPtr
-  (JNIEnv *, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetFinalizerPtr(JNIEnv*, jclass)
 {
     TR_ENTER()
     return reinterpret_cast<jlong>(&finalize_table);
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -43,8 +43,9 @@ inline static bool is_allowed_to_index(JNIEnv* env, DataType column_type)
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumn(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                      jint colType, jstring name, jboolean isNullable)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return 0;
+    }
     if (TBL(nativeTablePtr)->has_shared_type()) {
         ThrowException(env, UnsupportedOperation,
                        "Not allowed to add field in subtable. Use getSubtableSchema() on root table instead.");
@@ -52,13 +53,13 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumn(JNIEnv* env
     }
     try {
         JStringAccessor name2(env, name); // throws
-        bool is_column_nullable = isNullable != 0 ? true : false;
+        bool is_column_nullable = to_bool(isNullable);
 
         DataType dataType = DataType(colType);
         if (is_column_nullable && dataType == type_LinkList) {
             ThrowException(env, IllegalArgument, "List fields cannot be nullable.");
         }
-        return TBL(nativeTablePtr)->add_column(dataType, name2, is_column_nullable);
+        return static_cast<jlong>(TBL(nativeTablePtr)->add_column(dataType, name2, is_column_nullable));
     }
     CATCH_STD()
     return 0;
@@ -68,8 +69,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumnLink(JNIEnv*
                                                                          jint colType, jstring name,
                                                                          jlong targetTablePtr)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return 0;
+    }
     if (TBL(nativeTablePtr)->has_shared_type()) {
         ThrowException(env, UnsupportedOperation,
                        "Not allowed to add field in subtable. Use getSubtableSchema() on root table instead.");
@@ -81,7 +83,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddColumnLink(JNIEnv*
     }
     try {
         JStringAccessor name2(env, name); // throws
-        return TBL(nativeTablePtr)->add_column_link(DataType(colType), name2, *TBL(targetTablePtr));
+        return static_cast<jlong>(TBL(nativeTablePtr)->add_column_link(DataType(colType), name2, *TBL(targetTablePtr)));
     }
     CATCH_STD()
     return 0;
@@ -125,8 +127,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativePivot(JNIEnv* env, job
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveColumn(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
+    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex)) {
         return;
+    }
     if (TBL(nativeTablePtr)->has_shared_type()) {
         ThrowException(env, UnsupportedOperation,
                        "Not allowed to remove field in subtable. Use getSubtableSchema() on root table instead.");
@@ -141,8 +144,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveColumn(JNIEnv* e
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRenameColumn(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong columnIndex, jstring name)
 {
-    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
+    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex)) {
         return;
+    }
     if (TBL(nativeTablePtr)->has_shared_type()) {
         ThrowException(env, UnsupportedOperation,
                        "Not allowed to rename field in subtable. Use getSubtableSchema() on root table instead.");
@@ -161,14 +165,14 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsColumnNullable(J
 {
     Table* table = TBL(nativeTablePtr);
     if (!TBL_AND_COL_INDEX_VALID(env, table, columnIndex)) {
-        return false;
+        return JNI_FALSE;
     }
     if (table->has_shared_type()) {
         ThrowException(env, UnsupportedOperation, "Not allowed to convert field in subtable.");
-        return false;
+        return JNI_FALSE;
     }
     size_t column_index = S(columnIndex);
-    return table->is_nullable(column_index);
+    return to_jbool(table->is_nullable(column_index));
 }
 
 
@@ -406,15 +410,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNotNull
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSize(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return 0;
-    return TBL(nativeTablePtr)->size(); // noexcept
+    }
+    return static_cast<jlong>(TBL(nativeTablePtr)->size()); // noexcept
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeClear(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->clear();
     }
@@ -427,28 +433,31 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeClear(JNIEnv* env, job
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetColumnCount(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return 0;
-    return TBL(nativeTablePtr)->get_column_count(); // noexcept
+    }
+    return static_cast<jlong>(TBL(nativeTablePtr)->get_column_count()); // noexcept
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetColumnName(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                            jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
-        return NULL;
+    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex)) {
+        return nullptr;
+    }
     try {
         return to_jstring(env, TBL(nativeTablePtr)->get_column_name(S(columnIndex)));
     }
     CATCH_STD();
-    return NULL;
+    REALM_UNREACHABLE();
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetColumnIndex(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                           jstring columnName)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return 0;
+    }
     try {
         JStringAccessor columnName2(env, columnName);                                     // throws
         return to_jlong_or_not_found(TBL(nativeTablePtr)->get_column_index(columnName2)); // noexcept
@@ -460,8 +469,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetColumnIndex(JNIEnv
 JNIEXPORT jint JNICALL Java_io_realm_internal_Table_nativeGetColumnType(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                         jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
+    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex)) {
         return 0;
+    }
 
     return static_cast<jint>(TBL(nativeTablePtr)->get_column_type(S(columnIndex))); // noexcept
 }
@@ -473,8 +483,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddEmptyRow(JNIEnv* e
                                                                        jlong rows)
 {
     Table* pTable = TBL(nativeTablePtr);
-    if (!TABLE_VALID(env, pTable))
+    if (!TABLE_VALID(env, pTable)) {
         return 0;
+    }
     if (pTable->get_column_count() < 1) {
         ThrowException(env, IndexOutOfBounds, concat_stringdata("Table has no columns: ", pTable->get_name()));
         return 0;
@@ -489,8 +500,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeAddEmptyRow(JNIEnv* e
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemove(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                  jlong rowIndex)
 {
-    if (!TBL_AND_ROW_INDEX_VALID(env, TBL(nativeTablePtr), rowIndex))
+    if (!TBL_AND_ROW_INDEX_VALID(env, TBL(nativeTablePtr), rowIndex)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->remove(S(rowIndex));
     }
@@ -499,8 +511,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemove(JNIEnv* env, jo
 
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveLast(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->remove_last();
     }
@@ -510,8 +523,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveLast(JNIEnv* env
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeMoveLastOver(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong rowIndex)
 {
-    if (!TBL_AND_ROW_INDEX_VALID_OFFSET(env, TBL(nativeTablePtr), rowIndex, false))
+    if (!TBL_AND_ROW_INDEX_VALID_OFFSET(env, TBL(nativeTablePtr), rowIndex, false)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->move_last_over(S(rowIndex));
     }
@@ -523,25 +537,28 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeMoveLastOver(JNIEnv* e
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLong(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                    jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int)) {
         return 0;
+    }
     return TBL(nativeTablePtr)->get_int(S(columnIndex), S(rowIndex)); // noexcept
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeGetBoolean(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                          jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Bool))
-        return false;
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Bool)) {
+        return JNI_FALSE;
+    }
 
-    return TBL(nativeTablePtr)->get_bool(S(columnIndex), S(rowIndex)); // noexcept
+    return to_jbool(TBL(nativeTablePtr)->get_bool(S(columnIndex), S(rowIndex))); // noexcept
 }
 
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeGetFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                      jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Float))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Float)) {
         return 0;
+    }
 
     return TBL(nativeTablePtr)->get_float(S(columnIndex), S(rowIndex)); // noexcept
 }
@@ -549,8 +566,9 @@ JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeGetFloat(JNIEnv* env
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeGetDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Double))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Double)) {
         return 0;
+    }
 
     return TBL(nativeTablePtr)->get_double(S(columnIndex), S(rowIndex)); // noexcept
 }
@@ -558,8 +576,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeGetDouble(JNIEnv* e
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetTimestamp(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                         jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Timestamp))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Timestamp)) {
         return 0;
+    }
     try {
         return to_milliseconds(TBL(nativeTablePtr)->get_timestamp(S(columnIndex), S(rowIndex)));
     }
@@ -570,13 +589,14 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetTimestamp(JNIEnv* 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetString(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String))
-        return NULL;
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String)) {
+        return nullptr;
+    }
     try {
         return to_jstring(env, TBL(nativeTablePtr)->get_string(S(columnIndex), S(rowIndex)));
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 
@@ -596,8 +616,9 @@ JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_Table_nativeGetByteArray(JNI
                                                                              jlong nativeTablePtr, jlong columnIndex,
                                                                              jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Binary))
-        return NULL;
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Binary)) {
+        return nullptr;
+    }
 
     return tbl_GetByteArray<Table>(env, nativeTablePtr, columnIndex, rowIndex); // noexcept
 }
@@ -605,16 +626,18 @@ JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_Table_nativeGetByteArray(JNI
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLink(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                    jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link)) {
         return 0;
-    return TBL(nativeTablePtr)->get_link(S(columnIndex), S(rowIndex)); // noexcept
+    }
+    return static_cast<jlong>(TBL(nativeTablePtr)->get_link(S(columnIndex), S(rowIndex))); // noexcept
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLinkView(JNIEnv* env, jclass, jlong nativeTablePtr,
                                                                        jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_LinkList))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_LinkList)) {
         return 0;
+    }
     try {
         LinkViewRef* link_view_ptr = new LinkViewRef(TBL(nativeTablePtr)->get_linklist(S(columnIndex), S(rowIndex)));
         return reinterpret_cast<jlong>(link_view_ptr);
@@ -629,7 +652,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLinkTarget(JNIEnv*
     try {
         Table* pTable = &(*TBL(nativeTablePtr)->get_link_target(S(columnIndex)));
         LangBindHelper::bind_table_ptr(pTable);
-        return (jlong)pTable;
+        return reinterpret_cast<jlong>(pTable);
     }
     CATCH_STD()
     return 0;
@@ -638,7 +661,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetLinkTarget(JNIEnv*
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsNull(JNIEnv*, jobject, jlong nativeTablePtr,
                                                                      jlong columnIndex, jlong rowIndex)
 {
-    return TBL(nativeTablePtr)->is_null(S(columnIndex), S(rowIndex)) ? JNI_TRUE : JNI_FALSE; // noexcept
+    return to_jbool(TBL(nativeTablePtr)->is_null(S(columnIndex), S(rowIndex))); // noexcept
 }
 
 // ----------------- Set cell
@@ -647,8 +670,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLink(JNIEnv* env, j
                                                                   jlong columnIndex, jlong rowIndex,
                                                                   jlong targetRowIndex, jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_INSERT_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
+    if (!TBL_AND_INDEX_AND_TYPE_INSERT_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->set_link(S(columnIndex), S(rowIndex), S(targetRowIndex), B(isDefault));
     }
@@ -659,8 +683,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLong(JNIEnv* env, j
                                                                   jlong columnIndex, jlong rowIndex, jlong value,
                                                                   jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->set_int(S(columnIndex), S(rowIndex), value, B(isDefault));
     }
@@ -671,8 +696,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetLongUnique(JNIEnv* 
                                                                         jlong columnIndex, jlong rowIndex,
                                                                         jlong value)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Int)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->set_int_unique(S(columnIndex), S(rowIndex), value);
     }
@@ -683,8 +709,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetBoolean(JNIEnv* env
                                                                      jlong columnIndex, jlong rowIndex,
                                                                      jboolean value, jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Bool))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Bool)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->set_bool(S(columnIndex), S(rowIndex), B(value), B(isDefault));
     }
@@ -695,8 +722,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetFloat(JNIEnv* env, 
                                                                    jlong columnIndex, jlong rowIndex, jfloat value,
                                                                    jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Float))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Float)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->set_float(S(columnIndex), S(rowIndex), value, B(isDefault));
     }
@@ -707,8 +735,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetDouble(JNIEnv* env,
                                                                     jlong columnIndex, jlong rowIndex, jdouble value,
                                                                     jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Double))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Double)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->set_double(S(columnIndex), S(rowIndex), value, B(isDefault));
     }
@@ -719,10 +748,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetString(JNIEnv* env,
                                                                     jlong columnIndex, jlong rowIndex, jstring value,
                                                                     jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String)) {
         return;
+    }
     try {
-        if (value == NULL) {
+        if (value == nullptr) {
             if (!TBL_AND_COL_NULLABLE(env, TBL(nativeTablePtr), columnIndex)) {
                 return;
             }
@@ -737,10 +767,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetStringUnique(JNIEnv
                                                                           jlong columnIndex, jlong rowIndex,
                                                                           jstring value)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_String)) {
         return;
+    }
     try {
-        if (value == NULL) {
+        if (value == nullptr) {
             if (!TBL_AND_COL_NULLABLE(env, TBL(nativeTablePtr), columnIndex)) {
                 return;
             }
@@ -758,8 +789,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetTimestamp(JNIEnv* e
                                                                        jlong columnIndex, jlong rowIndex,
                                                                        jlong timestampValue, jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Timestamp))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Timestamp)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)
             ->set_timestamp(S(columnIndex), S(rowIndex), from_milliseconds(timestampValue), B(isDefault));
@@ -783,10 +815,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetByteArray(JNIEnv* e
                                                                        jlong columnIndex, jlong rowIndex,
                                                                        jbyteArray dataArray, jboolean isDefault)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Binary))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Binary)) {
         return;
+    }
     try {
-        if (dataArray == NULL && !TBL_AND_COL_NULLABLE(env, TBL(nativeTablePtr), columnIndex)) {
+        if (dataArray == nullptr && !TBL_AND_COL_NULLABLE(env, TBL(nativeTablePtr), columnIndex)) {
             return;
         }
 
@@ -801,12 +834,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetNull(JNIEnv* env, j
                                                                   jboolean isDefault)
 {
     Table* pTable = TBL(nativeTablePtr);
-    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
+    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex)) {
         return;
-    if (!TBL_AND_ROW_INDEX_VALID(env, pTable, rowIndex))
+    }
+    if (!TBL_AND_ROW_INDEX_VALID(env, pTable, rowIndex)) {
         return;
-    if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex))
+    }
+    if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex)) {
         return;
+    }
+
     try {
         pTable->set_null(S(columnIndex), S(rowIndex), B(isDefault));
     }
@@ -817,12 +854,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeSetNullUnique(JNIEnv* 
                                                                         jlong columnIndex, jlong rowIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
-    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
+    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex)) {
         return;
-    if (!TBL_AND_ROW_INDEX_VALID(env, pTable, rowIndex))
+    }
+    if (!TBL_AND_ROW_INDEX_VALID(env, pTable, rowIndex)) {
         return;
-    if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex))
+    }
+    if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex)) {
         return;
+    }
+
     try {
         pTable->set_null_unique(S(columnIndex), S(rowIndex));
     }
@@ -838,7 +879,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeGetRowPtr(JNIEnv* env
         return reinterpret_cast<jlong>(row);
     }
     CATCH_STD()
-    return 0;
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 //--------------------- Indexing methods:
@@ -847,8 +888,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeAddSearchIndex(JNIEnv*
                                                                          jlong columnIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
-    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
+    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex)) {
         return;
+    }
 
     DataType column_type = pTable->get_column_type(S(columnIndex));
     if (!is_allowed_to_index(env, column_type)) {
@@ -865,8 +907,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveSearchIndex(JNIE
                                                                             jlong nativeTablePtr, jlong columnIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
-    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
+    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex)) {
         return;
+    }
     DataType column_type = pTable->get_column_type(S(columnIndex));
     if (!is_allowed_to_index(env, column_type)) {
         return;
@@ -881,29 +924,32 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeRemoveSearchIndex(JNIE
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeHasSearchIndex(JNIEnv* env, jobject,
                                                                              jlong nativeTablePtr, jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex))
-        return false;
+    if (!TBL_AND_COL_INDEX_VALID(env, TBL(nativeTablePtr), columnIndex)) {
+        return JNI_FALSE;
+    }
     try {
-        return TBL(nativeTablePtr)->has_search_index(S(columnIndex));
+        return to_jbool(TBL(nativeTablePtr)->has_search_index(S(columnIndex)));
     }
     CATCH_STD()
-    return false;
+    return JNI_FALSE;
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsNullLink(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                          jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
-        return 0;
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link)) {
+        return JNI_FALSE;
+    }
 
-    return TBL(nativeTablePtr)->is_null_link(S(columnIndex), S(rowIndex));
+    return to_jbool(TBL(nativeTablePtr)->is_null_link(S(columnIndex), S(rowIndex)));
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeNullifyLink(JNIEnv* env, jclass, jlong nativeTablePtr,
                                                                       jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link))
+    if (!TBL_AND_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, rowIndex, type_Link)) {
         return;
+    }
     try {
         TBL(nativeTablePtr)->nullify_link(S(columnIndex), S(rowIndex));
     }
@@ -915,8 +961,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeNullifyLink(JNIEnv* en
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSumInt(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                   jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->sum_int(S(columnIndex));
     }
@@ -927,8 +974,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSumInt(JNIEnv* env, j
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumInt(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                       jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->maximum_int(S(columnIndex));
     }
@@ -939,8 +987,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumInt(JNIEnv* en
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumInt(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                       jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->minimum_int(S(columnIndex));
     }
@@ -951,8 +1000,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumInt(JNIEnv* en
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageInt(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                         jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->average_int(S(columnIndex));
     }
@@ -965,8 +1015,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageInt(JNIEnv* 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                       jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->sum_float(S(columnIndex));
     }
@@ -977,8 +1028,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumFloat(JNIEnv* en
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMaximumFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                          jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->maximum_float(S(columnIndex));
     }
@@ -989,8 +1041,9 @@ JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMaximumFloat(JNIEnv*
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMinimumFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                          jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->minimum_float(S(columnIndex));
     }
@@ -1001,8 +1054,9 @@ JNIEXPORT jfloat JNICALL Java_io_realm_internal_Table_nativeMinimumFloat(JNIEnv*
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                           jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->average_float(S(columnIndex));
     }
@@ -1016,8 +1070,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageFloat(JNIEnv
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->sum_double(S(columnIndex));
     }
@@ -1028,8 +1083,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeSumDouble(JNIEnv* e
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMaximumDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                            jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->maximum_double(S(columnIndex));
     }
@@ -1040,8 +1096,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMaximumDouble(JNIEn
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMinimumDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                            jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->minimum_double(S(columnIndex));
     }
@@ -1052,8 +1109,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeMinimumDouble(JNIEn
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                            jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double)) {
         return 0;
+    }
     try {
         return TBL(nativeTablePtr)->average_double(S(columnIndex));
     }
@@ -1067,8 +1125,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_Table_nativeAverageDouble(JNIEn
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumTimestamp(JNIEnv* env, jobject,
                                                                             jlong nativeTablePtr, jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp)) {
         return 0;
+    }
     try {
         return to_milliseconds(TBL(nativeTablePtr)->maximum_timestamp(S(columnIndex)));
     }
@@ -1079,8 +1138,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMaximumTimestamp(JNIE
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumTimestamp(JNIEnv* env, jobject,
                                                                             jlong nativeTablePtr, jlong columnIndex)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp)) {
         return 0;
+    }
     try {
         return to_milliseconds(TBL(nativeTablePtr)->minimum_timestamp(S(columnIndex)));
     }
@@ -1093,10 +1153,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeMinimumTimestamp(JNIE
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountLong(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                      jlong columnIndex, jlong value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
     try {
-        return TBL(nativeTablePtr)->count_int(S(columnIndex), value);
+        return static_cast<jlong>(TBL(nativeTablePtr)->count_int(S(columnIndex), value));
     }
     CATCH_STD()
     return 0;
@@ -1105,10 +1166,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountLong(JNIEnv* env
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                       jlong columnIndex, jfloat value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float)) {
         return 0;
+    }
     try {
-        return TBL(nativeTablePtr)->count_float(S(columnIndex), value);
+        return static_cast<jlong>(TBL(nativeTablePtr)->count_float(S(columnIndex), value));
     }
     CATCH_STD()
     return 0;
@@ -1117,10 +1179,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountFloat(JNIEnv* en
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong columnIndex, jdouble value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double)) {
         return 0;
+    }
     try {
-        return TBL(nativeTablePtr)->count_double(S(columnIndex), value);
+        return static_cast<jlong>(TBL(nativeTablePtr)->count_double(S(columnIndex), value));
     }
     CATCH_STD()
     return 0;
@@ -1129,12 +1192,12 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountDouble(JNIEnv* e
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountString(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                        jlong columnIndex, jstring value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_String))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_String)) {
         return 0;
-
+    }
     try {
         JStringAccessor value2(env, value); // throws
-        return TBL(nativeTablePtr)->count_string(S(columnIndex), value2);
+        return static_cast<jlong>(TBL(nativeTablePtr)->count_string(S(columnIndex), value2));
     }
     CATCH_STD()
     return 0;
@@ -1143,14 +1206,15 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeCountString(JNIEnv* e
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeWhere(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
-    if (!TABLE_VALID(env, TBL(nativeTablePtr)))
+    if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return 0;
+    }
     try {
         Query* queryPtr = new Query(TBL(nativeTablePtr)->where());
         return reinterpret_cast<jlong>(queryPtr);
     }
     CATCH_STD()
-    return 0;
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 //----------------------- FindFirst
@@ -1158,8 +1222,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeWhere(JNIEnv* env, jo
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstInt(JNIEnv* env, jclass, jlong nativeTablePtr,
                                                                         jlong columnIndex, jlong value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
     try {
         return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_int(S(columnIndex), value));
     }
@@ -1170,10 +1235,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstInt(JNIEnv* 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstBool(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                          jlong columnIndex, jboolean value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Bool))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Bool)) {
         return 0;
+    }
     try {
-        return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_bool(S(columnIndex), value != 0 ? true : false));
+        return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_bool(S(columnIndex), to_bool(value)));
     }
     CATCH_STD()
     return 0;
@@ -1182,8 +1248,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstBool(JNIEnv*
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstFloat(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                           jlong columnIndex, jfloat value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Float)) {
         return 0;
+    }
     try {
         return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_float(S(columnIndex), value));
     }
@@ -1194,8 +1261,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstFloat(JNIEnv
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstDouble(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                            jlong columnIndex, jdouble value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Double)) {
         return 0;
+    }
     try {
         return to_jlong_or_not_found(TBL(nativeTablePtr)->find_first_double(S(columnIndex), value));
     }
@@ -1207,8 +1275,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstTimestamp(JN
                                                                               jlong nativeTablePtr, jlong columnIndex,
                                                                               jlong dateTimeValue)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Timestamp)) {
         return 0;
+    }
     try {
         size_t res = TBL(nativeTablePtr)->find_first_timestamp(S(columnIndex), from_milliseconds(dateTimeValue));
         return to_jlong_or_not_found(res);
@@ -1220,8 +1289,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstTimestamp(JN
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstString(JNIEnv* env, jclass, jlong nativeTablePtr,
                                                                            jlong columnIndex, jstring value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_String))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_String)) {
         return 0;
+    }
 
     try {
         JStringAccessor value2(env, value); // throws
@@ -1235,15 +1305,17 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFindFirstNull(JNIEnv*
                                                                          jlong columnIndex)
 {
     Table* pTable = TBL(nativeTablePtr);
-    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex))
-        return jlong(-1);
-    if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex))
-        return jlong(-1);
+    if (!TBL_AND_COL_INDEX_VALID(env, pTable, columnIndex)) {
+        return to_jlong_or_not_found(-1);
+    }
+    if (!TBL_AND_COL_NULLABLE(env, pTable, columnIndex)) {
+        return to_jlong_or_not_found(-1);
+    }
     try {
         return to_jlong_or_not_found(pTable->find_first_null(S(columnIndex)));
     }
     CATCH_STD()
-    return jlong(-1);
+    return to_jlong_or_not_found(-1);
 }
 
 // FindAll
@@ -1270,12 +1342,13 @@ from_milliseconds(dateTimeValue)));
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeLowerBoundInt(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                          jlong columnIndex, jlong value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
 
     Table* pTable = TBL(nativeTablePtr);
     try {
-        return pTable->lower_bound_int(S(columnIndex), S(value));
+        return static_cast<jlong>(pTable->lower_bound_int(S(columnIndex), S(value)));
     }
     CATCH_STD()
     return 0;
@@ -1286,12 +1359,13 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeLowerBoundInt(JNIEnv*
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeUpperBoundInt(JNIEnv* env, jobject, jlong nativeTablePtr,
                                                                          jlong columnIndex, jlong value)
 {
-    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int))
+    if (!TBL_AND_COL_INDEX_AND_TYPE_VALID(env, TBL(nativeTablePtr), columnIndex, type_Int)) {
         return 0;
+    }
 
     Table* pTable = TBL(nativeTablePtr);
     try {
-        return pTable->upper_bound_int(S(columnIndex), S(value));
+        return static_cast<jlong>(pTable->upper_bound_int(S(columnIndex), S(value)));
     }
     CATCH_STD()
     return 0;
@@ -1361,20 +1435,22 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeGetName(JNIEnv* env
 {
     try {
         Table* table = TBL(nativeTablePtr);
-        if (!TABLE_VALID(env, table))
-            return NULL;
+        if (!TABLE_VALID(env, table)) {
+            return nullptr;
+        }
         return to_jstring(env, table->get_name());
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToJson(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
     Table* table = TBL(nativeTablePtr);
-    if (!TABLE_VALID(env, table))
-        return NULL;
+    if (!TABLE_VALID(env, table)) {
+        return nullptr;
+    }
 
     // Write table to string in JSON format
     try {
@@ -1385,13 +1461,13 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_Table_nativeToJson(JNIEnv* env,
         return to_jstring(env, str);
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsValid(JNIEnv*, jobject, jlong nativeTablePtr)
 {
     TR_ENTER_PTR(nativeTablePtr)
-    return TBL(nativeTablePtr)->is_attached(); // noexcept
+    return to_jbool(TBL(nativeTablePtr)->is_attached()); // noexcept
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_createNative(JNIEnv* env, jobject)
@@ -1478,7 +1554,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(JNIEnv*
             if (row_index != realm::not_found) {
                 pk_table->remove(row_index);
             }
-            return jlong(io_realm_internal_Table_NO_PRIMARY_KEY);
+            return io_realm_internal_Table_NO_PRIMARY_KEY;
         }
         else {
             JStringAccessor new_primary_key_column_name(env, columnName);
@@ -1506,7 +1582,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSetPrimaryKey(JNIEnv*
                 }
             }
 
-            return jlong(primary_key_column_index);
+            return static_cast<jlong>(primary_key_column_index);
         }
     }
     CATCH_STD()
@@ -1617,13 +1693,13 @@ Java_io_realm_internal_Table_nativePrimaryKeyTableNeedsMigration(JNIEnv*, jclass
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeHasSameSchema(JNIEnv*, jobject, jlong thisTablePtr,
                                                                             jlong otherTablePtr)
 {
-    return *TBL(thisTablePtr)->get_descriptor() == *TBL(otherTablePtr)->get_descriptor();
+    return to_jbool(*TBL(thisTablePtr)->get_descriptor() == *TBL(otherTablePtr)->get_descriptor());
 }
 
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeVersion(JNIEnv* env, jobject, jlong nativeTablePtr)
 {
-    bool valid = (TBL(nativeTablePtr) != NULL);
+    bool valid = (TBL(nativeTablePtr) != nullptr);
     if (valid) {
         if (!TBL(nativeTablePtr)->is_attached()) {
             ThrowException(env, IllegalState, "The Realm has been closed and is no longer accessible.");
@@ -1631,7 +1707,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeVersion(JNIEnv* env, 
         }
     }
     try {
-        return (jlong)TBL(nativeTablePtr)->get_version_counter();
+        return static_cast<jlong>(TBL(nativeTablePtr)->get_version_counter());
     }
     CATCH_STD()
     return 0;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -55,7 +55,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableQuery_nativeValidateQuery(
         return to_jstring(env, sd);
     }
     CATCH_STD();
-    return NULL;
+    return nullptr;
 }
 
 
@@ -981,8 +981,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3J_3B
 JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGroup(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
-    if (!QUERY_VALID(env, pQuery))
+    if (!QUERY_VALID(env, pQuery)) {
         return;
+    }
     try {
         pQuery->group();
     }
@@ -992,8 +993,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGroup(JNIEnv* env
 JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEndGroup(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
-    if (!QUERY_VALID(env, pQuery))
+    if (!QUERY_VALID(env, pQuery)) {
         return;
+    }
     try {
         pQuery->end_group();
     }
@@ -1004,8 +1006,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeOr(JNIEnv* env, j
 {
     // No verification of parameters needed?
     Query* pQuery = Q(nativeQueryPtr);
-    if (!QUERY_VALID(env, pQuery))
+    if (!QUERY_VALID(env, pQuery)) {
         return;
+    }
     try {
         pQuery->Or();
     }
@@ -1015,8 +1018,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeOr(JNIEnv* env, j
 JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNot(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
-    if (!QUERY_VALID(env, pQuery))
+    if (!QUERY_VALID(env, pQuery)) {
         return;
+    }
     try {
         pQuery->Not();
     }
@@ -1031,8 +1035,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeFind(JNIEnv* env
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery))
+    if (!QUERY_VALID(env, pQuery)) {
         return -1;
+    }
     // It's valid to go 1 past the end index
     if ((fromTableRow < 0) || (S(fromTableRow) > pTable->size())) {
         // below check will fail with appropriate exception
@@ -1054,8 +1059,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeFindAll(JNIEnv* 
     TR_ENTER()
     Query* query = Q(nativeQueryPtr);
     TableRef table = query->get_table();
-    if (!QUERY_VALID(env, query) || !ROW_INDEXES_VALID(env, table.get(), start, end, limit))
+    if (!QUERY_VALID(env, query) || !ROW_INDEXES_VALID(env, table.get(), start, end, limit)) {
         return -1;
+    }
     try {
         TableView* tableView = new TableView(query->find_all(S(start), S(end), S(limit)));
         return reinterpret_cast<jlong>(tableView);
@@ -1073,8 +1079,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeSumInt(JNIEnv* e
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
         return 0;
+    }
     try {
         return pQuery->sum_int(S(columnIndex), NULL, S(start), S(end), S(limit));
     }
@@ -1089,8 +1096,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumInt(JNI
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         int64_t result = pQuery->maximum_int(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
@@ -1099,7 +1107,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumInt(JNI
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumInt(JNIEnv* env, jobject,
@@ -1109,8 +1117,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumInt(JNI
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         int64_t result = pQuery->minimum_int(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
@@ -1119,7 +1128,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumInt(JNI
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageInt(JNIEnv* env, jobject,
@@ -1129,8 +1138,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageInt(JNI
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
         return 0;
+    }
     try {
         size_t resultcount;
         // TODO: return resultcount?
@@ -1152,8 +1162,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeSumFloat(JNIEn
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
         return 0;
+    }
     try {
         return pQuery->sum_float(S(columnIndex), NULL, S(start), S(end), S(limit));
     }
@@ -1169,8 +1180,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumFloat(J
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         float result = pQuery->maximum_float(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
@@ -1179,7 +1191,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumFloat(J
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumFloat(JNIEnv* env, jobject,
@@ -1190,8 +1202,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumFloat(J
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         float result = pQuery->minimum_float(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
@@ -1200,7 +1213,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumFloat(J
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageFloat(JNIEnv* env, jobject,
@@ -1211,8 +1224,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageFloat(J
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
         return 0;
+    }
     try {
         size_t resultcount;
         double avg = pQuery->average_float(S(columnIndex), &resultcount, S(start), S(end), S(limit));
@@ -1231,8 +1245,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeSumDouble(JNIE
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
         return 0;
+    }
     try {
         return pQuery->sum_double(S(columnIndex), NULL, S(start), S(end), S(limit));
     }
@@ -1248,8 +1263,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumDouble(
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         double result = pQuery->maximum_double(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
@@ -1258,7 +1274,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumDouble(
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumDouble(JNIEnv* env, jobject,
@@ -1269,8 +1285,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumDouble(
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         double result = pQuery->minimum_double(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
@@ -1279,7 +1296,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumDouble(
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageDouble(JNIEnv* env, jobject,
@@ -1290,8 +1307,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageDouble(
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
         return 0;
+    }
     try {
         // TODO: Return resultcount
         size_t resultcount;
@@ -1313,8 +1331,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumTimesta
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Timestamp) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         Timestamp result = pQuery->find_all().maximum_timestamp(S(columnIndex), &return_ndx);
@@ -1323,7 +1342,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumTimesta
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumTimestamp(JNIEnv* env, jobject,
@@ -1334,8 +1353,9 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumTimesta
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
     if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Timestamp) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
-        return NULL;
+        !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
+        return nullptr;
+    }
     try {
         size_t return_ndx;
         Timestamp result = pQuery->find_all().minimum_timestamp(S(columnIndex), &return_ndx);
@@ -1344,7 +1364,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumTimesta
         }
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 // Count, Remove
@@ -1354,10 +1374,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeCount(JNIEnv* en
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) || !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+    if (!QUERY_VALID(env, pQuery) || !ROW_INDEXES_VALID(env, pTable, start, end, limit)) {
         return 0;
+    }
     try {
-        return pQuery->count(S(start), S(end), S(limit));
+        return static_cast<jlong>(pQuery->count(S(start), S(end), S(limit)));
     }
     CATCH_STD()
     return 0;
@@ -1366,10 +1387,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeCount(JNIEnv* en
 JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeRemove(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
-    if (!QUERY_VALID(env, pQuery))
+    if (!QUERY_VALID(env, pQuery)) {
         return 0;
+    }
     try {
-        return pQuery->remove();
+        return static_cast<jlong>(pQuery->remove());
     }
     CATCH_STD()
     return 0;
@@ -1414,9 +1436,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(JNIEnv* en
                     Q(nativeQueryPtr)->equal(S(column_idx), realm::null());
                     break;
                 default:
-                    // this point is unreachable
-                    ThrowException(env, FatalError, "This is not reachable.");
-                    return;
+                    REALM_UNREACHABLE();
             }
         }
         else {
@@ -1450,9 +1470,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(JNIEnv* en
                     pQuery->and_query(src_table_ref->column<Timestamp>(S(column_idx)) == realm::null());
                     break;
                 default:
-                    // this point is unreachable
-                    ThrowException(env, FatalError, "This is not reachable.");
-                    return;
+                    REALM_UNREACHABLE();
             }
         }
     }
@@ -1488,8 +1506,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeHandoverQuery(JN
 {
     TR_ENTER_PTR(nativeQueryPtr)
     Query* pQuery = Q(nativeQueryPtr);
-    if (!QUERY_VALID(env, pQuery))
+    if (!QUERY_VALID(env, pQuery)) {
         return 0;
+    }
     try {
         auto sharedRealm = *(reinterpret_cast<SharedRealm*>(bgSharedRealmPtr));
         using rf = realm::_impl::RealmFriend;
@@ -1538,9 +1557,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull(JNIEnv*
                     pQuery->not_equal(S(column_idx), realm::null());
                     break;
                 default:
-                    // this point is unreachable
-                    ThrowException(env, FatalError, "This is not reachable.");
-                    return;
+                    REALM_UNREACHABLE();
             }
         }
         else {
@@ -1575,9 +1592,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull(JNIEnv*
                     pQuery->and_query(src_table_ref->column<Timestamp>(S(column_idx)) != realm::null());
                     break;
                 default:
-                    // this point is unreachable
-                    ThrowException(env, FatalError, "This is not reachable.");
-                    return;
+                    REALM_UNREACHABLE();
             }
         }
     }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -29,9 +29,9 @@ using namespace realm;
 using namespace realm::jni_util;
 
 #if 1
-#define QUERY_COL_TYPE_VALID(env, jPtr, col, type)  query_col_type_valid(env, jPtr, col, type)
+#define QUERY_COL_TYPE_VALID(env, jPtr, col, type) query_col_type_valid(env, jPtr, col, type)
 #else
-#define QUERY_COL_TYPE_VALID(env, jPtr, col, type)  (true)
+#define QUERY_COL_TYPE_VALID(env, jPtr, col, type) (true)
 #endif
 
 static void finalize_table_query(jlong ptr);
@@ -46,14 +46,15 @@ const char* ERR_IMPORT_CLOSED_REALM = "Can not import results from a closed Real
 const char* ERR_SORT_NOT_SUPPORTED = "Sort is not supported on binary data, object references and RealmList";
 //-------------------------------------------------------
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_TableQuery_nativeValidateQuery
-(JNIEnv *env, jobject, jlong nativeQueryPtr)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_TableQuery_nativeValidateQuery(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr)
 {
     try {
         const std::string str = Q(nativeQueryPtr)->validate();
         StringData sd(str);
         return to_jstring(env, sd);
-    } CATCH_STD();
+    }
+    CATCH_STD();
     return NULL;
 }
 
@@ -61,7 +62,8 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_TableQuery_nativeValidateQuery
 // helper functions
 
 // Return TableRef used for build link queries
-static TableRef getTableForLinkQuery(jlong nativeQueryPtr, JniLongArray& indicesArray) {
+static TableRef getTableForLinkQuery(jlong nativeQueryPtr, JniLongArray& indicesArray)
+{
     TableRef table_ref = Q(nativeQueryPtr)->get_table();
     jsize link_element_count = indicesArray.len() - 1;
     for (int i = 0; i < link_element_count; i++) {
@@ -71,7 +73,8 @@ static TableRef getTableForLinkQuery(jlong nativeQueryPtr, JniLongArray& indices
 }
 
 // Return TableRef point to original table or the link table
-static TableRef getTableByArray(jlong nativeQueryPtr, JniLongArray& indicesArray) {
+static TableRef getTableByArray(jlong nativeQueryPtr, JniLongArray& indicesArray)
+{
     TableRef table_ref = Q(nativeQueryPtr)->get_table();
     jsize link_element_count = indicesArray.len() - 1;
     for (int i = 0; i < link_element_count; i++) {
@@ -81,40 +84,47 @@ static TableRef getTableByArray(jlong nativeQueryPtr, JniLongArray& indicesArray
 }
 
 template <typename coretype, typename cpptype, typename javatype>
-Query numeric_link_equal(TableRef tbl, jlong columnIndex, javatype value) {
+Query numeric_link_equal(TableRef tbl, jlong columnIndex, javatype value)
+{
     return tbl->column<coretype>(size_t(columnIndex)) == cpptype(value);
 }
 
 template <typename coretype, typename cpptype, typename javatype>
-Query numeric_link_notequal(TableRef tbl, jlong columnIndex, javatype value) {
+Query numeric_link_notequal(TableRef tbl, jlong columnIndex, javatype value)
+{
     return tbl->column<coretype>(size_t(columnIndex)) != cpptype(value);
 }
 
 template <typename coretype, typename cpptype, typename javatype>
-Query numeric_link_greater(TableRef tbl, jlong columnIndex, javatype value) {
+Query numeric_link_greater(TableRef tbl, jlong columnIndex, javatype value)
+{
     return tbl->column<coretype>(size_t(columnIndex)) > cpptype(value);
 }
 
 template <typename coretype, typename cpptype, typename javatype>
-Query numeric_link_greaterequal(TableRef tbl, jlong columnIndex, javatype value) {
+Query numeric_link_greaterequal(TableRef tbl, jlong columnIndex, javatype value)
+{
     return tbl->column<coretype>(size_t(columnIndex)) >= cpptype(value);
 }
 
 template <typename coretype, typename cpptype, typename javatype>
-Query numeric_link_less(TableRef tbl, jlong columnIndex, javatype value) {
+Query numeric_link_less(TableRef tbl, jlong columnIndex, javatype value)
+{
     return tbl->column<coretype>(size_t(columnIndex)) < cpptype(value);
 }
 
 template <typename coretype, typename cpptype, typename javatype>
-Query numeric_link_lessequal(TableRef tbl, jlong columnIndex, javatype value) {
+Query numeric_link_lessequal(TableRef tbl, jlong columnIndex, javatype value)
+{
     return tbl->column<coretype>(size_t(columnIndex)) <= cpptype(value);
 }
 
 
 // Integer
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JJ(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JJ(JNIEnv* env, jobject,
+                                                                            jlong nativeQueryPtr,
+                                                                            jlongArray columnIndexes, jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -127,13 +137,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JJ(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_equal<Int, int64_t, jlong>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)->and_query(numeric_link_equal<Int, int64_t, jlong>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3JJ(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3JJ(JNIEnv* env, jobject,
+                                                                                       jlong nativeQueryPtr,
+                                                                                       jlongArray columnIndexes,
+                                                                                       jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -146,13 +159,16 @@ JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual_
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_notequal<Int, int64_t, jlong>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_notequal<Int, int64_t, jlong>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JJ(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JJ(JNIEnv* env, jobject,
+                                                                              jlong nativeQueryPtr,
+                                                                              jlongArray columnIndexes, jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -165,13 +181,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JJ(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greater<Int, int64_t, jlong>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greater<Int, int64_t, jlong>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3JJ(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3JJ(JNIEnv* env, jobject,
+                                                                                   jlong nativeQueryPtr,
+                                                                                   jlongArray columnIndexes,
+                                                                                   jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -184,13 +204,15 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greaterequal<Int, int64_t, jlong>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greaterequal<Int, int64_t, jlong>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JJ(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JJ(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                           jlongArray columnIndexes, jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -203,13 +225,15 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JJ(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_less<Int, int64_t, jlong>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)->and_query(numeric_link_less<Int, int64_t, jlong>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JJ(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JJ(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlongArray columnIndexes, jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -222,13 +246,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JJ(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_lessequal<Int, int64_t, jlong>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_lessequal<Int, int64_t, jlong>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JJJ(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value1, jlong value2)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JJJ(JNIEnv* env, jobject,
+                                                                               jlong nativeQueryPtr,
+                                                                               jlongArray columnIndexes, jlong value1,
+                                                                               jlong value2)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -238,7 +266,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JJJ(
         }
         try {
             Q(nativeQueryPtr)->between(S(arr[0]), static_cast<int64_t>(value1), static_cast<int64_t>(value2));
-        } CATCH_STD()
+        }
+        CATCH_STD()
     }
     else {
         ThrowException(env, IllegalArgument, "between() does not support queries using child object fields.");
@@ -247,8 +276,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JJJ(
 
 // Float
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JF(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jfloat value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JF(JNIEnv* env, jobject,
+                                                                            jlong nativeQueryPtr,
+                                                                            jlongArray columnIndexes, jfloat value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -261,13 +291,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JF(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_equal<Float, float, jfloat>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_equal<Float, float, jfloat>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3JF(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jfloat value)
+JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3JF(JNIEnv* env, jobject,
+                                                                                       jlong nativeQueryPtr,
+                                                                                       jlongArray columnIndexes,
+                                                                                       jfloat value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -280,13 +314,16 @@ JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual_
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_notequal<Float, float, jfloat>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_notequal<Float, float, jfloat>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JF(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jfloat value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JF(JNIEnv* env, jobject,
+                                                                              jlong nativeQueryPtr,
+                                                                              jlongArray columnIndexes, jfloat value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -299,13 +336,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JF(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greater<Float, float, jfloat>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greater<Float, float, jfloat>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3JF(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jfloat value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3JF(JNIEnv* env, jobject,
+                                                                                   jlong nativeQueryPtr,
+                                                                                   jlongArray columnIndexes,
+                                                                                   jfloat value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -318,13 +359,15 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greaterequal<Float, float, jfloat>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greaterequal<Float, float, jfloat>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JF(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jfloat value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JF(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                           jlongArray columnIndexes, jfloat value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -337,13 +380,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JF(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_less<Float, float, jfloat>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)->and_query(numeric_link_less<Float, float, jfloat>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JF(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jfloat value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JF(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlongArray columnIndexes,
+                                                                                jfloat value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -356,13 +402,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JF(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_lessequal<Float, float, jfloat>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_lessequal<Float, float, jfloat>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JFF(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jfloat value1, jfloat value2)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JFF(JNIEnv* env, jobject,
+                                                                               jlong nativeQueryPtr,
+                                                                               jlongArray columnIndexes,
+                                                                               jfloat value1, jfloat value2)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -376,14 +426,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JFF(
         else {
             ThrowException(env, IllegalArgument, "between() does not support queries using child object fields.");
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
 // Double
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JD(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jdouble value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JD(JNIEnv* env, jobject,
+                                                                            jlong nativeQueryPtr,
+                                                                            jlongArray columnIndexes, jdouble value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -396,13 +448,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JD(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_equal<Double, double, jdouble>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_equal<Double, double, jdouble>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3JD(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jdouble value)
+JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3JD(JNIEnv* env, jobject,
+                                                                                       jlong nativeQueryPtr,
+                                                                                       jlongArray columnIndexes,
+                                                                                       jdouble value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -415,13 +471,16 @@ JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual_
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_notequal<Double, double, jdouble>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_notequal<Double, double, jdouble>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JD(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jdouble value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JD(JNIEnv* env, jobject,
+                                                                              jlong nativeQueryPtr,
+                                                                              jlongArray columnIndexes, jdouble value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -434,13 +493,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreater__J_3JD(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greater<Double, double, jdouble>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greater<Double, double, jdouble>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3JD(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jdouble value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3JD(JNIEnv* env, jobject,
+                                                                                   jlong nativeQueryPtr,
+                                                                                   jlongArray columnIndexes,
+                                                                                   jdouble value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -453,13 +516,15 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqual__J_3
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greaterequal<Double, double, jdouble>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greaterequal<Double, double, jdouble>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JD(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jdouble value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JD(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                           jlongArray columnIndexes, jdouble value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -472,13 +537,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLess__J_3JD(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_less<Double, double, jdouble>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_less<Double, double, jdouble>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JD(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jdouble value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JD(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlongArray columnIndexes,
+                                                                                jdouble value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -491,13 +560,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqual__J_3JD(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_lessequal<Double, double, jdouble>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_lessequal<Double, double, jdouble>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JDD(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jdouble value1, jdouble value2)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JDD(JNIEnv* env, jobject,
+                                                                               jlong nativeQueryPtr,
+                                                                               jlongArray columnIndexes,
+                                                                               jdouble value1, jdouble value2)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -511,14 +584,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetween__J_3JDD(
         else {
             ThrowException(env, IllegalArgument, "between() does not support queries using child object fields.");
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
 // Timestamp
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqualTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqualTimestamp(JNIEnv* env, jobject,
+                                                                              jlong nativeQueryPtr,
+                                                                              jlongArray columnIndexes, jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -531,13 +606,18 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqualTimestamp(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_equal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len-1], from_milliseconds(value)));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_equal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len - 1],
+                                                                                from_milliseconds(value)));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqualTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqualTimestamp(JNIEnv* env, jobject,
+                                                                                         jlong nativeQueryPtr,
+                                                                                         jlongArray columnIndexes,
+                                                                                         jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -550,13 +630,17 @@ JNIEXPORT void JNICALL JNICALL Java_io_realm_internal_TableQuery_nativeNotEqualT
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_notequal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len-1], from_milliseconds(value)));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_notequal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len - 1],
+                                                                                   from_milliseconds(value)));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterTimestamp(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlongArray columnIndexes, jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -569,13 +653,18 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterTimestamp(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greater<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len-1], from_milliseconds(value)));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greater<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len - 1],
+                                                                                  from_milliseconds(value)));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqualTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqualTimestamp(JNIEnv* env, jobject,
+                                                                                     jlong nativeQueryPtr,
+                                                                                     jlongArray columnIndexes,
+                                                                                     jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -588,13 +677,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGreaterEqualTimes
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_greaterequal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len-1], from_milliseconds(value)));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_greaterequal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len - 1],
+                                                                                       from_milliseconds(value)));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessTimestamp(JNIEnv* env, jobject,
+                                                                             jlong nativeQueryPtr,
+                                                                             jlongArray columnIndexes, jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -607,13 +700,18 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessTimestamp(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_less<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len-1], from_milliseconds(value)));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_less<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len - 1],
+                                                                               from_milliseconds(value)));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqualTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqualTimestamp(JNIEnv* env, jobject,
+                                                                                  jlong nativeQueryPtr,
+                                                                                  jlongArray columnIndexes,
+                                                                                  jlong value)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -626,13 +724,18 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLessEqualTimestam
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_lessequal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len-1], from_milliseconds(value)));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_lessequal<Timestamp, Timestamp, Timestamp>(table_ref, arr[arr_len - 1],
+                                                                                    from_milliseconds(value)));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetweenTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jlong value1, jlong value2)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetweenTimestamp(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlongArray columnIndexes,
+                                                                                jlong value1, jlong value2)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -641,21 +744,26 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBetweenTimestamp(
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_Timestamp)) {
                 return;
             }
-            Q(nativeQueryPtr)->greater_equal(S(arr[0]), from_milliseconds(value1)).less_equal(S(arr[0]), from_milliseconds(value2));
+            Q(nativeQueryPtr)
+                ->greater_equal(S(arr[0]), from_milliseconds(value1))
+                .less_equal(S(arr[0]), from_milliseconds(value2));
         }
         else {
             ThrowException(env, IllegalArgument, "between() does not support queries using child object fields.");
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 // Bool
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JZ(
-  JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jboolean value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JZ(JNIEnv* env, jobject,
+                                                                            jlong nativeQueryPtr,
+                                                                            jlongArray columnIndexes, jboolean value)
 {
     JniLongArray arr(env, columnIndexes);
-    try {    jsize arr_len = arr.len();
+    try {
+        jsize arr_len = arr.len();
 
         if (arr_len == 1) {
             if (!QUERY_COL_TYPE_VALID(env, nativeQueryPtr, arr[0], type_Bool)) {
@@ -665,29 +773,26 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JZ(
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-            Q(nativeQueryPtr)->and_query(numeric_link_equal<Bool, bool, jboolean>(table_ref, arr[arr_len-1], value));
+            Q(nativeQueryPtr)
+                ->and_query(numeric_link_equal<Bool, bool, jboolean>(table_ref, arr[arr_len - 1], value));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 // String
 
-enum StringPredicate {
-    StringEqual,
-    StringNotEqual,
-    StringContains,
-    StringBeginsWith,
-    StringEndsWith,
-    StringLike
-};
+enum StringPredicate { StringEqual, StringNotEqual, StringContains, StringBeginsWith, StringEndsWith, StringLike };
 
 
-static void TableQuery_StringPredicate(JNIEnv *env, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive, StringPredicate predicate) {
+static void TableQuery_StringPredicate(JNIEnv* env, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value,
+                                       jboolean caseSensitive, StringPredicate predicate)
+{
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
     try {
         if (value == NULL) {
-            if (!TBL_AND_COL_NULLABLE(env, getTableByArray(nativeQueryPtr, arr).get(), arr[arr_len-1])) {
+            if (!TBL_AND_COL_NULLABLE(env, getTableByArray(nativeQueryPtr, arr).get(), arr[arr_len - 1])) {
                 return;
             }
         }
@@ -698,103 +803,119 @@ static void TableQuery_StringPredicate(JNIEnv *env, jlong nativeQueryPtr, jlongA
                 return;
             }
             switch (predicate) {
-            case StringEqual:
-                Q(nativeQueryPtr)->equal(S(arr[0]), value2, is_case_sensitive);
-                break;
-            case StringNotEqual:
-                Q(nativeQueryPtr)->not_equal(S(arr[0]), value2, is_case_sensitive);
-                break;
-            case StringContains:
-                Q(nativeQueryPtr)->contains(S(arr[0]), value2, is_case_sensitive);
-                break;
-            case StringBeginsWith:
-                Q(nativeQueryPtr)->begins_with(S(arr[0]), value2, is_case_sensitive);
-                break;
-            case StringEndsWith:
-                Q(nativeQueryPtr)->ends_with(S(arr[0]), value2, is_case_sensitive);
-                break;
-            case StringLike:
-                Q(nativeQueryPtr)->like(S(arr[0]), value2, is_case_sensitive);
-                break;
+                case StringEqual:
+                    Q(nativeQueryPtr)->equal(S(arr[0]), value2, is_case_sensitive);
+                    break;
+                case StringNotEqual:
+                    Q(nativeQueryPtr)->not_equal(S(arr[0]), value2, is_case_sensitive);
+                    break;
+                case StringContains:
+                    Q(nativeQueryPtr)->contains(S(arr[0]), value2, is_case_sensitive);
+                    break;
+                case StringBeginsWith:
+                    Q(nativeQueryPtr)->begins_with(S(arr[0]), value2, is_case_sensitive);
+                    break;
+                case StringEndsWith:
+                    Q(nativeQueryPtr)->ends_with(S(arr[0]), value2, is_case_sensitive);
+                    break;
+                case StringLike:
+                    Q(nativeQueryPtr)->like(S(arr[0]), value2, is_case_sensitive);
+                    break;
             }
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
             switch (predicate) {
-            case StringEqual:
-                Q(nativeQueryPtr)->and_query(table_ref->column<String>(size_t(arr[arr_len-1])).equal(StringData(value2), is_case_sensitive));
-                break;
-            case StringNotEqual:
-                Q(nativeQueryPtr)->and_query(table_ref->column<String>(size_t(arr[arr_len-1])).not_equal(StringData(value2), is_case_sensitive));
-                break;
-            case StringContains:
-                Q(nativeQueryPtr)->and_query(table_ref->column<String>(size_t(arr[arr_len-1])).contains(StringData(value2), is_case_sensitive));
-                break;
-            case StringBeginsWith:
-                Q(nativeQueryPtr)->and_query(table_ref->column<String>(size_t(arr[arr_len-1])).begins_with(StringData(value2), is_case_sensitive));
-                break;
-            case StringEndsWith:
-                Q(nativeQueryPtr)->and_query(table_ref->column<String>(size_t(arr[arr_len-1])).ends_with(StringData(value2), is_case_sensitive));
-                break;
-            case StringLike:
-                Q(nativeQueryPtr)->and_query(table_ref->column<String>(size_t(arr[arr_len-1])).like(StringData(value2), is_case_sensitive));
-                break;
+                case StringEqual:
+                    Q(nativeQueryPtr)
+                        ->and_query(table_ref->column<String>(size_t(arr[arr_len - 1]))
+                                        .equal(StringData(value2), is_case_sensitive));
+                    break;
+                case StringNotEqual:
+                    Q(nativeQueryPtr)
+                        ->and_query(table_ref->column<String>(size_t(arr[arr_len - 1]))
+                                        .not_equal(StringData(value2), is_case_sensitive));
+                    break;
+                case StringContains:
+                    Q(nativeQueryPtr)
+                        ->and_query(table_ref->column<String>(size_t(arr[arr_len - 1]))
+                                        .contains(StringData(value2), is_case_sensitive));
+                    break;
+                case StringBeginsWith:
+                    Q(nativeQueryPtr)
+                        ->and_query(table_ref->column<String>(size_t(arr[arr_len - 1]))
+                                        .begins_with(StringData(value2), is_case_sensitive));
+                    break;
+                case StringEndsWith:
+                    Q(nativeQueryPtr)
+                        ->and_query(table_ref->column<String>(size_t(arr[arr_len - 1]))
+                                        .ends_with(StringData(value2), is_case_sensitive));
+                    break;
+                case StringLike:
+                    Q(nativeQueryPtr)
+                        ->and_query(table_ref->column<String>(size_t(arr[arr_len - 1]))
+                                        .like(StringData(value2), is_case_sensitive));
+                    break;
             }
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3JLjava_lang_String_2Z(
-    JNIEnv *env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
+    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
 {
     TableQuery_StringPredicate(env, nativeQueryPtr, columnIndexes, value, caseSensitive, StringEqual);
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3JLjava_lang_String_2Z(
-    JNIEnv *env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
+    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
 {
     TableQuery_StringPredicate(env, nativeQueryPtr, columnIndexes, value, caseSensitive, StringNotEqual);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBeginsWith(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeBeginsWith(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                          jlongArray columnIndexes, jstring value,
+                                                                          jboolean caseSensitive)
 {
     TableQuery_StringPredicate(env, nativeQueryPtr, columnIndexes, value, caseSensitive, StringBeginsWith);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEndsWith(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEndsWith(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                        jlongArray columnIndexes, jstring value,
+                                                                        jboolean caseSensitive)
 {
     TableQuery_StringPredicate(env, nativeQueryPtr, columnIndexes, value, caseSensitive, StringEndsWith);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLike(
-        JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeLike(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                    jlongArray columnIndexes, jstring value,
+                                                                    jboolean caseSensitive)
 {
     TableQuery_StringPredicate(env, nativeQueryPtr, columnIndexes, value, caseSensitive, StringLike);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeContains(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes, jstring value, jboolean caseSensitive)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeContains(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                        jlongArray columnIndexes, jstring value,
+                                                                        jboolean caseSensitive)
 {
     TableQuery_StringPredicate(env, nativeQueryPtr, columnIndexes, value, caseSensitive, StringContains);
 }
 
 // Binary
 
-enum BinaryPredicate {
-    BinaryEqual,
-    BinaryNotEqual
-};
+enum BinaryPredicate { BinaryEqual, BinaryNotEqual };
 
-static void TableQuery_BinaryPredicate(JNIEnv *env, jlong nativeQueryPtr, jlongArray columnIndices, jbyteArray value, BinaryPredicate predicate) {
+static void TableQuery_BinaryPredicate(JNIEnv* env, jlong nativeQueryPtr, jlongArray columnIndices, jbyteArray value,
+                                       BinaryPredicate predicate)
+{
     JniLongArray arr(env, columnIndices);
     jsize arr_len = arr.len();
     try {
         JniByteArray bytes(env, value);
         BinaryData value2;
         if (value == NULL) {
-            if (!TBL_AND_COL_NULLABLE(env, getTableByArray(nativeQueryPtr, arr).get(), arr[arr_len-1])) {
+            if (!TBL_AND_COL_NULLABLE(env, getTableByArray(nativeQueryPtr, arr).get(), arr[arr_len - 1])) {
                 return;
             }
             value2 = BinaryData();
@@ -812,36 +933,41 @@ static void TableQuery_BinaryPredicate(JNIEnv *env, jlong nativeQueryPtr, jlongA
                 return;
             }
             switch (predicate) {
-            case BinaryEqual:
-                Q(nativeQueryPtr)->equal(S(arr[0]), value2);
-                break;
-            case BinaryNotEqual:
-                Q(nativeQueryPtr)->not_equal(S(arr[0]), value2);
-                break;
+                case BinaryEqual:
+                    Q(nativeQueryPtr)->equal(S(arr[0]), value2);
+                    break;
+                case BinaryNotEqual:
+                    Q(nativeQueryPtr)->not_equal(S(arr[0]), value2);
+                    break;
             }
         }
         else {
             TableRef table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
             switch (predicate) {
-            case BinaryEqual:
-                Q(nativeQueryPtr)->and_query(table_ref->column<Binary>(size_t(arr[arr_len-1])) == value2);
-                break;
-            case BinaryNotEqual:
-                Q(nativeQueryPtr)->and_query(table_ref->column<Binary>(size_t(arr[arr_len-1])) != value2);
-                break;
+                case BinaryEqual:
+                    Q(nativeQueryPtr)->and_query(table_ref->column<Binary>(size_t(arr[arr_len - 1])) == value2);
+                    break;
+                case BinaryNotEqual:
+                    Q(nativeQueryPtr)->and_query(table_ref->column<Binary>(size_t(arr[arr_len - 1])) != value2);
+                    break;
             }
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3J_3B
-  (JNIEnv *env, jobject, jlong nativeQueryPtr, jlongArray columnIndices, jbyteArray value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEqual__J_3J_3B(JNIEnv* env, jobject,
+                                                                              jlong nativeQueryPtr,
+                                                                              jlongArray columnIndices,
+                                                                              jbyteArray value)
 {
     TableQuery_BinaryPredicate(env, nativeQueryPtr, columnIndices, value, BinaryEqual);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3J_3B
-  (JNIEnv *env, jobject, jlong nativeQueryPtr, jlongArray columnIndices, jbyteArray value)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3J_3B(JNIEnv* env, jobject,
+                                                                                 jlong nativeQueryPtr,
+                                                                                 jlongArray columnIndices,
+                                                                                 jbyteArray value)
 {
     TableQuery_BinaryPredicate(env, nativeQueryPtr, columnIndices, value, BinaryNotEqual);
 }
@@ -852,30 +978,29 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNotEqual__J_3J_3B
 // as they are called for each method when building up the query.
 // Consider to reduce to just the "action" methods on Query
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGroup(
-    JNIEnv* env, jobject, jlong nativeQueryPtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeGroup(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
     if (!QUERY_VALID(env, pQuery))
         return;
     try {
         pQuery->group();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEndGroup(
-    JNIEnv* env, jobject, jlong nativeQueryPtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeEndGroup(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
     if (!QUERY_VALID(env, pQuery))
         return;
     try {
         pQuery->end_group();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeOr(
-    JNIEnv* env, jobject, jlong nativeQueryPtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeOr(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     // No verification of parameters needed?
     Query* pQuery = Q(nativeQueryPtr);
@@ -883,25 +1008,26 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeOr(
         return;
     try {
         pQuery->Or();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNot(
-    JNIEnv* env, jobject, jlong nativeQueryPtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeNot(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
     if (!QUERY_VALID(env, pQuery))
         return;
     try {
         pQuery->Not();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 // Find --------------------------------------
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeFind(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlong fromTableRow)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeFind(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                     jlong fromTableRow)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
@@ -910,59 +1036,59 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeFind(
     // It's valid to go 1 past the end index
     if ((fromTableRow < 0) || (S(fromTableRow) > pTable->size())) {
         // below check will fail with appropriate exception
-        (void) ROW_INDEX_VALID(env, pTable, fromTableRow);
+        (void)ROW_INDEX_VALID(env, pTable, fromTableRow);
         return -1;
     }
 
     try {
-        size_t r = pQuery->find( S(fromTableRow) );
+        size_t r = pQuery->find(S(fromTableRow));
         return (r == not_found) ? jlong(-1) : jlong(r);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return -1;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeFindAll(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlong start, jlong end, jlong limit)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeFindAll(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                        jlong start, jlong end, jlong limit)
 {
     TR_ENTER()
     Query* query = Q(nativeQueryPtr);
-    TableRef table =  query->get_table();
-    if (!QUERY_VALID(env, query) ||
-        !ROW_INDEXES_VALID(env, table.get(), start, end, limit))
+    TableRef table = query->get_table();
+    if (!QUERY_VALID(env, query) || !ROW_INDEXES_VALID(env, table.get(), start, end, limit))
         return -1;
     try {
-        TableView* tableView = new TableView( query->find_all(S(start), S(end), S(limit)) );
+        TableView* tableView = new TableView(query->find_all(S(start), S(end), S(limit)));
         return reinterpret_cast<jlong>(tableView);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return -1;
 }
 
 // Integer Aggregates
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeSumInt(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeSumInt(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                       jlong columnIndex, jlong start, jlong end,
+                                                                       jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return 0;
     try {
         return pQuery->sum_int(S(columnIndex), NULL, S(start), S(end), S(limit));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumInt(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumInt(JNIEnv* env, jobject,
+                                                                             jlong nativeQueryPtr, jlong columnIndex,
+                                                                             jlong start, jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -971,18 +1097,18 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumInt(
         if (return_ndx != npos) {
             return NewLong(env, result);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumInt(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumInt(JNIEnv* env, jobject,
+                                                                             jlong nativeQueryPtr, jlong columnIndex,
+                                                                             jlong start, jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -991,57 +1117,58 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumInt(
         if (return_ndx != npos) {
             return NewLong(env, result);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageInt(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageInt(JNIEnv* env, jobject,
+                                                                             jlong nativeQueryPtr, jlong columnIndex,
+                                                                             jlong start, jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Int) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return 0;
     try {
         size_t resultcount;
-        //TODO: return resultcount?
+        // TODO: return resultcount?
         double avg = pQuery->average_int(S(columnIndex), &resultcount, S(start), S(end), S(limit));
-        //fprintf(stderr, "!!!Average(%d, %d) = %f (%d results)\n", start, end, avg, resultcount); fflush(stderr);
+        // fprintf(stderr, "!!!Average(%d, %d) = %f (%d results)\n", start, end, avg, resultcount); fflush(stderr);
         return avg;
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 
 // float Aggregates
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeSumFloat(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeSumFloat(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                           jlong columnIndex, jlong start, jlong end,
+                                                                           jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return 0;
     try {
         return pQuery->sum_float(S(columnIndex), NULL, S(start), S(end), S(limit));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumFloat(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumFloat(JNIEnv* env, jobject,
+                                                                               jlong nativeQueryPtr,
+                                                                               jlong columnIndex, jlong start,
+                                                                               jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -1050,18 +1177,19 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumFloat(
         if (return_ndx != npos) {
             return NewFloat(env, result);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumFloat(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumFloat(JNIEnv* env, jobject,
+                                                                               jlong nativeQueryPtr,
+                                                                               jlong columnIndex, jlong start,
+                                                                               jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -1070,54 +1198,56 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumFloat(
         if (return_ndx != npos) {
             return NewFloat(env, result);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageFloat(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageFloat(JNIEnv* env, jobject,
+                                                                               jlong nativeQueryPtr,
+                                                                               jlong columnIndex, jlong start,
+                                                                               jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Float) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return 0;
     try {
         size_t resultcount;
         double avg = pQuery->average_float(S(columnIndex), &resultcount, S(start), S(end), S(limit));
         return avg;
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 // double Aggregates
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeSumDouble(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeSumDouble(JNIEnv* env, jobject,
+                                                                            jlong nativeQueryPtr, jlong columnIndex,
+                                                                            jlong start, jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return 0;
     try {
         return pQuery->sum_double(S(columnIndex), NULL, S(start), S(end), S(limit));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumDouble(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumDouble(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlong columnIndex, jlong start,
+                                                                                jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -1126,18 +1256,19 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumDouble(
         if (return_ndx != npos) {
             return NewDouble(env, result);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumDouble(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumDouble(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlong columnIndex, jlong start,
+                                                                                jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -1146,40 +1277,42 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumDouble(
         if (return_ndx != npos) {
             return NewDouble(env, result);
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageDouble(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_TableQuery_nativeAverageDouble(JNIEnv* env, jobject,
+                                                                                jlong nativeQueryPtr,
+                                                                                jlong columnIndex, jlong start,
+                                                                                jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Double) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return 0;
     try {
-        //TODO: Return resultcount
+        // TODO: Return resultcount
         size_t resultcount;
         double avg = pQuery->average_double(S(columnIndex), &resultcount, S(start), S(end), S(limit));
         return avg;
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 
 // date aggregates
 // FIXME: This is a rough workaround while waiting for https://github.com/realm/realm-core/issues/1745 to be solved
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumTimestamp(JNIEnv* env, jobject,
+                                                                                   jlong nativeQueryPtr,
+                                                                                   jlong columnIndex, jlong start,
+                                                                                   jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Timestamp) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Timestamp) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -1188,18 +1321,19 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumTimesta
         if (return_ndx != npos && !result.is_null()) {
             return NewLong(env, to_milliseconds(result));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumTimestamp(
-    JNIEnv* env, jobject, jlong nativeQueryPtr,
-    jlong columnIndex, jlong start, jlong end, jlong limit)
+JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumTimestamp(JNIEnv* env, jobject,
+                                                                                   jlong nativeQueryPtr,
+                                                                                   jlong columnIndex, jlong start,
+                                                                                   jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Timestamp) ||
+    if (!QUERY_VALID(env, pQuery) || !COL_INDEX_AND_TYPE_VALID(env, pTable, columnIndex, type_Timestamp) ||
         !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return NULL;
     try {
@@ -1208,42 +1342,43 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumTimesta
         if (return_ndx != npos && !result.is_null()) {
             return NewLong(env, to_milliseconds(result));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return NULL;
 }
 
 // Count, Remove
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeCount(
-    JNIEnv* env, jobject, jlong nativeQueryPtr, jlong start, jlong end, jlong limit)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeCount(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                      jlong start, jlong end, jlong limit)
 {
     Query* pQuery = Q(nativeQueryPtr);
     Table* pTable = pQuery->get_table().get();
-    if (!QUERY_VALID(env, pQuery) ||
-        !ROW_INDEXES_VALID(env, pTable, start, end, limit))
+    if (!QUERY_VALID(env, pQuery) || !ROW_INDEXES_VALID(env, pTable, start, end, limit))
         return 0;
     try {
         return pQuery->count(S(start), S(end), S(limit));
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeRemove(
-    JNIEnv* env, jobject, jlong nativeQueryPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeRemove(JNIEnv* env, jobject, jlong nativeQueryPtr)
 {
     Query* pQuery = Q(nativeQueryPtr);
     if (!QUERY_VALID(env, pQuery))
         return 0;
     try {
         return pQuery->remove();
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 // isNull and isNotNull
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(
-    JNIEnv *env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes)
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                      jlongArray columnIndexes)
 {
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -1251,7 +1386,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(
 
     try {
         TableRef src_table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-        jlong column_idx = arr[arr_len-1];
+        jlong column_idx = arr[arr_len - 1];
         TableRef table_ref = getTableByArray(nativeQueryPtr, arr);
         if (!TBL_AND_COL_NULLABLE(env, table_ref.get(), column_idx)) {
             return;
@@ -1283,7 +1418,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(
                     ThrowException(env, FatalError, "This is not reachable.");
                     return;
             }
-        } else {
+        }
+        else {
             switch (col_type) {
                 case type_Link:
                     ThrowException(env, IllegalArgument, "isNull() by nested query for link field is not supported.");
@@ -1319,32 +1455,36 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(
                     return;
             }
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeImportHandoverRowIntoSharedGroup
-  (JNIEnv *env, jclass, jlong handoverPtr, jlong callerSharedGrpPtr)
-  {
-      TR_ENTER_PTR(handoverPtr)
-      SharedGroup::Handover<Row> *handoverRowPtr = HO(Row, handoverPtr);
-      std::unique_ptr<SharedGroup::Handover<Row>> handoverRow(handoverRowPtr);
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeImportHandoverRowIntoSharedGroup(
+    JNIEnv* env, jclass, jlong handoverPtr, jlong callerSharedGrpPtr)
+{
+    TR_ENTER_PTR(handoverPtr)
+    SharedGroup::Handover<Row>* handoverRowPtr = HO(Row, handoverPtr);
+    std::unique_ptr<SharedGroup::Handover<Row>> handoverRow(handoverRowPtr);
 
-      try {
-          // import_from_handover will free (delete) the handover
-          auto sharedRealm = *(reinterpret_cast<SharedRealm*>(callerSharedGrpPtr));
-          if (!sharedRealm->is_closed()) {
-              using rf = realm::_impl::RealmFriend;
-              auto row = rf::get_shared_group(*sharedRealm).import_from_handover(std::move(handoverRow));
-              return reinterpret_cast<jlong>(row.release());
-          } else {
-              ThrowException(env, RuntimeError, ERR_IMPORT_CLOSED_REALM);
-          }
-      } CATCH_STD()
-      return 0;
-  }
+    try {
+        // import_from_handover will free (delete) the handover
+        auto sharedRealm = *(reinterpret_cast<SharedRealm*>(callerSharedGrpPtr));
+        if (!sharedRealm->is_closed()) {
+            using rf = realm::_impl::RealmFriend;
+            auto row = rf::get_shared_group(*sharedRealm).import_from_handover(std::move(handoverRow));
+            return reinterpret_cast<jlong>(row.release());
+        }
+        else {
+            ThrowException(env, RuntimeError, ERR_IMPORT_CLOSED_REALM);
+        }
+    }
+    CATCH_STD()
+    return 0;
+}
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeHandoverQuery
-   (JNIEnv* env, jobject, jlong bgSharedRealmPtr, jlong nativeQueryPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeHandoverQuery(JNIEnv* env, jobject,
+                                                                              jlong bgSharedRealmPtr,
+                                                                              jlong nativeQueryPtr)
 {
     TR_ENTER_PTR(nativeQueryPtr)
     Query* pQuery = Q(nativeQueryPtr);
@@ -1355,19 +1495,21 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeHandoverQuery
         using rf = realm::_impl::RealmFriend;
         auto handover = rf::get_shared_group(*sharedRealm).export_for_handover(*pQuery, ConstSourcePayload::Copy);
         return reinterpret_cast<jlong>(handover.release());
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull
-  (JNIEnv *env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes) {
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                         jlongArray columnIndexes)
+{
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
     Query* pQuery = Q(nativeQueryPtr);
     try {
         TableRef src_table_ref = getTableForLinkQuery(nativeQueryPtr, arr);
-        jlong column_idx = arr[arr_len-1];
+        jlong column_idx = arr[arr_len - 1];
         TableRef table_ref = getTableByArray(nativeQueryPtr, arr);
 
         if (!TBL_AND_COL_NULLABLE(env, table_ref.get(), column_idx)) {
@@ -1404,7 +1546,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull
         else {
             switch (col_type) {
                 case type_Link:
-                    ThrowException(env, IllegalArgument, "isNotNull() by nested query for link field is not supported.");
+                    ThrowException(env, IllegalArgument,
+                                   "isNotNull() by nested query for link field is not supported.");
                     break;
                 case type_LinkList:
                     // Cannot get here. Exception will be thrown in TBL_AND_COL_NULLABLE
@@ -1437,11 +1580,13 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull
                     return;
             }
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsEmpty
-    (JNIEnv *env, jobject, jlong nativeQueryPtr, jlongArray columnIndexes) {
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsEmpty(JNIEnv* env, jobject, jlong nativeQueryPtr,
+                                                                       jlongArray columnIndexes)
+{
 
     JniLongArray arr(env, columnIndexes);
     jsize arr_len = arr.len();
@@ -1494,11 +1639,13 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsEmpty
                 case type_Double:
                 case type_Timestamp:
                 default:
-                    ThrowException(env, IllegalArgument, "isEmpty() only works on String, byte[] and RealmList across links.");
+                    ThrowException(env, IllegalArgument,
+                                   "isEmpty() only works on String, byte[] and RealmList across links.");
                     return;
             }
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 static void finalize_table_query(jlong ptr)
@@ -1507,10 +1654,8 @@ static void finalize_table_query(jlong ptr)
     delete Q(ptr);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeGetFinalizerPtr
-  (JNIEnv *, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TableQuery_nativeGetFinalizerPtr(JNIEnv*, jclass)
 {
     TR_ENTER()
     return reinterpret_cast<jlong>(&finalize_table_query);
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TestUtil.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TestUtil.cpp
@@ -76,7 +76,7 @@ static jstring throwOrGetExpectedMessage(JNIEnv* env, jlong testcase, bool shoul
             break;
     }
     if (should_throw) {
-        return NULL;
+        return nullptr;
     }
     return to_jstring(env, expect);
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TestUtil.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TestUtil.cpp
@@ -1,28 +1,25 @@
 #include "io_realm_internal_TestUtil.h"
 #include "util.hpp"
 
-static jstring throwOrGetExpectedMessage(JNIEnv *env, jlong testcase, bool should_throw);
+static jstring throwOrGetExpectedMessage(JNIEnv* env, jlong testcase, bool should_throw);
 
-JNIEXPORT jlong JNICALL
-Java_io_realm_internal_TestUtil_getMaxExceptionNumber(JNIEnv*, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_TestUtil_getMaxExceptionNumber(JNIEnv*, jclass)
 {
     return ExceptionKindMax;
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_realm_internal_TestUtil_getExpectedMessage(JNIEnv *env, jclass, jlong exception_kind)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_TestUtil_getExpectedMessage(JNIEnv* env, jclass,
+                                                                             jlong exception_kind)
 {
     return throwOrGetExpectedMessage(env, exception_kind, false);
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_TestUtil_testThrowExceptions(JNIEnv *env, jclass, jlong exception_kind)
+JNIEXPORT void JNICALL Java_io_realm_internal_TestUtil_testThrowExceptions(JNIEnv* env, jclass, jlong exception_kind)
 {
     throwOrGetExpectedMessage(env, exception_kind, true);
 }
 
-static jstring
-throwOrGetExpectedMessage(JNIEnv *env, jlong testcase, bool should_throw)
+static jstring throwOrGetExpectedMessage(JNIEnv* env, jlong testcase, bool should_throw)
 {
     std::string expect;
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
@@ -21,8 +21,7 @@ using namespace realm;
 
 static void finalize_unchecked_row(jlong ptr);
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnCount
-  (JNIEnv*, jobject, jlong nativeRowPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnCount(JNIEnv*, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW(nativeRowPtr)->is_attached())
@@ -31,42 +30,45 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnCount
     return ROW(nativeRowPtr)->get_column_count(); // noexcept
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnName
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnName(JNIEnv* env, jobject,
+                                                                                  jlong nativeRowPtr,
+                                                                                  jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
     try {
-        return to_jstring(env, ROW(nativeRowPtr)->get_column_name( S(columnIndex)));
-    } CATCH_STD();
+        return to_jstring(env, ROW(nativeRowPtr)->get_column_name(S(columnIndex)));
+    }
+    CATCH_STD();
     return NULL;
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jstring columnName)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(JNIEnv* env, jobject,
+                                                                                 jlong nativeRowPtr,
+                                                                                 jstring columnName)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW(nativeRowPtr)->is_attached())
         return 0;
 
     try {
-        JStringAccessor columnName2(env, columnName); // throws
-        return to_jlong_or_not_found( ROW(nativeRowPtr)->get_column_index(columnName2) ); // noexcept
-    } CATCH_STD()
+        JStringAccessor columnName2(env, columnName);                                   // throws
+        return to_jlong_or_not_found(ROW(nativeRowPtr)->get_column_index(columnName2)); // noexcept
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT jint JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnType
-  (JNIEnv*, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jint JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnType(JNIEnv*, jobject, jlong nativeRowPtr,
+                                                                               jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    return static_cast<jint>( ROW(nativeRowPtr)->get_column_type( S(columnIndex)) ); // noexcept
+    return static_cast<jint>(ROW(nativeRowPtr)->get_column_type(S(columnIndex))); // noexcept
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetIndex
-  (JNIEnv* env, jobject, jlong nativeRowPtr)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetIndex(JNIEnv* env, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
@@ -75,85 +77,88 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetIndex
     return ROW(nativeRowPtr)->get_index();
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLong
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLong(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                          jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    return ROW(nativeRowPtr)->get_int( S(columnIndex) );
+    return ROW(nativeRowPtr)->get_int(S(columnIndex));
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeGetBoolean
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeGetBoolean(JNIEnv* env, jobject,
+                                                                                jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    return ROW(nativeRowPtr)->get_bool( S(columnIndex) );
+    return ROW(nativeRowPtr)->get_bool(S(columnIndex));
 }
 
-JNIEXPORT jfloat JNICALL Java_io_realm_internal_UncheckedRow_nativeGetFloat
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jfloat JNICALL Java_io_realm_internal_UncheckedRow_nativeGetFloat(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                            jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    return ROW(nativeRowPtr)->get_float( S(columnIndex) );
+    return ROW(nativeRowPtr)->get_float(S(columnIndex));
 }
 
-JNIEXPORT jdouble JNICALL Java_io_realm_internal_UncheckedRow_nativeGetDouble
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jdouble JNICALL Java_io_realm_internal_UncheckedRow_nativeGetDouble(JNIEnv* env, jobject,
+                                                                              jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    return ROW(nativeRowPtr)->get_double( S(columnIndex) );
+    return ROW(nativeRowPtr)->get_double(S(columnIndex));
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetTimestamp
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetTimestamp(JNIEnv* env, jobject,
+                                                                               jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    return to_milliseconds(ROW(nativeRowPtr)->get_timestamp( S(columnIndex) ));
+    return to_milliseconds(ROW(nativeRowPtr)->get_timestamp(S(columnIndex)));
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetString
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetString(JNIEnv* env, jobject,
+                                                                              jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
     try {
-        StringData value = ROW(nativeRowPtr)->get_string( S(columnIndex) );
-        return to_jstring(env,  value);
-    } CATCH_STD()
+        StringData value = ROW(nativeRowPtr)->get_string(S(columnIndex));
+        return to_jstring(env, value);
+    }
+    CATCH_STD()
     return NULL;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_UncheckedRow_nativeGetByteArray
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_UncheckedRow_nativeGetByteArray(JNIEnv* env, jobject,
+                                                                                    jlong nativeRowPtr,
+                                                                                    jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    BinaryData bin = ROW(nativeRowPtr)->get_binary( S(columnIndex) );
+    BinaryData bin = ROW(nativeRowPtr)->get_binary(S(columnIndex));
     if (bin.is_null()) {
         return NULL;
     }
     else if (bin.size() <= MAX_JSIZE) {
         jbyteArray jresult = env->NewByteArray(static_cast<jsize>(bin.size()));
         if (jresult)
-            env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()), reinterpret_cast<const jbyte*>(bin.data()));  // throws
+            env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()),
+                                    reinterpret_cast<const jbyte*>(bin.data())); // throws
         return jresult;
     }
     else {
@@ -162,119 +167,128 @@ JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_UncheckedRow_nativeGetByteAr
     }
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLink
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLink(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                          jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    if (ROW(nativeRowPtr)->is_null_link( S(columnIndex) ))
+    if (ROW(nativeRowPtr)->is_null_link(S(columnIndex)))
         return jlong(-1);
 
-    return ROW(nativeRowPtr)->get_link( S(columnIndex) );
+    return ROW(nativeRowPtr)->get_link(S(columnIndex));
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNullLink
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNullLink(JNIEnv* env, jobject,
+                                                                                jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    return ROW(nativeRowPtr)->is_null_link( S(columnIndex) );
+    return ROW(nativeRowPtr)->is_null_link(S(columnIndex));
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLinkView
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLinkView(JNIEnv* env, jobject,
+                                                                              jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return 0;
 
-    LinkViewRef* link_view_ptr = const_cast<LinkViewRef*>(&(LangBindHelper::get_linklist_ptr(*ROW(nativeRowPtr), S(columnIndex))));
+    LinkViewRef* link_view_ptr =
+        const_cast<LinkViewRef*>(&(LangBindHelper::get_linklist_ptr(*ROW(nativeRowPtr), S(columnIndex))));
     return reinterpret_cast<jlong>(link_view_ptr);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLong
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLong(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                         jlong columnIndex, jlong value)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        ROW(nativeRowPtr)->set_int( S(columnIndex), value);
-    } CATCH_STD()
+        ROW(nativeRowPtr)->set_int(S(columnIndex), value);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetBoolean
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jboolean value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetBoolean(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                            jlong columnIndex, jboolean value)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        ROW(nativeRowPtr)->set_bool( S(columnIndex), value);
-    } CATCH_STD()
+        ROW(nativeRowPtr)->set_bool(S(columnIndex), value);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetFloat
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jfloat value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetFloat(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                          jlong columnIndex, jfloat value)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        ROW(nativeRowPtr)->set_float( S(columnIndex), value);
-    } CATCH_STD()
+        ROW(nativeRowPtr)->set_float(S(columnIndex), value);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetDouble
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jdouble value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetDouble(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                           jlong columnIndex, jdouble value)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        ROW(nativeRowPtr)->set_double( S(columnIndex), value);
-    } CATCH_STD()
+        ROW(nativeRowPtr)->set_double(S(columnIndex), value);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetTimestamp
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetTimestamp(JNIEnv* env, jobject,
+                                                                              jlong nativeRowPtr, jlong columnIndex,
+                                                                              jlong value)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        ROW(nativeRowPtr)->set_timestamp( S(columnIndex), from_milliseconds(value));
-    } CATCH_STD()
+        ROW(nativeRowPtr)->set_timestamp(S(columnIndex), from_milliseconds(value));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetString
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jstring value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetString(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                           jlong columnIndex, jstring value)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        if ((value == NULL) && !(ROW(nativeRowPtr)->get_table()->is_nullable( S(columnIndex) ))) {
+        if ((value == NULL) && !(ROW(nativeRowPtr)->get_table()->is_nullable(S(columnIndex)))) {
             ThrowNullValueException(env, ROW(nativeRowPtr)->get_table(), S(columnIndex));
             return;
         }
         JStringAccessor value2(env, value); // throws
-        ROW(nativeRowPtr)->set_string( S(columnIndex), value2);
-    } CATCH_STD()
+        ROW(nativeRowPtr)->set_string(S(columnIndex), value2);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetByteArray
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jbyteArray value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetByteArray(JNIEnv* env, jobject,
+                                                                              jlong nativeRowPtr, jlong columnIndex,
+                                                                              jbyteArray value)
 {
     TR_ENTER_PTR(nativeRowPtr)
 
@@ -297,61 +311,65 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetByteArray
                 return;
             }
             size_t dataLen = S(env->GetArrayLength(value));
-            ROW(nativeRowPtr)->set_binary( S(columnIndex), BinaryData(reinterpret_cast<char*>(bytePtr), dataLen));
+            ROW(nativeRowPtr)->set_binary(S(columnIndex), BinaryData(reinterpret_cast<char*>(bytePtr), dataLen));
         }
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     if (bytePtr) {
         env->ReleaseByteArrayElements(value, bytePtr, JNI_ABORT);
     }
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLink
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex, jlong value)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLink(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                         jlong columnIndex, jlong value)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        ROW(nativeRowPtr)->set_link( S(columnIndex), value);
-    } CATCH_STD()
+        ROW(nativeRowPtr)->set_link(S(columnIndex), value);
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeNullifyLink
-  (JNIEnv* env, jobject, jlong nativeRowPtr, jlong columnIndex)
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeNullifyLink(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                             jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
 
     try {
-        ROW(nativeRowPtr)->nullify_link( S(columnIndex) );
-    } CATCH_STD()
+        ROW(nativeRowPtr)->nullify_link(S(columnIndex));
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsAttached
-  (JNIEnv*, jobject, jlong nativeRowPtr)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsAttached(JNIEnv*, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(nativeRowPtr)
     return ROW(nativeRowPtr)->is_attached();
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeHasColumn
-  (JNIEnv* env, jobject obj, jlong nativeRowPtr, jstring columnName)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeHasColumn(JNIEnv* env, jobject obj,
+                                                                               jlong nativeRowPtr, jstring columnName)
 {
     jlong ndx = Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(env, obj, nativeRowPtr, columnName);
     return ndx != to_jlong_or_not_found(realm::not_found);
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNull
-  (JNIEnv*, jobject, jlong nativeRowPtr, jlong columnIndex) {
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNull(JNIEnv*, jobject, jlong nativeRowPtr,
+                                                                            jlong columnIndex)
+{
     TR_ENTER_PTR(nativeRowPtr)
     return ROW(nativeRowPtr)->is_null(columnIndex);
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetNull
-  (JNIEnv *env, jobject, jlong nativeRowPtr, jlong columnIndex) {
+JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetNull(JNIEnv* env, jobject, jlong nativeRowPtr,
+                                                                         jlong columnIndex)
+{
     TR_ENTER_PTR(nativeRowPtr)
     if (!ROW_VALID(env, ROW(nativeRowPtr)))
         return;
@@ -359,7 +377,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetNull
         return;
     try {
         ROW(nativeRowPtr)->set_null(columnIndex);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 static void finalize_unchecked_row(jlong ptr)
@@ -368,10 +387,8 @@ static void finalize_unchecked_row(jlong ptr)
     delete ROW(ptr);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetFinalizerPtr
-  (JNIEnv *, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetFinalizerPtr(JNIEnv*, jclass)
 {
     TR_ENTER()
     return reinterpret_cast<jlong>(&finalize_unchecked_row);
 }
-

--- a/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
@@ -24,10 +24,11 @@ static void finalize_unchecked_row(jlong ptr);
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnCount(JNIEnv*, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW(nativeRowPtr)->is_attached())
+    if (!ROW(nativeRowPtr)->is_attached()) {
         return 0;
+    }
 
-    return ROW(nativeRowPtr)->get_column_count(); // noexcept
+    return static_cast<jlong>(ROW(nativeRowPtr)->get_column_count()); // noexcept
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnName(JNIEnv* env, jobject,
@@ -35,8 +36,9 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnNam
                                                                                   jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
     try {
         return to_jstring(env, ROW(nativeRowPtr)->get_column_name(S(columnIndex)));
@@ -50,8 +52,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex
                                                                                  jstring columnName)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW(nativeRowPtr)->is_attached())
+    if (!ROW(nativeRowPtr)->is_attached()) {
         return 0;
+    }
 
     try {
         JStringAccessor columnName2(env, columnName);                                   // throws
@@ -71,18 +74,20 @@ JNIEXPORT jint JNICALL Java_io_realm_internal_UncheckedRow_nativeGetColumnType(J
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetIndex(JNIEnv* env, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
-    return ROW(nativeRowPtr)->get_index();
+    return static_cast<jlong>(ROW(nativeRowPtr)->get_index());
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLong(JNIEnv* env, jobject, jlong nativeRowPtr,
                                                                           jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
     return ROW(nativeRowPtr)->get_int(S(columnIndex));
 }
@@ -91,18 +96,20 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeGetBoolean(
                                                                                 jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
-    return ROW(nativeRowPtr)->get_bool(S(columnIndex));
+    return to_jbool(ROW(nativeRowPtr)->get_bool(S(columnIndex)));
 }
 
 JNIEXPORT jfloat JNICALL Java_io_realm_internal_UncheckedRow_nativeGetFloat(JNIEnv* env, jobject, jlong nativeRowPtr,
                                                                             jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
     return ROW(nativeRowPtr)->get_float(S(columnIndex));
 }
@@ -111,8 +118,9 @@ JNIEXPORT jdouble JNICALL Java_io_realm_internal_UncheckedRow_nativeGetDouble(JN
                                                                               jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
     return ROW(nativeRowPtr)->get_double(S(columnIndex));
 }
@@ -121,8 +129,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetTimestamp(J
                                                                                jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
     return to_milliseconds(ROW(nativeRowPtr)->get_timestamp(S(columnIndex)));
 }
@@ -131,15 +140,16 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_UncheckedRow_nativeGetString(JN
                                                                               jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
+        return nullptr;
+    }
 
     try {
         StringData value = ROW(nativeRowPtr)->get_string(S(columnIndex));
         return to_jstring(env, value);
     }
     CATCH_STD()
-    return NULL;
+    return nullptr;
 }
 
 JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_UncheckedRow_nativeGetByteArray(JNIEnv* env, jobject,
@@ -147,23 +157,25 @@ JNIEXPORT jbyteArray JNICALL Java_io_realm_internal_UncheckedRow_nativeGetByteAr
                                                                                     jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
-        return 0;
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
+        return nullptr;
+    }
 
     BinaryData bin = ROW(nativeRowPtr)->get_binary(S(columnIndex));
     if (bin.is_null()) {
-        return NULL;
+        return nullptr;
     }
     else if (bin.size() <= MAX_JSIZE) {
         jbyteArray jresult = env->NewByteArray(static_cast<jsize>(bin.size()));
-        if (jresult)
+        if (jresult) {
             env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()),
-                                    reinterpret_cast<const jbyte*>(bin.data())); // throws
+                                    reinterpret_cast<const jbyte *>(bin.data())); // throws
+        }
         return jresult;
     }
     else {
         ThrowException(env, IllegalArgument, "Length of ByteArray is larger than an Int.");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -171,31 +183,35 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLink(JNIEnv
                                                                           jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
-    if (ROW(nativeRowPtr)->is_null_link(S(columnIndex)))
+    if (ROW(nativeRowPtr)->is_null_link(S(columnIndex))) {
         return jlong(-1);
+    }
 
-    return ROW(nativeRowPtr)->get_link(S(columnIndex));
+    return static_cast<jlong>(ROW(nativeRowPtr)->get_link(S(columnIndex)));
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNullLink(JNIEnv* env, jobject,
                                                                                 jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
-    return ROW(nativeRowPtr)->is_null_link(S(columnIndex));
+    return to_jbool(ROW(nativeRowPtr)->is_null_link(S(columnIndex)));
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeGetLinkView(JNIEnv* env, jobject,
                                                                               jlong nativeRowPtr, jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return 0;
+    }
 
     LinkViewRef* link_view_ptr =
         const_cast<LinkViewRef*>(&(LangBindHelper::get_linklist_ptr(*ROW(nativeRowPtr), S(columnIndex))));
@@ -206,8 +222,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLong(JNIEnv*
                                                                          jlong columnIndex, jlong value)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
         ROW(nativeRowPtr)->set_int(S(columnIndex), value);
@@ -219,8 +236,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetBoolean(JNIE
                                                                             jlong columnIndex, jboolean value)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
         ROW(nativeRowPtr)->set_bool(S(columnIndex), value);
@@ -232,8 +250,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetFloat(JNIEnv
                                                                           jlong columnIndex, jfloat value)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
         ROW(nativeRowPtr)->set_float(S(columnIndex), value);
@@ -245,8 +264,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetDouble(JNIEn
                                                                            jlong columnIndex, jdouble value)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
         ROW(nativeRowPtr)->set_double(S(columnIndex), value);
@@ -259,8 +279,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetTimestamp(JN
                                                                               jlong value)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
         ROW(nativeRowPtr)->set_timestamp(S(columnIndex), from_milliseconds(value));
@@ -272,11 +293,12 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetString(JNIEn
                                                                            jlong columnIndex, jstring value)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
-        if ((value == NULL) && !(ROW(nativeRowPtr)->get_table()->is_nullable(S(columnIndex)))) {
+        if ((value == nullptr) && !(ROW(nativeRowPtr)->get_table()->is_nullable(S(columnIndex)))) {
             ThrowNullValueException(env, ROW(nativeRowPtr)->get_table(), S(columnIndex));
             return;
         }
@@ -292,12 +314,13 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetByteArray(JN
 {
     TR_ENTER_PTR(nativeRowPtr)
 
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
-    jbyte* bytePtr = NULL;
+    jbyte* bytePtr = nullptr;
     try {
-        if (value == NULL) {
+        if (value == nullptr) {
             if (!(ROW(nativeRowPtr)->get_table()->is_nullable(S(columnIndex)))) {
                 ThrowNullValueException(env, ROW(nativeRowPtr)->get_table(), S(columnIndex));
                 return;
@@ -325,8 +348,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetLink(JNIEnv*
                                                                          jlong columnIndex, jlong value)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
         ROW(nativeRowPtr)->set_link(S(columnIndex), value);
@@ -338,8 +362,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeNullifyLink(JNI
                                                                              jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
+    }
 
     try {
         ROW(nativeRowPtr)->nullify_link(S(columnIndex));
@@ -350,31 +375,33 @@ JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeNullifyLink(JNI
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsAttached(JNIEnv*, jobject, jlong nativeRowPtr)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    return ROW(nativeRowPtr)->is_attached();
+    return to_jbool(ROW(nativeRowPtr)->is_attached());
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeHasColumn(JNIEnv* env, jobject obj,
                                                                                jlong nativeRowPtr, jstring columnName)
 {
     jlong ndx = Java_io_realm_internal_UncheckedRow_nativeGetColumnIndex(env, obj, nativeRowPtr, columnName);
-    return ndx != to_jlong_or_not_found(realm::not_found);
+    return to_jbool(ndx != to_jlong_or_not_found(realm::not_found));
 }
 
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_UncheckedRow_nativeIsNull(JNIEnv*, jobject, jlong nativeRowPtr,
                                                                             jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    return ROW(nativeRowPtr)->is_null(columnIndex);
+    return to_jbool(ROW(nativeRowPtr)->is_null(columnIndex));
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_UncheckedRow_nativeSetNull(JNIEnv* env, jobject, jlong nativeRowPtr,
                                                                          jlong columnIndex)
 {
     TR_ENTER_PTR(nativeRowPtr)
-    if (!ROW_VALID(env, ROW(nativeRowPtr)))
+    if (!ROW_VALID(env, ROW(nativeRowPtr))) {
         return;
-    if (!TBL_AND_COL_NULLABLE(env, ROW(nativeRowPtr)->get_table(), columnIndex))
+    }
+    if (!TBL_AND_COL_NULLABLE(env, ROW(nativeRowPtr)->get_table(), columnIndex)) {
         return;
+    }
     try {
         ROW(nativeRowPtr)->set_null(columnIndex);
     }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
@@ -76,7 +76,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void*)
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_Util_nativeGetMemUsage(JNIEnv*, jclass)
 {
-    return GetMemUsage();
+    return static_cast<jlong>(GetMemUsage());
 }
 
 JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeGetTablePrefix(JNIEnv* env, jclass)

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
@@ -29,7 +29,7 @@ using namespace realm::jni_util;
 
 //#define USE_VLD
 #if defined(_MSC_VER) && defined(_DEBUG) && defined(USE_VLD)
-    #include "C:\\Program Files (x86)\\Visual Leak Detector\\include\\vld.h"
+#include "C:\\Program Files (x86)\\Visual Leak Detector\\include\\vld.h"
 #endif
 
 const string TABLE_PREFIX("class_");
@@ -38,21 +38,21 @@ const string TABLE_PREFIX("class_");
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
 {
     JNIEnv* env;
-    if (vm->GetEnv((void **) &env, JNI_VERSION_1_6) != JNI_OK) {
+    if (vm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
         return JNI_ERR;
     }
     else {
         JniUtils::initialize(vm, JNI_VERSION_1_6);
         // Loading classes and constructors for later use - used by box typed fields and a few methods' return value
-        java_lang_long        = GetClass(env, "java/lang/Long");
-        java_lang_long_init   = env->GetMethodID(java_lang_long, "<init>", "(J)V");
-        java_lang_float       = GetClass(env, "java/lang/Float");
-        java_lang_float_init  = env->GetMethodID(java_lang_float, "<init>", "(F)V");
-        java_lang_double      = GetClass(env, "java/lang/Double");
-        java_lang_string      = GetClass(env, "java/lang/String");
+        java_lang_long = GetClass(env, "java/lang/Long");
+        java_lang_long_init = env->GetMethodID(java_lang_long, "<init>", "(J)V");
+        java_lang_float = GetClass(env, "java/lang/Float");
+        java_lang_float_init = env->GetMethodID(java_lang_float, "<init>", "(F)V");
+        java_lang_double = GetClass(env, "java/lang/Double");
+        java_lang_string = GetClass(env, "java/lang/String");
         java_lang_double_init = env->GetMethodID(java_lang_double, "<init>", "(D)V");
-        java_util_date        = GetClass(env, "java/util/Date");
-        java_util_date_init   = env->GetMethodID(java_util_date, "<init>", "(J)V");
+        java_util_date = GetClass(env, "java/util/Date");
+        java_util_date_init = env->GetMethodID(java_util_date, "<init>", "(J)V");
     }
 
     return JNI_VERSION_1_6;
@@ -61,7 +61,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
 JNIEXPORT void JNI_OnUnload(JavaVM* vm, void*)
 {
     JNIEnv* env;
-    if (vm->GetEnv((void **) &env, JNI_VERSION_1_6) != JNI_OK) {
+    if (vm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
         return;
     }
     else {
@@ -79,8 +79,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Util_nativeGetMemUsage(JNIEnv*, j
     return GetMemUsage();
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeGetTablePrefix(
-    JNIEnv* env, jclass)
+JNIEXPORT jstring JNICALL Java_io_realm_internal_Util_nativeGetTablePrefix(JNIEnv* env, jclass)
 {
     realm::StringData sd(TABLE_PREFIX);
     return to_jstring(env, sd);

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_ObjectServerSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_ObjectServerSession.cpp
@@ -37,26 +37,29 @@ using namespace realm;
 using namespace sync;
 
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeCreateSession
-  (JNIEnv *env, jobject obj, jstring localRealmPath)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeCreateSession(
+    JNIEnv* env, jobject obj, jstring localRealmPath)
 {
     TR_ENTER()
     try {
         JStringAccessor local_path(env, localRealmPath);
         JniSession* jni_session = new JniSession(env, local_path, obj);
         return reinterpret_cast<jlong>(jni_session);
-    } CATCH_STD()
+    }
+    CATCH_STD()
     return 0;
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeBind
-  (JNIEnv *env, jobject, jlong sessionPointer, jstring remoteUrl, jstring accessToken)
+JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeBind(JNIEnv* env, jobject,
+                                                                                          jlong sessionPointer,
+                                                                                          jstring remoteUrl,
+                                                                                          jstring accessToken)
 {
     TR_ENTER()
     try {
-        auto *session_wrapper = reinterpret_cast<JniSession*>(sessionPointer);
+        auto* session_wrapper = reinterpret_cast<JniSession*>(sessionPointer);
 
-        const char *token_tmp = env->GetStringUTFChars(accessToken, NULL);
+        const char* token_tmp = env->GetStringUTFChars(accessToken, NULL);
         std::string access_token(token_tmp);
         env->ReleaseStringUTFChars(accessToken, token_tmp);
 
@@ -65,20 +68,22 @@ JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_n
 
         // Bind the local Realm to the remote one
         session_wrapper->get_session()->bind(remote_url, access_token);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
 
-JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeUnbind
-  (JNIEnv *, jobject, jlong sessionPointer)
+JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeUnbind(JNIEnv*, jobject,
+                                                                                            jlong sessionPointer)
 {
     TR_ENTER()
     JniSession* session = reinterpret_cast<JniSession*>(sessionPointer);
     delete session; // TODO Can we avoid killing the session here?
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeRefresh
-  (JNIEnv *env, jobject, jlong sessionPointer, jstring accessToken)
+JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeRefresh(JNIEnv* env, jobject,
+                                                                                             jlong sessionPointer,
+                                                                                             jstring accessToken)
 {
     TR_ENTER()
     try {
@@ -88,18 +93,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_n
         StringData access_token = StringData(token_tmp);
 
         session_wrapper->get_session()->refresh(access_token);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_internal_objectserver_ObjectServerSession_nativeNotifyCommitHappened
-  (JNIEnv *env, jobject, jlong sessionPointer, jlong version)
+JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_nativeNotifyCommitHappened(
+    JNIEnv* env, jobject, jlong sessionPointer, jlong version)
 {
     TR_ENTER()
     try {
         JniSession* session_wrapper = reinterpret_cast<JniSession*>(sessionPointer);
         session_wrapper->get_session()->nonsync_transact_notify(version);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
-
-

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_ObjectServerSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectserver_ObjectServerSession.cpp
@@ -103,7 +103,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_objectserver_ObjectServerSession_n
     TR_ENTER()
     try {
         JniSession* session_wrapper = reinterpret_cast<JniSession*>(sessionPointer);
-        session_wrapper->get_session()->nonsync_transact_notify(version);
+        session_wrapper->get_session()->nonsync_transact_notify(static_cast<Session::version_type>(version));
     }
     CATCH_STD()
 }

--- a/realm/realm-library/src/main/cpp/io_realm_log_RealmLog.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_log_RealmLog.cpp
@@ -21,64 +21,64 @@
 using namespace realm::util;
 using namespace realm::jni_util;
 
-JNIEXPORT void JNICALL
-Java_io_realm_log_RealmLog_nativeAddLogger(JNIEnv *env, jclass, jobject java_logger)
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeAddLogger(JNIEnv* env, jclass, jobject java_logger)
 {
     try {
         Log::shared().add_java_logger(env, java_logger);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_log_RealmLog_nativeRemoveLogger(JNIEnv *env, jclass, jobject java_logger)
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeRemoveLogger(JNIEnv* env, jclass, jobject java_logger)
 {
     try {
         Log::shared().remove_java_logger(env, java_logger);
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_log_RealmLog_nativeClearLoggers(JNIEnv *env, jclass)
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeClearLoggers(JNIEnv* env, jclass)
 {
     try {
         Log::shared().clear_loggers();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_log_RealmLog_nativeRegisterDefaultLogger(JNIEnv *env, jclass)
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeRegisterDefaultLogger(JNIEnv* env, jclass)
 {
     try {
         Log::shared().register_default_logger();
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_log_RealmLog_nativeLog(JNIEnv *env, jclass, jint level, jstring tag, jthrowable throwable,
-                                     jstring message)
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeLog(JNIEnv* env, jclass, jint level, jstring tag,
+                                                            jthrowable throwable, jstring message)
 {
     try {
         JStringAccessor tag_accessor(env, tag);
         JStringAccessor message_accessor(env, message);
         Log::shared().log(static_cast<Log::Level>(level), std::string(tag_accessor).c_str(), throwable,
                           std::string(message_accessor).c_str());
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT void JNICALL
-Java_io_realm_log_RealmLog_nativeSetLogLevel(JNIEnv *env, jclass, jint level)
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeSetLogLevel(JNIEnv* env, jclass, jint level)
 {
     try {
         Log::shared().set_level(static_cast<Log::Level>(level));
-    } CATCH_STD()
+    }
+    CATCH_STD()
 }
 
-JNIEXPORT jint JNICALL
-Java_io_realm_log_RealmLog_nativeGetLogLevel(JNIEnv *env, jclass)
+JNIEXPORT jint JNICALL Java_io_realm_log_RealmLog_nativeGetLogLevel(JNIEnv* env, jclass)
 {
     try {
         return static_cast<jint>(Log::shared().get_level());
-    } CATCH_STD()
+    }
+    CATCH_STD()
 
     return static_cast<jint>(Log::Level::all);
 }

--- a/realm/realm-library/src/main/cpp/java_binding_context.cpp
+++ b/realm/realm-library/src/main/cpp/java_binding_context.cpp
@@ -29,7 +29,7 @@ void JavaBindingContext::before_notify()
         return;
     }
     if (m_java_notifier) {
-        m_java_notifier.call_with_local_ref([&] (JNIEnv* env, jobject notifier_obj) {
+        m_java_notifier.call_with_local_ref([&](JNIEnv* env, jobject notifier_obj) {
             // Method IDs from RealmNotifier implementation. Cache them as member vars.
             static JavaMethod notify_by_other_method(env, notifier_obj, "beforeNotify", "()V");
             env->CallVoidMethod(notifier_obj, notify_by_other_method);
@@ -37,9 +37,8 @@ void JavaBindingContext::before_notify()
     }
 }
 
-void JavaBindingContext::did_change(std::vector<BindingContext::ObserverState> const&,
-                        std::vector<void*> const&,
-                        bool version_changed)
+void JavaBindingContext::did_change(std::vector<BindingContext::ObserverState> const&, std::vector<void*> const&,
+                                    bool version_changed)
 {
     auto env = JniUtils::get_env();
 
@@ -47,10 +46,9 @@ void JavaBindingContext::did_change(std::vector<BindingContext::ObserverState> c
         return;
     }
     if (version_changed) {
-        m_java_notifier.call_with_local_ref(env, [&] (JNIEnv*, jobject notifier_obj) {
+        m_java_notifier.call_with_local_ref(env, [&](JNIEnv*, jobject notifier_obj) {
             static JavaMethod realm_notifier_did_change_method(env, notifier_obj, "didChange", "()V");
             env->CallVoidMethod(notifier_obj, realm_notifier_did_change_method);
         });
     }
 }
-

--- a/realm/realm-library/src/main/cpp/java_binding_context.hpp
+++ b/realm/realm-library/src/main/cpp/java_binding_context.hpp
@@ -41,14 +41,15 @@ private:
     jni_util::JavaGlobalWeakRef m_java_notifier;
 
 public:
-    virtual ~JavaBindingContext() { };
+    virtual ~JavaBindingContext(){};
     virtual void before_notify();
-    virtual void did_change(std::vector<ObserverState> const& observers,
-                            std::vector<void*> const& invalidated,
-                            bool version_changed=true);
+    virtual void did_change(std::vector<ObserverState> const& observers, std::vector<void*> const& invalidated,
+                            bool version_changed = true);
 
     explicit JavaBindingContext(const ConcreteJavaBindContext& concrete_context)
-            : m_java_notifier(concrete_context.jni_env, concrete_context.java_notifier) { }
+        : m_java_notifier(concrete_context.jni_env, concrete_context.java_notifier)
+    {
+    }
     JavaBindingContext(const JavaBindingContext&) = delete;
     JavaBindingContext& operator=(const JavaBindingContext&) = delete;
     JavaBindingContext(JavaBindingContext&&) = delete;
@@ -65,4 +66,3 @@ public:
 } // namespace realm
 
 #endif
-

--- a/realm/realm-library/src/main/cpp/java_sort_descriptor.cpp
+++ b/realm/realm-library/src/main/cpp/java_sort_descriptor.cpp
@@ -35,9 +35,8 @@ JavaSortDescriptor::operator realm::SortDescriptor() const noexcept
     static JavaMethod getTablePtr(m_env, m_sort_desc_obj, "getTablePtr", "()J");
 
     jobjectArray column_indices =
-            static_cast<jobjectArray>(m_env->CallObjectMethod(m_sort_desc_obj, getColumnIndices));
-    jbooleanArray ascendings =
-            static_cast<jbooleanArray >(m_env->CallObjectMethod(m_sort_desc_obj, getAscendings));
+        static_cast<jobjectArray>(m_env->CallObjectMethod(m_sort_desc_obj, getColumnIndices));
+    jbooleanArray ascendings = static_cast<jbooleanArray>(m_env->CallObjectMethod(m_sort_desc_obj, getAscendings));
     jlong table_ptr = m_env->CallLongMethod(m_sort_desc_obj, getTablePtr);
 
     JniArrayOfArrays<JniLongArray, jlongArray> arrays(m_env, column_indices);
@@ -51,7 +50,7 @@ JavaSortDescriptor::operator realm::SortDescriptor() const noexcept
         JniLongArray& jni_long_array = arrays[i];
         std::vector<size_t> col_indices;
         for (int j = 0; j < jni_long_array.len(); ++j) {
-            col_indices.push_back(static_cast<size_t >(jni_long_array[j]));
+            col_indices.push_back(static_cast<size_t>(jni_long_array[j]));
         }
         indices.push_back(std::move(col_indices));
         if (ascendings) {
@@ -59,9 +58,7 @@ JavaSortDescriptor::operator realm::SortDescriptor() const noexcept
         }
     }
 
-    return ascendings ?
-           SortDescriptor(*reinterpret_cast<Table*>(table_ptr), std::move(indices), std::move(ascending_list))
-                      : SortDescriptor(*reinterpret_cast<Table*>(table_ptr), std::move(indices));
+    return ascendings
+               ? SortDescriptor(*reinterpret_cast<Table*>(table_ptr), std::move(indices), std::move(ascending_list))
+               : SortDescriptor(*reinterpret_cast<Table*>(table_ptr), std::move(indices));
 }
-
-

--- a/realm/realm-library/src/main/cpp/java_sort_descriptor.hpp
+++ b/realm/realm-library/src/main/cpp/java_sort_descriptor.hpp
@@ -30,7 +30,11 @@ namespace _impl {
 // doesn't make too much sense and causes troubles with memory management.
 class JavaSortDescriptor {
 public:
-    JavaSortDescriptor(JNIEnv* env, jobject sort_desc_obj) : m_env(env), m_sort_desc_obj(sort_desc_obj) {}
+    JavaSortDescriptor(JNIEnv* env, jobject sort_desc_obj)
+        : m_env(env)
+        , m_sort_desc_obj(sort_desc_obj)
+    {
+    }
 
     JavaSortDescriptor(const JavaSortDescriptor&) = delete;
     JavaSortDescriptor& operator=(const JavaSortDescriptor&) = delete;
@@ -46,4 +50,4 @@ private:
 
 } // namespace _impl
 } // namespace realm
-#endif //JAVA_SORT_DESCRIPTOR_HPP
+#endif // JAVA_SORT_DESCRIPTOR_HPP

--- a/realm/realm-library/src/main/cpp/jni_impl/android_logger.cpp
+++ b/realm/realm-library/src/main/cpp/jni_impl/android_logger.cpp
@@ -32,7 +32,8 @@ std::shared_ptr<AndroidLogger> AndroidLogger::shared()
     return android_logger;
 }
 
-void AndroidLogger::log(Log::Level level, const char* tag, jthrowable, const char* message) {
+void AndroidLogger::log(Log::Level level, const char* tag, jthrowable, const char* message)
+{
     android_LogPriority android_log_priority;
     switch (level) {
         case Log::Level::trace:
@@ -53,7 +54,7 @@ void AndroidLogger::log(Log::Level level, const char* tag, jthrowable, const cha
         case Log::Level::fatal:
             android_log_priority = ANDROID_LOG_FATAL;
             break;
-        default:// Cannot get here.
+        default: // Cannot get here.
             throw std::invalid_argument(format("Invalid log level: %1.", level));
     }
     if (message) {
@@ -74,7 +75,8 @@ void AndroidLogger::print(android_LogPriority priority, const char* tag, const c
             __android_log_write(priority, tag, tmp_str.c_str());
             start += count;
         }
-    } else {
+    }
+    else {
         __android_log_write(priority, tag, log_string);
     }
 }
@@ -86,8 +88,5 @@ std::shared_ptr<JniLogger> get_default_logger()
 {
     return std::static_pointer_cast<JniLogger>(AndroidLogger::shared());
 }
-
 }
 }
-
-

--- a/realm/realm-library/src/main/cpp/jni_impl/android_logger.hpp
+++ b/realm/realm-library/src/main/cpp/jni_impl/android_logger.hpp
@@ -23,7 +23,7 @@
 namespace realm {
 namespace jni_impl {
 
-//Default logger implementation for Android.
+// Default logger implementation for Android.
 class AndroidLogger : public realm::jni_util::JniLogger {
 public:
     static std::shared_ptr<AndroidLogger> shared();
@@ -32,11 +32,10 @@ protected:
     void log(realm::jni_util::Log::Level level, const char* tag, jthrowable throwable, const char* message) override;
 
 private:
-    AndroidLogger() {};
+    AndroidLogger(){};
     static void print(android_LogPriority priority, const char* tag, const char* log_string);
     static const size_t LOG_ENTRY_MAX_LENGTH = 4000;
 };
-
 }
 }
 

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
@@ -38,4 +38,3 @@ bool JavaGlobalWeakRef::call_with_local_ref(std::function<Callback> callback)
 {
     return call_with_local_ref(JniUtils::get_env(), callback);
 }
-

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
@@ -28,8 +28,14 @@ namespace jni_util {
 // RAII wrapper for weak global ref.
 class JavaGlobalWeakRef {
 public:
-    JavaGlobalWeakRef() : m_weak(nullptr) {}
-    JavaGlobalWeakRef(JNIEnv* env, jobject obj) : m_weak(obj ? env->NewWeakGlobalRef(obj) : nullptr) { }
+    JavaGlobalWeakRef()
+        : m_weak(nullptr)
+    {
+    }
+    JavaGlobalWeakRef(JNIEnv* env, jobject obj)
+        : m_weak(obj ? env->NewWeakGlobalRef(obj) : nullptr)
+    {
+    }
     ~JavaGlobalWeakRef()
     {
         if (m_weak) {
@@ -37,10 +43,15 @@ public:
         }
     }
 
-    JavaGlobalWeakRef(JavaGlobalWeakRef&& rhs) : m_weak(rhs.m_weak) { rhs.m_weak = nullptr; }
-    JavaGlobalWeakRef& operator=(JavaGlobalWeakRef&& rhs) {
+    JavaGlobalWeakRef(JavaGlobalWeakRef&& rhs)
+        : m_weak(rhs.m_weak)
+    {
+        rhs.m_weak = nullptr;
+    }
+    JavaGlobalWeakRef& operator=(JavaGlobalWeakRef&& rhs)
+    {
         this->~JavaGlobalWeakRef();
-        new(this) JavaGlobalWeakRef(std::move(rhs));
+        new (this) JavaGlobalWeakRef(std::move(rhs));
         return *this;
     }
 
@@ -68,4 +79,3 @@ private:
 } // namespace realm
 
 #endif // REALM_JNI_UTIL_JAVA_GLOBAL_WEAK_REF_HPP
-

--- a/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_local_ref.hpp
@@ -22,29 +22,43 @@
 namespace realm {
 namespace jni_util {
 
-struct NeedToCreateLocalRef {};
+struct NeedToCreateLocalRef {
+};
 static constexpr NeedToCreateLocalRef need_to_create_local_ref{};
 
 // Wraps jobject and automatically calls DeleteLocalRef when this object is destroyed.
 // DeleteLocalRef is not necessary to be called in most cases since all local references will be cleaned up when the
-// program returns to Java from native. But if the local ref is created in a loop, consider to use this class to wrap it
+// program returns to Java from native. But if the local ref is created in a loop, consider to use this class to wrap
+// it
 // because the size of local reference table is relative small (512 bytes on Android).
 template <typename T>
 class JavaLocalRef {
 public:
     // need_to_create is useful when acquire a local ref from a global weak ref.
-    inline JavaLocalRef(JNIEnv* env, T obj) noexcept : m_jobject(obj), m_env(env) {};
+    inline JavaLocalRef(JNIEnv* env, T obj) noexcept
+        : m_jobject(obj)
+        , m_env(env){};
     inline JavaLocalRef(JNIEnv* env, T obj, NeedToCreateLocalRef) noexcept
-            : m_jobject(env->NewLocalRef(obj)), m_env(env) {};
-    inline ~JavaLocalRef() { m_env->DeleteLocalRef(m_jobject); }
+        : m_jobject(env->NewLocalRef(obj))
+        , m_env(env){};
+    inline ~JavaLocalRef()
+    {
+        m_env->DeleteLocalRef(m_jobject);
+    }
 
     JavaLocalRef(const JavaLocalRef&) = delete;
     JavaLocalRef& operator=(const JavaLocalRef&) = delete;
     JavaLocalRef(JavaLocalRef&& rhs) = delete;
     JavaLocalRef& operator=(JavaLocalRef&& rhs) = delete;
 
-    inline operator bool() const noexcept { return m_jobject != nullptr; };
-    inline operator T() const noexcept { return m_jobject; }
+    inline operator bool() const noexcept
+    {
+        return m_jobject != nullptr;
+    };
+    inline operator T() const noexcept
+    {
+        return m_jobject;
+    }
 
 private:
     T m_jobject;
@@ -54,4 +68,3 @@ private:
 } // namespace realm
 } // namespace jni_util
 #endif // REALM_JNI_UTIL_JAVA_LOCAL_REF_HPP
-

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
@@ -20,13 +20,13 @@
 
 using namespace realm::jni_util;
 
-JavaMethod::JavaMethod(JNIEnv *env, jclass cls, const char* method_name, const char* signature)
+JavaMethod::JavaMethod(JNIEnv* env, jclass cls, const char* method_name, const char* signature)
 {
     m_method_id = env->GetMethodID(cls, method_name, signature);
     REALM_ASSERT_DEBUG(m_method_id != nullptr);
 }
 
-JavaMethod::JavaMethod(JNIEnv *env, jobject obj, const char* method_name, const char* signature)
+JavaMethod::JavaMethod(JNIEnv* env, jobject obj, const char* method_name, const char* signature)
 {
     jclass cls = env->GetObjectClass(obj);
     m_method_id = env->GetMethodID(cls, method_name, signature);
@@ -34,10 +34,9 @@ JavaMethod::JavaMethod(JNIEnv *env, jobject obj, const char* method_name, const 
     env->DeleteLocalRef(cls);
 }
 
-JavaMethod::JavaMethod(JNIEnv *env, const char* class_name, const char* method_name, const char* signature)
+JavaMethod::JavaMethod(JNIEnv* env, const char* class_name, const char* method_name, const char* signature)
 {
     jclass cls = env->FindClass(class_name);
     REALM_ASSERT_DEBUG(cls != nullptr);
     m_method_id = env->GetMethodID(cls, method_name, signature);
 }
-

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.hpp
@@ -26,20 +26,31 @@ namespace jni_util {
 // safe to have a static JavaMethod object to avoid calling GetMethodID multiple times.
 class JavaMethod {
 public:
-    JavaMethod() : m_method_id(nullptr) {}
-    JavaMethod(JNIEnv *env, jclass cls, const char* method_name, const char* signature);
-    JavaMethod(JNIEnv *env, jobject obj, const char* method_name, const char* signature);
-    JavaMethod(JNIEnv *env, const char* class_name, const char* method_name, const char* signature);
+    JavaMethod()
+        : m_method_id(nullptr)
+    {
+    }
+    JavaMethod(JNIEnv* env, jclass cls, const char* method_name, const char* signature);
+    JavaMethod(JNIEnv* env, jobject obj, const char* method_name, const char* signature);
+    JavaMethod(JNIEnv* env, const char* class_name, const char* method_name, const char* signature);
 
     JavaMethod(const JavaMethod&) = default;
     JavaMethod& operator=(const JavaMethod&) = default;
     JavaMethod(JavaMethod&& rhs) = delete;
     JavaMethod& operator=(JavaMethod&& rhs) = delete;
 
-    ~JavaMethod() { }
+    ~JavaMethod()
+    {
+    }
 
-    inline operator bool() const noexcept { return m_method_id != nullptr; }
-    inline operator const jmethodID&() const noexcept { return m_method_id; }
+    inline operator bool() const noexcept
+    {
+        return m_method_id != nullptr;
+    }
+    inline operator const jmethodID&() const noexcept
+    {
+        return m_method_id;
+    }
 
 private:
     jmethodID m_method_id;
@@ -48,4 +59,4 @@ private:
 } // namespace realm
 } // namespace jni_util
 
-#endif //REALM_JNI_UTIL_JAVA_METHOD_HPP
+#endif // REALM_JNI_UTIL_JAVA_METHOD_HPP

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
@@ -24,13 +24,15 @@ using namespace realm::jni_util;
 
 static std::unique_ptr<JniUtils> s_instance;
 
-void JniUtils::initialize(JavaVM *vm, jint vm_version) noexcept {
+void JniUtils::initialize(JavaVM* vm, jint vm_version) noexcept
+{
     REALM_ASSERT_DEBUG(!s_instance);
 
     s_instance = std::unique_ptr<JniUtils>(new JniUtils(vm, vm_version));
 }
 
-JNIEnv* JniUtils::get_env(bool attach_if_needed) {
+JNIEnv* JniUtils::get_env(bool attach_if_needed)
+{
     REALM_ASSERT_DEBUG(s_instance);
 
     JNIEnv* env;
@@ -38,11 +40,11 @@ JNIEnv* JniUtils::get_env(bool attach_if_needed) {
         if (attach_if_needed) {
             jint ret = s_instance->m_vm->AttachCurrentThread(&env, nullptr);
             REALM_ASSERT_RELEASE(ret == JNI_OK);
-        } else {
+        }
+        else {
             REALM_ASSERT_RELEASE(false);
         }
     }
 
     return env;
 }
-

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
@@ -25,7 +25,9 @@ namespace jni_util {
 // Util functions for JNI.
 class JniUtils {
 public:
-    ~JniUtils() {}
+    ~JniUtils()
+    {
+    }
 
     // Call this only once in JNI_OnLoad.
     static void initialize(JavaVM* vm, jint vm_version) noexcept;
@@ -34,7 +36,11 @@ public:
     static JNIEnv* get_env(bool attach_if_needed = false);
 
 private:
-    JniUtils(JavaVM* vm, jint vm_version) noexcept : m_vm(vm), m_vm_version(vm_version) {}
+    JniUtils(JavaVM* vm, jint vm_version) noexcept
+        : m_vm(vm)
+        , m_vm_version(vm_version)
+    {
+    }
 
     JavaVM* m_vm;
     jint m_vm_version;
@@ -43,4 +49,4 @@ private:
 } // namespace realm
 } // namespace jni_util
 
-#endif //REALM_JNI_UTIL_JNI_UTILS_HPP
+#endif // REALM_JNI_UTIL_JNI_UTILS_HPP

--- a/realm/realm-library/src/main/cpp/jni_util/log.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.cpp
@@ -46,8 +46,8 @@ private:
 
     inline JNIEnv* get_current_env() noexcept
     {
-        JNIEnv *env;
-        if (m_jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        JNIEnv* env;
+        if (m_jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
             m_jvm->AttachCurrentThread(&env, nullptr); // Should never fail
         }
         return env;
@@ -55,17 +55,17 @@ private:
 };
 
 JniLogger::JniLogger()
-    :m_is_java_logger(false)
+    : m_is_java_logger(false)
 {
 }
 
 JniLogger::JniLogger(bool is_java_logger)
-    :m_is_java_logger(is_java_logger)
+    : m_is_java_logger(is_java_logger)
 {
 }
 
 JavaLogger::JavaLogger(JNIEnv* env, jobject java_logger)
-    :JniLogger(true)
+    : JniLogger(true)
 {
     jint ret = env->GetJavaVM(&m_jvm);
     if (ret != 0) {
@@ -83,13 +83,14 @@ JavaLogger::~JavaLogger()
 
 void JavaLogger::log(Log::Level level, const char* tag, jthrowable throwable, const char* message)
 {
-    JNIEnv *env = get_current_env();
+    JNIEnv* env = get_current_env();
 
     // NOTE: If a Java exception has been thrown in native code, the below call will trigger an JNI exception
-    // "JNI called with pending exception". This is something that should be avoided when printing log in JNI -- Always
+    // "JNI called with pending exception". This is something that should be avoided when printing log in JNI --
+    // Always
     // print log before calling env->ThrowNew. Doing env->ExceptionCheck() here creates overhead for normal cases.
-    env->CallVoidMethod(m_java_logger, m_log_method, level, env->NewStringUTF(tag),
-            throwable, env->NewStringUTF(message));
+    env->CallVoidMethod(m_java_logger, m_log_method, level, env->NewStringUTF(tag), throwable,
+                        env->NewStringUTF(message));
 }
 
 bool JavaLogger::is_same_object(JNIEnv* env, jobject java_logger)
@@ -118,9 +119,13 @@ void Log::add_java_logger(JNIEnv* env, const jobject java_logger)
 void Log::remove_java_logger(JNIEnv* env, const jobject java_logger)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_loggers.erase(std::remove_if(m_loggers.begin(), m_loggers.end(), [&](const auto& obj) {
-        return obj->m_is_java_logger && std::static_pointer_cast<JavaLogger>(obj)->is_same_object(env, java_logger);
-    }), m_loggers.end());
+    m_loggers.erase(std::remove_if(m_loggers.begin(), m_loggers.end(),
+                                   [&](const auto& obj) {
+                                       return obj->m_is_java_logger &&
+                                              std::static_pointer_cast<JavaLogger>(obj)->is_same_object(env,
+                                                                                                        java_logger);
+                                   }),
+                    m_loggers.end());
 }
 
 void Log::add_logger(std::shared_ptr<JniLogger> logger)
@@ -135,12 +140,13 @@ void Log::remove_logger(std::shared_ptr<JniLogger> logger)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    m_loggers.erase(std::remove_if(m_loggers.begin(), m_loggers.end(), [&](const auto& obj) {
-        return obj == logger;
-    }), m_loggers.end());
+    m_loggers.erase(
+        std::remove_if(m_loggers.begin(), m_loggers.end(), [&](const auto& obj) { return obj == logger; }),
+        m_loggers.end());
 }
 
-void Log::register_default_logger() {
+void Log::register_default_logger()
+{
     add_logger(get_default_logger());
 }
 
@@ -170,13 +176,25 @@ void CoreLoggerBridge::do_log(realm::util::Logger::Level level, std::string msg)
     // Ignore the level threshold from the root logger.
     Log::Level jni_level = Log::all; // Initial value to suppress the false positive compile warning.
     switch (level) {
-        case Level::trace: jni_level = Log::trace; break;
+        case Level::trace:
+            jni_level = Log::trace;
+            break;
         case Level::debug: // Fall through. Map to same level debug.
-        case Level::detail: jni_level = Log::debug; break;
-        case Level::info: jni_level = Log::info; break;
-        case Level::warn: jni_level = Log::warn; break;
-        case Level::error: jni_level = Log::error; break;
-        case Level::fatal: jni_level = Log::fatal; break;
+        case Level::detail:
+            jni_level = Log::debug;
+            break;
+        case Level::info:
+            jni_level = Log::info;
+            break;
+        case Level::warn:
+            jni_level = Log::warn;
+            break;
+        case Level::error:
+            jni_level = Log::error;
+            break;
+        case Level::fatal:
+            jni_level = Log::fatal;
+            break;
         case Level::all: // Fall through.
         case Level::off: // Fall through.
             throw std::invalid_argument(format("Invalid log level."));

--- a/realm/realm-library/src/main/cpp/jni_util/log.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.hpp
@@ -29,13 +29,13 @@
 #include "realm/util/logger.hpp"
 #include "util/format.hpp"
 
-#define TR_ENTER() \
-    if (realm::jni_util::Log::s_level <= realm::jni_util::Log::trace) { \
-        realm::jni_util::Log::t(" --> %1", __FUNCTION__); \
+#define TR_ENTER()                                                                                                   \
+    if (realm::jni_util::Log::s_level <= realm::jni_util::Log::trace) {                                              \
+        realm::jni_util::Log::t(" --> %1", __FUNCTION__);                                                            \
     }
-#define TR_ENTER_PTR(ptr) \
-    if (realm::jni_util::Log::s_level <= realm::jni_util::Log::trace) { \
-        realm::jni_util::Log::t(" --> %1 %2", __FUNCTION__, static_cast<int64_t>(ptr)); \
+#define TR_ENTER_PTR(ptr)                                                                                            \
+    if (realm::jni_util::Log::s_level <= realm::jni_util::Log::trace) {                                              \
+        realm::jni_util::Log::t(" --> %1 %2", __FUNCTION__, static_cast<int64_t>(ptr));                              \
     }
 
 namespace realm {
@@ -73,7 +73,8 @@ public:
     void register_default_logger();
 
     void set_level(Level level);
-    inline Level get_level() {
+    inline Level get_level()
+    {
         return s_level;
     };
 
@@ -110,33 +111,34 @@ public:
         shared().log(fatal, REALM_JNI_TAG, nullptr, message);
     }
 
-    template<typename... Args>
+    template <typename... Args>
     inline static void t(const char* fmt, Args&&... args)
     {
         shared().log(trace, REALM_JNI_TAG, nullptr, _impl::format(fmt, {_impl::Printable(args)...}).c_str());
     }
-    template<typename... Args>
+    template <typename... Args>
     inline static void d(const char* fmt, Args&&... args)
     {
         shared().log(debug, REALM_JNI_TAG, nullptr, _impl::format(fmt, {_impl::Printable(args)...}).c_str());
     }
-    template<typename... Args>
+    template <typename... Args>
     inline static void i(const char* fmt, Args&&... args)
     {
         shared().log(info, REALM_JNI_TAG, nullptr, _impl::format(fmt, {_impl::Printable(args)...}).c_str());
     }
-    template<typename... Args>
+    template <typename... Args>
     inline static void w(const char* fmt, Args&&... args)
     {
         shared().log(warn, REALM_JNI_TAG, nullptr, _impl::format(fmt, {_impl::Printable(args)...}).c_str());
     }
-    template<typename... Args>
+    template <typename... Args>
     inline static void e(const char* fmt, Args&&... args)
     {
         shared().log(error, REALM_JNI_TAG, nullptr, _impl::format(fmt, {_impl::Printable(args)...}).c_str());
     }
-    template<typename... Args>
-    inline static void f(const char* fmt, Args&&... args) {
+    template <typename... Args>
+    inline static void f(const char* fmt, Args&&... args)
+    {
         shared().log(fatal, REALM_JNI_TAG, nullptr, _impl::format(fmt, {_impl::Printable(args)...}).c_str());
     }
 
@@ -147,6 +149,7 @@ public:
     // Accessing to this var won't be thread safe and it is not necessary to be. Changing log level concurrently
     // won't be a critical issue for commons cases.
     static Level s_level;
+
 private:
     Log();
 
@@ -154,7 +157,6 @@ private:
     std::mutex m_mutex;
     // Log tag for generic Realm JNI.
     static const char* REALM_JNI_TAG;
-
 };
 
 // Base Logger class.
@@ -182,7 +184,7 @@ public:
     static CoreLoggerBridge& shared();
 
 private:
-    CoreLoggerBridge() {};
+    CoreLoggerBridge(){};
     // Log tag for Realm core & sync.
     static const char* TAG;
 };

--- a/realm/realm-library/src/main/cpp/mem_usage.cpp
+++ b/realm/realm-library/src/main/cpp/mem_usage.cpp
@@ -20,7 +20,7 @@
 
 size_t GetMemUsage()
 {
-  return 0;
+    return 0;
 }
 
 #elif defined(_MSC_VER) // Microsoft Windows
@@ -37,16 +37,16 @@ DWORD CalculateWSPrivate(DWORD processID);
 // Calculate Private Working Set
 // Source: http://www.codeproject.com/KB/cpp/XPWSPrivate.aspx
 
-int Compare( const void * Val1, const void * Val2 )
+int Compare(const void* Val1, const void* Val2)
 {
-    if ( *(PDWORD)Val1 == *(PDWORD)Val2 )
-    return 0;
+    if (*(PDWORD)Val1 == *(PDWORD)Val2)
+        return 0;
 
     return *(PDWORD)Val1 > *(PDWORD)Val2 ? 1 : -1;
 }
 
-DWORD dWorkingSetPages[ 1024 * 128 ]; // hold the working set
-                // information get from QueryWorkingSet()
+DWORD dWorkingSetPages[1024 * 128]; // hold the working set
+                                    // information get from QueryWorkingSet()
 DWORD dPageSize = 0x1000;
 
 DWORD CalculateWSPrivate(DWORD processID)
@@ -55,23 +55,20 @@ DWORD CalculateWSPrivate(DWORD processID)
     DWORD dPrivatePages = 0;
     DWORD dPageTablePages = 0;
 
-    HANDLE hProcess = OpenProcess( PROCESS_QUERY_INFORMATION |
-        PROCESS_VM_READ, FALSE, processID );
+    HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, processID);
 
-    if ( !hProcess )
-    return 0;
+    if (!hProcess)
+        return 0;
 
-    __try
-    {
-        if ( !QueryWorkingSet(hProcess, dWorkingSetPages, sizeof(dWorkingSetPages)) )
-        __leave;
+    __try {
+        if (!QueryWorkingSet(hProcess, dWorkingSetPages, sizeof(dWorkingSetPages)))
+            __leave;
 
         DWORD dPages = dWorkingSetPages[0];
 
-        qsort( &dWorkingSetPages[1], dPages, sizeof(DWORD), Compare );
+        qsort(&dWorkingSetPages[1], dPages, sizeof(DWORD), Compare);
 
-        for ( DWORD i = 1; i <= dPages; i++ )
-        {
+        for (DWORD i = 1; i <= dPages; i++) {
             DWORD dCurrentPageStatus = 0;
             DWORD dCurrentPageAddress;
             DWORD dNextPageAddress;
@@ -79,38 +76,35 @@ DWORD CalculateWSPrivate(DWORD processID)
             DWORD dPageAddress = dWorkingSetPages[i] & 0xFFFFF000;
             DWORD dPageFlags = dWorkingSetPages[i] & 0x00000FFF;
 
-            while ( i <= dPages ) // iterate all pages
+            while (i <= dPages) // iterate all pages
             {
                 dCurrentPageStatus++;
 
-                if ( i == dPages ) //if last page
-                break;
+                if (i == dPages) // if last page
+                    break;
 
                 dCurrentPageAddress = dWorkingSetPages[i] & 0xFFFFF000;
-                dNextPageAddress = dWorkingSetPages[i+1] & 0xFFFFF000;
-                dNextPageFlags = dWorkingSetPages[i+1] & 0x00000FFF;
+                dNextPageAddress = dWorkingSetPages[i + 1] & 0xFFFFF000;
+                dNextPageFlags = dWorkingSetPages[i + 1] & 0x00000FFF;
 
-                //decide whether iterate further or exit
+                // decide whether iterate further or exit
                 //(this is non-contiguous page or have different flags)
-                if ( (dNextPageAddress == (dCurrentPageAddress + dPageSize))
-            && (dNextPageFlags == dPageFlags) )
-                {
+                if ((dNextPageAddress == (dCurrentPageAddress + dPageSize)) && (dNextPageFlags == dPageFlags)) {
                     i++;
                 }
                 else
-                break;
+                    break;
             }
 
-            if ( (dPageAddress < 0xC0000000) || (dPageAddress > 0xE0000000) )
-            {
-                if ( dPageFlags & 0x100 ) // this is shared one
-                dSharedPages += dCurrentPageStatus;
+            if ((dPageAddress < 0xC0000000) || (dPageAddress > 0xE0000000)) {
+                if (dPageFlags & 0x100) // this is shared one
+                    dSharedPages += dCurrentPageStatus;
 
                 else // private one
-                dPrivatePages += dCurrentPageStatus;
+                    dPrivatePages += dCurrentPageStatus;
             }
             else
-            dPageTablePages += dCurrentPageStatus; //page table region
+                dPageTablePages += dCurrentPageStatus; // page table region
         }
 
         DWORD dTotal = dPages * 4;
@@ -119,9 +113,8 @@ DWORD CalculateWSPrivate(DWORD processID)
 
         return WSPrivate;
     }
-    __finally
-    {
-        CloseHandle( hProcess );
+    __finally {
+        CloseHandle(hProcess);
     }
     return -1;
 }
@@ -134,7 +127,7 @@ size_t GetMemUsage()
 }
 
 
-#elif defined (__APPLE__) // Mac / Darwin
+#elif defined(__APPLE__) // Mac / Darwin
 
 
 #include <mach/mach.h>
@@ -145,7 +138,8 @@ size_t GetMemUsage()
 
     mach_msg_type_number_t t_info_count = TASK_BASIC_INFO_COUNT;
 
-    if (KERN_SUCCESS != task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count)) return -1;
+    if (KERN_SUCCESS != task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count))
+        return -1;
 
     // resident size is in t_info.resident_size;
     // virtual size is in t_info.virtual_size;
@@ -164,9 +158,9 @@ size_t GetMemUsage()
 
 size_t GetMemUsage()
 {
-  struct proc_t usage;
-  look_up_our_self(&usage);
-  return usage.vsize;
+    struct proc_t usage;
+    look_up_our_self(&usage);
+    return usage.vsize;
 }
 
 

--- a/realm/realm-library/src/main/cpp/tablebase_tpl.hpp
+++ b/realm/realm-library/src/main/cpp/tablebase_tpl.hpp
@@ -25,14 +25,15 @@ jbyteArray tbl_GetByteArray(JNIEnv* env, jlong nativeTablePtr, jlong columnIndex
     if (!TBL_AND_INDEX_VALID(env, reinterpret_cast<T*>(nativeTablePtr), columnIndex, rowIndex))
         return NULL;
 
-    realm::BinaryData bin = reinterpret_cast<T*>(nativeTablePtr)->get_binary( S(columnIndex), S(rowIndex));
+    realm::BinaryData bin = reinterpret_cast<T*>(nativeTablePtr)->get_binary(S(columnIndex), S(rowIndex));
     if (bin.is_null()) {
         return NULL;
     }
     if (bin.size() <= MAX_JSIZE) {
         jbyteArray jresult = env->NewByteArray(static_cast<jsize>(bin.size()));
         if (jresult)
-            env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()), reinterpret_cast<const jbyte*>(bin.data()));  // throws
+            env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()),
+                                    reinterpret_cast<const jbyte*>(bin.data())); // throws
         return jresult;
     }
     else {

--- a/realm/realm-library/src/main/cpp/tablebase_tpl.hpp
+++ b/realm/realm-library/src/main/cpp/tablebase_tpl.hpp
@@ -22,23 +22,25 @@
 template <class T>
 jbyteArray tbl_GetByteArray(JNIEnv* env, jlong nativeTablePtr, jlong columnIndex, jlong rowIndex)
 {
-    if (!TBL_AND_INDEX_VALID(env, reinterpret_cast<T*>(nativeTablePtr), columnIndex, rowIndex))
-        return NULL;
+    if (!TBL_AND_INDEX_VALID(env, reinterpret_cast<T*>(nativeTablePtr), columnIndex, rowIndex)) {
+        return nullptr;
+    }
 
     realm::BinaryData bin = reinterpret_cast<T*>(nativeTablePtr)->get_binary(S(columnIndex), S(rowIndex));
     if (bin.is_null()) {
-        return NULL;
+        return nullptr;
     }
     if (bin.size() <= MAX_JSIZE) {
         jbyteArray jresult = env->NewByteArray(static_cast<jsize>(bin.size()));
-        if (jresult)
+        if (jresult) {
             env->SetByteArrayRegion(jresult, 0, static_cast<jsize>(bin.size()),
-                                    reinterpret_cast<const jbyte*>(bin.data())); // throws
+                                    reinterpret_cast<const jbyte *>(bin.data())); // throws
+        }
         return jresult;
     }
     else {
         ThrowException(env, IllegalArgument, "Length of ByteArray is larger than an Int.");
-        return NULL;
+        return nullptr;
     }
 }
 

--- a/realm/realm-library/src/main/cpp/utf8.hpp
+++ b/realm/realm-library/src/main/cpp/utf8.hpp
@@ -35,7 +35,8 @@ namespace util {
 ///
 /// \tparam Traits16 Must define to_int_type() and to_char_type() for
 /// \a Char16.
-template<class Char16, class Traits16 = std::char_traits<Char16> > struct Utf8x16 {
+template <class Char16, class Traits16 = std::char_traits<Char16>>
+struct Utf8x16 {
     /// Transcode as much as possible of the specified UTF-8 input, to
     /// UTF-16. Returns true if all input characters were transcoded, or
     /// transcoding stopped because the next character did not fit into the
@@ -46,14 +47,13 @@ template<class Char16, class Traits16 = std::char_traits<Char16> > struct Utf8x1
     /// advanced to the position where transcoding stopped.
     ///
     /// Throws only if Traits16::to_char_type() throws.
-    static size_t to_utf16(const char*& in_begin, const char* in_end,
-                           Char16*& out_begin, Char16* out_end);
+    static size_t to_utf16(const char*& in_begin, const char* in_end, Char16*& out_begin, Char16* out_end);
 
     /// Same as to_utf16(), but in reverse.
     ///
     /// Throws only if Traits16::to_int_type() throws.
-    static size_t to_utf8(const Char16*& in_begin, const Char16* in_end,
-                        char*& out_begin, char* out_end, size_t& error_code);
+    static size_t to_utf8(const Char16*& in_begin, const Char16* in_end, char*& out_begin, char* out_end,
+                          size_t& error_code);
 
     /// Summarize the number of UTF-16 elements needed to hold the result of
     /// transcoding the specified UTF-8 string. Upon return, if \a in_begin !=
@@ -76,17 +76,14 @@ template<class Char16, class Traits16 = std::char_traits<Char16> > struct Utf8x1
 };
 
 
-
-
-
 // Implementation:
 
 // Adapted from reference implementation.
 // http://www.unicode.org/resources/utf8.html
 // http://www.bsdua.org/files/unicode.tar.gz
-template<class Char16, class Traits16>
-inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const char* in_end,
-                                                  Char16*& out_begin, Char16* out_end)
+template <class Char16, class Traits16>
+inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const char* in_end, Char16*& out_begin,
+                                                  Char16* out_end)
 {
     using namespace std;
     typedef char_traits<char> traits8;
@@ -119,8 +116,7 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
                 invalid = 2;
                 break; // Invalid continuation byte
             }
-            uint_fast16_t v = uint_fast16_t(((v1 & 0x1F) << 6) |
-                                            ((v2 & 0x3F) << 0));
+            uint_fast16_t v = uint_fast16_t(((v1 & 0x1F) << 6) | ((v2 & 0x3F) << 0));
             if (REALM_UNLIKELY(v < 0x80)) {
                 invalid = 3;
                 break; // Overlong encoding is invalid
@@ -141,9 +137,7 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
                 invalid = true;
                 break; // Invalid continuation byte
             }
-            uint_fast16_t v = uint_fast16_t(((v1 & 0x0F) << 12) |
-                                            ((v2 & 0x3F) <<  6) |
-                                            ((v3 & 0x3F) <<  0));
+            uint_fast16_t v = uint_fast16_t(((v1 & 0x0F) << 12) | ((v2 & 0x3F) << 6) | ((v3 & 0x3F) << 0));
             if (REALM_UNLIKELY(v < 0x800)) {
                 invalid = 5;
                 break; // Overlong encoding is invalid
@@ -164,21 +158,19 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
                 invalid = 7;
                 break; // Incomplete UTF-8 sequence
             }
-            uint_fast32_t w1 = uint_fast32_t(v1); // 16 bit -> 32 bit
+            uint_fast32_t w1 = uint_fast32_t(v1);                          // 16 bit -> 32 bit
             uint_fast32_t v2 = uint_fast32_t(traits8::to_int_type(in[1])); // 32 bit intended
             uint_fast16_t v3 = uint_fast16_t(traits8::to_int_type(in[2])); // 16 bit intended
             uint_fast16_t v4 = uint_fast16_t(traits8::to_int_type(in[3])); // 16 bit intended
             // UTF-8 layout: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-            if (REALM_UNLIKELY((v2 & 0xC0) != 0x80 || (v3 & 0xC0) != 0x80 ||
-                                 (v4 & 0xC0) != 0x80)) {
+            if (REALM_UNLIKELY((v2 & 0xC0) != 0x80 || (v3 & 0xC0) != 0x80 || (v4 & 0xC0) != 0x80)) {
                 invalid = 8;
                 break; // Invalid continuation byte
             }
-            uint_fast32_t v =
-                uint_fast32_t(((w1 & 0x07) << 18) | // Parenthesis is 32 bit partial result
-                              ((v2 & 0x3F) << 12) | // Parenthesis is 32 bit partial result
-                              ((v3 & 0x3F) <<  6) | // Parenthesis is 16 bit partial result
-                              ((v4 & 0x3F) <<  0)); // Parenthesis is 16 bit partial result
+            uint_fast32_t v = uint_fast32_t(((w1 & 0x07) << 18) | // Parenthesis is 32 bit partial result
+                                            ((v2 & 0x3F) << 12) | // Parenthesis is 32 bit partial result
+                                            ((v3 & 0x3F) << 6) |  // Parenthesis is 16 bit partial result
+                                            ((v4 & 0x3F) << 0));  // Parenthesis is 16 bit partial result
             if (REALM_UNLIKELY(v < 0x10000)) {
                 invalid = 9;
                 break; // Overlong encoding is invalid
@@ -198,15 +190,14 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf16(const char*& in_begin, const c
         break;
     }
 
-    in_begin  = in;
+    in_begin = in;
     out_begin = out;
     return invalid;
 }
 
 
-template<class Char16, class Traits16>
-inline std::size_t Utf8x16<Char16, Traits16>::find_utf16_buf_size(const char*& in_begin,
-                                                                  const char*  in_end,
+template <class Char16, class Traits16>
+inline std::size_t Utf8x16<Char16, Traits16>::find_utf16_buf_size(const char*& in_begin, const char* in_end,
                                                                   size_t& error_code)
 {
     using namespace std;
@@ -257,18 +248,17 @@ inline std::size_t Utf8x16<Char16, Traits16>::find_utf16_buf_size(const char*& i
         break;
     }
 
-    in_begin  = in;
+    in_begin = in;
     return num_out;
 }
-
 
 
 // Adapted from reference implementation.
 // http://www.unicode.org/resources/utf8.html
 // http://www.bsdua.org/files/unicode.tar.gz
-template<class Char16, class Traits16>
-inline size_t Utf8x16<Char16, Traits16>::to_utf8(const Char16*& in_begin, const Char16* in_end,
-                                               char*& out_begin, char* out_end, size_t& error_code)
+template <class Char16, class Traits16>
+inline size_t Utf8x16<Char16, Traits16>::to_utf8(const Char16*& in_begin, const Char16* in_end, char*& out_begin,
+                                                 char* out_end, size_t& error_code)
 {
     using namespace std;
     typedef char_traits<char> traits8;
@@ -343,15 +333,14 @@ inline size_t Utf8x16<Char16, Traits16>::to_utf8(const Char16*& in_begin, const 
         in += 2;
     }
 
-    in_begin  = in;
+    in_begin = in;
     out_begin = out;
     return !invalid;
 }
 
 
-template<class Char16, class Traits16>
-inline std::size_t Utf8x16<Char16, Traits16>::find_utf8_buf_size(const Char16*& in_begin,
-                                                                 const Char16*  in_end,
+template <class Char16, class Traits16>
+inline std::size_t Utf8x16<Char16, Traits16>::find_utf8_buf_size(const Char16*& in_begin, const Char16* in_end,
                                                                  size_t& error_code)
 {
     using namespace std;
@@ -394,7 +383,7 @@ inline std::size_t Utf8x16<Char16, Traits16>::find_utf8_buf_size(const Char16*& 
         }
     }
 
-    in_begin  = in;
+    in_begin = in;
     return num_out;
 }
 } // namespace util

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -353,8 +353,9 @@ static string string_to_hex(const string& message, const jchar* str, size_t size
 
     ret << message << "; ";
     ret << "error_code = " << error_code << "; ";
-    for (size_t i = 0; i < size; ++i)
-        ret << " 0x" << std::hex << std::setfill('0') << std::setw(4) << (int)str[i];
+    for (size_t i = 0; i < size; ++i) {
+        ret << " 0x" << std::hex << std::setfill('0') << std::setw(4) << (int) str[i];
+    }
     return ret.str();
 }
 
@@ -392,37 +393,43 @@ jstring to_jstring(JNIEnv* env, StringData str)
 
     if (str.size() <= stack_buf_size) {
         size_t retcode = Xcode::to_utf16(in_begin, in_end, out_curr, out_end);
-        if (retcode != 0)
+        if (retcode != 0) {
             throw runtime_error(string_to_hex("Failure when converting short string to UTF-16", str, in_begin, in_end,
                                               out_curr, out_end, size_t(0), retcode));
-        if (in_begin == in_end)
+        }
+        if (in_begin == in_end) {
             goto transcode_complete;
+        }
     }
 
     {
         const char* in_begin2 = in_begin;
         size_t error_code;
         size_t size = Xcode::find_utf16_buf_size(in_begin2, in_end, error_code);
-        if (in_begin2 != in_end)
+        if (in_begin2 != in_end) {
             throw runtime_error(string_to_hex("Failure when computing UTF-16 size", str, in_begin, in_end, out_curr,
                                               out_end, size, error_code));
-        if (int_add_with_overflow_detect(size, stack_buf_size))
+        }
+        if (int_add_with_overflow_detect(size, stack_buf_size)) {
             throw runtime_error("String size overflow");
+        }
         dyn_buf.reset(new jchar[size]);
         out_curr = copy(out_begin, out_curr, dyn_buf.get());
         out_begin = dyn_buf.get();
         out_end = dyn_buf.get() + size;
         size_t retcode = Xcode::to_utf16(in_begin, in_end, out_curr, out_end);
-        if (retcode != 0)
+        if (retcode != 0) {
             throw runtime_error(string_to_hex("Failure when converting long string to UTF-16", str, in_begin, in_end,
                                               out_curr, out_end, size_t(0), retcode));
+        }
         REALM_ASSERT(in_begin == in_end);
     }
 
 transcode_complete : {
     jsize out_size;
-    if (int_cast_with_overflow_detect(out_curr - out_begin, out_size))
+    if (int_cast_with_overflow_detect(out_curr - out_begin, out_size)) {
         throw runtime_error("String size overflow");
+    }
 
     return env->NewString(out_begin, out_size);
 }

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -48,7 +48,7 @@ jmethodID session_error_handler;
 
 void ThrowRealmFileException(JNIEnv* env, const std::string& message, realm::RealmFileException::Kind kind);
 
-void ConvertException(JNIEnv* env, const char *file, int line)
+void ConvertException(JNIEnv* env, const char* file, int line)
 {
     ostringstream ss;
     try {
@@ -71,11 +71,11 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         ThrowException(env, IllegalArgument, ss.str());
     }
     catch (RealmFileException& e) {
-        ss << e.what() << " (" <<  e.underlying() << ") (" << e.path() << ") in " << file << " line " << line;
+        ss << e.what() << " (" << e.underlying() << ") (" << e.path() << ") in " << file << " line " << line;
         ThrowRealmFileException(env, ss.str(), e.kind());
     }
     catch (File::AccessError& e) {
-        ss << e.what() << " (" <<  e.get_path() <<  ") in " << file << " line " << line;
+        ss << e.what() << " (" << e.get_path() << ") in " << file << " line " << line;
         ThrowException(env, FatalError, ss.str());
     }
     catch (InvalidTransactionException& e) {
@@ -87,18 +87,17 @@ void ConvertException(JNIEnv* env, const char *file, int line)
         ThrowException(env, IllegalArgument, ss.str());
     }
     catch (Results::OutOfBoundsIndexException& e) {
-        ss << "Out of range  in " << file << " line " << line
-           << "(requested: " << e.requested << " valid: " << e.valid_count << ")";
+        ss << "Out of range  in " << file << " line " << line << "(requested: " << e.requested
+           << " valid: " << e.valid_count << ")";
         ThrowException(env, IndexOutOfBounds, ss.str());
     }
     catch (Results::IncorrectTableException& e) {
-        ss << "Incorrect class in " << file << " line " << line
-           << "(actual: " << e.actual << " expected: " << e.expected << ")";
+        ss << "Incorrect class in " << file << " line " << line << "(actual: " << e.actual
+           << " expected: " << e.expected << ")";
         ThrowException(env, IllegalArgument, ss.str());
     }
     catch (Results::UnsupportedColumnTypeException& e) {
-        ss << "Unsupported type in " << file << " line " << line
-           << "(field name: " << e.column_name << ")";
+        ss << "Unsupported type in " << file << " line " << line << "(field name: " << e.column_name << ")";
         ThrowException(env, IllegalArgument, ss.str());
     }
     catch (Results::InvalidatedException& e) {
@@ -119,7 +118,7 @@ void ConvertException(JNIEnv* env, const char *file, int line)
     /* catch (...) is not needed if we only throw exceptions derived from std::exception */
 }
 
-void ThrowException(JNIEnv* env, ExceptionKind exception, const char *classStr)
+void ThrowException(JNIEnv* env, ExceptionKind exception, const char* classStr)
 {
     ThrowException(env, exception, classStr, "");
 }
@@ -238,17 +237,15 @@ jclass GetClass(JNIEnv* env, const char* classStr)
         return NULL;
     }
 
-    jclass myClass = reinterpret_cast<jclass>( env->NewGlobalRef(localRefClass) );
+    jclass myClass = reinterpret_cast<jclass>(env->NewGlobalRef(localRefClass));
     env->DeleteLocalRef(localRefClass);
     return myClass;
 }
 
-void ThrowNullValueException(JNIEnv* env, Table* table, size_t col_ndx) {
+void ThrowNullValueException(JNIEnv* env, Table* table, size_t col_ndx)
+{
     std::ostringstream ss;
-    ss << "Trying to set a non-nullable field '"
-       << table->get_column_name(col_ndx)
-       << "' in '"
-       << table->get_name()
+    ss << "Trying to set a non-nullable field '" << table->get_column_name(col_ndx) << "' in '" << table->get_name()
        << "' to null.";
     ThrowException(env, IllegalArgument, ss.str());
 }
@@ -280,19 +277,36 @@ namespace {
 // non-sign value bits, that is, an unsigned 16-bit integer, or any
 // signed or unsigned integer with more than 16 bits.
 struct JcharTraits {
-    static jchar to_int_type(jchar c)  noexcept { return c; }
-    static jchar to_char_type(jchar i) noexcept { return i; }
+    static jchar to_int_type(jchar c) noexcept
+    {
+        return c;
+    }
+    static jchar to_char_type(jchar i) noexcept
+    {
+        return i;
+    }
 };
 
 struct JStringCharsAccessor {
-    JStringCharsAccessor(JNIEnv* e, jstring s):
-        m_env(e), m_string(s), m_data(e->GetStringChars(s,0)), m_size(get_size(e,s)) {}
+    JStringCharsAccessor(JNIEnv* e, jstring s)
+        : m_env(e)
+        , m_string(s)
+        , m_data(e->GetStringChars(s, 0))
+        , m_size(get_size(e, s))
+    {
+    }
     ~JStringCharsAccessor()
     {
         m_env->ReleaseStringChars(m_string, m_data);
     }
-    const jchar* data() const noexcept { return m_data; }
-    size_t size() const noexcept { return m_size; }
+    const jchar* data() const noexcept
+    {
+        return m_data;
+    }
+    size_t size() const noexcept
+    {
+        return m_size;
+    }
 
 private:
     JNIEnv* const m_env;
@@ -312,10 +326,11 @@ private:
 } // anonymous namespace
 
 static string string_to_hex(const string& message, StringData& str, const char* in_begin, const char* in_end,
-                     jchar* out_curr, jchar* out_end, size_t retcode, size_t error_code) {
+                            jchar* out_curr, jchar* out_end, size_t retcode, size_t error_code)
+{
     ostringstream ret;
 
-    const char *s = str.data();
+    const char* s = str.data();
     ret << message << " ";
     ret << "error_code = " << error_code << "; ";
     ret << "retcode = " << retcode << "; ";
@@ -332,7 +347,8 @@ static string string_to_hex(const string& message, StringData& str, const char* 
     return ret.str();
 }
 
-static string string_to_hex(const string& message, const jchar *str, size_t size, size_t error_code) {
+static string string_to_hex(const string& message, const jchar* str, size_t size, size_t error_code)
+{
     ostringstream ret;
 
     ret << message << "; ";
@@ -342,7 +358,7 @@ static string string_to_hex(const string& message, const jchar *str, size_t size
     return ret.str();
 }
 
-string concat_stringdata(const char *message, StringData strData)
+string concat_stringdata(const char* message, StringData strData)
 {
     if (strData.is_null()) {
         return std::string(message);
@@ -367,17 +383,18 @@ jstring to_jstring(JNIEnv* env, StringData str)
     std::unique_ptr<jchar[]> dyn_buf;
 
     const char* in_begin = str.data();
-    const char* in_end   = str.data() + str.size();
+    const char* in_end = str.data() + str.size();
     jchar* out_begin = stack_buf;
-    jchar* out_curr  = stack_buf;
-    jchar* out_end   = stack_buf + stack_buf_size;
+    jchar* out_curr = stack_buf;
+    jchar* out_end = stack_buf + stack_buf_size;
 
     typedef Utf8x16<jchar, JcharTraits> Xcode;
 
     if (str.size() <= stack_buf_size) {
         size_t retcode = Xcode::to_utf16(in_begin, in_end, out_curr, out_end);
         if (retcode != 0)
-            throw runtime_error(string_to_hex("Failure when converting short string to UTF-16",  str, in_begin, in_end, out_curr, out_end, size_t(0), retcode));
+            throw runtime_error(string_to_hex("Failure when converting short string to UTF-16", str, in_begin, in_end,
+                                              out_curr, out_end, size_t(0), retcode));
         if (in_begin == in_end)
             goto transcode_complete;
     }
@@ -387,27 +404,28 @@ jstring to_jstring(JNIEnv* env, StringData str)
         size_t error_code;
         size_t size = Xcode::find_utf16_buf_size(in_begin2, in_end, error_code);
         if (in_begin2 != in_end)
-            throw runtime_error(string_to_hex("Failure when computing UTF-16 size", str, in_begin, in_end, out_curr, out_end, size, error_code));
+            throw runtime_error(string_to_hex("Failure when computing UTF-16 size", str, in_begin, in_end, out_curr,
+                                              out_end, size, error_code));
         if (int_add_with_overflow_detect(size, stack_buf_size))
             throw runtime_error("String size overflow");
         dyn_buf.reset(new jchar[size]);
         out_curr = copy(out_begin, out_curr, dyn_buf.get());
         out_begin = dyn_buf.get();
-        out_end   = dyn_buf.get() + size;
+        out_end = dyn_buf.get() + size;
         size_t retcode = Xcode::to_utf16(in_begin, in_end, out_curr, out_end);
         if (retcode != 0)
-            throw runtime_error(string_to_hex("Failure when converting long string to UTF-16", str, in_begin, in_end, out_curr, out_end, size_t(0), retcode));
+            throw runtime_error(string_to_hex("Failure when converting long string to UTF-16", str, in_begin, in_end,
+                                              out_curr, out_end, size_t(0), retcode));
         REALM_ASSERT(in_begin == in_end);
     }
 
-  transcode_complete:
-    {
-        jsize out_size;
-        if (int_cast_with_overflow_detect(out_curr - out_begin, out_size))
-            throw runtime_error("String size overflow");
+transcode_complete : {
+    jsize out_size;
+    if (int_cast_with_overflow_detect(out_curr - out_begin, out_size))
+        throw runtime_error("String size overflow");
 
-        return env->NewString(out_begin, out_size);
-    }
+    return env->NewString(out_begin, out_size);
+}
 }
 
 
@@ -430,14 +448,14 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
 
     typedef Utf8x16<jchar, JcharTraits> Xcode;
     size_t max_project_size = 48;
-    REALM_ASSERT(max_project_size <= numeric_limits<size_t>::max()/4);
+    REALM_ASSERT(max_project_size <= numeric_limits<size_t>::max() / 4);
     size_t buf_size;
     if (chars.size() <= max_project_size) {
         buf_size = chars.size() * 4;
     }
     else {
         const jchar* begin = chars.data();
-        const jchar* end   = begin + chars.size();
+        const jchar* end = begin + chars.size();
         size_t error_code;
         buf_size = Xcode::find_utf8_buf_size(begin, end, error_code);
     }
@@ -445,19 +463,20 @@ JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
     m_data.reset(tmp_char_array);
     {
         const jchar* in_begin = chars.data();
-        const jchar* in_end   = in_begin + chars.size();
+        const jchar* in_end = in_begin + chars.size();
         char* out_begin = m_data.get();
-        char* out_end   = m_data.get() + buf_size;
+        char* out_end = m_data.get() + buf_size;
         size_t error_code;
         if (!Xcode::to_utf8(in_begin, in_end, out_begin, out_end, error_code)) {
-            throw invalid_argument(string_to_hex("Failure when converting to UTF-8", chars.data(), chars.size(), error_code));
+            throw invalid_argument(
+                string_to_hex("Failure when converting to UTF-8", chars.data(), chars.size(), error_code));
         }
         if (in_begin != in_end) {
-            throw invalid_argument(string_to_hex("in_begin != in_end when converting to UTF-8", chars.data(), chars.size(), error_code));
+            throw invalid_argument(
+                string_to_hex("in_begin != in_end when converting to UTF-8", chars.data(), chars.size(), error_code));
         }
         m_size = out_begin - m_data.get();
         // FIXME: Does this help on string issues? Or does it only help lldb?
         std::memset(tmp_char_array + m_size, 0, buf_size - m_size);
     }
 }
-

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -38,13 +38,13 @@
 
 #include "jni_util/log.hpp"
 
-#define CHECK_PARAMETERS    1       // Check all parameters in API and throw exceptions in java if invalid
+#define CHECK_PARAMETERS 1 // Check all parameters in API and throw exceptions in java if invalid
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved);
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved);
 
 #ifdef __cplusplus
 }
@@ -54,35 +54,36 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved);
 #define STRINGIZE(x) STRINGIZE_DETAIL(x)
 
 // Exception handling
-#define CATCH_STD() \
-    catch (...) { \
-        ConvertException(env, __FILE__, __LINE__); \
+#define CATCH_STD()                                                                                                  \
+    catch (...)                                                                                                      \
+    {                                                                                                                \
+        ConvertException(env, __FILE__, __LINE__);                                                                   \
     }
 
 template <typename T>
 std::string num_to_string(T pNumber)
 {
- std::ostringstream oOStrStream;
- oOStrStream << pNumber;
- return oOStrStream.str();
+    std::ostringstream oOStrStream;
+    oOStrStream << pNumber;
+    return oOStrStream.str();
 }
 
 
-#define MAX_JINT   0x7FFFFFFFL
-#define MAX_JSIZE  MAX_JINT
+#define MAX_JINT 0x7FFFFFFFL
+#define MAX_JSIZE MAX_JINT
 
 // TODO: Clean up those marcos. Casting with marcos reduces the readability, and it is actually breaking the C++ type
 // conversion. e.g.: You cannot cast a pointer with S64 below.
 // Helper macros for better readability
-#define S(x)    static_cast<size_t>(x)
-#define B(x)    static_cast<bool>(x)
-#define S64(x)  static_cast<int64_t>(x)
-#define TBL(x)  reinterpret_cast<realm::Table*>(x)
-#define TV(x)   reinterpret_cast<realm::TableView*>(x)
-#define LV(x)   reinterpret_cast<realm::LinkViewRef*>(x)
-#define Q(x)    reinterpret_cast<realm::Query*>(x)
-#define ROW(x)  reinterpret_cast<realm::Row*>(x)
-#define HO(T, ptr) reinterpret_cast<realm::SharedGroup::Handover <T>* >(ptr)
+#define S(x) static_cast<size_t>(x)
+#define B(x) static_cast<bool>(x)
+#define S64(x) static_cast<int64_t>(x)
+#define TBL(x) reinterpret_cast<realm::Table*>(x)
+#define TV(x) reinterpret_cast<realm::TableView*>(x)
+#define LV(x) reinterpret_cast<realm::LinkViewRef*>(x)
+#define Q(x) reinterpret_cast<realm::Query*>(x)
+#define ROW(x) reinterpret_cast<realm::Row*>(x)
+#define HO(T, ptr) reinterpret_cast<realm::SharedGroup::Handover<T>*>(ptr)
 
 // Exception handling
 enum ExceptionKind {
@@ -103,70 +104,73 @@ enum ExceptionKind {
     ExceptionKindMax // Always keep this as the last one!
 };
 
-void ConvertException(JNIEnv* env, const char *file, int line);
-void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& classStr, const std::string& itemStr="");
-void ThrowException(JNIEnv* env, ExceptionKind exception, const char *classStr);
-void ThrowNullValueException(JNIEnv* env, realm::Table *table, size_t col_ndx);
+void ConvertException(JNIEnv* env, const char* file, int line);
+void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& classStr,
+                    const std::string& itemStr = "");
+void ThrowException(JNIEnv* env, ExceptionKind exception, const char* classStr);
+void ThrowNullValueException(JNIEnv* env, realm::Table* table, size_t col_ndx);
 
 jclass GetClass(JNIEnv* env, const char* classStr);
 
 
 // Check parameters
 
-#define TABLE_VALID(env,ptr)    TableIsValid(env, ptr)
-#define ROW_VALID(env,ptr)      RowIsValid(env, ptr)
-#define QUERY_VALID(env, ptr)   QueryIsValid(env, ptr)
+#define TABLE_VALID(env, ptr) TableIsValid(env, ptr)
+#define ROW_VALID(env, ptr) RowIsValid(env, ptr)
+#define QUERY_VALID(env, ptr) QueryIsValid(env, ptr)
 
 #if CHECK_PARAMETERS
 
-#define ROW_INDEXES_VALID(env,ptr,start,end, range)             RowIndexesValid(env, ptr, start, end, range)
-#define ROW_INDEX_VALID(env,ptr,row)                            RowIndexValid(env, ptr, row)
-#define ROW_INDEX_VALID_OFFSET(env,ptr,row)                     RowIndexValid(env, ptr, row, true)
-#define TBL_AND_ROW_INDEX_VALID(env,ptr,row)                    TblRowIndexValid(env, ptr, row)
-#define TBL_AND_ROW_INDEX_VALID_OFFSET(env,ptr,row, offset)     TblRowIndexValid(env, ptr, row, offset)
-#define COL_INDEX_VALID(env,ptr,col)                            ColIndexValid(env, ptr, col)
-#define TBL_AND_COL_INDEX_VALID(env,ptr,col)                    TblColIndexValid(env, ptr, col)
-#define COL_INDEX_AND_TYPE_VALID(env,ptr,col,type)              ColIndexAndTypeValid(env, ptr, col, type)
-#define TBL_AND_COL_INDEX_AND_TYPE_VALID(env,ptr,col, type)     TblColIndexAndTypeValid(env, ptr, col, type)
-#define TBL_AND_COL_INDEX_AND_LINK_OR_LINKLIST(env,ptr,col)     TblColIndexAndLinkOrLinkList(env, ptr, col)
-#define TBL_AND_COL_NULLABLE(env,ptr,col)                       TblColIndexAndNullable(env, ptr, col)
-#define INDEX_VALID(env,ptr,col,row)                            IndexValid(env, ptr, col, row)
-#define TBL_AND_INDEX_VALID(env,ptr,col,row)                    TblIndexValid(env, ptr, col, row)
-#define TBL_AND_INDEX_INSERT_VALID(env,ptr,col,row)             TblIndexInsertValid(env, ptr, col, row)
-#define INDEX_AND_TYPE_VALID(env,ptr,col,row,type)              IndexAndTypeValid(env, ptr, col, row, type)
-#define TBL_AND_INDEX_AND_TYPE_VALID(env,ptr,col,row,type)      TblIndexAndTypeValid(env, ptr, col, row, type)
-#define TBL_AND_INDEX_AND_TYPE_INSERT_VALID(env,ptr,col,row,type) TblIndexAndTypeInsertValid(env, ptr, col, row, type)
+#define ROW_INDEXES_VALID(env, ptr, start, end, range) RowIndexesValid(env, ptr, start, end, range)
+#define ROW_INDEX_VALID(env, ptr, row) RowIndexValid(env, ptr, row)
+#define ROW_INDEX_VALID_OFFSET(env, ptr, row) RowIndexValid(env, ptr, row, true)
+#define TBL_AND_ROW_INDEX_VALID(env, ptr, row) TblRowIndexValid(env, ptr, row)
+#define TBL_AND_ROW_INDEX_VALID_OFFSET(env, ptr, row, offset) TblRowIndexValid(env, ptr, row, offset)
+#define COL_INDEX_VALID(env, ptr, col) ColIndexValid(env, ptr, col)
+#define TBL_AND_COL_INDEX_VALID(env, ptr, col) TblColIndexValid(env, ptr, col)
+#define COL_INDEX_AND_TYPE_VALID(env, ptr, col, type) ColIndexAndTypeValid(env, ptr, col, type)
+#define TBL_AND_COL_INDEX_AND_TYPE_VALID(env, ptr, col, type) TblColIndexAndTypeValid(env, ptr, col, type)
+#define TBL_AND_COL_INDEX_AND_LINK_OR_LINKLIST(env, ptr, col) TblColIndexAndLinkOrLinkList(env, ptr, col)
+#define TBL_AND_COL_NULLABLE(env, ptr, col) TblColIndexAndNullable(env, ptr, col)
+#define INDEX_VALID(env, ptr, col, row) IndexValid(env, ptr, col, row)
+#define TBL_AND_INDEX_VALID(env, ptr, col, row) TblIndexValid(env, ptr, col, row)
+#define TBL_AND_INDEX_INSERT_VALID(env, ptr, col, row) TblIndexInsertValid(env, ptr, col, row)
+#define INDEX_AND_TYPE_VALID(env, ptr, col, row, type) IndexAndTypeValid(env, ptr, col, row, type)
+#define TBL_AND_INDEX_AND_TYPE_VALID(env, ptr, col, row, type) TblIndexAndTypeValid(env, ptr, col, row, type)
+#define TBL_AND_INDEX_AND_TYPE_INSERT_VALID(env, ptr, col, row, type)                                                \
+    TblIndexAndTypeInsertValid(env, ptr, col, row, type)
 
-#define ROW_AND_COL_INDEX_AND_TYPE_VALID(env,ptr,col,type)     RowColIndexAndTypeValid(env, ptr, col, type)
-#define ROW_AND_COL_INDEX_VALID(env,ptr,col)                    RowColIndexValid(env, ptr, col)
+#define ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ptr, col, type) RowColIndexAndTypeValid(env, ptr, col, type)
+#define ROW_AND_COL_INDEX_VALID(env, ptr, col) RowColIndexValid(env, ptr, col)
 
 #else
 
-#define ROW_INDEXES_VALID(env,ptr,start,end, range)             (true)
-#define ROW_INDEX_VALID(env,ptr,row)                            (true)
-#define ROW_INDEX_VALID_OFFSET(env,ptr,row)                     (true)
-#define TBL_AND_ROW_INDEX_VALID(env,ptr,row)                    (true)
-#define TBL_AND_ROW_INDEX_VALID_OFFSET(env,ptr,row, offset)     (true)
-#define COL_INDEX_VALID(env,ptr,col)                            (true)
-#define TBL_AND_COL_INDEX_VALID(env,ptr,col)                    (true)
-#define COL_INDEX_AND_TYPE_VALID(env,ptr,col,type)              (true)
-#define TBL_AND_COL_INDEX_AND_TYPE_VALID(env,ptr,col, type)     (true)
-#define TBL_AND_COL_INDEX_AND_LINK_OR_LINKLIST(env,ptr,col)     (true)
-#define TBL_AND_COL_NULLABLE(env,ptr,col)                       (true)
-#define INDEX_VALID(env,ptr,col,row)                            (true)
-#define TBL_AND_INDEX_VALID(env,ptr,col,row)                    (true)
-#define TBL_AND_INDEX_INSERT_VALID(env,ptr,col,row)             (true)
-#define INDEX_AND_TYPE_VALID(env,ptr,col,row,type)              (true)
-#define TBL_AND_INDEX_AND_TYPE_VALID(env,ptr,col,row,type)      (true)
-#define TBL_AND_INDEX_AND_TYPE_INSERT_VALID(env,ptr,col,row,type) (true)
+#define ROW_INDEXES_VALID(env, ptr, start, end, range) (true)
+#define ROW_INDEX_VALID(env, ptr, row) (true)
+#define ROW_INDEX_VALID_OFFSET(env, ptr, row) (true)
+#define TBL_AND_ROW_INDEX_VALID(env, ptr, row) (true)
+#define TBL_AND_ROW_INDEX_VALID_OFFSET(env, ptr, row, offset) (true)
+#define COL_INDEX_VALID(env, ptr, col) (true)
+#define TBL_AND_COL_INDEX_VALID(env, ptr, col) (true)
+#define COL_INDEX_AND_TYPE_VALID(env, ptr, col, type) (true)
+#define TBL_AND_COL_INDEX_AND_TYPE_VALID(env, ptr, col, type) (true)
+#define TBL_AND_COL_INDEX_AND_LINK_OR_LINKLIST(env, ptr, col) (true)
+#define TBL_AND_COL_NULLABLE(env, ptr, col) (true)
+#define INDEX_VALID(env, ptr, col, row) (true)
+#define TBL_AND_INDEX_VALID(env, ptr, col, row) (true)
+#define TBL_AND_INDEX_INSERT_VALID(env, ptr, col, row) (true)
+#define INDEX_AND_TYPE_VALID(env, ptr, col, row, type) (true)
+#define TBL_AND_INDEX_AND_TYPE_VALID(env, ptr, col, row, type) (true)
+#define TBL_AND_INDEX_AND_TYPE_INSERT_VALID(env, ptr, col, row, type) (true)
 
-#define ROW_AND_COL_INDEX_AND_TYPE_VALID(env,ptr,col, type)     (true)
-#define ROW_AND_COL_INDEX_VALID(env,ptr,col)                    (true)
+#define ROW_AND_COL_INDEX_AND_TYPE_VALID(env, ptr, col, type) (true)
+#define ROW_AND_COL_INDEX_VALID(env, ptr, col) (true)
 
 #endif
 
 
-inline jlong to_jlong_or_not_found(size_t res) {
+inline jlong to_jlong_or_not_found(size_t res)
+{
     return (res == realm::not_found) ? jlong(-1) : jlong(res);
 }
 
@@ -180,7 +184,6 @@ inline bool TableIsValid(JNIEnv* env, T* objPtr)
             valid = TBL(objPtr)->is_attached();
         }
         // TODO: Add check for TableView
-
     }
     if (!valid) {
         realm::jni_util::Log::e("Table %1 is no longer attached!", reinterpret_cast<int64_t>(objPtr));
@@ -194,7 +197,8 @@ inline bool RowIsValid(JNIEnv* env, realm::Row* rowPtr)
     bool valid = (rowPtr != NULL && rowPtr->is_attached());
     if (!valid) {
         realm::jni_util::Log::e("Row %1 is no longer attached!", reinterpret_cast<int64_t>(rowPtr));
-        ThrowException(env, IllegalState, "Object is no longer valid to operate on. Was it deleted by another thread?");
+        ThrowException(env, IllegalState,
+                       "Object is no longer valid to operate on. Was it deleted by another thread?");
     }
     return valid;
 }
@@ -229,8 +233,7 @@ bool RowIndexesValid(JNIEnv* env, T* pTable, jlong startIndex, jlong endIndex, j
         return false;
     }
     if (startIndex > endIndex) {
-        realm::jni_util::Log::e(
-                "startIndex %1 > endIndex %2 - invalid!", S64(startIndex), S64(endIndex));
+        realm::jni_util::Log::e("startIndex %1 > endIndex %2 - invalid!", S64(startIndex), S64(endIndex));
         ThrowException(env, IndexOutOfBounds, "startIndex > endIndex.");
         return false;
     }
@@ -245,7 +248,7 @@ bool RowIndexesValid(JNIEnv* env, T* pTable, jlong startIndex, jlong endIndex, j
 }
 
 template <class T>
-inline bool RowIndexValid(JNIEnv* env, T pTable, jlong rowIndex, bool offset=false)
+inline bool RowIndexValid(JNIEnv* env, T pTable, jlong rowIndex, bool offset = false)
 {
     if (rowIndex < 0) {
         ThrowException(env, IndexOutOfBounds, "rowIndex is less than 0.");
@@ -258,14 +261,13 @@ inline bool RowIndexValid(JNIEnv* env, T pTable, jlong rowIndex, bool offset=fal
     if (rowErr) {
         realm::jni_util::Log::e("rowIndex %1 > %2 - invalid!", S64(rowIndex), S64(size));
         ThrowException(env, IndexOutOfBounds,
-            "rowIndex > available rows: " +
-            num_to_string(rowIndex) + " > " + num_to_string(size));
+                       "rowIndex > available rows: " + num_to_string(rowIndex) + " > " + num_to_string(size));
     }
     return !rowErr;
 }
 
 template <class T>
-inline bool TblRowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset=false)
+inline bool TblRowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset = false)
 {
     if (std::is_same<realm::Table, T>::value) {
         if (!TableIsValid(env, TBL(pTable)))
@@ -283,8 +285,7 @@ inline bool ColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
     }
     bool colErr = realm::util::int_greater_than_or_equal(columnIndex, pTable->get_column_count());
     if (colErr) {
-        realm::jni_util::Log::e(
-                "columnIndex %1 > %2 - invalid!", S64(columnIndex), S64(pTable->get_column_count()));
+        realm::jni_util::Log::e("columnIndex %1 > %2 - invalid!", S64(columnIndex), S64(pTable->get_column_count()));
         ThrowException(env, IndexOutOfBounds, "columnIndex > available columns.");
     }
     return !colErr;
@@ -308,15 +309,13 @@ inline bool RowColIndexValid(JNIEnv* env, realm::Row* pRow, jlong columnIndex)
 template <class T>
 inline bool IndexValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
 {
-    return ColIndexValid(env, pTable, columnIndex)
-        && RowIndexValid(env, pTable, rowIndex);
+    return ColIndexValid(env, pTable, columnIndex) && RowIndexValid(env, pTable, rowIndex);
 }
 
 template <class T>
 inline bool TblIndexValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
 {
-    return TableIsValid(env, pTable)
-        && IndexValid(env, pTable, columnIndex, rowIndex);
+    return TableIsValid(env, pTable) && IndexValid(env, pTable, columnIndex, rowIndex);
 }
 
 template <class T>
@@ -324,12 +323,11 @@ inline bool TblIndexInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong
 {
     if (!TblColIndexValid(env, pTable, columnIndex))
         return false;
-    bool rowErr = realm::util::int_greater_than(rowIndex, pTable->size()+1);
+    bool rowErr = realm::util::int_greater_than(rowIndex, pTable->size() + 1);
     if (rowErr) {
         realm::jni_util::Log::e("rowIndex %1 > %2 - invalid!", S64(rowIndex), S64(pTable->size()));
-        ThrowException(env, IndexOutOfBounds,
-            "rowIndex " + num_to_string(rowIndex) +
-            " > available rows " + num_to_string(pTable->size()) + ".");
+        ThrowException(env, IndexOutOfBounds, "rowIndex " + num_to_string(rowIndex) + " > available rows " +
+                                                  num_to_string(pTable->size()) + ".");
     }
     return !rowErr;
 }
@@ -356,8 +354,8 @@ inline bool TypeIsLinkLike(JNIEnv* env, T* pTable, jlong columnIndex)
         return true;
     }
 
-    realm::jni_util::Log::e(
-            "Expected columnType %1 or %2, but got %3", realm::type_Link, realm::type_LinkList, colType);
+    realm::jni_util::Log::e("Expected columnType %1 or %2, but got %3", realm::type_Link, realm::type_LinkList,
+                            colType);
     ThrowException(env, IllegalArgument, "ColumnType invalid: expected type_Link or type_LinkList");
     return false;
 }
@@ -388,41 +386,37 @@ inline bool ColIsNullable(JNIEnv* env, T* pTable, jlong columnIndex)
 template <class T>
 inline bool ColIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
 {
-    return ColIndexValid(env, pTable, columnIndex)
-        && TypeValid(env, pTable, columnIndex, expectColType);
+    return ColIndexValid(env, pTable, columnIndex) && TypeValid(env, pTable, columnIndex, expectColType);
 }
 template <class T>
 inline bool TblColIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, int expectColType)
 {
-    return TableIsValid(env, pTable)
-        && ColIndexAndTypeValid(env, pTable, columnIndex, expectColType);
+    return TableIsValid(env, pTable) && ColIndexAndTypeValid(env, pTable, columnIndex, expectColType);
 }
 
 template <class T>
-inline bool TblColIndexAndLinkOrLinkList(JNIEnv* env, T* pTable, jlong columnIndex) {
-    return TableIsValid(env, pTable)
-        && TypeIsLinkLike(env, pTable, columnIndex);
+inline bool TblColIndexAndLinkOrLinkList(JNIEnv* env, T* pTable, jlong columnIndex)
+{
+    return TableIsValid(env, pTable) && TypeIsLinkLike(env, pTable, columnIndex);
 }
 
 // FIXME Usually this is called after TBL_AND_INDEX_AND_TYPE_VALID which will validate Table as well.
 // Try to avoid duplicated checks to improve performance.
 template <class T>
-inline bool TblColIndexAndNullable(JNIEnv* env, T* pTable, jlong columnIndex) {
-    return TableIsValid(env, pTable)
-        && ColIsNullable(env, pTable, columnIndex);
+inline bool TblColIndexAndNullable(JNIEnv* env, T* pTable, jlong columnIndex)
+{
+    return TableIsValid(env, pTable) && ColIsNullable(env, pTable, columnIndex);
 }
 
 inline bool RowColIndexAndTypeValid(JNIEnv* env, realm::Row* pRow, jlong columnIndex, int expectColType)
 {
-    return RowIsValid(env, pRow)
-        && ColIndexAndTypeValid(env, pRow->get_table(), columnIndex, expectColType);
+    return RowIsValid(env, pRow) && ColIndexAndTypeValid(env, pRow->get_table(), columnIndex, expectColType);
 }
 
 template <class T>
 inline bool IndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
 {
-    return IndexValid(env, pTable, columnIndex, rowIndex)
-        && TypeValid(env, pTable, columnIndex, expectColType);
+    return IndexValid(env, pTable, columnIndex, rowIndex) && TypeValid(env, pTable, columnIndex, expectColType);
 }
 template <class T>
 inline bool TblIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
@@ -433,8 +427,8 @@ inline bool TblIndexAndTypeValid(JNIEnv* env, T* pTable, jlong columnIndex, jlon
 template <class T>
 inline bool TblIndexAndTypeInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex, int expectColType)
 {
-    return TblIndexInsertValid(env, pTable, columnIndex, rowIndex)
-        && TypeValid(env, pTable, columnIndex, expectColType);
+    return TblIndexInsertValid(env, pTable, columnIndex, rowIndex) &&
+           TypeValid(env, pTable, columnIndex, expectColType);
 }
 
 bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, realm::BinaryData& data);
@@ -442,7 +436,7 @@ bool GetBinaryData(JNIEnv* env, jobject jByteBuffer, realm::BinaryData& data);
 
 // Utility function for appending StringData, which is returned
 // by a lot of core functions, and might potentially be NULL.
-std::string concat_stringdata(const char *message, realm::StringData data);
+std::string concat_stringdata(const char* message, realm::StringData data);
 
 // Note: JNI offers methods to convert between modified UTF-8 and
 // UTF-16. Unfortunately these methods are not appropriate in this
@@ -459,7 +453,7 @@ jstring to_jstring(JNIEnv*, realm::StringData);
 
 class JStringAccessor {
 public:
-    JStringAccessor(JNIEnv*, jstring);  // throws
+    JStringAccessor(JNIEnv*, jstring); // throws
 
     operator realm::StringData() const noexcept
     {
@@ -492,17 +486,18 @@ public:
         , m_javaArray(javaArray)
         , m_arrayLength(javaArray == NULL ? 0 : env->GetArrayLength(javaArray))
         , m_array(javaArray == NULL ? NULL : env->GetLongArrayElements(javaArray, NULL))
-        , m_releaseMode(JNI_ABORT) {
+        , m_releaseMode(JNI_ABORT)
+    {
     }
 
     JniLongArray(JniLongArray& other) = delete;
 
     JniLongArray(JniLongArray&& other)
-            : m_env(other.m_env)
-            , m_javaArray(other.m_javaArray)
-            , m_arrayLength(other.m_arrayLength)
-            , m_array(other.m_array)
-            , m_releaseMode(other.m_releaseMode)
+        : m_env(other.m_env)
+        , m_javaArray(other.m_javaArray)
+        , m_arrayLength(other.m_arrayLength)
+        , m_array(other.m_array)
+        , m_releaseMode(other.m_releaseMode)
     {
         other.m_env = nullptr;
         other.m_javaArray = nullptr;
@@ -538,20 +533,20 @@ public:
     }
 
 private:
-    JNIEnv*    m_env;
+    JNIEnv* m_env;
     jlongArray m_javaArray;
-    jsize      m_arrayLength;
-    jlong*     m_array;
-    jint       m_releaseMode;
+    jsize m_arrayLength;
+    jlong* m_array;
+    jint m_releaseMode;
 };
 
 template <typename T, typename J>
 class JniArrayOfArrays {
 public:
     JniArrayOfArrays(JNIEnv* env, jobjectArray javaArray)
-            : m_env(env)
-            , m_javaArray(javaArray)
-            , m_arrayLength(javaArray == nullptr ? 0 : env->GetArrayLength(javaArray))
+        : m_env(env)
+        , m_javaArray(javaArray)
+        , m_arrayLength(javaArray == nullptr ? 0 : env->GetArrayLength(javaArray))
     {
         for (int i = 0; i < m_arrayLength; ++i) {
             // No type checking. Internal use only.
@@ -588,10 +583,12 @@ public:
         , m_javaArray(javaArray)
         , m_arrayLength(javaArray == NULL ? 0 : env->GetArrayLength(javaArray))
         , m_array(javaArray == NULL ? NULL : env->GetByteArrayElements(javaArray, NULL))
-        , m_releaseMode(JNI_ABORT) {
+        , m_releaseMode(JNI_ABORT)
+    {
         if (m_javaArray != nullptr && m_array == nullptr) {
             // javaArray is not null but GetByteArrayElements returns null, something is really wrong.
-            throw std::runtime_error(realm::util::format("GetByteArrayElements failed on byte array %x", m_javaArray));
+            throw std::runtime_error(
+                realm::util::format("GetByteArrayElements failed on byte array %x", m_javaArray));
         }
     }
 
@@ -617,11 +614,13 @@ public:
         return m_array[index];
     }
 
-    inline operator realm::BinaryData() const noexcept {
-        return realm::BinaryData(reinterpret_cast<const char *>(m_array), m_arrayLength);
+    inline operator realm::BinaryData() const noexcept
+    {
+        return realm::BinaryData(reinterpret_cast<const char*>(m_array), m_arrayLength);
     }
 
-    inline operator std::vector<char>() const noexcept {
+    inline operator std::vector<char>() const noexcept
+    {
         if (m_array == nullptr) {
             return {};
         }
@@ -637,11 +636,11 @@ public:
     }
 
 private:
-    JNIEnv*    const m_env;
+    JNIEnv* const m_env;
     jbyteArray const m_javaArray;
-    jsize      const m_arrayLength;
-    jbyte*     const m_array;
-    jint             m_releaseMode;
+    jsize const m_arrayLength;
+    jbyte* const m_array;
+    jint m_releaseMode;
 };
 
 class JniBooleanArray {
@@ -651,7 +650,8 @@ public:
         , m_javaArray(javaArray)
         , m_arrayLength(javaArray == NULL ? 0 : env->GetArrayLength(javaArray))
         , m_array(javaArray == NULL ? NULL : env->GetBooleanArrayElements(javaArray, NULL))
-        , m_releaseMode(JNI_ABORT) {
+        , m_releaseMode(JNI_ABORT)
+    {
     }
 
     ~JniBooleanArray()
@@ -682,11 +682,11 @@ public:
     }
 
 private:
-    JNIEnv*       const m_env;
+    JNIEnv* const m_env;
     jbooleanArray const m_javaArray;
-    jsize         const m_arrayLength;
-    jboolean*     const m_array;
-    jint                m_releaseMode;
+    jsize const m_arrayLength;
+    jboolean* const m_array;
+    jint m_releaseMode;
 };
 
 extern jclass java_lang_long;
@@ -736,18 +736,21 @@ inline realm::Timestamp from_milliseconds(jlong milliseconds)
     return realm::Timestamp(seconds, nanoseconds);
 }
 
-inline jobject NewDate(JNIEnv* env, const realm::Timestamp& ts) {
+inline jobject NewDate(JNIEnv* env, const realm::Timestamp& ts)
+{
     return env->NewObject(java_util_date, java_util_date_init, to_milliseconds(ts));
 }
 
 extern const std::string TABLE_PREFIX;
 
-static inline bool to_bool(jboolean b) {
+static inline bool to_bool(jboolean b)
+{
     return b == JNI_TRUE;
 }
 
-static inline jboolean to_jbool(bool b) {
-    return b?JNI_TRUE:JNI_FALSE;
+static inline jboolean to_jbool(bool b)
+{
+    return b ? JNI_TRUE : JNI_FALSE;
 }
 
 #endif // REALM_JAVA_UTIL_HPP

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -177,7 +177,7 @@ inline jlong to_jlong_or_not_found(size_t res)
 template <class T>
 inline bool TableIsValid(JNIEnv* env, T* objPtr)
 {
-    bool valid = (objPtr != NULL);
+    bool valid = (objPtr != nullptr);
     if (valid) {
         // Check if Table is valid
         if (std::is_same<realm::Table, T>::value) {
@@ -214,8 +214,9 @@ template <class T>
 bool RowIndexesValid(JNIEnv* env, T* pTable, jlong startIndex, jlong endIndex, jlong range)
 {
     size_t maxIndex = pTable->size();
-    if (endIndex == -1)
+    if (endIndex == -1) {
         endIndex = maxIndex;
+    }
     if (startIndex < 0) {
         realm::jni_util::Log::e("startIndex %1 < 0 - invalid!", S64(startIndex));
         ThrowException(env, IndexOutOfBounds, "startIndex < 0.");
@@ -255,8 +256,9 @@ inline bool RowIndexValid(JNIEnv* env, T pTable, jlong rowIndex, bool offset = f
         return false;
     }
     size_t size = pTable->size();
-    if (size > 0 && offset)
+    if (size > 0 && offset) {
         size -= 1;
+    }
     bool rowErr = realm::util::int_greater_than_or_equal(rowIndex, size);
     if (rowErr) {
         realm::jni_util::Log::e("rowIndex %1 > %2 - invalid!", S64(rowIndex), S64(size));
@@ -270,8 +272,9 @@ template <class T>
 inline bool TblRowIndexValid(JNIEnv* env, T* pTable, jlong rowIndex, bool offset = false)
 {
     if (std::is_same<realm::Table, T>::value) {
-        if (!TableIsValid(env, TBL(pTable)))
+        if (!TableIsValid(env, TBL(pTable))) {
             return false;
+        }
     }
     return RowIndexValid(env, pTable, rowIndex, offset);
 }
@@ -295,8 +298,9 @@ template <class T>
 inline bool TblColIndexValid(JNIEnv* env, T* pTable, jlong columnIndex)
 {
     if (std::is_same<realm::Table, T>::value) {
-        if (!TableIsValid(env, TBL(pTable)))
+        if (!TableIsValid(env, TBL(pTable))) {
             return false;
+        }
     }
     return ColIndexValid(env, pTable, columnIndex);
 }
@@ -321,8 +325,9 @@ inline bool TblIndexValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIn
 template <class T>
 inline bool TblIndexInsertValid(JNIEnv* env, T* pTable, jlong columnIndex, jlong rowIndex)
 {
-    if (!TblColIndexValid(env, pTable, columnIndex))
+    if (!TblColIndexValid(env, pTable, columnIndex)) {
         return false;
+    }
     bool rowErr = realm::util::int_greater_than(rowIndex, pTable->size() + 1);
     if (rowErr) {
         realm::jni_util::Log::e("rowIndex %1 > %2 - invalid!", S64(rowIndex), S64(pTable->size()));


### PR DESCRIPTION
Superseed #4280 (targeting `releases` instead)