### PR TITLE
Add JNI helper class JavaGlabalRef and JavaClass

### DIFF
--- a/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
@@ -53,9 +53,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
         java_lang_double_init = env->GetMethodID(java_lang_double, "<init>", "(D)V");
         java_util_date = GetClass(env, "java/util/Date");
         java_util_date_init = env->GetMethodID(java_util_date, "<init>", "(J)V");
-#if REALM_ENABLE_SYNC
-        java_syncmanager = GetClass(env, "io/realm/SyncManager");
-#endif
     }
 
     return JNI_VERSION_1_6;
@@ -73,9 +70,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void*)
         env->DeleteGlobalRef(java_lang_double);
         env->DeleteGlobalRef(java_util_date);
         env->DeleteGlobalRef(java_lang_string);
-#if REALM_ENABLE_SYNC
-        env->DeleteGlobalRef(java_syncmanager);
-#endif
+        JniUtils::release();
     }
 }
 

--- a/realm/realm-library/src/main/cpp/jni_util/java_class.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_class.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "java_class.hpp"
+#include "jni_utils.hpp"
+
+#include <realm/util/assert.hpp>
+
+using namespace realm::jni_util;
+
+JavaClass::JavaClass(JNIEnv* env, const char* class_name, bool free_on_unload)
+    : m_ref_owner(get_jclass(env, class_name))
+    , m_class(reinterpret_cast<jclass>(m_ref_owner.get()))
+{
+    if (free_on_unload) {
+        // Move the ownership of global ref to JNIUtils which will be released when JNI_OnUnload.
+        JniUtils::keep_global_ref(m_ref_owner);
+    }
+}
+
+JavaGlobalRef JavaClass::get_jclass(JNIEnv* env, const char* class_name)
+{
+    jclass cls = env->FindClass(class_name);
+    REALM_ASSERT_DEBUG(cls);
+
+    JavaGlobalRef cls_ref(env, cls);
+    env->DeleteLocalRef(cls);
+    return cls_ref;
+}

--- a/realm/realm-library/src/main/cpp/jni_util/java_class.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_class.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_JNI_UTIL_JAVA_CLASS_HPP
+#define REALM_JNI_UTIL_JAVA_CLASS_HPP
+
+#include <jni.h>
+
+#include "java_global_ref.hpp"
+
+namespace realm {
+namespace jni_util {
+
+// To find the jclass and manage the lifecycle for the jclass's global ref.
+class JavaClass {
+public:
+    // when free_on_unload is true, the jclass's global ref will be released when JNI_OnUnload called. This is useful
+    // when the JavaClass instance is static. Otherwise the jclass's global ref will be released when this object is
+    // deleted.
+    JavaClass(JNIEnv* env, const char* class_name, bool free_on_unload = true);
+    ~JavaClass()
+    {
+    }
+
+    inline jclass get() noexcept
+    {
+        return m_class;
+    }
+
+    inline operator jclass() const noexcept
+    {
+        return m_class;
+    }
+
+    // Not implemented for now.
+    JavaClass(JavaClass&&) = delete;
+    JavaClass(JavaClass&) = delete;
+    JavaClass& operator=(JavaClass&&) = delete;
+
+private:
+    JavaGlobalRef m_ref_owner;
+    jclass m_class;
+    static JavaGlobalRef get_jclass(JNIEnv* env, const char* class_name);
+};
+
+} // jni_util
+} // realm
+
+#endif

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_ref.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_ref.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "java_global_ref.hpp"
+#include "jni_utils.hpp"
+
+#include <memory>
+
+using namespace realm::jni_util;
+
+JavaGlobalRef::~JavaGlobalRef()
+{
+    if (m_ref) {
+        JniUtils::get_env()->DeleteGlobalRef(m_ref);
+    }
+}
+
+JavaGlobalRef& JavaGlobalRef::operator=(JavaGlobalRef&& rhs)
+{
+    this->~JavaGlobalRef();
+    new (this) JavaGlobalRef(std::move(rhs));
+    return *this;
+}

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_ref.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_JNI_UTIL_JAVA_GLOBAL_REF_HPP
+#define REALM_JNI_UTIL_JAVA_GLOBAL_REF_HPP
+
+#include <jni.h>
+
+namespace realm {
+namespace jni_util {
+
+// Manage the lifecycle of jobject's global ref.
+class JavaGlobalRef {
+public:
+    JavaGlobalRef()
+        : m_ref(nullptr)
+    {
+    }
+    JavaGlobalRef(JNIEnv* env, jobject obj)
+        : m_ref(obj ? env->NewGlobalRef(obj) : nullptr)
+    {
+    }
+    JavaGlobalRef(JavaGlobalRef&& rhs)
+        : m_ref(rhs.m_ref)
+    {
+        rhs.m_ref = nullptr;
+    }
+    ~JavaGlobalRef();
+
+    JavaGlobalRef& operator=(JavaGlobalRef&& rhs);
+
+    inline operator bool() const noexcept
+    {
+        return m_ref != nullptr;
+    }
+
+    inline jobject get() noexcept
+    {
+        return m_ref;
+    }
+
+    // Not implemented for now.
+    JavaGlobalRef(JavaGlobalRef&) = delete;
+
+private:
+    jobject m_ref;
+};
+}
+}
+
+#endif // REALM_JNI_UTIL_JAVA_GLOBAL_REF_HPP

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.cpp
@@ -31,6 +31,12 @@ void JniUtils::initialize(JavaVM* vm, jint vm_version) noexcept
     s_instance = std::unique_ptr<JniUtils>(new JniUtils(vm, vm_version));
 }
 
