### PR TITLE
Dont reset SharedRealm ptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@
 
 ### Enhancements
 
-* An `IllegalStateException` will be thrown when starting iterating `OrderedRealmCollection` if the Realm is closed (#4471).
-
 ### Bug Fixes
 
 * Crash caused by JNI couldn't find `OsObject.notifyChangeListeners` when ProGuard is enabled (#4461).
 * Incompatible return type of `RealmSchema.getAll()` and `BaseRealm.getSchema()` (#4443).
+* An `IllegalStateException` will be thrown when starting iterating `OrderedRealmCollection` if the Realm is closed (#4471).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* A ISE will be thrown when starting iterating `OrderedRealmCollection` if the Realm is closed (#4471).
+
 ### Bug Fixes
 
 * Crash caused by JNI couldn't find `OsObject.notifyChangeListeners` when ProGuard is enabled (#4461).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-* An ISE will be thrown when starting iterating `OrderedRealmCollection` if the Realm is closed (#4471).
+* An `IllegalStateException` will be thrown when starting iterating `OrderedRealmCollection` if the Realm is closed (#4471).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-* A ISE will be thrown when starting iterating `OrderedRealmCollection` if the Realm is closed (#4471).
+* An ISE will be thrown when starting iterating `OrderedRealmCollection` if the Realm is closed (#4471).
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
@@ -487,6 +487,14 @@ public class CollectionTests {
     }
 
     @Test
+    public void collectionIterator_newInstance_throwsWhenSharedRealmIsClosed() {
+        final Collection collection = new Collection(sharedRealm, table.where());
+        sharedRealm.close();
+        thrown.expect(IllegalStateException.class);
+        new TestIterator(collection);
+    }
+
+    @Test
     public void getMode() {
         Collection collection = new Collection(sharedRealm, table.where());
         assertTrue(Collection.Mode.QUERY == collection.getMode());

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/SharedRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/SharedRealmTests.java
@@ -53,7 +53,9 @@ public class SharedRealmTests {
 
     @After
     public void tearDown() {
-        sharedRealm.close();
+        if (sharedRealm != null) {
+            sharedRealm.close();
+        }
     }
 
     @Test
@@ -98,6 +100,13 @@ public class SharedRealmTests {
         assertTrue(sharedRealm.isInTransaction());
         sharedRealm.cancelTransaction();
         assertFalse(sharedRealm.isInTransaction());
+    }
+
+    @Test
+    public void isInTransaction_returnFalseWhenRealmClosed() {
+        sharedRealm.close();
+        assertFalse(sharedRealm.isInTransaction());
+        sharedRealm = null;
     }
 
     @Test
@@ -230,5 +239,20 @@ public class SharedRealmTests {
         sharedRealm.refresh();
         assertTrue(listenerCalled.get());
         assertEquals(before + 1, schemaVersionFromListener.get());
+    }
+
+    @Test
+    public void isClosed() {
+        sharedRealm.close();
+        assertTrue(sharedRealm.isClosed());
+        sharedRealm = null;
+    }
+
+    @Test
+    public void close_twice() {
+        sharedRealm.close();
+        sharedRealm.close();
+        assertTrue(sharedRealm.isClosed());
+        sharedRealm = null;
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -225,7 +225,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeCloseSharedRealm
 
     auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
     // Close the SharedRealm only. Let the finalizer daemon thread free the SharedRealm
-    shared_realm->close();
+    if (!shared_realm->is_closed()) {
+        shared_realm->close();
+    }
 }
 
 JNIEXPORT void JNICALL Java_io_realm_internal_SharedRealm_nativeBeginTransaction(JNIEnv* env, jclass,

--- a/realm/realm-library/src/main/java/io/realm/internal/Collection.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Collection.java
@@ -32,6 +32,9 @@ import io.realm.RealmChangeListener;
 @Keep
 public class Collection implements NativeObject {
 
+    private static final String CLOSED_REALM_MESSAGE =
+            "This Realm instance has already been closed, making it unusable.";
+
     private static class CollectionObserverPair<T> extends ObserverPairList.ObserverPair<T, Object> {
         public CollectionObserverPair(T observer, Object listener) {
             super(observer, listener);
@@ -94,6 +97,10 @@ public class Collection implements NativeObject {
         protected int pos = -1;
 
         public Iterator(Collection collection) {
+            if (collection.sharedRealm.isClosed()) {
+                throw new IllegalStateException(CLOSED_REALM_MESSAGE);
+            }
+
             this.iteratorCollection = collection;
 
             if (collection.isSnapshot) {

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -319,7 +319,7 @@ public final class SharedRealm implements Closeable, NativeObject {
     }
 
     public boolean isClosed() {
-        return nativePtr == 0 || nativeIsClosed(nativePtr);
+        return nativeIsClosed(nativePtr);
     }
 
     public void writeCopy(File file, byte[] key) {

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -176,7 +176,7 @@ public final class SharedRealm implements Closeable, NativeObject {
 
     private final RealmConfiguration configuration;
 
-    private long nativePtr;
+    final private long nativePtr;
     final Context context;
     private long lastSchemaVersion;
     private final SchemaVersionListener schemaChangeListener;
@@ -368,12 +368,9 @@ public final class SharedRealm implements Closeable, NativeObject {
             realmNotifier.close();
         }
         synchronized (context) {
-            if (nativePtr != 0) {
-                nativeCloseSharedRealm(nativePtr);
-                // It is OK to clear the nativePtr. It has been saved to the NativeObjectReference when adding to the
-                // context.
-                nativePtr = 0;
-            }
+            nativeCloseSharedRealm(nativePtr);
+            // Don't reset the nativePtr since we still rely on Object Store to check if the given SharedRealm ptr
+            // is closed or not.
         }
     }
 


### PR DESCRIPTION
- Keep the SharedRealm ptr valid when close it. To allow the is_closed
  checking could throw in the Object Store and it can be converted to a
  friendly Java exception.
- Check if SharedRealm is closed when create collection iterator. Throw
  an ISE if it is. Fix #4471 .