### PR TITLE
Try to create getFilesDir if it doesn't exist on startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * Added missing row validation check in certain cases on invalidated/deleted objects (#4540).
+* Initializing Realm is now more resilient if `Context.getFilesDir()` isn't working correctly (#4493).
 
 ## 3.1.3 (2017-04-20)
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3844,7 +3844,7 @@ public class RealmTests {
     // This is pretty hard to test, so forced to break encapsulation in this case.
     @Test
     public void init_waitForFilesDir() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, IOException {
-        java.lang.reflect.Method m = Realm.class.getDeclaredMethod("checkUserDirectoryAvailable", android.content.Context.class);
+        java.lang.reflect.Method m = Realm.class.getDeclaredMethod("checkFilesDirAvailable", Context.class);
         m.setAccessible(true);
 
         // A) Check it fails if getFilesDir is never created

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -38,12 +38,17 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -116,6 +121,9 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 
 @RunWith(AndroidJUnit4.class)
 public class RealmTests {
@@ -127,6 +135,8 @@ public class RealmTests {
     public final RunInLooperThread looperThread = new RunInLooperThread();
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
@@ -3828,5 +3838,38 @@ public class RealmTests {
         // Tests if it works when the namedPipeDir and the named pipe files already exist.
         realmOnExternalStorage = Realm.getInstance(config);
         realmOnExternalStorage.close();
+    }
+
+    // Verify that the logic for waiting for the users file dir to be come available isn't totally broken
+    // This is pretty hard to test, so forced to break encapsulation in this case.
+    @Test
+    public void init_waitForFilesDir() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, IOException {
+        java.lang.reflect.Method m = Realm.class.getDeclaredMethod("checkUserDirectoryAvailable", android.content.Context.class);
+        m.setAccessible(true);
+
+        // A) Check it fails if getFilesDir is never created
+        Context mockContext = mock(Context.class);
+        when(mockContext.getFilesDir()).thenReturn(null);
+
+        try {
+            m.invoke(null, mockContext);
+            fail();
+        } catch (InvocationTargetException e) {
+            assertEquals(IllegalStateException.class, e.getCause().getClass());
+        }
+
+        // B) Check we return if the filesDir becomes available after a while
+        mockContext = mock(Context.class);
+        when(mockContext.getFilesDir()).then(new Answer<File>() {
+            int calls = 0;
+            File userFolder = tmpFolder.newFolder();
+            @Override
+            public File answer(InvocationOnMock invocationOnMock) throws Throwable {
+                calls++;
+                return (calls > 5) ? userFolder : null; // Start returning the correct folder after 5 attempts
+            }
+        });
+
+        assertNull(m.invoke(null, mockContext));
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -245,7 +245,7 @@ public class Realm extends BaseRealm {
 
         // One final check before giving up
         if (context.getFilesDir() == null || !context.getFilesDir().exists()) {
-            throw new IllegalStateException("Context.getFilesDir() could not be found. See https://issuetracker.google.com/issues/36918154");
+            throw new IllegalStateException("Context.getFilesDir() returns " + context.getFilesDir() + " which is not an existing directory. See https://issuetracker.google.com/issues/36918154");
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -211,13 +211,17 @@ public class Realm extends BaseRealm {
      */
     private static void checkUserDirectoryAvailable(Context context) {
         File userDir = context.getFilesDir();
-        if (userDir != null && !userDir.exists()) {
-            try {
-                // This was reported as working on some devices, which I really hope is just the race condition
-                // kicking in, otherwise something is seriously wrong with the permission system on those devices.
-                // We will try it anyway, since starting a loop will be slower by many magnitudes.
-                userDir.mkdirs();
-            } catch (SecurityException ignored) {
+        if (userDir != null) {
+            if (userDir.exists()) {
+                return; // Everything is fine. Escape as soon as possible
+            } else {
+                try {
+                    // This was reported as working on some devices, which I really hope is just the race condition
+                    // kicking in, otherwise something is seriously wrong with the permission system on those devices.
+                    // We will try it anyway, since starting a loop will be slower by many magnitudes.
+                    userDir.mkdirs();
+                } catch (SecurityException ignored) {
+                }
             }
         }
         if (userDir == null || !userDir.exists()) {
@@ -244,7 +248,7 @@ public class Realm extends BaseRealm {
             throw new IllegalStateException("Context.getFilesDir() could not be found. See https://issuetracker.google.com/issues/36918154");
         }
     }
-    
+
     /**
      * Realm static constructor that returns the Realm instance defined by the {@link io.realm.RealmConfiguration} set
      * by {@link #setDefaultConfiguration(RealmConfiguration)}

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -20,6 +20,7 @@ import android.annotation.TargetApi;
 import android.app.IntentService;
 import android.content.Context;
 import android.os.Build;
+import android.os.SystemClock;
 import android.util.JsonReader;
 
 import org.json.JSONArray;
@@ -179,6 +180,7 @@ public class Realm extends BaseRealm {
      *
      * @param context the Application Context.
      * @throws IllegalArgumentException if a {@code null} context is provided.
+     * @throws IllegalStateException if {@link Context#getFilesDir()} could not be found.
      * @see #getDefaultInstance()
      */
     public static synchronized void init(Context context) {
@@ -186,6 +188,7 @@ public class Realm extends BaseRealm {
             if (context == null) {
                 throw new IllegalArgumentException("Non-null context required.");
             }
+            checkUserDirectoryAvailable(context);
             RealmCore.loadLibrary(context);
             defaultConfiguration = new RealmConfiguration.Builder(context).build();
             ObjectServerFacade.getSyncFacadeIfPossible().init(context);
@@ -194,6 +197,54 @@ public class Realm extends BaseRealm {
         }
     }
 
+    /**
+     * In some cases, Context.getFilesDir() is not available when the app launches the first time.
+     * This should never happen according to the official Android documentation, but the race condition wasn't fixed
+     * until Android 4.4.
+     * <p>
+     * This method attempts to fix that situation. If this doesn't work an {@link IllegalStateException} will be
+     * thrown.
+     * <p>
+     * See these links for further details:
+     * https://issuetracker.google.com/issues/36918154
+     * https://github.com/realm/realm-java/issues/4493#issuecomment-295349044
+     */
+    private static void checkUserDirectoryAvailable(Context context) {
+        File userDir = context.getFilesDir();
+        if (userDir != null && !userDir.exists()) {
+            try {
+                // This was reported as working on some devices, which I really hope is just the race condition
+                // kicking in, otherwise something is seriously wrong with the permission system on those devices.
+                // We will try it anyway, since starting a loop will be slower by many magnitudes.
+                userDir.mkdirs();
+            } catch (SecurityException ignored) {
+            }
+        }
+        if (userDir == null || !userDir.exists()) {
+            // Wait a "reasonable" amount of time before quitting.
+            // In this case we define reasonable as 200 ms (~12 dropped frames) before giving up (which most likely
+            // will result in the app crashing). This lag would only be seen in worst case scenarios, and then, only
+            // when the app is started the first time.
+            long[] timeoutsMs = new long[]{1, 2, 5, 10, 16}; // Exponential waits, capped at 16 ms;
+            long maxTotalWaitMs = 200;
+            long currentTotalWaitMs = 0;
+            int waitIndex = -1;
+            while (context.getFilesDir() == null || !context.getFilesDir().exists()) {
+                long waitMs = timeoutsMs[Math.min(++waitIndex, timeoutsMs.length - 1)];
+                SystemClock.sleep(waitMs);
+                currentTotalWaitMs += waitMs;
+                if (currentTotalWaitMs > maxTotalWaitMs) {
+                    break;
+                }
+            }
+        }
+
+        // One final check before giving up
+        if (context.getFilesDir() == null || !context.getFilesDir().exists()) {
+            throw new IllegalStateException("Context.getFilesDir() could not be found. See https://issuetracker.google.com/issues/36918154");
+        }
+    }
+    
     /**
      * Realm static constructor that returns the Realm instance defined by the {@link io.realm.RealmConfiguration} set
      * by {@link #setDefaultConfiguration(RealmConfiguration)}

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -188,7 +188,7 @@ public class Realm extends BaseRealm {
             if (context == null) {
                 throw new IllegalArgumentException("Non-null context required.");
             }
-            checkUserDirectoryAvailable(context);
+            checkFilesDirAvailable(context);
             RealmCore.loadLibrary(context);
             defaultConfiguration = new RealmConfiguration.Builder(context).build();
             ObjectServerFacade.getSyncFacadeIfPossible().init(context);
@@ -209,22 +209,22 @@ public class Realm extends BaseRealm {
      * https://issuetracker.google.com/issues/36918154
      * https://github.com/realm/realm-java/issues/4493#issuecomment-295349044
      */
-    private static void checkUserDirectoryAvailable(Context context) {
-        File userDir = context.getFilesDir();
-        if (userDir != null) {
-            if (userDir.exists()) {
+    private static void checkFilesDirAvailable(Context context) {
+        File filesDir = context.getFilesDir();
+        if (filesDir != null) {
+            if (filesDir.exists()) {
                 return; // Everything is fine. Escape as soon as possible
             } else {
                 try {
                     // This was reported as working on some devices, which I really hope is just the race condition
                     // kicking in, otherwise something is seriously wrong with the permission system on those devices.
                     // We will try it anyway, since starting a loop will be slower by many magnitudes.
-                    userDir.mkdirs();
+                    filesDir.mkdirs();
                 } catch (SecurityException ignored) {
                 }
             }
         }
-        if (userDir == null || !userDir.exists()) {
+        if (filesDir == null || !filesDir.exists()) {
             // Wait a "reasonable" amount of time before quitting.
             // In this case we define reasonable as 200 ms (~12 dropped frames) before giving up (which most likely
             // will result in the app crashing). This lag would only be seen in worst case scenarios, and then, only


### PR DESCRIPTION
Closes #4493 

We cannot "fix" it, but this way we try as hard as possible to recover from the situation, and if that fails we throw a better exception, explaining the situation.

/cc @rajuashok 