+void JniUtils::release()
+{
+    REALM_ASSERT_DEBUG(s_instance);
+    s_instance.release();
+}
+
 JNIEnv* JniUtils::get_env(bool attach_if_needed)
 {
     REALM_ASSERT_DEBUG(s_instance);
@@ -53,3 +59,9 @@ void JniUtils::detach_current_thread()
 {
     s_instance->m_vm->DetachCurrentThread();
 }
+
+void JniUtils::keep_global_ref(JavaGlobalRef& ref)
+{
+    s_instance->m_global_refs.push_back(std::move(ref));
+}
+

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
@@ -19,6 +19,10 @@
 
 #include <jni.h>
 
+#include <vector>
+
+#include "java_global_ref.hpp"
+
 namespace realm {
 namespace jni_util {
 
@@ -31,12 +35,16 @@ public:
 
     // Call this only once in JNI_OnLoad.
     static void initialize(JavaVM* vm, jint vm_version) noexcept;
+    // Call this in JNI_OnUnload.
+    static void release();
     // When attach_if_needed is false, returns the JNIEnv if there is one attached to this thread. Assert if there is
     // none. When attach_if_needed is true, try to attach and return a JNIEnv if necessary.
     static JNIEnv* get_env(bool attach_if_needed = false);
     // Detach the current thread from the JVM. Only required for C++ threads that where attached in the first place.
     // Failing to do so is a resource leak.
     static void detach_current_thread();
+    // Keep the given global reference until the JNI_OnUnload called.
+    static void keep_global_ref(JavaGlobalRef& ref);
 
 private:
     JniUtils(JavaVM* vm, jint vm_version) noexcept
@@ -47,6 +55,7 @@ private:
 
     JavaVM* m_vm;
     jint m_vm_version;
+    std::vector<JavaGlobalRef> m_global_refs;
 };
 
 } // namespace realm

--- a/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/jni_utils.hpp
@@ -43,7 +43,7 @@ public:
     // Detach the current thread from the JVM. Only required for C++ threads that where attached in the first place.
     // Failing to do so is a resource leak.
     static void detach_current_thread();
-    // Keep the given global reference until the JNI_OnUnload called.
+    // Keep the given global reference until JNI_OnUnload is called.
     static void keep_global_ref(JavaGlobalRef& ref);
 
 private:


### PR DESCRIPTION
- Added two class to help manage the jobject lifecycle.
- Use a static local JavaClass for SyncManager.

Since to support old/new values for object notification, we need to create java objects from JNI frequently. Clean up this part to make future work easier.