### PR TITLE
remove com.neenbedankt.android-apt plugin from example projects.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -26,7 +26,6 @@ allprojects {
             classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
             classpath 'com.github.JakeWharton:sdk-manager-plugin:0ce4cdf08009d79223850a59959d9d6e774d0f77'
             classpath 'com.novoda:gradle-android-command-plugin:1.5.0'
-            classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
             classpath "io.realm:realm-gradle-plugin:${currentVersion}"
         }
     }

--- a/examples/jsonExample/build.gradle
+++ b/examples/jsonExample/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'android-command'
 apply plugin: 'realm-android'
 
@@ -29,5 +28,5 @@ android {
 
 dependencies {
     provided 'org.projectlombok:lombok:1.16.6'
-    apt 'org.projectlombok:lombok:1.16.6'
+    annotationProcessor 'org.projectlombok:lombok:1.16.6'
 }


### PR DESCRIPTION
Users don't need to use `com.neenbedankt.android-apt` plugin anymore.

@realm/java 