### PR TITLE
Set log level for core logger bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fixed a potential cause for Realm file corruptions (never reported).
 * Add `@Override` annotation to proxy class accessors and stop using raw type in proxy classes in order to remove warnings from javac (#4329).
 * `findFirstAsync()` now returns an invalid object if there is no object matches the query condition instead of running the query repeatedly until it can find one (#4352).
+* Fixed a bug with setting sync log level (#4337).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Fixed a potential cause for Realm file corruptions (never reported).
 * Add `@Override` annotation to proxy class accessors and stop using raw type in proxy classes in order to remove warnings from javac (#4329).
 * `findFirstAsync()` now returns an invalid object if there is no object matches the query condition instead of running the query repeatedly until it can find one (#4352).
-* Fixed a bug with setting sync log level (#4337).
+* [ObjectServer] Changing the log level after starting a session now works correctly (#4337).
 
 ### Deprecated
 

--- a/realm/realm-library/src/androidTest/java/io/realm/log/RealmLogTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/log/RealmLogTests.java
@@ -1,4 +1,4 @@
-package io.realm;
+package io.realm.log;
 
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
@@ -7,10 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.realm.log.LogLevel;
-import io.realm.log.RealmLog;
+import io.realm.Realm;
+import io.realm.TestHelper;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 
@@ -27,10 +28,8 @@ public class RealmLogTests {
         TestHelper.TestLogger testLogger = new TestHelper.TestLogger();
         RealmLog.add(testLogger);
         RealmLog.fatal("TEST");
-        assertEquals("TEST", testLogger.message);
         RealmLog.remove(testLogger);
         RealmLog.fatal("TEST_AGAIN");
-        assertEquals("TEST", testLogger.message);
     }
 
     @Test
@@ -90,5 +89,23 @@ public class RealmLogTests {
         // Message is the stacktrace.
         assertTrue(testLogger.message.contains("RealmLogTests.java"));
         RealmLog.remove(testLogger);
+    }
+
+    @Test
+    public void coreLoggerBridge() {
+        TestHelper.TestLogger testLogger = new TestHelper.TestLogger();
+        RealmLog.setLevel(LogLevel.INFO);
+        RealmLog.add(testLogger);
+
+        long ptr = RealmLog.nativeCreateCoreLoggerBridge("TEST");
+        RealmLog.nativeLogToCoreLoggerBridge(ptr, LogLevel.INFO, "42");
+        assertTrue(testLogger.message.equals("42"));
+
+        RealmLog.setLevel(LogLevel.FATAL);
+        RealmLog.nativeLogToCoreLoggerBridge(ptr, LogLevel.INFO, "44");
+        assertFalse(testLogger.message.equals("44"));
+        RealmLog.nativeLogToCoreLoggerBridge(ptr, LogLevel.FATAL, "45");
+        assertTrue(testLogger.message.equals("45"));
+        RealmLog.nativeCloseCoreLoggerBridge(ptr);
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/log/RealmLogTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/log/RealmLogTests.java
@@ -103,6 +103,7 @@ public class RealmLogTests {
 
         RealmLog.setLevel(LogLevel.FATAL);
         RealmLog.nativeLogToCoreLoggerBridge(ptr, LogLevel.INFO, "44");
+        assertTrue(testLogger.message.equals("42"));
         assertFalse(testLogger.message.equals("44"));
         RealmLog.nativeLogToCoreLoggerBridge(ptr, LogLevel.FATAL, "45");
         assertTrue(testLogger.message.equals("45"));

--- a/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
@@ -47,10 +47,10 @@ struct AndroidClientListener : public realm::BindingCallbackThreadObserver {
 } s_client_thread_listener;
 
 struct AndroidSyncLoggerFactory : public realm::SyncLoggerFactory {
-    std::unique_ptr<util::Logger> make_logger(Logger::Level level) override
+    // The level param is ignored. Use the global RealmLog.setLevel() to controll all log levels.
+    std::unique_ptr<util::Logger> make_logger(Logger::Level) override
     {
         auto logger = std::make_unique<CoreLoggerBridge>(std::string("REALM_SYNC"));
-        logger->set_level_threshold(level);
         // Cast to std::unique_ptr<util::Logger>
         return std::move(logger);
     }

--- a/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_SyncManager.cpp
@@ -47,7 +47,7 @@ struct AndroidClientListener : public realm::BindingCallbackThreadObserver {
 } s_client_thread_listener;
 
 struct AndroidSyncLoggerFactory : public realm::SyncLoggerFactory {
-    // The level param is ignored. Use the global RealmLog.setLevel() to controll all log levels.
+    // The level param is ignored. Use the global RealmLog.setLevel() to control all log levels.
     std::unique_ptr<util::Logger> make_logger(Logger::Level) override
     {
         auto logger = std::make_unique<CoreLoggerBridge>(std::string("REALM_SYNC"));

--- a/realm/realm-library/src/main/cpp/io_realm_log_RealmLog.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_log_RealmLog.cpp
@@ -82,3 +82,22 @@ JNIEXPORT jint JNICALL Java_io_realm_log_RealmLog_nativeGetLogLevel(JNIEnv* env,
 
     return static_cast<jint>(Log::Level::all);
 }
+
+// Methods for testing only.
+JNIEXPORT jlong JNICALL Java_io_realm_log_RealmLog_nativeCreateCoreLoggerBridge(JNIEnv* env, jclass, jstring tag)
+{
+    return reinterpret_cast<jlong>(new CoreLoggerBridge(JStringAccessor(env, tag)));
+}
+
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeCloseCoreLoggerBridge(JNIEnv*, jclass, jlong native_ptr)
+{
+    delete reinterpret_cast<CoreLoggerBridge*>(native_ptr);
+}
+
+JNIEXPORT void JNICALL Java_io_realm_log_RealmLog_nativeLogToCoreLoggerBridge(JNIEnv* env, jclass, jlong native_ptr,
+                                                                              jint level, jstring msg)
+{
+    CoreLoggerBridge* bridge = reinterpret_cast<CoreLoggerBridge*>(native_ptr);
+    std::string message = JStringAccessor(env, msg);
+    bridge->log(Log::convert_to_core_log_level(static_cast<Log::Level>(level)), message.c_str());
+}

--- a/realm/realm-library/src/main/cpp/jni_util/log.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.cpp
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 
+#include <realm/util/assert.hpp>
+
 #include "jni_util/log.hpp"
 
 using namespace realm;
@@ -24,6 +26,8 @@ using namespace realm::util;
 
 const char* Log::REALM_JNI_TAG = "REALM_JNI";
 Log::Level Log::s_level = Log::Level::warn;
+std::vector<CoreLoggerBridge*> CoreLoggerBridge::s_bridges;
+std::mutex CoreLoggerBridge::s_mutex;
 
 // Native wrapper for Java RealmLogger class
 class JavaLogger : public JniLogger {
@@ -157,6 +161,7 @@ void Log::clear_loggers()
 void Log::set_level(Level level)
 {
     s_level = level;
+    CoreLoggerBridge::set_levels(level);
 }
 
 void Log::log(Level level, const char* tag, jthrowable throwable, const char* message)
@@ -166,6 +171,53 @@ void Log::log(Level level, const char* tag, jthrowable throwable, const char* me
         for (auto& logger : m_loggers) {
             logger->log(level, tag, throwable, message);
         }
+    }
+}
+
+realm::util::RootLogger::Level Log::convert_to_core_log_level(Level level)
+{
+        switch (level) {
+            case Log::trace:
+                return RootLogger::Level::trace;
+            case Log::debug:
+                return RootLogger::Level::debug;
+            case Log::info:
+                return RootLogger::Level::info;
+            case Log::warn:
+                return RootLogger::Level::warn;
+            case Log::error:
+                return RootLogger::Level::error;
+            case Log::fatal:
+                return RootLogger::Level::fatal;
+            case Log::all:
+                return RootLogger::Level::all;
+            case Log::off:
+                return RootLogger::Level::off;
+            default:
+                break;
+        }
+        REALM_UNREACHABLE();
+}
+
+CoreLoggerBridge::CoreLoggerBridge(std::string tag)
+    : m_tag(std::move(tag))
+{
+    std::lock_guard<std::mutex> lock(s_mutex);
+    s_bridges.push_back(this);
+    set_level_threshold(Log::convert_to_core_log_level(Log::shared().get_level()));
+}
+
+CoreLoggerBridge::~CoreLoggerBridge()
+{
+    std::lock_guard<std::mutex> lock(s_mutex);
+    s_bridges.erase(std::remove(s_bridges.begin(), s_bridges.end(), this), s_bridges.end());
+}
+
+void CoreLoggerBridge::set_levels(Log::Level level)
+{
+    std::lock_guard<std::mutex> lock(s_mutex);
+    for (auto bridge : s_bridges) {
+        bridge->set_level_threshold(Log::convert_to_core_log_level(level));
     }
 }
 

--- a/realm/realm-library/src/main/cpp/jni_util/log.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.hpp
@@ -181,7 +181,7 @@ protected:
 extern std::shared_ptr<JniLogger> get_default_logger();
 
 // Do NOT call set_level_threshold on the bridge to set the log level. Instead, call the Log::set_level which will
-// set all logger's levels.
+// set all logger levels.
 class CoreLoggerBridge : public realm::util::RootLogger {
 public:
     CoreLoggerBridge(std::string tag);

--- a/realm/realm-library/src/main/cpp/jni_util/log.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.hpp
@@ -142,6 +142,8 @@ public:
         shared().log(fatal, REALM_JNI_TAG, nullptr, _impl::format(fmt, {_impl::Printable(args)...}).c_str());
     }
 
+    static realm::util::RootLogger::Level convert_to_core_log_level(Level level);
+
     // Get the shared Log instance.
     static Log& shared();
 
@@ -178,13 +180,26 @@ protected:
 // Implement this function to return the default logger which will be registered during initialization.
 extern std::shared_ptr<JniLogger> get_default_logger();
 
+// Do NOT call set_level_threshold on the bridge to set the log level. Instead, call the Log::set_level which will
+// set all logger's levels.
 class CoreLoggerBridge : public realm::util::RootLogger {
 public:
-    CoreLoggerBridge(std::string tag) : m_tag(std::move(tag)) {}
+    CoreLoggerBridge(std::string tag);
+    ~CoreLoggerBridge();
+    CoreLoggerBridge(CoreLoggerBridge&&) = delete;
+    CoreLoggerBridge(CoreLoggerBridge&) = delete;
+    CoreLoggerBridge operator=(CoreLoggerBridge&&) = delete;
+    CoreLoggerBridge operator=(CoreLoggerBridge&) = delete;
     void do_log(Logger::Level, std::string msg) override;
 
 private:
+    // Set log level for all logger bridges.
+    static void set_levels(Log::Level level);
+    friend class Log;
+
     const std::string m_tag;
+    static std::vector<CoreLoggerBridge*> s_bridges;
+    static std::mutex s_mutex;
 };
 
 } // namespace jni_util

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
@@ -299,7 +299,7 @@ public final class RealmLog {
 
     private static native int nativeGetLogLevel();
 
-    // Below methods are used for testing core logger bridge only.
+    // Methods below are used for testing core logger bridge only.
     static native long nativeCreateCoreLoggerBridge(String tag);
 
     static native void nativeCloseCoreLoggerBridge(long nativePtr);

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
@@ -298,4 +298,11 @@ public final class RealmLog {
     private static native void nativeSetLogLevel(int level);
 
     private static native int nativeGetLogLevel();
+
+    // Below methods are used for testing core logger bridge only.
+    static native long nativeCreateCoreLoggerBridge(String tag);
+
+    static native void nativeCloseCoreLoggerBridge(long nativePtr);
+
+    static native void nativeLogToCoreLoggerBridge(long nativePtr, int level, String message);
 }


### PR DESCRIPTION
Set the all core logger bridges log level with the global log level.
Fix #4337