### PR TITLE
findFirstAsync returns invalid row if no object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `Realm.migrateRealm(RealmConfiguration)` now fails correctly with an `IllegalArgumentException` if a `SyncConfiguration` is provided (#4075).
 * Fixed a potential cause for Realm file corruptions (never reported).
 * Add `@Override` annotation to proxy class accessors and stop using raw type in proxy classes in order to remove warnings from javac (#4329).
+* `findFirstAsync()` now returns an invalid object if there is no object matches the query condition instead of running the query repeatedly until it can find one (#4352).
 
 ### Deprecated
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -551,34 +551,26 @@ public class RealmAsyncQueryTests {
         });
     }
 
+    // When there is no object match the query condition, findFirstAsync should return with an invalid row.
     @Test
     @RunTestInLooperThread
-    public void findFirstAsync_initalEmptyRow() throws Throwable {
+    public void findFirstAsync_initialEmptyRow() throws Throwable {
         Realm realm = looperThread.realm;
         final AllTypes firstAsync = realm.where(AllTypes.class).findFirstAsync();
         looperThread.keepStrongReference.add(firstAsync);
         firstAsync.addChangeListener(new RealmChangeListener<AllTypes>() {
             @Override
             public void onChange(AllTypes object) {
-                assertTrue(firstAsync.load());
                 assertTrue(firstAsync.isLoaded());
-                assertTrue(firstAsync.isValid());
-                assertEquals(0, firstAsync.getColumnLong());
+                assertFalse(firstAsync.isValid());
                 looperThread.testComplete();
             }
         });
-
-        realm.beginTransaction();
-        realm.createObject(AllTypes.class).setColumnLong(0);
-        realm.commitTransaction();
-
-        assertTrue(firstAsync.load());
-        assertTrue(firstAsync.isLoaded());
     }
 
     @Test
     @RunTestInLooperThread
-    public void findFirstAsync_updatedIfsyncRealmObjectIsUpdated() throws Throwable {
+    public void findFirstAsync_updatedIfSyncRealmObjectIsUpdated() throws Throwable {
         populateTestRealm(looperThread.realm, 1);
         AllTypes firstSync = looperThread.realm.where(AllTypes.class).findFirst();
         assertEquals(0, firstSync.getColumnLong());

--- a/realm/realm-library/src/main/java/io/realm/ProxyState.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyState.java
@@ -135,7 +135,7 @@ public final class ProxyState<E extends RealmModel> implements PendingRow.FrontE
     }
 
     private void registerToRealmNotifier() {
-        if (realm.sharedRealm == null || realm.sharedRealm.isClosed()) {
+        if (realm.sharedRealm == null || realm.sharedRealm.isClosed() || !row.isAttached()) {
             return;
         }
 
@@ -172,9 +172,11 @@ public final class ProxyState<E extends RealmModel> implements PendingRow.FrontE
     @Override
     public void onQueryFinished(Row row) {
         this.row = row;
-        // getTable should return a non-null table since the row should always be valid here.
-        currentTableVersion = row.getTable().getVersion();
         notifyChangeListeners();
-        registerToRealmNotifier();
+        if (row.isAttached()) {
+            // getTable should return a non-null table since the row should always be valid here.
+            currentTableVersion = row.getTable().getVersion();
+            registerToRealmNotifier();
+        }
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
@@ -58,12 +58,12 @@ public class PendingRow implements Row {
                         Row row = returnCheckedRow ? CheckedRow.getFromRow(uncheckedRow) : uncheckedRow;
                         // Ask the front end to reset the row and stop async query.
                         frontEnd.onQueryFinished(row);
-                        clearPendingCollection();
+                    } else {
+                        frontEnd.onQueryFinished(InvalidRow.INSTANCE);
                     }
-                } else {
-                    // The Realm is closed. Do nothing then.
-                    clearPendingCollection();
                 }
+
+                clearPendingCollection();
             }
         };
         pendingCollection.addListener(this, listener);


### PR DESCRIPTION
Fix #4352
The findFirstAsync()'s behavior doesn't match the javadoc from the first
day the API was introduced. It kept running the query until it could
find a row match the query condition. This behavior create difficulties
if user want to check if there is no object in the db. Also it was not
consistent with the behavior of findFirst() which will return an invalid
row in the same condition.