### PR TITLE
Trigger collection listeners when commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * Now `targetSdkVersion` is 25.
+* Listeners on `RealmList` and `RealmResults` will be triggered immediately when the transaction is committed on the same thread (#4245).
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
@@ -386,7 +386,6 @@ public class CollectionTests {
         final SharedRealm sharedRealm = getSharedRealm();
         Table table = sharedRealm.getTable("test_table");
         final AtomicInteger listenerCounter = new AtomicInteger(0);
-        final AtomicBoolean transactionCommitted = new AtomicBoolean(false);
 
         final Collection collection = new Collection(sharedRealm, table.where());
         looperThread.keepStrongReference.add(collection);
@@ -398,15 +397,17 @@ public class CollectionTests {
                         assertEquals(collection1.size(), 4);
                         break;
                     case 1:
-                        assertFalse(transactionCommitted.get());
                         assertEquals(collection1.size(), 5);
                         sharedRealm.close();
+                        break;
+                    default:
+                        fail();
                         break;
                 }
             }
         });
         addRow(sharedRealm);
-        transactionCommitted.set(true);
+        assertEquals(2, listenerCounter.get());
         looperThread.testComplete();
     }
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -146,6 +146,12 @@ JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeCommitTransactio
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     try {
         shared_realm->commit_transaction();
+        // Realm could be closed in the RealmNotifier.didChange().
+        if (!shared_realm->is_closed()) {
+            // To trigger async queries, so the UI can be refreshed immediately to avoid inconsistency.
+            // See more discussion on https://github.com/realm/realm-java/issues/4245
+            shared_realm->refresh();
+        }
     }
     CATCH_STD()
 }


### PR DESCRIPTION
- The listeners on RealmList/RealmResults will be tiggered immediately
  when the transaction committed on the same thread if the collections
  are changed or the async query should return.
- Listeners on the RealmObject will have same behaviour after #4331
  merged.

This is to solve the problem for predictive UI animations and local
transactions.
Fix #4245