### PR TITLE
Enable build from core source

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -29,7 +29,9 @@ if (!ext.coreArchiveDir) {
 }
 ext.coreArchiveFile = rootProject.file("${ext.coreArchiveDir}/realm-sync-android-${project.coreVersion}.tar.gz")
 ext.coreDistributionDir = file("${projectDir}/distribution/realm-core/")
-ext.coreDir = file("${project.coreDistributionDir.getAbsolutePath()}/core-${project.coreVersion}")
+ext.coreDir = file(project.coreSourcePath ?
+        "${project.coreSourcePath}/android-lib" :
+        "${project.coreDistributionDir.getAbsolutePath()}/core-${project.coreVersion}")
 ext.ccachePath = project.findProperty('ccachePath') ?: System.getenv('NDK_CCACHE')
 ext.lcachePath = project.findProperty('lcachePath') ?: System.getenv('NDK_LCACHE')
 
@@ -46,11 +48,11 @@ android {
         externalNativeBuild {
             cmake {
                 arguments "-DREALM_CORE_DIST_DIR:STRING=${project.coreDir.getAbsolutePath()}",
-                          // FIXME:
-                          // This is copied from https://dl.google.com/android/repository/cmake-3.4.2909474-linux-x86_64.zip
-                          // because of the android.toolchain.cmake shipped with Android SDK CMake 3.6 doesn't work with our
-                          // JNI build currently (lack of lto linking support).
-                          // This file should be removed and use the one from Android SDK cmake package when it supports lto.
+                        // FIXME:
+                        // This is copied from https://dl.google.com/android/repository/cmake-3.4.2909474-linux-x86_64.zip
+                        // because of the android.toolchain.cmake shipped with Android SDK CMake 3.6 doesn't work with our
+                        // JNI build currently (lack of lto linking support).
+                        // This file should be removed and use the one from Android SDK cmake package when it supports lto.
                         "-DCMAKE_TOOLCHAIN_FILE=${project.file('src/main/cpp/android.toolchain.cmake').path}"
                 if (project.ccachePath) arguments "-DNDK_CCACHE=$project.ccachePath"
                 if (project.lcachePath) arguments "-DNDK_LCACHE=$project.lcachePath"
@@ -110,6 +112,15 @@ android {
                 }
             }
             consumerProguardFiles 'proguard-rules-common.pro', 'proguard-rules-objectServer.pro'
+        }
+    }
+
+    variantFilter { variant ->
+        def names = variant.flavors*.name
+
+        // Ignore the objectServer flavour when building from core source.
+        if (coreSourcePath && names.contains("objectServer")) {
+            variant.ignore = true
         }
     }
 }
@@ -178,7 +189,7 @@ task javadoc(type: Javadoc) {
         links "http://reactivex.io/RxJava/javadoc/"
         linksOffline "https://developer.android.com/reference/", "${project.android.sdkDirectory}/docs/reference"
 
-        tags = [ betaTag ]
+        tags = [betaTag]
     }
     exclude '**/internal/**'
     exclude '**/BuildConfig.java'
