### PR TITLE
refactor internal method name in RealmSchema

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3694,7 +3694,7 @@ public class RealmTests {
 
         // get the pre-update index for the "name" column.
         CatRealmProxy.CatColumnInfo catColumnInfo
-                = (CatRealmProxy.CatColumnInfo) realm.schema.getColumnIndices().getColumnInfo(Cat.class);
+                = (CatRealmProxy.CatColumnInfo) realm.schema.getColumnInfo(Cat.class);
         final long nameIndex = catColumnInfo.nameIndex;
 
         // Change the index of the column "name".
@@ -3717,7 +3717,7 @@ public class RealmTests {
         assertNotEquals(nameIndex, nameIndexNew);
 
         // Verify that the index in the ColumnInfo has been updated.
-        catColumnInfo = (CatRealmProxy.CatColumnInfo) realm.schema.getColumnIndices().getColumnInfo(Cat.class);
+        catColumnInfo = (CatRealmProxy.CatColumnInfo) realm.schema.getColumnInfo(Cat.class);
         assertEquals(nameIndexNew.get(), catColumnInfo.nameIndex);
         assertEquals(nameIndexNew.get(), (long) catColumnInfo.getIndicesMap().get(Cat.FIELD_NAME));
 

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -293,7 +293,7 @@ public class Realm extends BaseRealm {
 
         if (columnIndices != null) {
             // Copies global cache as a Realm local indices cache.
-            realm.schema.setColumnIndices(columnIndices);
+            realm.schema.setInitialColumnIndices(columnIndices);
         } else {
             final boolean syncingConfig = configuration.isSyncConfiguration();
 
@@ -359,7 +359,7 @@ public class Realm extends BaseRealm {
                 columnInfoMap.put(modelClass, mediator.validateTable(modelClass, realm.sharedRealm, false));
             }
 
-            realm.getSchema().setColumnIndices(
+            realm.getSchema().setInitialColumnIndices(
                     (unversioned) ? configuration.getSchemaVersion() : currentVersion,
                     columnInfoMap);
 
@@ -425,7 +425,7 @@ public class Realm extends BaseRealm {
                 columnInfoMap.put(modelClass, mediator.validateTable(modelClass, realm.sharedRealm, false));
             }
 
-            realm.getSchema().setColumnIndices(
+            realm.getSchema().setInitialColumnIndices(
                     (unversioned) ? newVersion : currentVersion,
                     columnInfoMap);
 
@@ -1690,7 +1690,7 @@ public class Realm extends BaseRealm {
 
             cacheForCurrentVersion = createdGlobalCache = new ColumnIndices(currentSchemaVersion, map);
         }
-        schema.setColumnIndices(cacheForCurrentVersion, mediator);
+        schema.updateColumnIndices(cacheForCurrentVersion, mediator);
         return createdGlobalCache;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -164,7 +164,7 @@ final class RealmCache {
             if (realmClass == Realm.class && refAndCount.globalCount == 0) {
                 final BaseRealm realm = refAndCount.localRealm.get();
                 // Stores a copy of local ColumnIndices as a global cache.
-                RealmCache.storeColumnIndices(cache.typedColumnIndicesArray, realm.schema.getColumnIndices());
+                RealmCache.storeColumnIndices(cache.typedColumnIndicesArray, realm.schema.cloneColumnIndices());
             }
             // This is the first instance in current thread, increase the global count.
             refAndCount.globalCount++;

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -89,19 +89,35 @@ public abstract class RealmSchema {
      */
     public abstract boolean contains(String className);
 
-    final void setColumnIndices(ColumnIndices columnIndices) {
+    final void setInitialColumnIndices(ColumnIndices columnIndices) {
+        if (this.columnIndices != null) {
+            throw new IllegalStateException("An instance of ColumnIndices is already set.");
+        }
         this.columnIndices = columnIndices.clone();
     }
 
-    final void setColumnIndices(long version, Map<Class<? extends RealmModel>, ColumnInfo> columnInfoMap) {
+    final void setInitialColumnIndices(long version, Map<Class<? extends RealmModel>, ColumnInfo> columnInfoMap) {
+        if (this.columnIndices != null) {
+            throw new IllegalStateException("An instance of ColumnIndices is already set.");
+        }
         columnIndices = new ColumnIndices(version, columnInfoMap);
     }
 
-    void setColumnIndices(ColumnIndices cacheForCurrentVersion, RealmProxyMediator mediator) {
-        columnIndices.copyFrom(cacheForCurrentVersion, mediator);
+    /**
+     * Updates all {@link ColumnInfo} elements in {@code columnIndices}.
+     *
+     * <p>
+     * The ColumnInfo elements are shared between all {@link RealmObject}s created by the Realm instance
+     * which owns this RealmSchema. Updating them also means updating indices information in those {@link RealmObject}s.
+     *
+     * @param schemaVersion new schema version.
+     * @param mediator mediator for the Realm.
+     */
+    void updateColumnIndices(ColumnIndices schemaVersion, RealmProxyMediator mediator) {
+        columnIndices.copyFrom(schemaVersion, mediator);
     }
 
-    final ColumnIndices getColumnIndices() {
+    final ColumnIndices cloneColumnIndices() {
         checkIndices();
         return columnIndices.clone();
     }


### PR DESCRIPTION
@realm/java 

The main purpose of this refactoring is making it easy to distinguish updating `ColumnIndices` object itself and creating new `ColumnIndices` object.