### PR TITLE
KeepMember OsObject.notifyChangeListeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.2 (YYYY-MM-DD)
+
+### Bug Fixes
+
+* Crash caused by JNI couldn't find `OsObject.notifyChangeListeners` when ProGurad is enabled (#4461).
+
 ## 3.1.1 (2017-04-07)
 
 ### Deprecated

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
@@ -29,14 +29,14 @@ JavaMethod::JavaMethod(JNIEnv* env, jclass cls, const char* method_name, const c
         m_method_id = env->GetMethodID(cls, method_name, signature);
     }
 
-    REALM_ASSERT_DEBUG(m_method_id != nullptr);
+    REALM_ASSERT_RELEASE(m_method_id != nullptr);
 }
 
 JavaMethod::JavaMethod(JNIEnv* env, jobject obj, const char* method_name, const char* signature)
 {
     jclass cls = env->GetObjectClass(obj);
     m_method_id = env->GetMethodID(cls, method_name, signature);
-    REALM_ASSERT_DEBUG(m_method_id != nullptr);
+    REALM_ASSERT_RELEASE(m_method_id != nullptr);
     env->DeleteLocalRef(cls);
 }
 
@@ -44,7 +44,7 @@ JavaMethod::JavaMethod(JNIEnv* env, const char* class_name, const char* method_n
                        bool static_method)
 {
     jclass cls = env->FindClass(class_name);
-    REALM_ASSERT_DEBUG(cls != nullptr);
+    REALM_ASSERT_RELEASE(cls != nullptr);
     if (static_method) {
         m_method_id = env->GetStaticMethodID(cls, method_name, signature);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/OsObject.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsObject.java
@@ -24,6 +24,7 @@ import io.realm.RealmObjectChangeListener;
 /**
  * Java wrapper for Object Store's {@code Object} class. Currently it is only used for object notifications.
  */
+@KeepMember
 public class OsObject implements NativeObject {
 
     private static class OsObjectChangeSet implements ObjectChangeSet {
@@ -143,6 +144,7 @@ public class OsObject implements NativeObject {
 
     // Called by JNI
     @SuppressWarnings("unused")
+    @KeepMember
     private void notifyChangeListeners(String[] changedFields) {
         observerPairs.foreach(new Callback(changedFields));
     }


### PR DESCRIPTION
- Fix #4461.
- Use release assertion when finding java method.