### PR TITLE
Stale local ref crash with Object listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.1 (YYYY-MM-DD)
+
+### Bug Fixes
+
+* Crash caused by Listeners on `RealmObject` getting triggered the 2nd time with different changed field (#4437).
+
 ## 3.1.0 (2017-04-05)
 
 ### Breaking Changes

--- a/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
@@ -311,8 +311,8 @@ public class ObjectChangeSetTests {
                     assertFalse(longChanged.get());
                     longChanged.set(true);
                 } else if (changeSet.isFieldChanged(AllTypes.FIELD_FLOAT)) {
-                    assertFalse(stringChanged.get());
-                    assertFalse(longChanged.get());
+                    assertTrue(stringChanged.get());
+                    assertTrue(longChanged.get());
                     assertFalse(floatChanged.get());
                     floatChanged.set(true);
                     looperThread.testComplete();

--- a/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
@@ -288,9 +288,12 @@ public class ObjectChangeSetTests {
         realm.commitTransaction();
     }
 
+    // Relevant to https://github.com/realm/realm-java/issues/4437
+    // When the object listener triggered at the 2nd time, the local ref m_field_names_array has not been reset and it
+    // contains an invalid local ref which has been released before.
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
-    public void  changeDifferentFieldOneAfterAnother() {
+    public void changeDifferentFieldOneAfterAnother() {
         Realm realm = looperThread.realm;
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         final AtomicBoolean stringChanged = new AtomicBoolean(false);
@@ -308,6 +311,8 @@ public class ObjectChangeSetTests {
                     assertFalse(longChanged.get());
                     longChanged.set(true);
                 } else if (changeSet.isFieldChanged(AllTypes.FIELD_FLOAT)) {
+                    assertFalse(stringChanged.get());
+                    assertFalse(longChanged.get());
                     assertFalse(floatChanged.get());
                     floatChanged.set(true);
                     looperThread.testComplete();

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -122,10 +122,9 @@ struct ChangeCallback {
         m_wrapper->m_row_object_weak_ref.call_with_local_ref(env, [&](JNIEnv*, jobject row_obj) {
             static JavaMethod notify_change_listeners(env, row_obj, "notifyChangeListeners",
                                                       "([Ljava/lang/String;)V");
-            env->CallVoidMethod(row_obj, notify_change_listeners, m_field_names_array);
+            env->CallVoidMethod(row_obj, notify_change_listeners, m_deleted ? nullptr : m_field_names_array);
         });
         m_field_names_array = nullptr;
-        m_deleted = false;
     }
 
     void error(std::exception_ptr err)

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -125,6 +125,7 @@ struct ChangeCallback {
             env->CallVoidMethod(row_obj, notify_change_listeners, m_deleted ? nullptr : m_field_names_array);
         });
         m_field_names_array = nullptr;
+        m_deleted = false;
     }
 
     void error(std::exception_ptr err)

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -124,6 +124,8 @@ struct ChangeCallback {
                                                       "([Ljava/lang/String;)V");
             env->CallVoidMethod(row_obj, notify_change_listeners, m_field_names_array);
         });
+        m_field_names_array = nullptr;
+        m_deleted = false;
     }
 
     void error(std::exception_ptr err)


### PR DESCRIPTION
The changed field string array needs to be reset after sending
notifications.

Fix #4437