### PR TITLE
fix API incompatibility introduced in 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 3.1.2 (YYYY-MM-DD)
+
+### Deprecated
+
+### Enhancements
+
+### Bug Fixes
+
+* Incompatible return type of `RealmSchema.getAll()` and `BaseRealm.getSchema()` (#4443).
+
+### Internal
+
+
 ## 3.1.1 (2017-04-07)
 
 ### Deprecated

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -48,7 +48,7 @@ public class RealmObjectSchemaTests {
     private RealmObjectSchema DOG_SCHEMA;
     private DynamicRealm realm;
     private RealmObjectSchema schema;
-    private StandardRealmSchema realmSchema;
+    private RealmSchema realmSchema;
 
     @Before
     public void setUp() {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
@@ -47,7 +47,7 @@ public class RealmSchemaTests {
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
 
     private DynamicRealm realm;
-    private StandardRealmSchema realmSchema;
+    private RealmSchema realmSchema;
 
     @Before
     public void setUp() {

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -464,7 +464,7 @@ abstract class BaseRealm implements Closeable {
      *
      * @return The {@link RealmSchema} for this Realm.
      */
-    public StandardRealmSchema getSchema() {
+    public RealmSchema getSchema() {
         return schema;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/OsRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/OsRealmObjectSchema.java
@@ -18,6 +18,9 @@ package io.realm;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import io.realm.internal.Table;
+
+
 class OsRealmObjectSchema extends RealmObjectSchema {
     private final long nativePtr;
 
@@ -179,6 +182,16 @@ class OsRealmObjectSchema extends RealmObjectSchema {
 
     long getNativePtr() {
         return nativePtr;
+    }
+
+    @Override
+    Table getTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    long getAndCheckFieldIndex(String fieldName) {
+        throw new UnsupportedOperationException();
     }
 
     private Set<Property> getProperties() {

--- a/realm/realm-library/src/main/java/io/realm/OsRealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/OsRealmSchema.java
@@ -34,7 +34,7 @@ import io.realm.internal.Table;
  */
 class OsRealmSchema extends RealmSchema {
     static final class Creator extends RealmSchema {
-        private final Map<String, OsRealmObjectSchema> schema = new HashMap<>();
+        private final Map<String, RealmObjectSchema> schema = new HashMap<>();
 
         @Override
         public void close() { }
@@ -46,7 +46,7 @@ class OsRealmSchema extends RealmSchema {
         }
 
         @Override
-        public Set<OsRealmObjectSchema> getAll() {
+        public Set<RealmObjectSchema> getAll() {
             return new LinkedHashSet<>(schema.values());
         }
 
@@ -99,11 +99,11 @@ class OsRealmSchema extends RealmSchema {
     private final long nativePtr;
 
     OsRealmSchema(Creator creator) {
-        Set<OsRealmObjectSchema> realmObjectSchemas = creator.getAll();
+        Set<RealmObjectSchema> realmObjectSchemas = creator.getAll();
         long[] schemaNativePointers = new long[realmObjectSchemas.size()];
         int i = 0;
-        for (OsRealmObjectSchema schema : realmObjectSchemas) {
-            schemaNativePointers[i++] = schema.getNativePtr();
+        for (RealmObjectSchema schema : realmObjectSchemas) {
+            schemaNativePointers[i++] = ((OsRealmObjectSchema) schema).getNativePtr();
         }
         this.nativePtr = nativeCreateFromList(schemaNativePointers);
     }
@@ -115,7 +115,7 @@ class OsRealmSchema extends RealmSchema {
     // See BaseRealm uses a StandardRealmSchema, not a OsRealmSchema.
     @Override
     public void close() {
-        Set<OsRealmObjectSchema> schemas = getAll();
+        Set<RealmObjectSchema> schemas = getAll();
         for (RealmObjectSchema schema : schemas) {
             schema.close();
         }
@@ -140,9 +140,9 @@ class OsRealmSchema extends RealmSchema {
      * @return the set of all classes in this Realm or no RealmObject classes can be saved in the Realm.
      */
     @Override
-    public Set<OsRealmObjectSchema> getAll() {
+    public Set<RealmObjectSchema> getAll() {
         long[] ptrs = nativeGetAll(nativePtr);
-        Set<OsRealmObjectSchema> schemas = new LinkedHashSet<>(ptrs.length);
+        Set<RealmObjectSchema> schemas = new LinkedHashSet<>(ptrs.length);
         for (int i = 0; i < ptrs.length; i++) {
             schemas.add(new OsRealmObjectSchema(ptrs[i]));
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -19,6 +19,7 @@ package io.realm;
 import java.util.Set;
 
 import io.realm.annotations.Required;
+import io.realm.internal.Table;
 
 
 /**
@@ -290,4 +291,7 @@ public abstract class RealmObjectSchema {
             this.defaultNullable = defaultNullable;
         }
     }
+
+    abstract Table getTable();
+    abstract long getAndCheckFieldIndex(String fieldName);
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -54,7 +54,7 @@ public class RealmQuery<E extends RealmModel> {
     private final Table table;
     private final BaseRealm realm;
     private final TableQuery query;
-    private final StandardRealmObjectSchema schema;
+    private final RealmObjectSchema schema;
     private Class<E> clazz;
     private String className;
     private LinkView linkView;

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -54,7 +54,7 @@ public abstract class RealmSchema {
      *
      * @return the set of all classes in this Realm or no RealmObject classes can be saved in the Realm.
      */
-    public abstract Set<? extends RealmObjectSchema> getAll();
+    public abstract Set<RealmObjectSchema> getAll();
 
     /**
      * Adds a new class to the Realm.

--- a/realm/realm-library/src/main/java/io/realm/StandardRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/StandardRealmObjectSchema.java
@@ -81,7 +81,8 @@ class StandardRealmObjectSchema extends RealmObjectSchema {
         this.columnIndices = columnIndices;
     }
 
-    public Table getTable() {
+    @Override
+    Table getTable() {
         return table;
     }
 
@@ -652,6 +653,7 @@ class StandardRealmObjectSchema extends RealmObjectSchema {
      * @return column index.
      * @throws IllegalArgumentException if the field does not exists.
      */
+    @Override
     long getAndCheckFieldIndex(String fieldName) {
         Long index = columnIndices.get(fieldName);
         if (index == null) {


### PR DESCRIPTION
fixes #4443 

I fixed incompatibility of `RealmSchema.getAll()` in addition to `BaseRealm.getSchema()`.

@realm/java 