### PR TITLE
Cancel transaction explicitly

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1440,8 +1440,13 @@ public class Realm extends BaseRealm {
                 } catch (final Throwable e) {
                     exception[0] = e;
                 } finally {
-                    // SharedGroup::close() will cancel the transaction if needed.
-                    bgRealm.close();
+                    try {
+                        if (isInTransaction()) {
+                            bgRealm.cancelTransaction();
+                        }
+                    } finally {
+                        bgRealm.close();
+                    }
                 }
 
                 final Throwable backgroundException = exception[0];

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1441,7 +1441,7 @@ public class Realm extends BaseRealm {
                     exception[0] = e;
                 } finally {
                     try {
-                        if (isInTransaction()) {
+                        if (bgRealm.isInTransaction()) {
                             bgRealm.cancelTransaction();
                         }
                     } finally {


### PR DESCRIPTION
If `Realm.getInstance()` is called in the 'transaction' object, calling `close()` does not cancel current transaction. To ensure that the transaction is not left open, cancel it explicitly if needed.

@realm/java 