### PR TITLE
Re-add Realm.refresh()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [ObjectServer] Added support for `SyncUser.isAdmin()` (#4353).
 * Transient fields are now allowed in model classes, but are implicitly treated as having the `@Ignore` annotation (#4279).
+* Added `Realm.refresh()` and `DynamicRealm.refresh()` (#3476).
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3916,7 +3916,7 @@ public class RealmTests {
                 realm.close();
                 bgThreadDone.countDown();
             }
-        }).run();
+        }).start();
         TestHelper.awaitOrFail(bgThreadDone);
 
         realm.refresh();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -57,6 +57,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -3828,5 +3829,109 @@ public class RealmTests {
         // Tests if it works when the namedPipeDir and the named pipe files already exist.
         realmOnExternalStorage = Realm.getInstance(config);
         realmOnExternalStorage.close();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void refresh_triggerNotifications() {
+        final CountDownLatch bgThreadDone = new CountDownLatch(1);
+        final AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        Realm realm = looperThread.realm;
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
+        assertEquals(0, results.size());
+        results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> results) {
+                assertEquals(1, results.size());
+                listenerCalled.set(true);
+            }
+        });
+
+        // Advance the Realm on a background while blocking this thread. When we refresh, it should trigger
+        // the listener.
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(looperThread.realmConfiguration);
+                realm.beginTransaction();
+                realm.createObject(AllTypes.class);
+                realm.commitTransaction();
+                realm.close();
+                bgThreadDone.countDown();
+            }
+        }).run();
+        TestHelper.awaitOrFail(bgThreadDone);
+
+        realm.refresh();
+        assertTrue(listenerCalled.get());
+        looperThread.testComplete();
+    }
+
+    @Test
+    public void refresh_nonLooperThreadAdvances() {
+        final CountDownLatch bgThreadDone = new CountDownLatch(1);
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
+        assertEquals(0, results.size());
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(RealmTests.this.realm.getConfiguration());
+                realm.beginTransaction();
+                realm.createObject(AllTypes.class);
+                realm.commitTransaction();
+                realm.close();
+                bgThreadDone.countDown();
+            }
+        }).run();
+        TestHelper.awaitOrFail(bgThreadDone);
+
+        realm.refresh();
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void refresh_forceSynchronousNotifications() {
+        final CountDownLatch bgThreadDone = new CountDownLatch(1);
+        final AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        Realm realm = looperThread.realm;
+        RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
+        results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
+            @Override
+            public void onChange(RealmResults<AllTypes> results) {
+                // Will be forced synchronous
+                assertEquals(1, results.size());
+                listenerCalled.set(true);
+            }
+        });
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(looperThread.realmConfiguration);
+                realm.beginTransaction();
+                realm.createObject(AllTypes.class);
+                realm.commitTransaction();
+                realm.close();
+                bgThreadDone.countDown();
+            }
+        }).run();
+        TestHelper.awaitOrFail(bgThreadDone);
+
+        realm.refresh();
+        assertTrue(listenerCalled.get());
+        looperThread.testComplete();
+    }
+
+    @Test
+    public void refresh_insideTransactionThrows() {
+        realm.beginTransaction();
+        try {
+            realm.refresh();
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
+        realm.cancelTransaction();
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -115,9 +115,11 @@ abstract class BaseRealm implements Closeable {
 
     /**
      * Refreshes the Realm instance and all the RealmResults and RealmObjects instances coming from it.
-     * It also calls the listeners associated to the Realm instance.
-     *
-     * Calling this on a thread with async queries will turn those queries into synchronous queries.
+     * It also calls any listeners associated with the Realm if neeeded.
+     * <p>
+     * WARNING: Calling this on a thread with async queries will turn those queries into synchronous queries.
+     * In most cases it is better to use {@link RealmChangeListener}s to be notified about changes to the
+     * Realm on a given thread than it is to use this method. 
      *
      * @throws IllegalStateException if attempting to refresh from within a transaction.
      */

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -114,6 +114,22 @@ abstract class BaseRealm implements Closeable {
     }
 
     /**
+     * Refreshes the Realm instance and all the RealmResults and RealmObjects instances coming from it.
+     * It also calls the listeners associated to the Realm instance.
+     *
+     * Calling this on a thread with async queries will turn those queries into synchronous queries.
+     *
+     * @throws IllegalStateException if attempting to refresh from within a transaction.
+     */
+    public void refresh() {
+        checkIfValid();
+        if (isInTransaction()) {
+            throw new IllegalStateException("Cannot refresh a Realm instance inside a transaction.");
+        }
+        sharedRealm.refresh();
+    }
+
+    /**
      * Checks if the Realm is currently in a transaction.
      *
      * @return {@code true} if inside a transaction, {@code false} otherwise.


### PR DESCRIPTION
Closes #3476 

This PR adds back `refresh()`. Mostly for two reasons:

1) With the adoption of the ObjectStore and Snapshots for iterations, the reasons we originally removed `refresh()` in favour of `waitForChange()` for are no longer valid.

2) We keep getting support requests by people using event buses and such instead of RealmChangeListeners. In some of those cases `refresh()` does make sense, so this would lessen the support burden as well.

3) @Zhuinden no longer have to keep various hacks up to date ( Just kidding mate, we really appreciate what you are doing 😄  💯 ) 

Feel free to tell me if this is just stupid, but then we should probably also close #3476 with a Wont Fix.
