### PR TITLE
stop using deprecated findbugs annotation

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/internal/async/RealmThreadPoolExecutor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/async/RealmThreadPoolExecutor.java
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Custom thread pool settings, instances of this executor can be paused, and resumed, this will also set
@@ -66,7 +66,7 @@ public class RealmThreadPoolExecutor extends ThreadPoolExecutor {
      *
      * @return the number of threads to be allocated for the executor pool
      */
-    @SuppressWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static int calculateCorePoolSize() {
         int cpus = countFilesInDir(SYS_CPU_DIR, "cpu[0-9]+");
         if (cpus <= 0) {


### PR DESCRIPTION
`edu.umd.cs.findbugs.annotations.SuppressWarnings` is deprecated.
This PR replaces it with `edu.umd.cs.findbugs.annotations.SuppressFBWarnings`.

@realm/java 
