### PR TITLE
fix warnings in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * `Realm.migrateRealm(RealmConfiguration)` now fails correctly with an `IllegalArgumentException` if a `SyncConfiguration` is provided (#4075).
 * Fixed a potential cause for Realm file corruptions (never reported).
+* Add `@Override` annotation to accessors and stop using raw type in proxy classes in order to remove warnings from javac (#4329).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * `Realm.migrateRealm(RealmConfiguration)` now fails correctly with an `IllegalArgumentException` if a `SyncConfiguration` is provided (#4075).
 * Fixed a potential cause for Realm file corruptions (never reported).
-* Add `@Override` annotation to accessors and stop using raw type in proxy classes in order to remove warnings from javac (#4329).
+* Add `@Override` annotation to proxy class accessors and stop using raw type in proxy classes in order to remove warnings from javac (#4329).
 
 ### Deprecated
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -1608,6 +1608,7 @@ public class RealmProxyClassGenerator {
             return;
         }
         writer.emitAnnotation("Override");
+        writer.emitAnnotation("SuppressWarnings", "\"ArrayToString\"");
         writer.beginMethod("String", "toString", EnumSet.of(Modifier.PUBLIC));
         writer.beginControlFlow("if (!RealmObject.isValid(this))");
         writer.emitStatement("return \"Invalid object\"");

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -244,6 +244,7 @@ public class RealmProxyClassGenerator {
                 final String realmType = Constants.JAVA_TO_REALM_TYPES.get(fieldTypeCanonicalName);
 
                 // Getter
+                writer.emitAnnotation("Override");
                 writer.emitAnnotation("SuppressWarnings", "\"cast\"");
                 writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
                 writer.emitStatement("proxyState.getRealm$realm().checkIfValid()");
@@ -270,6 +271,7 @@ public class RealmProxyClassGenerator {
                 writer.emitEmptyLine();
 
                 // Setter
+                writer.emitAnnotation("Override");
                 writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
                 emitCodeForUnderConstruction(writer, metadata.isPrimaryKey(field), new CodeEmitter() {
                     @Override
@@ -324,6 +326,7 @@ public class RealmProxyClassGenerator {
                  */
 
                 // Getter
+                writer.emitAnnotation("Override");
                 writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
                 writer.emitStatement("proxyState.getRealm$realm().checkIfValid()");
                 writer.beginControlFlow("if (proxyState.getRow$realm().isNullLink(%s))", fieldIndexVariableReference(field));
@@ -335,6 +338,7 @@ public class RealmProxyClassGenerator {
                 writer.emitEmptyLine();
 
                 // Setter
+                writer.emitAnnotation("Override");
                 writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
                 emitCodeForUnderConstruction(writer, metadata.isPrimaryKey(field), new CodeEmitter() {
                     @Override
@@ -386,6 +390,7 @@ public class RealmProxyClassGenerator {
                 String genericType = Utils.getGenericTypeQualifiedName(field);
 
                 // Getter
+                writer.emitAnnotation("Override");
                 writer.beginMethod(fieldTypeCanonicalName, metadata.getGetter(fieldName), EnumSet.of(Modifier.PUBLIC));
                 writer.emitStatement("proxyState.getRealm$realm().checkIfValid()");
                 writer.emitSingleLineComment("use the cached value if available");
@@ -402,6 +407,7 @@ public class RealmProxyClassGenerator {
                 writer.emitEmptyLine();
 
                 // Setter
+                writer.emitAnnotation("Override");
                 writer.beginMethod("void", metadata.getSetter(fieldName), EnumSet.of(Modifier.PUBLIC), fieldTypeCanonicalName, "value");
                 emitCodeForUnderConstruction(writer, metadata.isPrimaryKey(field), new CodeEmitter() {
                     @Override
@@ -497,7 +503,7 @@ public class RealmProxyClassGenerator {
 
     private void emitRealmObjectProxyImplementation(JavaWriter writer) throws IOException {
         writer.emitAnnotation("Override");
-        writer.beginMethod("ProxyState", "realmGet$proxyState", EnumSet.of(Modifier.PUBLIC));
+        writer.beginMethod("ProxyState<?>", "realmGet$proxyState", EnumSet.of(Modifier.PUBLIC));
         writer.emitStatement("return proxyState");
         writer.endMethod();
         writer.emitEmptyLine();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -1209,6 +1209,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     }
 
     @Override
+    @SuppressWarnings("ArrayToString")
     public String toString() {
         if (!RealmObject.isValid(this)) {
             return "Invalid object";

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -126,12 +126,14 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
+    @Override
     @SuppressWarnings("cast")
     public String realmGet$columnString() {
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.columnStringIndex);
     }
 
+    @Override
     public void realmSet$columnString(String value) {
         if (proxyState.isUnderConstruction()) {
             // default value of the primary key is always ignored.
@@ -142,12 +144,14 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         throw new io.realm.exceptions.RealmException("Primary key field 'columnString' cannot be changed after object was created.");
     }
 
+    @Override
     @SuppressWarnings("cast")
     public long realmGet$columnLong() {
         proxyState.getRealm$realm().checkIfValid();
         return (long) proxyState.getRow$realm().getLong(columnInfo.columnLongIndex);
     }
 
+    @Override
     public void realmSet$columnLong(long value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -162,12 +166,14 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.getRow$realm().setLong(columnInfo.columnLongIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public float realmGet$columnFloat() {
         proxyState.getRealm$realm().checkIfValid();
         return (float) proxyState.getRow$realm().getFloat(columnInfo.columnFloatIndex);
     }
 
+    @Override
     public void realmSet$columnFloat(float value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -182,12 +188,14 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.getRow$realm().setFloat(columnInfo.columnFloatIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public double realmGet$columnDouble() {
         proxyState.getRealm$realm().checkIfValid();
         return (double) proxyState.getRow$realm().getDouble(columnInfo.columnDoubleIndex);
     }
 
+    @Override
     public void realmSet$columnDouble(double value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -202,12 +210,14 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.getRow$realm().setDouble(columnInfo.columnDoubleIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public boolean realmGet$columnBoolean() {
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.columnBooleanIndex);
     }
 
+    @Override
     public void realmSet$columnBoolean(boolean value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -222,12 +232,14 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.getRow$realm().setBoolean(columnInfo.columnBooleanIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Date realmGet$columnDate() {
         proxyState.getRealm$realm().checkIfValid();
         return (java.util.Date) proxyState.getRow$realm().getDate(columnInfo.columnDateIndex);
     }
 
+    @Override
     public void realmSet$columnDate(Date value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -248,12 +260,14 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.getRow$realm().setDate(columnInfo.columnDateIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public byte[] realmGet$columnBinary() {
         proxyState.getRealm$realm().checkIfValid();
         return (byte[]) proxyState.getRow$realm().getBinaryByteArray(columnInfo.columnBinaryIndex);
     }
 
+    @Override
     public void realmSet$columnBinary(byte[] value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -274,6 +288,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.getRow$realm().setBinaryByteArray(columnInfo.columnBinaryIndex, value);
     }
 
+    @Override
     public some.test.AllTypes realmGet$columnObject() {
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNullLink(columnInfo.columnObjectIndex)) {
@@ -282,6 +297,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         return proxyState.getRealm$realm().get(some.test.AllTypes.class, proxyState.getRow$realm().getLink(columnInfo.columnObjectIndex), false, Collections.<String>emptyList());
     }
 
+    @Override
     public void realmSet$columnObject(some.test.AllTypes value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -323,6 +339,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         proxyState.getRow$realm().setLink(columnInfo.columnObjectIndex, ((RealmObjectProxy)value).realmGet$proxyState().getRow$realm().getIndex());
     }
 
+    @Override
     public RealmList<some.test.AllTypes> realmGet$columnRealmList() {
         proxyState.getRealm$realm().checkIfValid();
         // use the cached value if available
@@ -335,6 +352,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         }
     }
 
+    @Override
     public void realmSet$columnRealmList(RealmList<some.test.AllTypes> value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -1236,7 +1254,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     }
 
     @Override
-    public ProxyState realmGet$proxyState() {
+    public ProxyState<?> realmGet$proxyState() {
         return proxyState;
     }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -100,12 +100,14 @@ public class BooleansRealmProxy extends some.test.Booleans
         proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
+    @Override
     @SuppressWarnings("cast")
     public boolean realmGet$done() {
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.doneIndex);
     }
 
+    @Override
     public void realmSet$done(boolean value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -120,12 +122,14 @@ public class BooleansRealmProxy extends some.test.Booleans
         proxyState.getRow$realm().setBoolean(columnInfo.doneIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public boolean realmGet$isReady() {
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.isReadyIndex);
     }
 
+    @Override
     public void realmSet$isReady(boolean value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -140,12 +144,14 @@ public class BooleansRealmProxy extends some.test.Booleans
         proxyState.getRow$realm().setBoolean(columnInfo.isReadyIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public boolean realmGet$mCompleted() {
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.mCompletedIndex);
     }
 
+    @Override
     public void realmSet$mCompleted(boolean value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -160,12 +166,14 @@ public class BooleansRealmProxy extends some.test.Booleans
         proxyState.getRow$realm().setBoolean(columnInfo.mCompletedIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public boolean realmGet$anotherBoolean() {
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.anotherBooleanIndex);
     }
 
+    @Override
     public void realmSet$anotherBoolean(boolean value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -520,7 +528,7 @@ public class BooleansRealmProxy extends some.test.Booleans
     }
 
     @Override
-    public ProxyState realmGet$proxyState() {
+    public ProxyState<?> realmGet$proxyState() {
         return proxyState;
     }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -503,6 +503,7 @@ public class BooleansRealmProxy extends some.test.Booleans
     }
 
     @Override
+    @SuppressWarnings("ArrayToString")
     public String toString() {
         if (!RealmObject.isValid(this)) {
             return "Invalid object";

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -2086,6 +2086,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     @Override
+    @SuppressWarnings("ArrayToString")
     public String toString() {
         if (!RealmObject.isValid(this)) {
             return "Invalid object";

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -185,12 +185,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
+    @Override
     @SuppressWarnings("cast")
     public String realmGet$fieldStringNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.fieldStringNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldStringNotNull(String value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -211,12 +213,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setString(columnInfo.fieldStringNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public String realmGet$fieldStringNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.fieldStringNullIndex);
     }
 
+    @Override
     public void realmSet$fieldStringNull(String value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -239,12 +243,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setString(columnInfo.fieldStringNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Boolean realmGet$fieldBooleanNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.fieldBooleanNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldBooleanNotNull(Boolean value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -265,6 +271,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setBoolean(columnInfo.fieldBooleanNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Boolean realmGet$fieldBooleanNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -274,6 +281,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (boolean) proxyState.getRow$realm().getBoolean(columnInfo.fieldBooleanNullIndex);
     }
 
+    @Override
     public void realmSet$fieldBooleanNull(Boolean value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -296,12 +304,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setBoolean(columnInfo.fieldBooleanNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public byte[] realmGet$fieldBytesNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (byte[]) proxyState.getRow$realm().getBinaryByteArray(columnInfo.fieldBytesNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldBytesNotNull(byte[] value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -322,12 +332,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setBinaryByteArray(columnInfo.fieldBytesNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public byte[] realmGet$fieldBytesNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (byte[]) proxyState.getRow$realm().getBinaryByteArray(columnInfo.fieldBytesNullIndex);
     }
 
+    @Override
     public void realmSet$fieldBytesNull(byte[] value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -350,12 +362,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setBinaryByteArray(columnInfo.fieldBytesNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Byte realmGet$fieldByteNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (byte) proxyState.getRow$realm().getLong(columnInfo.fieldByteNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldByteNotNull(Byte value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -376,6 +390,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldByteNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Byte realmGet$fieldByteNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -385,6 +400,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (byte) proxyState.getRow$realm().getLong(columnInfo.fieldByteNullIndex);
     }
 
+    @Override
     public void realmSet$fieldByteNull(Byte value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -407,12 +423,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldByteNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Short realmGet$fieldShortNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (short) proxyState.getRow$realm().getLong(columnInfo.fieldShortNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldShortNotNull(Short value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -433,6 +451,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldShortNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Short realmGet$fieldShortNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -442,6 +461,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (short) proxyState.getRow$realm().getLong(columnInfo.fieldShortNullIndex);
     }
 
+    @Override
     public void realmSet$fieldShortNull(Short value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -464,12 +484,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldShortNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Integer realmGet$fieldIntegerNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (int) proxyState.getRow$realm().getLong(columnInfo.fieldIntegerNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldIntegerNotNull(Integer value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -490,6 +512,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldIntegerNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Integer realmGet$fieldIntegerNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -499,6 +522,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (int) proxyState.getRow$realm().getLong(columnInfo.fieldIntegerNullIndex);
     }
 
+    @Override
     public void realmSet$fieldIntegerNull(Integer value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -521,12 +545,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldIntegerNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Long realmGet$fieldLongNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (long) proxyState.getRow$realm().getLong(columnInfo.fieldLongNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldLongNotNull(Long value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -547,6 +573,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldLongNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Long realmGet$fieldLongNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -556,6 +583,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (long) proxyState.getRow$realm().getLong(columnInfo.fieldLongNullIndex);
     }
 
+    @Override
     public void realmSet$fieldLongNull(Long value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -578,12 +606,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setLong(columnInfo.fieldLongNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Float realmGet$fieldFloatNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (float) proxyState.getRow$realm().getFloat(columnInfo.fieldFloatNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldFloatNotNull(Float value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -604,6 +634,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setFloat(columnInfo.fieldFloatNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Float realmGet$fieldFloatNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -613,6 +644,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (float) proxyState.getRow$realm().getFloat(columnInfo.fieldFloatNullIndex);
     }
 
+    @Override
     public void realmSet$fieldFloatNull(Float value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -635,12 +667,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setFloat(columnInfo.fieldFloatNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Double realmGet$fieldDoubleNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (double) proxyState.getRow$realm().getDouble(columnInfo.fieldDoubleNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldDoubleNotNull(Double value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -661,6 +695,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setDouble(columnInfo.fieldDoubleNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Double realmGet$fieldDoubleNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -670,6 +705,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (double) proxyState.getRow$realm().getDouble(columnInfo.fieldDoubleNullIndex);
     }
 
+    @Override
     public void realmSet$fieldDoubleNull(Double value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -692,12 +728,14 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setDouble(columnInfo.fieldDoubleNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Date realmGet$fieldDateNotNull() {
         proxyState.getRealm$realm().checkIfValid();
         return (java.util.Date) proxyState.getRow$realm().getDate(columnInfo.fieldDateNotNullIndex);
     }
 
+    @Override
     public void realmSet$fieldDateNotNull(Date value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -718,6 +756,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setDate(columnInfo.fieldDateNotNullIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public Date realmGet$fieldDateNull() {
         proxyState.getRealm$realm().checkIfValid();
@@ -727,6 +766,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return (java.util.Date) proxyState.getRow$realm().getDate(columnInfo.fieldDateNullIndex);
     }
 
+    @Override
     public void realmSet$fieldDateNull(Date value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -749,6 +789,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         proxyState.getRow$realm().setDate(columnInfo.fieldDateNullIndex, value);
     }
 
+    @Override
     public some.test.NullTypes realmGet$fieldObjectNull() {
         proxyState.getRealm$realm().checkIfValid();
         if (proxyState.getRow$realm().isNullLink(columnInfo.fieldObjectNullIndex)) {
@@ -757,6 +798,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return proxyState.getRealm$realm().get(some.test.NullTypes.class, proxyState.getRow$realm().getLink(columnInfo.fieldObjectNullIndex), false, Collections.<String>emptyList());
     }
 
+    @Override
     public void realmSet$fieldObjectNull(some.test.NullTypes value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -2137,7 +2179,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     @Override
-    public ProxyState realmGet$proxyState() {
+    public ProxyState<?> realmGet$proxyState() {
         return proxyState;
     }
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -90,12 +90,14 @@ public class SimpleRealmProxy extends some.test.Simple
         proxyState.setExcludeFields$realm(context.getExcludeFields());
     }
 
+    @Override
     @SuppressWarnings("cast")
     public String realmGet$name() {
         proxyState.getRealm$realm().checkIfValid();
         return (java.lang.String) proxyState.getRow$realm().getString(columnInfo.nameIndex);
     }
 
+    @Override
     public void realmSet$name(String value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -118,12 +120,14 @@ public class SimpleRealmProxy extends some.test.Simple
         proxyState.getRow$realm().setString(columnInfo.nameIndex, value);
     }
 
+    @Override
     @SuppressWarnings("cast")
     public int realmGet$age() {
         proxyState.getRealm$realm().checkIfValid();
         return (int) proxyState.getRow$realm().getLong(columnInfo.ageIndex);
     }
 
+    @Override
     public void realmSet$age(int value) {
         if (proxyState.isUnderConstruction()) {
             if (!proxyState.getAcceptDefaultValue$realm()) {
@@ -407,7 +411,7 @@ public class SimpleRealmProxy extends some.test.Simple
     }
 
     @Override
-    public ProxyState realmGet$proxyState() {
+    public ProxyState<?> realmGet$proxyState() {
         return proxyState;
     }
 


### PR DESCRIPTION
Add `Override` annotation to accessors and stop using raw type in proxy classes in order to remove warnings from java.

fixes #4329 
