### PR TITLE
Add manualClean task, which works without requiring any dependency artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,6 +289,12 @@ task manualClean {
             workingDir "${rootDir}"
             commandLine 'find', '.', '-mindepth', '2', '-type', 'd', '-name', '.gradle', '-print', '-exec', 'rm', '-rf', '{}', ';', '-prune'
         }
+
+        // clean ${System.env.HOME}/.m2/repository/io/realm
+        exec {
+            workingDir "${rootDir}"
+            commandLine 'sh', '-c', "echo \"${System.env.HOME}/.m2/repository/io/realm\" && rm -rf \"${System.env.HOME}/.m2/repository/io/realm\""
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -267,6 +267,31 @@ task clean {
     dependsOn cleanLocalMavenRepos
 }
 
+task manualClean {
+    description = 'Clean build files manually, which means that this task works without clean tasks'
+    group = 'Clean'
+
+    doLast {
+        // clean 'build' directories
+        exec {
+            workingDir "${rootDir}"
+            commandLine 'find', '.', '-type', 'd', '-name', 'build', '-print', '-exec', 'rm', '-rf', '{}', ';', '-prune'
+        }
+
+        // clean '.externalNativeBuild' directories
+        exec {
+            workingDir "${rootDir}"
+            commandLine 'find', '.', '-type', 'd', '-name', '.externalNativeBuild', '-print', '-exec', 'rm', '-rf', '{}', ';', '-prune'
+        }
+
+        // clean '.gradle' directories except one in the root
+        exec {
+            workingDir "${rootDir}"
+            commandLine 'find', '.', '-mindepth', '2', '-type', 'd', '-name', '.gradle', '-print', '-exec', 'rm', '-rf', '{}', ';', '-prune'
+        }
+    }
+}
+
 task uploadDistributionPackage {
     group = 'Release'
     description = 'Upload the distribution package to S3'

--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ task clean {
 }
 
 task manualClean {
-    description = 'Clean build files manually, which means that this task works without clean tasks'
+    description = 'Clean build files without using clean tasks defined in sub projects'
     group = 'Clean'
 
     doLast {


### PR DESCRIPTION
Current `clean` task depends on the artifacts of the project itself. That means `clean` task only works after successful build.

I've added `manualClean` task, which removes all build files without requiring any artifacts.

@realm/java 