### PR TITLE
Clear pending collection first for findFirstAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 * `equals()` and `hashCode()` of managed `RealmObject`s that come from linking objects don't work correctly (#4487).
+* `NullPointerException` caused by local transaction inside the listener of `findFirstAsync()`'s results (#4495).
 
 ### Internal
 

--- a/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
@@ -227,8 +227,8 @@ public class PendingRow implements Row {
         if (pendingCollection.isValid()) {
             // PendingRow will always get the first Row of the query since we only support findFirst.
             UncheckedRow uncheckedRow = pendingCollection.firstUncheckedRow();
-            // Clear the pending collection immediately in case beginTransaction called in the listener which execute
-            // the query again.
+            // Clear the pending collection immediately in case beginTransaction is called in the listener which will
+            // execute the query again
             clearPendingCollection();
             // If no rows returned by the query, notify the frontend with an invalid row.
             if (uncheckedRow != null) {

--- a/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
@@ -222,6 +222,9 @@ public class PendingRow implements Row {
         if (pendingCollection.isValid()) {
             // PendingRow will always get the first Row of the query since we only support findFirst.
             UncheckedRow uncheckedRow = pendingCollection.firstUncheckedRow();
+            // Clear the pending collection immediately in case beginTransaction called in the listener which execute
+            // the query again.
+            clearPendingCollection();
             // If no rows returned by the query, notify the frontend with an invalid row.
             if (uncheckedRow != null) {
                 Row row = returnCheckedRow ? CheckedRow.getFromRow(uncheckedRow) : uncheckedRow;
@@ -231,9 +234,10 @@ public class PendingRow implements Row {
                 // No row matches the query, return a invalid row.
                 frontEnd.onQueryFinished(InvalidRow.INSTANCE);
             }
+        } else {
+            clearPendingCollection();
         }
 
-        clearPendingCollection();
     }
 
     // Execute the query immediately and call frontend's onQueryFinished().

--- a/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
@@ -228,7 +228,7 @@ public class PendingRow implements Row {
             // PendingRow will always get the first Row of the query since we only support findFirst.
             UncheckedRow uncheckedRow = pendingCollection.firstUncheckedRow();
             // Clear the pending collection immediately in case beginTransaction is called in the listener which will
-            // execute the query again
+            // execute the query again.
             clearPendingCollection();
             // If no rows returned by the query, notify the frontend with an invalid row.
             if (uncheckedRow != null) {


### PR DESCRIPTION
Otherwise the pending query will be executed again if there is a local
transaction in the listener. That would cause a infinite recursion or
NPE (like #4495).

Fix #4495