@@ -252,7 +263,7 @@ task checkstyle(type: Checkstyle) {
 // Configuration options can be found here:
 // http://developer.android.com/reference/android/support/test/runner/AndroidJUnitRunner.html
 task connectedBenchmarks(type: GradleBuild) {
-    description =  'Run all benchmarks on connected devices'
+    description = 'Run all benchmarks on connected devices'
     group = 'Verification'
     buildFile = file("${projectDir}/build.gradle")
     startParameter.getProjectProperties().put('android.testInstrumentationRunnerArguments.package', 'io.realm.benchmarks')
@@ -260,7 +271,7 @@ task connectedBenchmarks(type: GradleBuild) {
 }
 
 task connectedUnitTests(type: GradleBuild) {
-    description =  'Run all unit tests on connected devices'
+    description = 'Run all unit tests on connected devices'
     group = 'Verification'
     buildFile = file("${projectDir}/build.gradle")
     startParameter.getProjectProperties().put('android.testInstrumentationRunnerArguments.notPackage', 'io.realm.benchmarks')
@@ -358,7 +369,7 @@ publishing {
                 accessKey project.hasProperty('s3AccessKey') ? s3AccessKey : 'noAccessKey'
                 secretKey project.hasProperty('s3SecretKey') ? s3SecretKey : 'noSecretKey'
             }
-            if(project.version.endsWith('-SNAPSHOT')) {
+            if (project.version.endsWith('-SNAPSHOT')) {
                 url "s3://realm-ci-artifacts/maven/snapshots/"
             } else {
                 url "s3://realm-ci-artifacts/maven/releases/"
@@ -398,7 +409,7 @@ task downloadCore() {
         return project.hasProperty('coreSha256Hash') && !project.coreSha256Hash.empty
     }
 
-    def calcSha256Hash = {File targetFile ->
+    def calcSha256Hash = { File targetFile ->
         MessageDigest sha = MessageDigest.getInstance("SHA-256")
         Formatter hexHash = new Formatter()
         sha.digest(targetFile.bytes).each { b -> hexHash.format('%02x', b) }
@@ -482,9 +493,14 @@ task deployCore(group: 'build setup', description: 'Deploy the latest version of
         coreSourcePath ? compileCore : downloadCore
     }
 
+    // Build with the output from core source dir. No need to deploy anything.
+    onlyIf {
+        return !coreSourcePath
+    }
+
     outputs.upToDateWhen {
-        // Clean up the coreDir if it is newly downloaded or compiled from source
-        if (coreDownloaded || coreSourcePath) {
+        // Clean up the coreDir if it is newly downloaded
+        if (coreDownloaded) {
             return false
         }
 
@@ -575,52 +591,52 @@ android.productFlavors.all { flavor ->
         dependsOn "assemble${flavor.name.capitalize()}"
         group = 'Publishing'
         commandLine 'curl',
-            '-X',
-            'PUT',
-            '-T',
-            "${buildDir}/outputs/aar/realm-android-library-${flavor.name}-release.aar",
-            '-u',
-            "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}.aar?publish=0"
+                '-X',
+                'PUT',
+                '-T',
+                "${buildDir}/outputs/aar/realm-android-library-${flavor.name}-release.aar",
+                '-u',
+                "${userName}:${accessKey}",
+                "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}.aar?publish=0"
     }
 
     task("bintraySources${flavor.name.capitalize()}", type: Exec) {
         dependsOn sourcesJar
         group = 'Publishing'
         commandLine 'curl',
-            '-X',
-            'PUT',
-            '-T',
-            "${buildDir}/libs/realm-android-library-${project.version}-sources.jar",
-            '-u',
-            "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}-sources.jar?publish=0"
+                '-X',
+                'PUT',
+                '-T',
+                "${buildDir}/libs/realm-android-library-${project.version}-sources.jar",
+                '-u',
+                "${userName}:${accessKey}",
+                "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}-sources.jar?publish=0"
     }
 
     task("bintrayJavadoc${flavor.name.capitalize()}", type: Exec) {
         dependsOn javadocJar
         group = 'Publishing'
         commandLine 'curl',
-            '-X',
-            'PUT',
-            '-T',
-            "${buildDir}/libs/realm-android-library-${project.version}-javadoc.jar",
-            '-u',
-            "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}-javadoc.jar?publish=0"
+                '-X',
+                'PUT',
+                '-T',
+                "${buildDir}/libs/realm-android-library-${project.version}-javadoc.jar",
+                '-u',
+                "${userName}:${accessKey}",
+                "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}-javadoc.jar?publish=0"
     }
 
     task("bintrayPom${flavor.name.capitalize()}", type: Exec) {
         dependsOn "publish${flavor.name.capitalize()}PublicationPublicationToMavenLocal"
         group = 'Publishing'
         commandLine 'curl',
-            '-X',
-            'PUT',
-            '-T',
-            "${buildDir}/publications/${flavor.name}Publication/pom-default.xml",
-            '-u',
-            "${userName}:${accessKey}",
-            "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}.pom?publish=0"
+                '-X',
+                'PUT',
+                '-T',
+                "${buildDir}/publications/${flavor.name}Publication/pom-default.xml",
+                '-u',
+                "${userName}:${accessKey}",
+                "https://api.bintray.com/content/realm/maven/realm-android-library${librarySuffix}/${project.version}/io/realm/realm-android-library${librarySuffix}/${project.version}/realm-android-library${librarySuffix}-${project.version}.pom?publish=0"
     }
 
     // OJO
@@ -724,11 +740,11 @@ def checkNdk(String ndkPath) {
     }
     if (detectedNdkVersion != project.ndkVersion) {
         throw new GradleException("Your NDK version: ${detectedNdkVersion}."
-                +" Realm JNI must be compiled with the version ${project.ndkVersion} of NDK.")
+                + " Realm JNI must be compiled with the version ${project.ndkVersion} of NDK.")
     }
 }
 
-def getValueFromPropertiesFile(File propFile, String key) {
+static def getValueFromPropertiesFile(File propFile, String key) {
     if (!propFile.isFile() || !propFile.canRead()) {
         return null
     }

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -84,23 +84,25 @@ add_library(lib_realm_core STATIC IMPORTED)
 set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_PATH}
                                                 IMPORTED_LINK_INTERFACE_LIBRARIES atomic)
 
-# Sync static library
-set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-${ANDROID_ABI}.a)
-# Workaround for old core's funny ABI nicknames
-if (NOT EXISTS ${sync_lib_PATH})
-    if (ARMEABI)
-        set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm.a)
-    elseif (ARMEABI_V7A)
-        set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm-v7a.a)
-    elseif (ARM64_V8A)
-        set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm64.a)
-    else()
-        message(FATAL_ERROR "Cannot find core lib file: ${sync_lib_PATH}")
+if (build_SYNC)
+    # Sync static library
+    set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-${ANDROID_ABI}.a)
+    # Workaround for old core's funny ABI nicknames
+    if (NOT EXISTS ${sync_lib_PATH})
+        if (ARMEABI)
+            set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm.a)
+        elseif (ARMEABI_V7A)
+            set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm-v7a.a)
+        elseif (ARM64_V8A)
+            set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm64.a)
+        else()
+            message(FATAL_ERROR "Cannot find sync lib file: ${sync_lib_PATH}")
+        endif()
     endif()
+    add_library(lib_realm_sync STATIC IMPORTED)
+    set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_PATH}
+                                                    IMPORTED_LINK_INTERFACE_LIBRARIES lib_realm_core)
 endif()
-add_library(lib_realm_sync STATIC IMPORTED)
-set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_PATH}
-                                                IMPORTED_LINK_INTERFACE_LIBRARIES lib_realm_core)
 
 # build application's shared lib
 include_directories(${REALM_CORE_DIST_DIR}/include


### PR DESCRIPTION
Fix #4130

- Fix the problem with build.gradle's coreSourcePath.
- Build with output in the core source dir instead of deploy the
  tarball.
- Skip objectServer flavor when build from core source.
- Build sync from source code is still not supported.

There are still a lot of improvements can be done in the future:
- Build specific ABI only when build core.
- Skip core tarball generation.

But it would be a good idea to do above after core switches to cmake.
Our current build system sucks.