### PR TITLE
Acquire a global ref of jstring for field changes

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
@@ -337,4 +337,36 @@ public class ObjectChangeSetTests {
         allTypes.deleteFromRealm();
         realm.commitTransaction();
     }
+
+    @Test
+    @RunTestInLooperThread
+    public void moreFieldsChangedThanLocalRefTableSize() {
+        final String CLASS_NAME = "ManyFields";
+        final int FIELD_COUNT = 1024;
+        RealmConfiguration config = looperThread.createConfiguration("many_fields");
+        DynamicRealm realm = DynamicRealm.getInstance(config);
+
+        realm.beginTransaction();
+        RealmSchema schema = realm.getSchema();
+        RealmObjectSchema objectSchema = schema.create(CLASS_NAME);
+        for (int i = 0; i < FIELD_COUNT; i++) {
+            objectSchema.addField("field" + i, int.class);
+        }
+        DynamicRealmObject obj = realm.createObject(CLASS_NAME);
+        realm.commitTransaction();
+
+        obj.addChangeListener(new RealmObjectChangeListener<DynamicRealmObject>() {
+            @Override
+            public void onChange(DynamicRealmObject object, ObjectChangeSet changeSet) {
+                assertEquals(FIELD_COUNT, changeSet.getChangedFields().length);
+                looperThread.testComplete();
+            }
+        });
+
+        realm.beginTransaction();
+        for (int i = 0; i < FIELD_COUNT; i++) {
+            obj.setInt("field" + i, 42);
+        }
+        realm.commitTransaction();
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
@@ -338,13 +338,14 @@ public class ObjectChangeSetTests {
         realm.commitTransaction();
     }
 
+    // When there are more than 512 fields change, the JNI local ref table size limitation may be reached.
     @Test
     @RunTestInLooperThread
     public void moreFieldsChangedThanLocalRefTableSize() {
         final String CLASS_NAME = "ManyFields";
         final int FIELD_COUNT = 1024;
         RealmConfiguration config = looperThread.createConfiguration("many_fields");
-        DynamicRealm realm = DynamicRealm.getInstance(config);
+        final DynamicRealm realm = DynamicRealm.getInstance(config);
 
         realm.beginTransaction();
         RealmSchema schema = realm.getSchema();
@@ -359,6 +360,7 @@ public class ObjectChangeSetTests {
             @Override
             public void onChange(DynamicRealmObject object, ObjectChangeSet changeSet) {
                 assertEquals(FIELD_COUNT, changeSet.getChangedFields().length);
+                realm.close();
                 looperThread.testComplete();
             }
         });

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -70,7 +70,8 @@ struct ChangeCallback {
             return;
         }
 
-        std::vector<jstring> field_names;
+        // The local ref of jstring needs to be released to void reach the local ref table size limitation.
+        std::vector<JavaGlobalRef> field_names;
         auto table = m_wrapper->m_object.row().get_table();
         for (size_t i = 0; i < change_set.columns.size(); ++i) {
             if (change_set.columns[i].empty()) {
@@ -78,11 +79,11 @@ struct ChangeCallback {
             }
             // FIXME: After full integration of the OS schema, parse the column name from
             // wrapper->m_object.get_object_schema() will be faster.
-            field_names.push_back(to_jstring(env, table->get_column_name(i)));
+            field_names.push_back(JavaGlobalRef(env, to_jstring(env, table->get_column_name(i)), true));
         }
         m_field_names_array = env->NewObjectArray(field_names.size(), java_lang_string, 0);
         for (size_t i = 0; i < field_names.size(); ++i) {
-            env->SetObjectArrayElement(m_field_names_array, i, field_names[i]);
+            env->SetObjectArrayElement(m_field_names_array, i, field_names[i].get());
         }
     }
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -70,7 +70,7 @@ struct ChangeCallback {
             return;
         }
 
-        // The local ref of jstring needs to be released to void reach the local ref table size limitation.
+        // The local ref of jstring needs to be released to avoid reach the local ref table size limitation.
         std::vector<JavaGlobalRef> field_names;
         auto table = m_wrapper->m_object.row().get_table();
         for (size_t i = 0; i < change_set.columns.size(); ++i) {

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_ref.hpp
@@ -29,9 +29,13 @@ public:
         : m_ref(nullptr)
     {
     }
-    JavaGlobalRef(JNIEnv* env, jobject obj)
+    // Acquire a global ref on the given jobject. The local ref will be released if given release_local_ref is true.
+    JavaGlobalRef(JNIEnv* env, jobject obj, bool release_local_ref = false)
         : m_ref(obj ? env->NewGlobalRef(obj) : nullptr)
     {
+        if (release_local_ref) {
+            env->DeleteLocalRef(obj);
+        }
     }
     JavaGlobalRef(JavaGlobalRef&& rhs)
         : m_ref(rhs.m_ref)


### PR DESCRIPTION
When there are more than 512 fields change, the JNI local ref table size
limitation may be reached. Fix #4378