### PR TITLE
Fix threading bugs in RunInLooperThread rule

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -356,7 +356,7 @@ public class DynamicRealmTests {
                 .between(AllTypes.FIELD_LONG, 4, 9)
                 .findFirstAsync();
         assertFalse(allTypes.isLoaded());
-        looperThread.keepStrongReference.add(allTypes);
+        looperThread.keepStrongReference(allTypes);
         allTypes.addChangeListener(new RealmChangeListener<DynamicRealmObject>() {
             @Override
             public void onChange(DynamicRealmObject object) {
@@ -389,7 +389,7 @@ public class DynamicRealmTests {
                 looperThread.testComplete();
             }
         });
-        looperThread.keepStrongReference.add(allTypes);
+        looperThread.keepStrongReference(allTypes);
     }
 
     @Test
@@ -414,15 +414,15 @@ public class DynamicRealmTests {
                 looperThread.testComplete();
             }
         });
-        looperThread.keepStrongReference.add(allTypes);
+        looperThread.keepStrongReference(allTypes);
     }
 
     // Initializes a Dynamic Realm used by the *Async tests and keeps it ref in the looperThread.
     private DynamicRealm initializeDynamicRealm() {
-        RealmConfiguration defaultConfig = looperThread.realmConfiguration;
+        RealmConfiguration defaultConfig = looperThread.getConfiguration();
         final DynamicRealm dynamicRealm = DynamicRealm.getInstance(defaultConfig);
         populateTestRealm(dynamicRealm, 10);
-        looperThread.keepStrongReference.add(dynamicRealm);
+        looperThread.keepStrongReference(dynamicRealm);
         return dynamicRealm;
     }
 
@@ -531,8 +531,8 @@ public class DynamicRealmTests {
                 signalCallbackDone.run();
             }
         });
-        looperThread.keepStrongReference.add(realmResults1);
-        looperThread.keepStrongReference.add(realmResults2);
+        looperThread.keepStrongReference(realmResults1);
+        looperThread.keepStrongReference(realmResults2);
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/LinkingObjectsManagedTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/LinkingObjectsManagedTests.java
@@ -172,7 +172,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void notification_notSentAfterUnregisterListenerModelObject() {
-        final Realm looperThreadRealm = looperThread.realm;
+        final Realm looperThreadRealm = looperThread.getRealm();
 
         looperThreadRealm.beginTransaction();
         AllJavaTypes child = looperThreadRealm.createObject(AllJavaTypes.class, 10);
@@ -207,7 +207,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void notification_onCommitRealmResults() {
-        final Realm looperThreadRealm = looperThread.realm;
+        final Realm looperThreadRealm = looperThread.getRealm();
 
         looperThreadRealm.beginTransaction();
         AllJavaTypes child = looperThreadRealm.createObject(AllJavaTypes.class, 10);
@@ -243,7 +243,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void notification_notSentAfterUnregisterListenerRealmResults() {
-        final Realm looperThreadRealm = looperThread.realm;
+        final Realm looperThreadRealm = looperThread.getRealm();
 
         looperThreadRealm.beginTransaction();
         AllJavaTypes child = looperThreadRealm.createObject(AllJavaTypes.class, 10);
@@ -279,7 +279,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void notification_onDeleteRealmResults() {
-        final Realm looperThreadRealm = looperThread.realm;
+        final Realm looperThreadRealm = looperThread.getRealm();
 
         looperThreadRealm.beginTransaction();
         AllJavaTypes child = looperThreadRealm.createObject(AllJavaTypes.class, 10);
@@ -316,7 +316,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void notification_notSentOnUnrelatedChangeRealmResults() {
-        final Realm looperThreadRealm = looperThread.realm;
+        final Realm looperThreadRealm = looperThread.getRealm();
 
         looperThreadRealm.beginTransaction();
         AllJavaTypes child = looperThreadRealm.createObject(AllJavaTypes.class, 10);
@@ -405,7 +405,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void linkingObjects_IllegalStateException_ifNotYetLoaded() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.executeTransaction(new Realm.Transaction() {
             @Override
@@ -433,7 +433,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void linkingObjects_IllegalStateException_ifDeleted() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.executeTransaction(new Realm.Transaction() {
             @Override
@@ -468,7 +468,7 @@ public class LinkingObjectsManagedTests {
     @Test
     @RunTestInLooperThread
     public void linkingObjects_IllegalStateException_ifDeletedIndirectly() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.executeTransaction(new Realm.Transaction() {
             @Override
@@ -794,7 +794,9 @@ public class LinkingObjectsManagedTests {
         realm.commitTransaction();
 
         // Runnable is guaranteed to be enqueued on the Looper queue, after the notifications
-        looperThread.keepStrongReference.addAll(Arrays.asList(refs));
+        for (Object ref : refs) {
+            looperThread.keepStrongReference(ref);
+        }
         looperThread.postRunnable(
             new Runnable() {
                 @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/NotificationsTest.java
@@ -162,7 +162,7 @@ public class NotificationsTest {
             }
         };
 
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.addChangeListener(listener);
         realm.addChangeListener(listener);
         realm.addChangeListener(new RealmChangeListener<Realm>() {
@@ -317,7 +317,7 @@ public class NotificationsTest {
     @RunTestInLooperThread
     public void globalListener_looperThread_triggeredByLocalCommit() {
         final AtomicInteger success = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -335,7 +335,7 @@ public class NotificationsTest {
     @RunTestInLooperThread
     public void globalListener_looperThread_triggeredByRemoteCommit() {
         final AtomicInteger success = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -361,7 +361,7 @@ public class NotificationsTest {
                 looperThread.testComplete();
             }
         };
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.addChangeListener(listener);
         realm.beginTransaction();
         realm.commitTransaction();
@@ -370,7 +370,7 @@ public class NotificationsTest {
     @Test
     @RunTestInLooperThread
     public void addRemoveListenerConcurrency() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final AtomicInteger counter1 = new AtomicInteger(0);
         final AtomicInteger counter2 = new AtomicInteger(0);
         final AtomicInteger counter3 = new AtomicInteger(0);
@@ -447,7 +447,7 @@ public class NotificationsTest {
         // Test both ways to check accidental ordering from unordered collections.
         final AtomicInteger listenerACalled = new AtomicInteger(0);
         final AtomicInteger listenerBCalled = new AtomicInteger(0);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         final RealmChangeListener<Realm> listenerA = new RealmChangeListener<Realm>() {
 
@@ -690,12 +690,12 @@ public class NotificationsTest {
     @Test
     @RunTestInLooperThread
     public void asyncRealmResultsShouldNotBlockBackgroundCommitNotification() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmResults<Dog> dogs = realm.where(Dog.class).findAllAsync();
         final AtomicBoolean resultsListenerDone = new AtomicBoolean(false);
         final AtomicBoolean realmListenerDone = new AtomicBoolean(false);
 
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         assertTrue(dogs.load());
         assertEquals(0, dogs.size());
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
@@ -750,7 +750,7 @@ public class NotificationsTest {
     public void asyncRealmObjectShouldNotBlockBackgroundCommitNotification() {
         final AtomicInteger numberOfRealmCallbackInvocation = new AtomicInteger(0);
         final CountDownLatch signalClosedRealm = new CountDownLatch(1);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(final Realm realm) {
@@ -816,7 +816,7 @@ public class NotificationsTest {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void realmListener_realmResultShouldBeSynced() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
         assertEquals(1, results.size());
 
@@ -844,13 +844,13 @@ public class NotificationsTest {
     @Test
     @RunTestInLooperThread
     public void accessingSyncRealmResultInsideAsyncResultListener() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final AtomicInteger asyncResultCallback = new AtomicInteger(0);
 
         final RealmResults<AllTypes> syncResults = realm.where(AllTypes.class).findAll();
 
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
-        looperThread.keepStrongReference.add(results);
+        looperThread.keepStrongReference(results);
         results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> results) {
@@ -884,11 +884,11 @@ public class NotificationsTest {
     @Test
     @RunTestInLooperThread
     public void accessingSyncRealmResultsInsideAnotherResultListener() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmResults<AllTypes> syncResults1 = realm.where(AllTypes.class).findAll();
         final RealmResults<AllTypes> syncResults2 = realm.where(AllTypes.class).findAll();
 
-        looperThread.keepStrongReference.add(syncResults1);
+        looperThread.keepStrongReference(syncResults1);
         syncResults1.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> element) {
@@ -906,7 +906,7 @@ public class NotificationsTest {
     @Test
     @RunTestInLooperThread(threadName = "IntentService[1]")
     public void listenersNotAllowedOnIntentServiceThreads() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ObjectChangeSetTests.java
@@ -76,7 +76,7 @@ public class ObjectChangeSetTests {
                 looperThread.testComplete();
             }
         });
-        looperThread.keepStrongReference.add(allTypes);
+        looperThread.keepStrongReference(allTypes);
     }
 
     private void checkChangedField(AllTypes allTypes, final String... fieldNames) {
@@ -96,7 +96,7 @@ public class ObjectChangeSetTests {
                 looperThread.testComplete();
             }
         });
-        looperThread.keepStrongReference.add(allTypes);
+        looperThread.keepStrongReference(allTypes);
     }
 
     private void listenerShouldNotBeCalled(AllTypes allTypes) {
@@ -117,7 +117,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void objectDeleted() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkDeleted(allTypes);
         realm.beginTransaction();
@@ -128,7 +128,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeLongField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_LONG);
         realm.beginTransaction();
@@ -139,7 +139,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeStringField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_STRING);
         realm.beginTransaction();
@@ -150,7 +150,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeFloatField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_FLOAT);
         realm.beginTransaction();
@@ -161,7 +161,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeDoubleField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_DOUBLE);
         realm.beginTransaction();
@@ -172,7 +172,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeBooleanField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_BOOLEAN);
         realm.beginTransaction();
@@ -183,7 +183,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeDateField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_DATE);
         realm.beginTransaction();
@@ -194,7 +194,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeBinaryField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_BINARY);
         realm.beginTransaction();
@@ -205,7 +205,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeLinkFieldSetNewObject() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_REALMOBJECT);
         realm.beginTransaction();
@@ -216,7 +216,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeLinkFieldSetNull() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_REALMOBJECT);
         realm.beginTransaction();
@@ -227,7 +227,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeLinkFieldRemoveObject() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_REALMOBJECT);
         realm.beginTransaction();
@@ -238,7 +238,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeLinkFieldOriginalObjectChanged_notTrigger() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         listenerShouldNotBeCalled(allTypes);
         realm.beginTransaction();
@@ -249,7 +249,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeLinkListAddObject() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_REALMLIST);
         realm.beginTransaction();
@@ -260,7 +260,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeLinkListClear() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_REALMLIST);
         realm.beginTransaction();
@@ -271,7 +271,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeAllFields() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         checkChangedField(allTypes, AllTypes.FIELD_LONG, AllTypes.FIELD_REALMLIST, AllTypes.FIELD_REALMOBJECT,
                 AllTypes.FIELD_DOUBLE, AllTypes.FIELD_FLOAT, AllTypes.FIELD_STRING, AllTypes.FIELD_BOOLEAN,
@@ -295,7 +295,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void changeDifferentFieldOneAfterAnother() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirst();
         final AtomicBoolean stringChanged = new AtomicBoolean(false);
         final AtomicBoolean longChanged = new AtomicBoolean(false);
@@ -339,7 +339,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void findFirstAsync_changeSetIsNullWhenQueryReturns() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         AllTypes allTypes = realm.where(AllTypes.class).findFirstAsync();
         allTypes.addChangeListener(new RealmObjectChangeListener<AllTypes>() {
             @Override
@@ -357,7 +357,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread(before = PopulateOneAllTypes.class)
     public void findFirstAsync_queryExecutedByLocalCommit() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final AtomicInteger listenerCounter = new AtomicInteger(0);
         final AllTypes allTypes = realm.where(AllTypes.class).findFirstAsync();
         allTypes.addChangeListener(new RealmObjectChangeListener<AllTypes>() {
@@ -423,7 +423,7 @@ public class ObjectChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void allParentObjectShouldBeInChangeSet() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         Owner owner = realm.createObject(Owner.class);
@@ -443,7 +443,7 @@ public class ObjectChangeSetTests {
         realm.commitTransaction();
 
         RealmResults<Dog> dogs = realm.where(Dog.class).equalTo(Dog.FIELD_HAS_TAIL, true).findAll();
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> collection, OrderedCollectionChangeSet changeSet) {

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import android.util.Log;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -157,7 +159,7 @@ public class OrderedCollectionChangeSetTests {
         switch (type) {
             case REALM_RESULTS:
                 RealmResults<Dog> results = realm.where(Dog.class).findAllSorted(Dog.FIELD_AGE);
-                looperThread.keepStrongReference.add(results);
+                looperThread.keepStrongReference(results);
                 results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<Dog>>() {
                     @Override
                     public void onChange(RealmResults<Dog> collection, OrderedCollectionChangeSet changeSet) {
@@ -167,7 +169,7 @@ public class OrderedCollectionChangeSetTests {
                 break;
             case REALM_LIST:
                 RealmList<Dog> list = realm.where(Owner.class).findFirst().getDogs();
-                looperThread.keepStrongReference.add(list);
+                looperThread.keepStrongReference(list);
                 list.addChangeListener(new OrderedRealmCollectionChangeListener<RealmList<Dog>>() {
                     @Override
                     public void onChange(RealmList<Dog> collection, OrderedCollectionChangeSet changeSet) {
@@ -181,7 +183,7 @@ public class OrderedCollectionChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void deletion() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateData(realm, 10);
 
         final ChangesCheck changesCheck = new ChangesCheck() {
@@ -213,7 +215,7 @@ public class OrderedCollectionChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void insertion() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateData(realm, 0); // We need to create the owner.
         realm.beginTransaction();
         createObjects(realm, 0, 2, 5, 6, 7, 9);
@@ -247,7 +249,7 @@ public class OrderedCollectionChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void changes() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateData(realm, 10);
         ChangesCheck changesCheck = new ChangesCheck() {
             @Override
@@ -278,7 +280,7 @@ public class OrderedCollectionChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void moves() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateData(realm, 10);
         ChangesCheck changesCheck = new ChangesCheck() {
             @Override
@@ -307,7 +309,7 @@ public class OrderedCollectionChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void mixed_changes() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateData(realm, 10);
         ChangesCheck changesCheck = new ChangesCheck() {
             @Override
@@ -347,7 +349,7 @@ public class OrderedCollectionChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void changes_then_delete() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateData(realm, 10);
         ChangesCheck changesCheck = new ChangesCheck() {
             @Override
@@ -377,7 +379,7 @@ public class OrderedCollectionChangeSetTests {
     @Test
     @RunTestInLooperThread
     public void insert_then_delete() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateData(realm, 10);
         ChangesCheck changesCheck = new ChangesCheck() {
             @Override
@@ -409,7 +411,10 @@ public class OrderedCollectionChangeSetTests {
             looperThread.testComplete();
             return;
         }
-        Realm realm = looperThread.realm;
+
+        Log.d("####", "test running on thread: " + Thread.currentThread());
+
+        Realm realm = looperThread.getRealm();
         populateData(realm, 10);
         final RealmResults<Dog> results = realm.where(Dog.class).findAllSortedAsync(Dog.FIELD_AGE);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<Dog>>() {
@@ -429,7 +434,8 @@ public class OrderedCollectionChangeSetTests {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                Realm realm = Realm.getInstance(looperThread.realmConfiguration)      ;
+                Log.d("####", "runnable running on thread: " + Thread.currentThread());
+                Realm realm = Realm.getInstance(looperThread.getConfiguration())      ;
                 realm.beginTransaction();
                 realm.where(Dog.class).equalTo(Dog.FIELD_AGE, 0).findFirst().deleteFromRealm();
                 realm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -71,7 +71,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void executeTransactionAsync() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         assertEquals(0, realm.where(Owner.class).count());
 
         realm.executeTransactionAsync(new Realm.Transaction() {
@@ -99,7 +99,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void executeTransactionAsync_onSuccess() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         assertEquals(0, realm.where(Owner.class).count());
 
         realm.executeTransactionAsync(new Realm.Transaction() {
@@ -121,7 +121,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void executeTransactionAsync_onSuccessCallerRealmClosed() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         assertEquals(0, realm.where(Owner.class).count());
 
         realm.executeTransactionAsync(new Realm.Transaction() {
@@ -134,7 +134,7 @@ public class RealmAsyncQueryTests {
             @Override
             public void onSuccess() {
                 assertTrue(realm.isClosed());
-                Realm newRealm = Realm.getInstance(looperThread.realmConfiguration);
+                Realm newRealm = Realm.getInstance(looperThread.getConfiguration());
                 assertEquals(1, newRealm.where(Owner.class).count());
                 assertEquals("Owner", newRealm.where(Owner.class).findFirst().getName());
                 newRealm.close();
@@ -147,7 +147,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void executeTransactionAsync_onError() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RuntimeException runtimeException = new RuntimeException("Oh! What a Terrible Failure");
         assertEquals(0, realm.where(Owner.class).count());
 
@@ -170,7 +170,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void executeTransactionAsync_onErrorCallerRealmClosed() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RuntimeException runtimeException = new RuntimeException("Oh! What a Terrible Failure");
         assertEquals(0, realm.where(Owner.class).count());
 
@@ -183,7 +183,7 @@ public class RealmAsyncQueryTests {
             @Override
             public void onError(Throwable error) {
                 assertTrue(realm.isClosed());
-                Realm newRealm = Realm.getInstance(looperThread.realmConfiguration);
+                Realm newRealm = Realm.getInstance(looperThread.getConfiguration());
                 assertEquals(0, newRealm.where(Owner.class).count());
                 assertNull(newRealm.where(Owner.class).findFirst());
                 assertEquals(runtimeException, error);
@@ -197,7 +197,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void executeTransactionAsync_NoCallbacks() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         assertEquals(0, realm.where(Owner.class).count());
 
         realm.executeTransactionAsync(new Realm.Transaction() {
@@ -223,7 +223,7 @@ public class RealmAsyncQueryTests {
         final TestHelper.TestLogger testLogger = new TestHelper.TestLogger(LogLevel.DEBUG);
         RealmLog.add(testLogger);
 
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         assertEquals(0, realm.where(Owner.class).count());
 
@@ -257,7 +257,7 @@ public class RealmAsyncQueryTests {
     @RunTestInLooperThread
     public void executeTransactionAsync_realmClosedOnSuccess() {
         final AtomicInteger counter = new AtomicInteger(100);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmCache.Callback cacheCallback = new RealmCache.Callback() {
             @Override
             public void onResult(int count) {
@@ -296,7 +296,7 @@ public class RealmAsyncQueryTests {
     @RunTestInLooperThread
     public void executeTransaction_async_realmClosedOnError() {
         final AtomicInteger counter = new AtomicInteger(100);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmCache.Callback cacheCallback = new RealmCache.Callback() {
             @Override
             public void onResult(int count) {
@@ -337,7 +337,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void executeTransactionAsync_asyncQuery() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
         assertEquals(0, results.size());
 
@@ -414,7 +414,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findAllAsync() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
         final RealmResults<AllTypes> results = realm.where(AllTypes.class)
                 .between("columnLong", 0, 4)
@@ -423,7 +423,7 @@ public class RealmAsyncQueryTests {
         assertFalse(results.isLoaded());
         assertEquals(0, results.size());
 
-        looperThread.keepStrongReference.add(results);
+        looperThread.keepStrongReference(results);
         results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> object) {
@@ -438,7 +438,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void accessingRealmListOnUnloadedRealmObjectShouldThrow() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
         final AllTypes results = realm.where(AllTypes.class)
                 .equalTo("columnLong", 0)
@@ -481,7 +481,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findAllAsync_withNotification() throws Throwable {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
         final RealmResults<AllTypes> results = realm.where(AllTypes.class)
                 .between("columnLong", 0, 4)
@@ -496,7 +496,7 @@ public class RealmAsyncQueryTests {
                 looperThread.testComplete();
             }
         });
-        looperThread.keepStrongReference.add(results);
+        looperThread.keepStrongReference(results);
 
         assertFalse(results.isLoaded());
         assertEquals(0, results.size());
@@ -507,13 +507,13 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findAllAsync_forceLoad() throws Throwable {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
         final RealmResults<AllTypes> realmResults = realm.where(AllTypes.class)
                 .between("columnLong", 0, 4)
                 .findAllAsync();
 
-        looperThread.keepStrongReference.add(realmResults);
+        looperThread.keepStrongReference(realmResults);
         // Notification should be called as well.
         realmResults.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
@@ -543,13 +543,13 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findFirstAsync() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
 
         final AllTypes asyncObj = realm.where(AllTypes.class).findFirstAsync();
         assertFalse(asyncObj.isValid());
         assertFalse(asyncObj.isLoaded());
-        looperThread.keepStrongReference.add(asyncObj);
+        looperThread.keepStrongReference(asyncObj);
         asyncObj.addChangeListener(new RealmChangeListener<AllTypes>() {
             @Override
             public void onChange(AllTypes object) {
@@ -564,9 +564,9 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findFirstAsync_initialEmptyRow() throws Throwable {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final AllTypes firstAsync = realm.where(AllTypes.class).findFirstAsync();
-        looperThread.keepStrongReference.add(firstAsync);
+        looperThread.keepStrongReference(firstAsync);
         firstAsync.addChangeListener(new RealmChangeListener<AllTypes>() {
             @Override
             public void onChange(AllTypes object) {
@@ -580,19 +580,19 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findFirstAsync_updatedIfSyncRealmObjectIsUpdated() throws Throwable {
-        populateTestRealm(looperThread.realm, 1);
-        AllTypes firstSync = looperThread.realm.where(AllTypes.class).findFirst();
+        populateTestRealm(looperThread.getRealm(), 1);
+        AllTypes firstSync = looperThread.getRealm().where(AllTypes.class).findFirst();
         assertEquals(0, firstSync.getColumnLong());
         assertEquals("test data 0", firstSync.getColumnString());
 
-        final AllTypes firstAsync = looperThread.realm.where(AllTypes.class).findFirstAsync();
+        final AllTypes firstAsync = looperThread.getRealm().where(AllTypes.class).findFirstAsync();
         assertTrue(firstAsync.load());
         assertTrue(firstAsync.isLoaded());
         assertTrue(firstAsync.isValid());
         assertEquals(0, firstAsync.getColumnLong());
         assertEquals("test data 0", firstAsync.getColumnString());
 
-        looperThread.keepStrongReference.add(firstAsync);
+        looperThread.keepStrongReference(firstAsync);
         firstAsync.addChangeListener(new RealmChangeListener<AllTypes>() {
             @Override
             public void onChange(AllTypes object) {
@@ -601,9 +601,9 @@ public class RealmAsyncQueryTests {
             }
         });
 
-        looperThread.realm.beginTransaction();
+        looperThread.getRealm().beginTransaction();
         firstSync.setColumnString("Galacticon");
-        looperThread.realm.commitTransaction();
+        looperThread.getRealm().commitTransaction();
     }
 
     // Finds elements [0-4] asynchronously then waits for the promise to be loaded
@@ -611,13 +611,13 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findFirstAsync_withNotification() throws Throwable {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
         final AllTypes realmResults = realm.where(AllTypes.class)
                 .between("columnLong", 4, 9)
                 .findFirstAsync();
 
-        looperThread.keepStrongReference.add(realmResults);
+        looperThread.keepStrongReference(realmResults);
         realmResults.addChangeListener(new RealmChangeListener<AllTypes>() {
             @Override
             public void onChange(AllTypes object) {
@@ -642,7 +642,7 @@ public class RealmAsyncQueryTests {
     @RunTestInLooperThread
     public void findFirstAsync_forceLoad() throws Throwable {
         final AtomicBoolean listenerCalled = new AtomicBoolean(false);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
         final AllTypes realmResults = realm.where(AllTypes.class)
                 .between("columnLong", 4, 9)
@@ -671,7 +671,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findFirstAsync_twoListenersOnSameInvalidObjectsCauseNPE() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final AllTypes allTypes = realm.where(AllTypes.class).findFirstAsync();
         final AtomicBoolean firstListenerCalled = new AtomicBoolean(false);
 
@@ -707,7 +707,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void findAllSortedAsync() throws Throwable {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
 
         final RealmResults<AllTypes> results = realm.where(AllTypes.class)
@@ -717,7 +717,7 @@ public class RealmAsyncQueryTests {
         assertFalse(results.isLoaded());
         assertEquals(0, results.size());
 
-        looperThread.keepStrongReference.add(results);
+        looperThread.keepStrongReference(results);
         results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> object) {
@@ -735,9 +735,9 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void combiningAsyncAndSync() {
-        populateTestRealm(looperThread.realm, 10);
+        populateTestRealm(looperThread.getRealm(), 10);
 
-        final RealmResults<AllTypes> allTypesAsync = looperThread.realm.where(AllTypes.class).greaterThan("columnLong", 5).findAllAsync();
+        final RealmResults<AllTypes> allTypesAsync = looperThread.getRealm().where(AllTypes.class).greaterThan("columnLong", 5).findAllAsync();
         final RealmResults<AllTypes> allTypesSync = allTypesAsync.where().greaterThan("columnLong", 3).findAll();
 
         // Call where() on an async results will load query. But to maintain the pre version 2.4.0 behaviour of
@@ -752,7 +752,7 @@ public class RealmAsyncQueryTests {
                 looperThread.testComplete();
             }
         });
-        looperThread.keepStrongReference.add(allTypesAsync);
+        looperThread.keepStrongReference(allTypesAsync);
     }
 
     // Keeps advancing the Realm by sending 1 commit for each frame (16ms).
@@ -770,7 +770,7 @@ public class RealmAsyncQueryTests {
             @Override
             public void run() {
                 Random random = new Random(System.currentTimeMillis());
-                Realm backgroundThreadRealm = Realm.getInstance(looperThread.realm.getConfiguration());
+                Realm backgroundThreadRealm = Realm.getInstance(looperThread.getRealm().getConfiguration());
                 for (int i = 0; i < NUMBER_OF_COMMITS; i++) {
                     backgroundThreadRealm.beginTransaction();
                     AllTypes object = backgroundThreadRealm.createObject(AllTypes.class);
@@ -788,13 +788,13 @@ public class RealmAsyncQueryTests {
             }
         };
 
-        final RealmResults<AllTypes> allAsync = looperThread.realm.where(AllTypes.class).findAllAsync();
+        final RealmResults<AllTypes> allAsync = looperThread.getRealm().where(AllTypes.class).findAllAsync();
         allAsync.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> object) {
                 assertTrue(allAsync.isLoaded());
                 if (allAsync.size() == NUMBER_OF_COMMITS) {
-                    AllTypes lastInserted = looperThread.realm.where(AllTypes.class)
+                    AllTypes lastInserted = looperThread.getRealm().where(AllTypes.class)
                             .equalTo("columnLong", latestLongValue[0])
                             .equalTo("columnFloat", latestFloatValue[0])
                             .findFirst();
@@ -804,7 +804,7 @@ public class RealmAsyncQueryTests {
                 }
             }
         });
-        looperThread.keepStrongReference.add(allAsync);
+        looperThread.keepStrongReference(allAsync);
 
         looperThread.postRunnableDelayed(new Runnable() {
             @Override
@@ -817,7 +817,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void distinctAsync() throws Throwable {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // Must be greater than 1
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
@@ -853,10 +853,10 @@ public class RealmAsyncQueryTests {
             }
         };
 
-        looperThread.keepStrongReference.add(distinctBool);
-        looperThread.keepStrongReference.add(distinctLong);
-        looperThread.keepStrongReference.add(distinctDate);
-        looperThread.keepStrongReference.add(distinctString);
+        looperThread.keepStrongReference(distinctBool);
+        looperThread.keepStrongReference(distinctLong);
+        looperThread.keepStrongReference(distinctDate);
+        looperThread.keepStrongReference(distinctString);
         distinctBool.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
             @Override
             public void onChange(RealmResults<AnnotationIndexTypes> object) {
@@ -893,7 +893,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread()
     public void distinctAsync_rememberQueryParams() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         final int TEST_SIZE = 10;
         for (int i = 0; i < TEST_SIZE; i++) {
@@ -918,7 +918,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void distinctAsync_notIndexedFields() throws Throwable {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // Must be greater than 1
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
@@ -958,10 +958,10 @@ public class RealmAsyncQueryTests {
             }
         };
 
-        looperThread.keepStrongReference.add(distinctBool);
-        looperThread.keepStrongReference.add(distinctLong);
-        looperThread.keepStrongReference.add(distinctDate);
-        looperThread.keepStrongReference.add(distinctString);
+        looperThread.keepStrongReference(distinctBool);
+        looperThread.keepStrongReference(distinctLong);
+        looperThread.keepStrongReference(distinctDate);
+        looperThread.keepStrongReference(distinctString);
         distinctBool.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
             @Override
             public void onChange(RealmResults<AnnotationIndexTypes> object) {
@@ -998,7 +998,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void distinctAsync_noneExistingField() throws Throwable {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // Must be greater than 1
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
@@ -1014,7 +1014,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void batchUpdateDifferentTypeOfQueries() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         for (int i = 0; i < 5; ) {
             AllTypes allTypes = realm.createObject(AllTypes.class);
@@ -1036,10 +1036,10 @@ public class RealmAsyncQueryTests {
                 new Sort[]{Sort.ASCENDING, Sort.DESCENDING});
         RealmResults<AnnotationIndexTypes> findDistinct = realm.where(AnnotationIndexTypes.class).distinctAsync("indexString");
 
-        looperThread.keepStrongReference.add(findAllAsync);
-        looperThread.keepStrongReference.add(findAllSorted);
-        looperThread.keepStrongReference.add(findAllSortedMulti);
-        looperThread.keepStrongReference.add(findDistinct);
+        looperThread.keepStrongReference(findAllAsync);
+        looperThread.keepStrongReference(findAllSorted);
+        looperThread.keepStrongReference(findAllSortedMulti);
+        looperThread.keepStrongReference(findDistinct);
 
         final CountDownLatch queriesCompleted = new CountDownLatch(4);
         final CountDownLatch bgRealmClosedLatch = new CountDownLatch(1);
@@ -1149,10 +1149,10 @@ public class RealmAsyncQueryTests {
     @RunTestInLooperThread
     public void queryingLinkHandover() throws Throwable {
         final AtomicInteger numberOfInvocations = new AtomicInteger(0);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         final RealmResults<Dog> allAsync = realm.where(Dog.class).equalTo("owner.name", "kiba").findAllAsync();
-        looperThread.keepStrongReference.add(allAsync);
+        looperThread.keepStrongReference(allAsync);
         allAsync.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> object) {
@@ -1202,11 +1202,11 @@ public class RealmAsyncQueryTests {
     @RunTestInLooperThread
     public void badVersion_syncTransaction() throws NoSuchFieldException, IllegalAccessException {
         final AtomicInteger listenerCount = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
 
         // 1. Makes sure that async query is not started.
         final RealmResults<AllTypes> result = realm.where(AllTypes.class).findAllSortedAsync(AllTypes.FIELD_STRING);
-        looperThread.keepStrongReference.add(result);
+        looperThread.keepStrongReference(result);
         result.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> object) {
@@ -1250,7 +1250,7 @@ public class RealmAsyncQueryTests {
     @Test
     @RunTestInLooperThread
     public void batchUpdate_localRefIsDeletedInLoopOfNativeBatchUpdateQueries() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         // For Android, the size of local ref map is 512. Uses 1024 for more pressure.
         final int TEST_COUNT = 1024;
         final AtomicBoolean updatesTriggered = new AtomicBoolean(false);
@@ -1284,7 +1284,7 @@ public class RealmAsyncQueryTests {
                         // Step 2: Creates 2nd - TEST_COUNT queries.
                         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
                         results.addChangeListener(this);
-                        looperThread.keepStrongReference.add(results);
+                        looperThread.keepStrongReference(results);
                     }
                 }
             }
@@ -1292,7 +1292,7 @@ public class RealmAsyncQueryTests {
         // Step 1. Creates first async to kick the test start.
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
         results.addChangeListener(listener);
-        looperThread.keepStrongReference.add(results);
+        looperThread.keepStrongReference(results);
     }
 
     // *** Helper methods ***

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmChangeListenerTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmChangeListenerTests.java
@@ -63,7 +63,7 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedRealmIsNotNull() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm realm) {
@@ -79,7 +79,7 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedDynamicRealmIsNotNull() {
-        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.getConfiguration());
         dynamicRealm.addChangeListener(new RealmChangeListener<DynamicRealm>() {
             @Override
             public void onChange(DynamicRealm dynRealm) {
@@ -96,9 +96,9 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedRealmResultsIsNotNull() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         RealmResults<Cat> cats = realm.where(Cat.class).findAll();
-        looperThread.keepStrongReference.add(cats);
+        looperThread.keepStrongReference(cats);
         cats.addChangeListener(new RealmChangeListener<RealmResults<Cat>>() {
             @Override
             public void onChange(RealmResults<Cat> result) {
@@ -115,9 +115,9 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedRealmResultsOfModelIsNotNull() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         RealmResults<AllTypesRealmModel> alltypes = realm.where(AllTypesRealmModel.class).findAll();
-        looperThread.keepStrongReference.add(alltypes);
+        looperThread.keepStrongReference(alltypes);
         alltypes.addChangeListener(new RealmChangeListener<RealmResults<AllTypesRealmModel>>() {
             @Override
             public void onChange(RealmResults<AllTypesRealmModel> result) {
@@ -136,12 +136,12 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedRealmObjectIsNotNull() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
-        Cat cat = looperThread.realm.createObject(Cat.class);
+        Cat cat = realm.createObject(Cat.class);
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(cat);
+        looperThread.keepStrongReference(cat);
         cat.addChangeListener(new RealmChangeListener<Cat>() {
             @Override
             public void onChange(Cat object) {
@@ -158,12 +158,12 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedRealmModelIsNotNull() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         AllTypesRealmModel model = realm.createObject(AllTypesRealmModel.class, 0);
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(model);
+        looperThread.keepStrongReference(model);
         RealmObject.addChangeListener(model, new RealmChangeListener<AllTypesRealmModel>() {
             @Override
             public void onChange(AllTypesRealmModel object) {
@@ -180,15 +180,15 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedDynamicRealmObjectIsNotNull() {
-        Realm realm = Realm.getInstance(looperThread.realmConfiguration);
+        Realm realm = Realm.getInstance(looperThread.getConfiguration());
         realm.close();
 
-        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.getConfiguration());
         dynamicRealm.beginTransaction();
         DynamicRealmObject allTypes = dynamicRealm.createObject(AllTypes.CLASS_NAME);
         dynamicRealm.commitTransaction();
 
-        looperThread.keepStrongReference.add(allTypes);
+        looperThread.keepStrongReference(allTypes);
         allTypes.addChangeListener(new RealmChangeListener<DynamicRealmObject>() {
             @Override
             public void onChange(DynamicRealmObject object) {
@@ -205,12 +205,12 @@ public class RealmChangeListenerTests {
     @Test
     @RunTestInLooperThread
     public void returnedDynamicRealmResultsIsNotNull() {
-        Realm realm = Realm.getInstance(looperThread.realmConfiguration);
+        Realm realm = Realm.getInstance(looperThread.getConfiguration());
         realm.close();
 
-        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.getConfiguration());
         RealmResults<DynamicRealmObject> all = dynamicRealm.where(AllTypes.CLASS_NAME).findAll();
-        looperThread.keepStrongReference.add(all);
+        looperThread.keepStrongReference(all);
         all.addChangeListener(new RealmChangeListener<RealmResults<DynamicRealmObject>>() {
             @Override
             public void onChange(RealmResults<DynamicRealmObject> result) {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -993,7 +993,7 @@ public class RealmListTests extends CollectionTests {
     }
 
     private RealmList<Dog> prepareRealmListInLooperThread() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         Owner owner = realm.createObject(Owner.class);
         owner.setName("Owner");
@@ -1010,7 +1010,7 @@ public class RealmListTests extends CollectionTests {
     @RunTestInLooperThread
     public void addChangeListener() {
         collection = prepareRealmListInLooperThread();
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final AtomicInteger listenerCalledCount = new AtomicInteger(0);
         collection.addChangeListener(new RealmChangeListener<RealmList<Dog>>() {
             @Override
@@ -1039,7 +1039,7 @@ public class RealmListTests extends CollectionTests {
     @RunTestInLooperThread
     public void removeAllChangeListeners() {
         collection = prepareRealmListInLooperThread();
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final AtomicInteger listenerCalledCount = new AtomicInteger(0);
         collection.addChangeListener(new RealmChangeListener<RealmList<Dog>>() {
             @Override
@@ -1077,7 +1077,7 @@ public class RealmListTests extends CollectionTests {
     @RunTestInLooperThread
     public void removeChangeListener() {
         collection = prepareRealmListInLooperThread();
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final AtomicInteger listenerCalledCount = new AtomicInteger(0);
         RealmChangeListener<RealmList<Dog>> listener1 = new RealmChangeListener<RealmList<Dog>>() {
             @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmModelTests.java
@@ -195,11 +195,11 @@ public class RealmModelTests {
     @Test
     @RunTestInLooperThread
     public void async_query() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, TEST_DATA_SIZE);
 
         final RealmResults<AllTypesRealmModel> allTypesRealmModels = realm.where(AllTypesRealmModel.class).distinctAsync(AllTypesRealmModel.FIELD_STRING);
-        looperThread.keepStrongReference.add(allTypesRealmModels);
+        looperThread.keepStrongReference(allTypesRealmModels);
         allTypesRealmModels.addChangeListener(new RealmChangeListener<RealmResults<AllTypesRealmModel>>() {
             @Override
             public void onChange(RealmResults<AllTypesRealmModel> object) {
@@ -231,8 +231,8 @@ public class RealmModelTests {
     @Test
     @RunTestInLooperThread
     public void dynamicRealm() {
-        populateTestRealm(looperThread.realm, TEST_DATA_SIZE);
-        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        populateTestRealm(looperThread.getRealm(), TEST_DATA_SIZE);
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.getConfiguration());
 
         dynamicRealm.beginTransaction();
         DynamicRealmObject dog = dynamicRealm.createObject(AllTypesRealmModel.CLASS_NAME, 42);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1576,7 +1576,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void addChangeListener_throwOnAddingNullListenerFromLooperThread() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         Dog dog = createManagedDogObjectFromRealmInstance(realm);
 
         try {
@@ -1614,7 +1614,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void changeListener_triggeredWhenObjectIsDeleted() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();
@@ -1664,7 +1664,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void addChangeListener_throwInsiderTransaction() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         Dog dog = realm.createObject(Dog.class);
@@ -1695,7 +1695,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void removeChangeListener_throwOnRemovingNullListenerFromLooperThread() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         Dog dog = createManagedDogObjectFromRealmInstance(realm);
 
         try {
@@ -1733,7 +1733,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void removeChangeListener_insideTransaction() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final Dog dog = createManagedDogObjectFromRealmInstance(realm);
         RealmChangeListener<Dog> realmChangeListener = new RealmChangeListener<Dog>() {
             @Override
@@ -1762,7 +1762,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void removeAllChangeListeners() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         Dog dog = realm.createObject(Dog.class);
         dog.setAge(13);
@@ -1793,7 +1793,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void removeAllChangeListeners_thenAdd() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         Dog dog = realm.createObject(Dog.class);
         dog.setAge(13);
@@ -1866,7 +1866,7 @@ public class RealmObjectTests {
     @Test
     @RunTestInLooperThread
     public void addChangeListener_returnedObjectOfCopyToRealmOrUpdate() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         realm.createObject(AllTypesPrimaryKey.class, 1);
 
@@ -1876,7 +1876,7 @@ public class RealmObjectTests {
         allTypesPrimaryKey = realm.copyToRealmOrUpdate(allTypesPrimaryKey);
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(allTypesPrimaryKey);
+        looperThread.keepStrongReference(allTypesPrimaryKey);
         allTypesPrimaryKey.addChangeListener(new RealmChangeListener<AllTypesPrimaryKey>() {
             @Override
             public void onChange(AllTypesPrimaryKey element) {
@@ -1898,14 +1898,14 @@ public class RealmObjectTests {
     @RunTestInLooperThread
     public void addChangeListener_listenerShouldBeCalledIfObjectChangesAfterAsyncReturn() {
         final AtomicInteger listenerCounter = new AtomicInteger(0);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         realm.createObject(AllTypesPrimaryKey.class, 1);
         realm.commitTransaction();
 
         // Step 1
         final AllTypesPrimaryKey allTypesPrimaryKey = realm.where(AllTypesPrimaryKey.class).findFirstAsync();
-        looperThread.keepStrongReference.add(allTypesPrimaryKey);
+        looperThread.keepStrongReference(allTypesPrimaryKey);
         allTypesPrimaryKey.addChangeListener(new RealmChangeListener<AllTypesPrimaryKey>() {
             @Override
             public void onChange(AllTypesPrimaryKey element) {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -2994,11 +2994,11 @@ public class RealmQueryTests {
     @Test
     @RunTestInLooperThread
     public void findAllSortedAsync_onSubObjectField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         populateTestRealm(realm, TEST_DATA_SIZE);
         RealmResults<AllTypes> results = realm.where(AllTypes.class)
                 .findAllSortedAsync(AllTypes.FIELD_REALMOBJECT + "." + Dog.FIELD_AGE);
-        looperThread.keepStrongReference.add(results);
+        looperThread.keepStrongReference(results);
         results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> results) {
@@ -3029,7 +3029,7 @@ public class RealmQueryTests {
     @Test
     @RunTestInLooperThread
     public void findAllSortedAsync_listOnSubObjectField() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         String[] fieldNames = new String[2];
         fieldNames[0] = AllTypes.FIELD_REALMOBJECT + "." + Dog.FIELD_AGE;
         fieldNames[1] = AllTypes.FIELD_REALMOBJECT + "." + Dog.FIELD_AGE;
@@ -3041,7 +3041,7 @@ public class RealmQueryTests {
         populateTestRealm(realm, TEST_DATA_SIZE);
         RealmResults<AllTypes> results = realm.where(AllTypes.class)
                 .findAllSortedAsync(fieldNames, sorts);
-        looperThread.keepStrongReference.add(results);
+        looperThread.keepStrongReference(results);
         results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> results) {
@@ -3193,7 +3193,7 @@ public class RealmQueryTests {
     @RunTestInLooperThread
     public void distinctAsync() throws Throwable {
         final AtomicInteger changeListenerCalled = new AtomicInteger(4);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // Must be greater than 1
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
@@ -3228,10 +3228,10 @@ public class RealmQueryTests {
             }
         };
 
-        looperThread.keepStrongReference.add(distinctBool);
-        looperThread.keepStrongReference.add(distinctLong);
-        looperThread.keepStrongReference.add(distinctDate);
-        looperThread.keepStrongReference.add(distinctString);
+        looperThread.keepStrongReference(distinctBool);
+        looperThread.keepStrongReference(distinctLong);
+        looperThread.keepStrongReference(distinctDate);
+        looperThread.keepStrongReference(distinctString);
         distinctBool.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
             @Override
             public void onChange(RealmResults<AnnotationIndexTypes> object) {
@@ -3269,7 +3269,7 @@ public class RealmQueryTests {
     @RunTestInLooperThread
     public void distinctAsync_withNullValues() throws Throwable {
         final AtomicInteger changeListenerCalled = new AtomicInteger(2);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // must be greater than 1
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
@@ -3288,8 +3288,8 @@ public class RealmQueryTests {
             }
         };
 
-        looperThread.keepStrongReference.add(distinctDate);
-        looperThread.keepStrongReference.add(distinctString);
+        looperThread.keepStrongReference(distinctDate);
+        looperThread.keepStrongReference(distinctString);
 
         distinctDate.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
             @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -348,7 +348,7 @@ public class RealmResultsTests extends CollectionTests {
     @Test
     @RunTestInLooperThread
     public void changeListener_syncIfNeeded_updatedFromOtherThread() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);
 
         final RealmResults<AllTypes> results = realm.where(AllTypes.class).lessThan(AllTypes.FIELD_LONG, 10).findAll();
@@ -421,7 +421,7 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void distinctAsync() throws Throwable {
         final AtomicInteger changeListenerCalled = new AtomicInteger(4);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // Must be greater than 1
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
@@ -456,10 +456,10 @@ public class RealmResultsTests extends CollectionTests {
             }
         };
 
-        looperThread.keepStrongReference.add(distinctBool);
-        looperThread.keepStrongReference.add(distinctLong);
-        looperThread.keepStrongReference.add(distinctDate);
-        looperThread.keepStrongReference.add(distinctString);
+        looperThread.keepStrongReference(distinctBool);
+        looperThread.keepStrongReference(distinctLong);
+        looperThread.keepStrongReference(distinctDate);
+        looperThread.keepStrongReference(distinctString);
         distinctBool.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
             @Override
             public void onChange(RealmResults<AnnotationIndexTypes> object) {
@@ -497,7 +497,7 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void distinctAsync_withNullValues() throws Throwable {
         final AtomicInteger changeListenerCalled = new AtomicInteger(2);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10; // Must be greater than 1
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, true);
@@ -522,8 +522,8 @@ public class RealmResultsTests extends CollectionTests {
             }
         };
 
-        looperThread.keepStrongReference.add(distinctDate);
-        looperThread.keepStrongReference.add(distinctString);
+        looperThread.keepStrongReference(distinctDate);
+        looperThread.keepStrongReference(distinctString);
         distinctDate.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
             @Override
             public void onChange(RealmResults<AnnotationIndexTypes> object) {
@@ -545,7 +545,7 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void distinctAsync_notIndexedFields() {
         final AtomicInteger changeListenerCalled = new AtomicInteger(4);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         final long numberOfBlocks = 25;
         final long numberOfObjects = 10;
         populateForDistinct(realm, numberOfBlocks, numberOfObjects, false);
@@ -584,10 +584,10 @@ public class RealmResultsTests extends CollectionTests {
             }
         };
 
-        looperThread.keepStrongReference.add(distinctBool);
-        looperThread.keepStrongReference.add(distinctLong);
-        looperThread.keepStrongReference.add(distinctDate);
-        looperThread.keepStrongReference.add(distinctString);
+        looperThread.keepStrongReference(distinctBool);
+        looperThread.keepStrongReference(distinctLong);
+        looperThread.keepStrongReference(distinctDate);
+        looperThread.keepStrongReference(distinctString);
         distinctBool.addChangeListener(new RealmChangeListener<RealmResults<AnnotationIndexTypes>>() {
             @Override
             public void onChange(RealmResults<AnnotationIndexTypes> object) {
@@ -869,10 +869,10 @@ public class RealmResultsTests extends CollectionTests {
     @Test
     @RunTestInLooperThread
     public void accessors_resultsBuiltOnDeletedLinkView_deletionAsALocalCommit() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         // Step 1
         RealmResults<Dog> dogs = populateRealmResultsOnLinkView(realm);
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> dogs) {
@@ -930,9 +930,9 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void accessors_resultsBuiltOnDeletedLinkView_deletionAsARemoteCommit() {
         // Step 1
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         RealmResults<Dog> dogs = populateRealmResultsOnLinkView(realm);
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> dogs) {
@@ -983,10 +983,10 @@ public class RealmResultsTests extends CollectionTests {
     @Test
     @RunTestInLooperThread
     public void addChangeListener() {
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         collection.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> object) {
@@ -1003,7 +1003,7 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void addChangeListener_twice() {
         final AtomicInteger listenersTriggered = new AtomicInteger(0);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         RealmChangeListener<RealmResults<AllTypes>> listener = new RealmChangeListener<RealmResults<AllTypes>>() {
@@ -1031,7 +1031,7 @@ public class RealmResultsTests extends CollectionTests {
         });
 
         // Adding it twice will be ignored, so removing it will not cause the listener to be triggered.
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         collection.addChangeListener(listener);
         collection.addChangeListener(listener);
         collection.removeChangeListener(listener);
@@ -1055,7 +1055,7 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void removeChangeListener() {
         final AtomicInteger listenersTriggered = new AtomicInteger(0);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         RealmChangeListener<RealmResults<AllTypes>> listener = new RealmChangeListener<RealmResults<AllTypes>>() {
@@ -1065,7 +1065,7 @@ public class RealmResultsTests extends CollectionTests {
             }
         };
 
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         collection.addChangeListener(listener);
         collection.removeChangeListener(listener);
 
@@ -1100,7 +1100,7 @@ public class RealmResultsTests extends CollectionTests {
     @RunTestInLooperThread
     public void removeAllChangeListeners() {
         final AtomicInteger listenersTriggered = new AtomicInteger(0);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         RealmChangeListener<RealmResults<AllTypes>> listenerA = new RealmChangeListener<RealmResults<AllTypes>>() {
@@ -1116,7 +1116,7 @@ public class RealmResultsTests extends CollectionTests {
             }
         };
 
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         collection.addChangeListener(listenerA);
         collection.addChangeListener(listenerB);
         collection.removeAllChangeListeners();
@@ -1141,7 +1141,7 @@ public class RealmResultsTests extends CollectionTests {
     @Test
     @RunTestInLooperThread
     public void removeAllChangeListeners_thenAdd() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
 
         collection.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3075,7 +3075,7 @@ public class RealmTests {
     @Test
     @RunTestInLooperThread
     public void closeRealmInChangeListenerWhenThereIsListenerOnEmptyObject() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmChangeListener<AllTypes> dummyListener = new RealmChangeListener<AllTypes>() {
             @Override
             public void onChange(AllTypes object) {
@@ -3116,7 +3116,7 @@ public class RealmTests {
     @Test
     @RunTestInLooperThread
     public void closeRealmInChangeListenerWhenThereIsListenerOnObject() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmChangeListener<AllTypes> dummyListener = new RealmChangeListener<AllTypes>() {
             @Override
             public void onChange(AllTypes object) {
@@ -3161,7 +3161,7 @@ public class RealmTests {
     @Test
     @RunTestInLooperThread
     public void closeRealmInChangeListenerWhenThereIsListenerOnResults() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         final RealmChangeListener<RealmResults<AllTypes>> dummyListener = new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> object) {
@@ -3200,7 +3200,7 @@ public class RealmTests {
     @Test
     @RunTestInLooperThread
     public void addChangeListener_throwOnAddingNullListenerFromLooperThread() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         try {
             realm.addChangeListener(null);
@@ -3233,7 +3233,7 @@ public class RealmTests {
     @Test
     @RunTestInLooperThread
     public void removeChangeListener_throwOnRemovingNullListenerFromLooperThread() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         try {
             realm.removeChangeListener(null);
@@ -3836,7 +3836,7 @@ public class RealmTests {
     public void refresh_triggerNotifications() {
         final CountDownLatch bgThreadDone = new CountDownLatch(1);
         final AtomicBoolean listenerCalled = new AtomicBoolean(false);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
         assertEquals(0, results.size());
         results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
@@ -3852,7 +3852,7 @@ public class RealmTests {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                Realm realm = Realm.getInstance(looperThread.realmConfiguration);
+                Realm realm = Realm.getInstance(looperThread.getConfiguration());
                 realm.beginTransaction();
                 realm.createObject(AllTypes.class);
                 realm.commitTransaction();
@@ -3895,7 +3895,7 @@ public class RealmTests {
     public void refresh_forceSynchronousNotifications() {
         final CountDownLatch bgThreadDone = new CountDownLatch(1);
         final AtomicBoolean listenerCalled = new AtomicBoolean(false);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAllAsync();
         results.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
@@ -3909,7 +3909,7 @@ public class RealmTests {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                Realm realm = Realm.getInstance(looperThread.realmConfiguration);
+                Realm realm = Realm.getInstance(looperThread.getConfiguration());
                 realm.beginTransaction();
                 realm.createObject(AllTypes.class);
                 realm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
@@ -105,7 +105,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void realmObject_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         final AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();
@@ -167,7 +167,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void findFirstAsync_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();
@@ -189,7 +189,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void findFirstAsync_emittedOnDelete() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         final AllTypes obj = realm.createObject(AllTypes.class);
         realm.commitTransaction();
@@ -282,7 +282,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void realmResults_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         RealmResults<AllTypes> results = realm.where(AllTypes.class).findAll();
         realm.commitTransaction();
@@ -305,7 +305,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void realmList_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         final RealmList<Dog> list = realm.createObject(AllTypes.class).getColumnRealmList();
         realm.commitTransaction();
@@ -329,7 +329,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void dynamicRealmResults_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.getConfiguration());
         dynamicRealm.beginTransaction();
         RealmResults<DynamicRealmObject> results = dynamicRealm.where(AllTypes.CLASS_NAME).findAll();
         dynamicRealm.commitTransaction();
@@ -370,7 +370,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void findAllAsync_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         subscription = realm.where(AllTypes.class).findAllAsync().asObservable().subscribe(new Action1<RealmResults<AllTypes>>() {
             @Override
             public void call(RealmResults<AllTypes> rxResults) {
@@ -404,7 +404,7 @@ public class RxJavaTests {
     @RunTestInLooperThread
     public void realm_emittedOnUpdate() {
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
-        Realm realm = looperThread.realm;
+        Realm realm = looperThread.getRealm();
         subscription = realm.asObservable().subscribe(new Action1<Realm>() {
             @Override
             public void call(Realm rxRealm) {
@@ -445,7 +445,7 @@ public class RxJavaTests {
     @Test
     @RunTestInLooperThread
     public void dynamicRealm_emittedOnUpdate() {
-        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(looperThread.getConfiguration());
         final AtomicInteger subscriberCalled = new AtomicInteger(0);
         subscription = dynamicRealm.asObservable().subscribe(new Action1<DynamicRealm>() {
             @Override
@@ -700,7 +700,7 @@ public class RxJavaTests {
     public void realmResults_gcStressTest() {
         final int TEST_SIZE = 50;
         final AtomicLong innerCounter = new AtomicLong();
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         for (int i = 0; i < TEST_SIZE; i++) {
@@ -743,7 +743,7 @@ public class RxJavaTests {
     public void dynamicRealmResults_gcStressTest() {
         final int TEST_SIZE = 50;
         final AtomicLong innerCounter = new AtomicLong();
-        final DynamicRealm realm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        final DynamicRealm realm = DynamicRealm.getInstance(looperThread.getConfiguration());
 
         realm.beginTransaction();
         for (int i = 0; i < TEST_SIZE; i++) {
@@ -787,7 +787,7 @@ public class RxJavaTests {
     public void realmObject_gcStressTest() {
         final int TEST_SIZE = 50;
         final AtomicLong innerCounter = new AtomicLong();
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         for (int i = 0; i < TEST_SIZE; i++) {
@@ -830,7 +830,7 @@ public class RxJavaTests {
     public void dynamicRealmObject_gcStressTest() {
         final int TEST_SIZE = 50;
         final AtomicLong innerCounter = new AtomicLong();
-        final DynamicRealm realm = DynamicRealm.getInstance(looperThread.realmConfiguration);
+        final DynamicRealm realm = DynamicRealm.getInstance(looperThread.getConfiguration());
 
         realm.beginTransaction();
         for (int i = 0; i < TEST_SIZE; i++) {

--- a/realm/realm-library/src/androidTest/java/io/realm/SortTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/SortTest.java
@@ -347,7 +347,7 @@ public class SortTest {
     public void resorting() throws InterruptedException {
         final AtomicInteger changeListenerCalled = new AtomicInteger(4);
 
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.setAutoRefresh(true);
 
         final Runnable endTest = new Runnable() {
@@ -368,7 +368,7 @@ public class SortTest {
 
         // rr0: [0, 1, 2, 3]
         final RealmResults<AllTypes> rr0 = realm.where(AllTypes.class).findAll();
-        looperThread.keepStrongReference.add(rr0);
+        looperThread.keepStrongReference(rr0);
         rr0.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> element) {
@@ -380,7 +380,7 @@ public class SortTest {
 
         // rr1: [1, 2, 0, 3]
         final RealmResults<AllTypes> rr1 = realm.where(AllTypes.class).findAll().sort(FIELD_LONG, Sort.ASCENDING);
-        looperThread.keepStrongReference.add(rr1);
+        looperThread.keepStrongReference(rr1);
         rr1.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> element) {
@@ -396,7 +396,7 @@ public class SortTest {
 
         // rr2: [0, 3, 1, 2]
         final RealmResults<AllTypes> rr2 = realm.where(AllTypes.class).findAll().sort(FIELD_LONG, Sort.DESCENDING);
-        looperThread.keepStrongReference.add(rr2);
+        looperThread.keepStrongReference(rr2);
         rr2.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> element) {
@@ -485,7 +485,7 @@ public class SortTest {
 
         RealmResults<AllTypes> objectsAscending = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_DATE, Sort.ASCENDING);
         assertEquals(TEST_SIZE, objectsAscending.size());
-        looperThread.keepStrongReference.add(objectsAscending);
+        looperThread.keepStrongReference(objectsAscending);
         objectsAscending.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> element) {
@@ -501,7 +501,7 @@ public class SortTest {
 
         RealmResults<AllTypes> objectsDescending = realm.where(AllTypes.class).findAllSorted(AllTypes.FIELD_DATE, Sort.DESCENDING);
         assertEquals(TEST_SIZE, objectsDescending.size());
-        looperThread.keepStrongReference.add(objectsDescending);
+        looperThread.keepStrongReference(objectsDescending);
         objectsDescending.addChangeListener(new RealmChangeListener<RealmResults<AllTypes>>() {
             @Override
             public void onChange(RealmResults<AllTypes> element) {

--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
@@ -82,7 +82,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_createObject() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -102,7 +102,7 @@ public class TypeBasedNotificationsTests {
         final Dog dog = realm.createObject(Dog.class);
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         dog.addChangeListener(new RealmChangeListener<Dog>() {
             @Override
             public void onChange(Dog object) {
@@ -119,8 +119,8 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_createObject_dynamic_realm() {
-        final DynamicRealm realm = DynamicRealm.getInstance(looperThread.realmConfiguration);
-        looperThread.keepStrongReference.add(realm);
+        final DynamicRealm realm = DynamicRealm.getInstance(looperThread.getConfiguration());
+        looperThread.keepStrongReference(realm);
         realm.addChangeListener(new RealmChangeListener<DynamicRealm>() {
             @Override
             public void onChange(DynamicRealm object) {
@@ -141,7 +141,7 @@ public class TypeBasedNotificationsTests {
         final DynamicRealmObject dog = realm.createObject("Dog");
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         dog.addChangeListener(new RealmChangeListener<DynamicRealmObject>() {
             @Override
             public void onChange(DynamicRealmObject object) {
@@ -159,7 +159,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_copyToRealm() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -181,7 +181,7 @@ public class TypeBasedNotificationsTests {
         final Dog dog = realm.copyToRealm(akamaru);
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         dog.addChangeListener(new RealmChangeListener<Dog>() {
             @Override
             public void onChange(Dog object) {
@@ -199,7 +199,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_copyToRealmOrUpdate() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -223,7 +223,7 @@ public class TypeBasedNotificationsTests {
         final PrimaryKeyAsLong primaryKeyAsLong = realm.copyToRealmOrUpdate(obj);
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(primaryKeyAsLong);
+        looperThread.keepStrongReference(primaryKeyAsLong);
         primaryKeyAsLong.addChangeListener(new RealmChangeListener<PrimaryKeyAsLong>() {
             @Override
             public void onChange(PrimaryKeyAsLong object) {
@@ -250,7 +250,7 @@ public class TypeBasedNotificationsTests {
     public void callback_should_trigger_for_createObjectFromJson() {
         assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
 
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         try {
             InputStream in = TestHelper.loadJsonFromAssets(InstrumentationRegistry.getTargetContext(), "all_simple_types.json");
             realm.beginTransaction();
@@ -258,7 +258,7 @@ public class TypeBasedNotificationsTests {
             realm.commitTransaction();
             in.close();
 
-            looperThread.keepStrongReference.add(objectFromJson);
+            looperThread.keepStrongReference(objectFromJson);
             objectFromJson.addChangeListener(new RealmChangeListener<AllTypes>() {
                 @Override
                 public void onChange(AllTypes object) {
@@ -285,7 +285,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_createObjectFromJson_from_JSONObject() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         try {
             JSONObject json = new JSONObject();
@@ -300,7 +300,7 @@ public class TypeBasedNotificationsTests {
             final AllTypes objectFromJson = realm.createObjectFromJson(AllTypes.class, json);
             realm.commitTransaction();
 
-            looperThread.keepStrongReference.add(objectFromJson);
+            looperThread.keepStrongReference(objectFromJson);
             objectFromJson.addChangeListener(new RealmChangeListener<AllTypes>() {
                 @Override
                 public void onChange(AllTypes object) {
@@ -329,7 +329,7 @@ public class TypeBasedNotificationsTests {
     public void callback_should_trigger_for_createOrUpdateObjectFromJson() {
         assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.HONEYCOMB));
 
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -366,7 +366,7 @@ public class TypeBasedNotificationsTests {
             realm.commitTransaction();
             in.close();
 
-            looperThread.keepStrongReference.add(objectFromJson);
+            looperThread.keepStrongReference(objectFromJson);
             objectFromJson.addChangeListener(new RealmChangeListener<AllTypesPrimaryKey>() {
                 @Override
                 public void onChange(AllTypesPrimaryKey object) {
@@ -395,7 +395,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_should_trigger_for_createOrUpdateObjectFromJson_from_JSONObject() throws JSONException {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -426,7 +426,7 @@ public class TypeBasedNotificationsTests {
         final AllTypesPrimaryKey newObj = realm.createOrUpdateObjectFromJson(AllTypesPrimaryKey.class, json);
         realm.commitTransaction();
 
-        looperThread.keepStrongReference.add(newObj);
+        looperThread.keepStrongReference(newObj);
         newObj.addChangeListener(new RealmChangeListener<AllTypesPrimaryKey>() {
             @Override
             public void onChange(AllTypesPrimaryKey object) {
@@ -451,7 +451,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_with_relevant_commit_realmobject_sync() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         // Step 1: Creates object
         realm.beginTransaction();
@@ -460,7 +460,7 @@ public class TypeBasedNotificationsTests {
         realm.commitTransaction();
 
         final Dog dog = realm.where(Dog.class).findFirst();
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         dog.addChangeListener(new RealmChangeListener<Dog>() {
             @Override
             public void onChange(Dog object) {
@@ -491,7 +491,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_with_relevant_commit_realmobject_async() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         // Step 1: Creates object.
         realm.beginTransaction();
@@ -501,7 +501,7 @@ public class TypeBasedNotificationsTests {
 
         final Dog dog = realm.where(Dog.class).findFirstAsync();
 
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         dog.addChangeListener(new RealmChangeListener<Dog>() {
             @Override
             public void onChange(Dog object) {
@@ -543,7 +543,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_with_relevant_commit_realmresults_sync() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         // Step 1: Creates object.
         realm.beginTransaction();
@@ -552,7 +552,7 @@ public class TypeBasedNotificationsTests {
         realm.commitTransaction();
 
         final RealmResults<Dog> dogs = realm.where(Dog.class).findAll();
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> object) {
@@ -585,7 +585,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void callback_with_relevant_commit_realmresults_async() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         // Step 1: Creates object.
         realm.beginTransaction();
@@ -594,7 +594,7 @@ public class TypeBasedNotificationsTests {
         realm.commitTransaction();
 
         final RealmResults<Dog> dogs = realm.where(Dog.class).findAllAsync();
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> object) {
@@ -641,7 +641,7 @@ public class TypeBasedNotificationsTests {
     @RunTestInLooperThread
     public void multiple_callbacks_should_be_invoked_realmobject_sync() {
         final int NUMBER_OF_LISTENERS = 7;
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -660,7 +660,7 @@ public class TypeBasedNotificationsTests {
         realm.commitTransaction();
 
         Dog dog = realm.where(Dog.class).findFirst();
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         for (int i = 0; i < NUMBER_OF_LISTENERS; i++) {
             dog.addChangeListener(new RealmChangeListener<Dog>() {
                 @Override
@@ -680,7 +680,7 @@ public class TypeBasedNotificationsTests {
     @RunTestInLooperThread
     public void multiple_callbacks_should_be_invoked_realmobject_async() {
         final int NUMBER_OF_LISTENERS = 7;
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         Dog akamaru = realm.createObject(Dog.class);
@@ -688,7 +688,7 @@ public class TypeBasedNotificationsTests {
 
         Dog dog = realm.where(Dog.class).findFirstAsync();
         assertTrue(dog.load());
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         for (int i = 0; i < NUMBER_OF_LISTENERS; i++) {
             dog.addChangeListener(new RealmChangeListener<Dog>() {
                 @Override
@@ -719,14 +719,14 @@ public class TypeBasedNotificationsTests {
     @RunTestInLooperThread
     public void multiple_callbacks_should_be_invoked_realmresults_sync() {
         final int NUMBER_OF_LISTENERS = 7;
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         Dog akamaru = realm.createObject(Dog.class);
         realm.commitTransaction();
 
         RealmResults<Dog> dogs = realm.where(Dog.class).findAll();
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         for (int i = 0; i < NUMBER_OF_LISTENERS; i++) {
             dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
                 @Override
@@ -750,7 +750,7 @@ public class TypeBasedNotificationsTests {
     @RunTestInLooperThread
     public void multiple_callbacks_should_be_invoked_realmresults_async() {
         final int NUMBER_OF_LISTENERS = 7;
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         Dog akamaru = realm.createObject(Dog.class);
@@ -772,7 +772,7 @@ public class TypeBasedNotificationsTests {
         RealmResults<Dog> dogs = realm.where(Dog.class).findAllAsync();
         assertTrue(dogs.load());
 
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         for (int i = 0; i < NUMBER_OF_LISTENERS; i++) {
             dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
                 @Override
@@ -799,14 +799,14 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void non_looper_thread_commit_realmobject_sync() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         realm.createObject(Dog.class);
         realm.commitTransaction();
 
         Dog dog = realm.where(Dog.class).findFirst();
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         dog.addChangeListener(new RealmChangeListener<Dog>() {
             @Override
             public void onChange(Dog object) {
@@ -830,14 +830,14 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void non_looper_thread_commit_realmobject_async() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
 
         realm.beginTransaction();
         realm.createObject(Dog.class).setAge(1);
         realm.commitTransaction();
 
         Dog dog = realm.where(Dog.class).findFirstAsync();
-        looperThread.keepStrongReference.add(dog);
+        looperThread.keepStrongReference(dog);
         dog.addChangeListener(new RealmChangeListener<Dog>() {
             @Override
             public void onChange(Dog object) {
@@ -869,7 +869,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void non_looper_thread_commit_realmresults_sync() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -890,7 +890,7 @@ public class TypeBasedNotificationsTests {
         realm.commitTransaction();
 
         final RealmResults<Dog> dogs = realm.where(Dog.class).findAll();
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> object) {
@@ -924,7 +924,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void non_looper_thread_commit_realmresults_async() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.addChangeListener(new RealmChangeListener<Realm>() {
             @Override
             public void onChange(Realm object) {
@@ -956,7 +956,7 @@ public class TypeBasedNotificationsTests {
         };
 
         final RealmResults<Dog> dogs = realm.where(Dog.class).findAllAsync();
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> object) {
@@ -1080,7 +1080,7 @@ public class TypeBasedNotificationsTests {
     @Test
     @RunTestInLooperThread
     public void changeListener_onResultsBuiltOnDeletedLinkView() {
-        final Realm realm = looperThread.realm;
+        final Realm realm = looperThread.getRealm();
         realm.beginTransaction();
         AllTypes allTypes = realm.createObject(AllTypes.class);
         for (int i = 0; i < 10; i++) {
@@ -1092,7 +1092,7 @@ public class TypeBasedNotificationsTests {
 
         final RealmResults<Dog> dogs =
                 allTypes.getColumnRealmList().where().equalTo(Dog.FIELD_NAME, "name_0").findAll();
-        looperThread.keepStrongReference.add(dogs);
+        looperThread.keepStrongReference(dogs);
         dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> object) {

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
@@ -253,7 +253,7 @@ public class CollectionTests {
         Table table = sharedRealm.getTable("test_table");
 
         final Collection collection = new Collection(sharedRealm, table.where());
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         collection.addListener(collection, new RealmChangeListener<Collection>() {
             @Override
             public void onChange(Collection collection1) {
@@ -342,7 +342,7 @@ public class CollectionTests {
         Table table = sharedRealm.getTable("test_table");
 
         final Collection collection = new Collection(sharedRealm, table.where());
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         collection.addListener(collection, new RealmChangeListener<Collection>() {
             @Override
             public void onChange(Collection collection1) {
@@ -363,7 +363,7 @@ public class CollectionTests {
         Table table = sharedRealm.getTable("test_table");
 
         final Collection collection = new Collection(sharedRealm, table.where());
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         assertEquals(collection.size(), 4); // Trigger the query to run.
         collection.addListener(collection, new RealmChangeListener<Collection>() {
             @Override
@@ -388,7 +388,7 @@ public class CollectionTests {
         final AtomicInteger listenerCounter = new AtomicInteger(0);
 
         final Collection collection = new Collection(sharedRealm, table.where());
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         collection.addListener(collection, new RealmChangeListener<Collection>() {
             @Override
             public void onChange(Collection collection1) {
@@ -468,7 +468,7 @@ public class CollectionTests {
         Table table = sharedRealm.getTable("test_table");
         final Collection collection = new Collection(sharedRealm, table.where());
         final TestIterator iterator = new TestIterator(collection);
-        looperThread.keepStrongReference.add(collection);
+        looperThread.keepStrongReference(collection);
         assertFalse(iterator.isDetached(sharedRealm));
         collection.addListener(collection, new RealmChangeListener<Collection>() {
             @Override

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/RealmNotifierTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/RealmNotifierTests.java
@@ -85,7 +85,7 @@ public class RealmNotifierTests {
     @RunTestInLooperThread
     public void addChangeListener_byLocalChanges() {
         final AtomicBoolean commitReturns = new AtomicBoolean(false);
-        SharedRealm sharedRealm = getSharedRealm(looperThread.realmConfiguration);
+        SharedRealm sharedRealm = getSharedRealm(looperThread.getConfiguration());
         sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<SharedRealm>() {
             @Override
             public void onChange(SharedRealm sharedRealm) {
@@ -121,10 +121,10 @@ public class RealmNotifierTests {
         final AtomicInteger commitCounter = new AtomicInteger(0);
         final AtomicInteger listenerCounter = new AtomicInteger(0);
 
-        looperThread.realm.close();
+        looperThread.getRealm().close();
 
-        SharedRealm sharedRealm = getSharedRealm(looperThread.realmConfiguration);
-        looperThread.keepStrongReference.add(sharedRealm);
+        SharedRealm sharedRealm = getSharedRealm(looperThread.getConfiguration());
+        looperThread.keepStrongReference(sharedRealm);
         sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<SharedRealm>() {
             @Override
             public void onChange(SharedRealm sharedRealm) {
@@ -135,22 +135,22 @@ public class RealmNotifierTests {
                     sharedRealm.close();
                     looperThread.testComplete();
                 } else {
-                    makeRemoteChanges(looperThread.realmConfiguration);
+                    makeRemoteChanges(looperThread.getConfiguration());
                     commitCounter.getAndIncrement();
                 }
             }
         });
-        makeRemoteChanges(looperThread.realmConfiguration);
+        makeRemoteChanges(looperThread.getConfiguration());
         commitCounter.getAndIncrement();
     }
 
     @Test
     @RunTestInLooperThread
     public void removeChangeListeners() {
-        SharedRealm sharedRealm = getSharedRealm(looperThread.realmConfiguration);
+        SharedRealm sharedRealm = getSharedRealm(looperThread.getConfiguration());
         Integer dummyObserver = 1;
-        looperThread.keepStrongReference.add(dummyObserver);
-        looperThread.keepStrongReference.add(sharedRealm);
+        looperThread.keepStrongReference(dummyObserver);
+        looperThread.keepStrongReference(sharedRealm);
         sharedRealm.realmNotifier.addChangeListener(dummyObserver, new RealmChangeListener<Integer>() {
             @Override
             public void onChange(Integer dummy) {
@@ -168,6 +168,6 @@ public class RealmNotifierTests {
         // This should only remove the listeners related with dummyObserver
         sharedRealm.realmNotifier.removeChangeListeners(dummyObserver);
 
-        makeRemoteChanges(looperThread.realmConfiguration);
+        makeRemoteChanges(looperThread.getConfiguration());
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -40,186 +40,222 @@ import io.realm.TestHelper;
 
 import static org.junit.Assert.fail;
 
+
 /**
  * Rule that runs the test inside a worker looper thread. This rule is responsible
- * of creating a temp directory containing a Realm instance then delete it, once the test finishes.
- *
+ * of creating a temp directory containing a Realm instance then deleting it, once the test finishes.
+ * <p>
  * All Realms used in a method method annotated with {@code @RunTestInLooperThread } should use
- * {@link RunInLooperThread#createConfiguration()} and friends to create their configurations. Failing to do so can
- * result in the test failing because the Realm could not be deleted (Reason is that {@link TestRealmConfigurationFactory}
- * and this class does not agree in which order to delete all open Realms.
+ * {@link RunInLooperThread#createConfiguration()} and friends to create their configurations.
+ * Failing to do so can result in the test failing because the Realm could not be deleted
+ * (this class and {@link TestRealmConfigurationFactory} do not agree in which order to delete
+ * the open Realms).
  */
 public class RunInLooperThread extends TestRealmConfigurationFactory {
+    private static final long WAIT_TIMEOUT_MS = 60 * 1000;
+
+    // lock protecting objects shared with the test thread
+    private final Object lock = new Object();
+
+    // Thread safe
+    private final CountDownLatch signalTestCompleted = new CountDownLatch(1);
+
+    // Access guarded by 'lock'
+    private RealmConfiguration realmConfiguration;
 
     // Default Realm created by this Rule. It is guaranteed to be closed when the test finishes.
-    public Realm realm;
-    // Custom Realm used by the test. Saving the reference here will guarantee the instance is closed when exiting the test.
-    public List<Realm> testRealms = new ArrayList<Realm>();
-    public RealmConfiguration realmConfiguration;
-    private CountDownLatch signalTestCompleted;
+    // Access guarded by 'lock'
+    private Realm realm;
+
+    // Access guarded by 'lock'
     private Handler backgroundHandler;
 
     // the variables created inside the test are local and eligible for GC.
     // but sometimes we need the variables to survive across different Looper
     // events (Callbacks happening in the future), so we add a strong reference
     // to them for the duration of the test.
-    public LinkedList<Object> keepStrongReference;
+    // Access guarded by 'lock'
+    private LinkedList<Object> keepStrongReference;
 
-    @Override
-    protected void before() throws Throwable {
-        super.before();
-        realmConfiguration = createConfiguration(UUID.randomUUID().toString());
-        signalTestCompleted = new CountDownLatch(1);
-        keepStrongReference = new LinkedList<Object>();
-    }
+    // Custom Realm used by the test. Saving the reference here will guarantee the instance is closed when exiting the test.
+    // Access guarded by 'lock'
+    private List<Realm> testRealms;
 
-    @Override
-    protected void after() {
-        super.after();
-        realmConfiguration = null;
-        realm = null;
-        testRealms.clear();
-        keepStrongReference = null;
-    }
 
-    @Override
-    public Statement apply(final Statement base, Description description) {
-        final RunTestInLooperThread annotation = description.getAnnotation(RunTestInLooperThread.class);
-        if (annotation == null) {
-            return base;
+    /**
+     * Get the configuration for the test realm.
+     * <p>
+     * Set on main thread, accessed from test thread.
+     * Valid after {@code before}.
+     *
+     * @return the test realm configuration.
+     */
+    public RealmConfiguration getConfiguration() {
+        synchronized (lock) {
+            return realmConfiguration;
         }
-        return new Statement() {
-            private Throwable testException;
+    }
 
-            @Override
-            @SuppressWarnings({"ClassNewInstance", "Finally"})
-            public void evaluate() throws Throwable {
-                before();
-                final String threadName = annotation.threadName();
-                Class<? extends RunnableBefore> runnableBefore = annotation.before();
-                if (!runnableBefore.isInterface()) {
-                    runnableBefore.newInstance().run(realmConfiguration);
-                }
+    /**
+     * Get the test realm.
+     * <p>
+     * Set on test thread, accessed from main thread.
+     * Valid only after the test thread has started.
+     *
+     * @return the test realm.
+     */
+    public Realm getRealm() {
+        synchronized (lock) {
+            while (backgroundHandler == null) {
                 try {
-                    final CountDownLatch signalClosedRealm = new CountDownLatch(1);
-                    final Throwable[] threadAssertionError = new Throwable[1];
-                    final Looper[] backgroundLooper = new Looper[1];
-                    final ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactory() {
-                        @Override
-                        public Thread newThread(Runnable runnable) {
-                            return new Thread(runnable, threadName);
-                        }
-                    });
-                    //noinspection unused
-                    final Future<?> submit = executorService.submit(new Runnable() {
-                        @Override
-                        public void run() {
-                            Looper.prepare();
-                            backgroundLooper[0] = Looper.myLooper();
-                            backgroundHandler = new Handler(backgroundLooper[0]);
-                            try {
-                                realm = Realm.getInstance(realmConfiguration);
-                                base.evaluate();
-                                Looper.loop();
-                            } catch (Throwable e) {
-                                threadAssertionError[0] = e;
-                                unitTestFailed = true;
-                            } finally {
-                                try {
-                                    looperTearDown();
-                                } catch (Throwable t) {
-                                    if (threadAssertionError[0] == null) {
-                                        threadAssertionError[0] = t;
-                                    }
-                                    unitTestFailed = true;
-                                }
-                                signalTestCompleted.countDown();
-                                if (realm != null) {
-                                    realm.close();
-                                }
-                                if (!testRealms.isEmpty()) {
-                                    for (Realm testRealm : testRealms) {
-                                        testRealm.close();
-                                    }
-                                }
-                                signalClosedRealm.countDown();
-                            }
-                        }
-                    });
-                    TestHelper.exitOrThrow(executorService, signalTestCompleted, signalClosedRealm, backgroundLooper, threadAssertionError);
-                } catch (Throwable error) {
-                    // These exceptions should only come from TestHelper.awaitOrFail()
-                    testException = error;
-                } finally {
-                    // Tries as hard as possible to close down gracefully, while still keeping all exceptions intact.
-                    try {
-                        after();
-                    } catch (Throwable e) {
-                        if (testException != null) {
-                            // Both TestHelper.awaitOrFail() and after() threw an exception. Make sure we are aware of
-                            // that fact by printing both exceptions.
-                            StringWriter testStackTrace = new StringWriter();
-                            testException.printStackTrace(new PrintWriter(testStackTrace));
-
-                            StringWriter afterStackTrace = new StringWriter();
-                            e.printStackTrace(new PrintWriter(afterStackTrace));
-
-                            StringBuilder errorMessage = new StringBuilder()
-                                    .append("after() threw an error that shadows a test case error")
-                                    .append('\n')
-                                    .append("== Test case exception ==\n")
-                                    .append(testStackTrace.toString())
-                                    .append('\n')
-                                    .append("== after() exception ==\n")
-                                    .append(afterStackTrace.toString());
-                            fail(errorMessage.toString());
-                        } else {
-                            // Only after() threw an exception
-                            throw e;
-                        }
-                    }
-
-                    // Only TestHelper.awaitOrFail() threw an exception
-                    if (testException != null) {
-                        //noinspection ThrowFromFinallyBlock
-                        throw testException;
-                    }
+                    lock.wait(WAIT_TIMEOUT_MS);
+                } catch (InterruptedException ignore) {
+                    break;
                 }
             }
-        };
-    }
-
-    /**
-     * Signal that the test has completed.
-     */
-    public void testComplete() {
-        signalTestCompleted.countDown();
-    }
-
-    /**
-     * Signal that the test has completed.
-     *
-     * @param latches additional latches to wait before set the test completed flag.
-     */
-    public void testComplete(CountDownLatch... latches) {
-        for (CountDownLatch latch : latches) {
-            TestHelper.awaitOrFail(latch);
+            return realm;
         }
-        signalTestCompleted.countDown();
     }
 
     /**
-     * Posts a runnable to this worker threads looper.
+     * Hold a reference to an object, to prevent it from being GCed,
+     * until after the test completes.
+     * <p>
+     * Accessed only from the main thread, here, but synchronized in case it is called from within a test.
+     * Valid after {@code before}.
+     */
+    public void keepStrongReference(Object obj) {
+        synchronized (lock) {
+            keepStrongReference.add(obj);
+        }
+    }
+
+    /**
+     * Add a Realm to be closed when test is complete.
+     * <p>
+     * Accessed from both test and main threads.
+     * Valid after {@code before}.
+     */
+    public void addTestRealm(Realm realm) {
+        synchronized (lock) {
+            testRealms.add(realm);
+        }
+    }
+
+    /**
+     * Explicitly close all held realms.
+     * <p>
+     * 'testRealms' is ccessed from both test and main threads.
+     * 'testRealms' is valid after {@code before}.
+     */
+    public void closeTestRealms() {
+        List<Realm> realms = new ArrayList<>();
+        synchronized (lock) {
+            List<Realm> tmp = testRealms;
+            testRealms = realms;
+            realms = tmp;
+        }
+
+        for (Realm testRealm : realms) {
+            testRealm.close();
+        }
+    }
+
+    /**
+     * Posts a runnable to the currently running looper.
      */
     public void postRunnable(Runnable runnable) {
-        backgroundHandler.post(runnable);
+        getBackgroundHandler().post(runnable);
     }
 
     /**
      * Posts a runnable to this worker threads looper with a delay in milli second.
      */
     public void postRunnableDelayed(Runnable runnable, long delayMillis) {
-        backgroundHandler.postDelayed(runnable, delayMillis);
+        getBackgroundHandler().postDelayed(runnable, delayMillis);
+    }
+
+    /**
+     * Signal that the test has completed.
+     * <p>
+     * Used on both the main and test threads.
+     * Valid after {@code before}.
+     */
+    public void testComplete() {
+        signalTestCompleted.countDown();
+    }
+
+    /**
+     * Signal that the test has completed, after waiting for any additional latches.
+     *
+     * @param latches additional latches to wait on, before setting the test completed flag.
+     */
+    public void testComplete(CountDownLatch... latches) {
+        for (CountDownLatch latch : latches) {
+            TestHelper.awaitOrFail(latch);
+        }
+        testComplete();
+    }
+
+    // Accessed from both test and main threads
+    // Valid after the test thread has started.
+    Handler getBackgroundHandler() {
+        synchronized (lock) {
+            while (backgroundHandler == null) {
+                try {
+                    lock.wait(WAIT_TIMEOUT_MS);
+                } catch (InterruptedException ignore) {
+                    break;
+                }
+            }
+            return this.backgroundHandler;
+        }
+    }
+
+    // Accessed from both test and main threads
+    // Storing the handler is the gate that indicates that the test thread has started.
+    void setBackgroundHandler(Handler backgroundHandler) {
+        synchronized (lock) {
+            this.backgroundHandler = backgroundHandler;
+            lock.notifyAll();
+        }
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        super.before();
+
+        RealmConfiguration config = createConfiguration(UUID.randomUUID().toString());
+        LinkedList<Object> refs = new LinkedList<>();
+        List<Realm> realms = new LinkedList<>();
+
+        synchronized (lock) {
+            realmConfiguration = config;
+            realm = null;
+            backgroundHandler = null;
+            keepStrongReference = refs;
+            testRealms = realms;
+        }
+    }
+
+    @Override
+    protected void after() {
+        super.after();
+
+        // probably belt *and* suspenders...
+        synchronized (lock) {
+            backgroundHandler = null;
+            keepStrongReference = null;
+        }
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        final RunTestInLooperThread annotation = description.getAnnotation(RunTestInLooperThread.class);
+        if (annotation == null) {
+            return base;
+        }
+        return new RunInLooperThreadStatement(annotation, base);
     }
 
     /**
@@ -229,11 +265,177 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
     public void looperTearDown() {
     }
 
+    private void initRealm() {
+        synchronized (lock) {
+            realm = Realm.getInstance(realmConfiguration);
+        }
+    }
+
+    private void closeRealms() {
+        closeTestRealms();
+
+        Realm oldRealm;
+        synchronized (lock) {
+            oldRealm = realm;
+
+            realm = null;
+            realmConfiguration = null;
+        }
+
+        if (oldRealm != null) {
+            oldRealm.close();
+        }
+    }
+
     /**
      * If an implementation of this is supplied with the annotation, the {@link RunnableBefore#run(RealmConfiguration)}
      * will be executed before the looper thread starts. It is normally for populating the Realm before the test.
      */
     public interface RunnableBefore {
         void run(RealmConfiguration realmConfig);
+    }
+
+    class RunInLooperThreadStatement extends Statement {
+        private final RunTestInLooperThread annotation;
+        private final Statement base;
+
+        RunInLooperThreadStatement(RunTestInLooperThread annotation, Statement base) {
+            this.annotation = annotation;
+            this.base = base;
+        }
+
+        @Override
+        @SuppressWarnings({"ClassNewInstance", "Finally"})
+        public void evaluate() throws Throwable {
+            before();
+
+            Class<? extends RunnableBefore> runnableBefore = annotation.before();
+            if (!runnableBefore.isInterface()) {
+                // this is dangerous: config is mutable.
+                runnableBefore.newInstance().run(getConfiguration());
+            }
+
+            runTest(annotation.threadName());
+        }
+
+        @SuppressWarnings({"unused", "ThrowFromFinallyBlock"})
+        private void runTest(final String threadName) throws Throwable {
+            Exception testException = null;
+
+            try {
+                ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable runnable) { return new Thread(runnable, threadName); }
+                });
+
+                TestThread test = new TestThread(base);
+
+                Future<?> ignored = executorService.submit(test);
+
+                TestHelper.exitOrThrow(executorService, signalTestCompleted, test);
+            } catch (Exception error) {
+                // These exceptions should only come from TestHelper.awaitOrFail()
+                testException = error;
+            } finally {
+                // Tries as hard as possible to close down gracefully, while still keeping all exceptions intact.
+                cleanUp(testException);
+
+                // Only TestHelper.awaitOrFail() threw an exception
+                if (testException != null) {
+                    //noinspection ThrowFromFinallyBlock
+                    throw testException;
+                }
+            }
+        }
+
+        private void cleanUp(Exception testException) {
+            try {
+                after();
+            } catch (Throwable e) {
+                if (testException == null) {
+                    // Only after() threw an exception
+                    throw e;
+                }
+
+                // Both TestHelper.awaitOrFail() and after() threw an exception. Make sure we are aware of
+                // that fact by printing both exceptions.
+                StringWriter testStackTrace = new StringWriter();
+                testException.printStackTrace(new PrintWriter(testStackTrace));
+
+                StringWriter afterStackTrace = new StringWriter();
+                e.printStackTrace(new PrintWriter(afterStackTrace));
+
+                StringBuilder errorMessage = new StringBuilder()
+                        .append("after() threw an error that shadows a test case error")
+                        .append('\n')
+                        .append("== Test case exception ==\n")
+                        .append(testStackTrace.toString())
+                        .append('\n')
+                        .append("== after() exception ==\n")
+                        .append(afterStackTrace.toString());
+
+                fail(errorMessage.toString());
+            }
+        }
+    }
+
+    class TestThread implements Runnable, TestHelper.LooperTest {
+        private final CountDownLatch signalClosedRealm = new CountDownLatch(1);
+        private final Statement base;
+        private Looper looper;
+        private Throwable threadAssertionError;
+
+        TestThread(Statement base) {
+            this.base = base;
+        }
+
+        @Override
+        public CountDownLatch getRealmClosedSignal() {
+            return signalClosedRealm;
+        }
+
+        @Override
+        public synchronized Looper getLooper() {
+            return looper;
+        }
+
+        synchronized void setLooper(Looper looper) {
+            this.looper = looper;
+            setBackgroundHandler(new Handler(looper));
+        }
+
+        @Override
+        public synchronized Throwable getAssertionError() {
+            return threadAssertionError;
+        }
+
+        private synchronized void setException(Throwable threadAssertionError) {
+            if (this.threadAssertionError == null) {
+                this.threadAssertionError = threadAssertionError;
+            }
+        }
+
+        @Override
+        public void run() {
+            Looper.prepare();
+            try {
+                initRealm();
+                setLooper(Looper.myLooper());
+                base.evaluate();
+                Looper.loop();
+            } catch (Throwable e) {
+                setException(e);
+                setUnitTestFailed();
+            } finally {
+                try {
+                    looperTearDown();
+                } catch (Throwable t) {
+                    setUnitTestFailed();
+                }
+                testComplete();
+                closeRealms();
+                signalClosedRealm.countDown();
+            }
+        }
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
@@ -51,7 +51,8 @@ import static org.junit.Assert.assertTrue;
 public class TestRealmConfigurationFactory extends TemporaryFolder {
     private final Map<RealmConfiguration, Boolean> map = new ConcurrentHashMap<RealmConfiguration, Boolean>();
     private final Set<RealmConfiguration> configurations = Collections.newSetFromMap(map);
-    protected boolean unitTestFailed = false;
+
+    private boolean unitTestFailed = false;
 
     @Override
     public Statement apply(final Statement base, Description description) {
@@ -62,7 +63,7 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
                 try {
                     base.evaluate();
                 } catch (Throwable throwable) {
-                    unitTestFailed = true;
+                    setUnitTestFailed();
                     throw throwable;
                 } finally {
                     after();
@@ -89,13 +90,21 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
             }
         } catch (IllegalStateException e) {
             // Only throws the exception caused by deleting the opened Realm if the test case itself doesn't throw.
-            if (!unitTestFailed) {
+            if (!isUnitTestFailed()) {
                 throw e;
             }
         } finally {
             // This will delete the temp directory.
             super.after();
         }
+    }
+
+    public synchronized void setUnitTestFailed() {
+        this.unitTestFailed = true;
+    }
+
+    private synchronized boolean isUnitTestFailed() {
+        return this.unitTestFailed;
     }
 
     // This builder creates a configuration that is *NOT* managed.

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
@@ -88,7 +88,7 @@ public class SessionTests {
                 .build();
 
         Realm realm = Realm.getInstance(config);
-        looperThread.testRealms.add(realm);
+        looperThread.addTestRealm(realm);
 
         // Trigger error
         SyncManager.simulateClientReset(SyncManager.getSession(config));
@@ -117,7 +117,7 @@ public class SessionTests {
                         }
 
                         // Execute Client Reset
-                        looperThread.testRealms.get(0).close();
+                        looperThread.closeTestRealms();
                         handler.executeClientReset();
 
                         // Validate that files have been moved
@@ -129,10 +129,9 @@ public class SessionTests {
                 .build();
 
         Realm realm = Realm.getInstance(config);
-        looperThread.testRealms.add(realm);
+        looperThread.addTestRealm(realm);
 
         // Trigger error
         SyncManager.simulateClientReset(SyncManager.getSession(config));
     }
-
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -106,7 +106,7 @@ public class AuthTests extends BaseIntegrationTest {
                         .build();
 
                 final Realm realm = Realm.getInstance(config);
-                looperThread.testRealms.add(realm);
+                looperThread.addTestRealm(realm);
 
                 // FIXME: Right now we have no Java API for detecting when a session is established
                 // So we optimistically assume it has been connected after 1 second.

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ManagementRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ManagementRealmTests.java
@@ -69,7 +69,7 @@ public class ManagementRealmTests extends BaseIntegrationTest {
                 })
                 .build();
         final Realm realm1 = Realm.getInstance(config1);
-        looperThread.testRealms.add(realm1);
+        looperThread.addTestRealm(realm1);
         realm1.executeTransactionAsync(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
@@ -83,7 +83,7 @@ public class ManagementRealmTests extends BaseIntegrationTest {
         // 3. Create PermissionOffer
         final AtomicReference<String> offerId = new AtomicReference<String>(null);
         final Realm user1ManagementRealm = user1.getManagementRealm();
-        looperThread.testRealms.add(user1ManagementRealm);
+        looperThread.addTestRealm(user1ManagementRealm);
         user1ManagementRealm.executeTransactionAsync(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {
@@ -103,7 +103,7 @@ public class ManagementRealmTests extends BaseIntegrationTest {
                 RealmResults<PermissionOffer> offers = user1ManagementRealm.where(PermissionOffer.class)
                         .equalTo("id", offerId.get())
                         .findAllAsync();
-                looperThread.keepStrongReference.add(offers);
+                looperThread.keepStrongReference(offers);
                 offers.addChangeListener(new RealmChangeListener<RealmResults<PermissionOffer>>() {
                     @Override
                     public void onChange(RealmResults<PermissionOffer> offers) {
@@ -113,7 +113,7 @@ public class ManagementRealmTests extends BaseIntegrationTest {
                             final String offerToken = offer.getToken();
                             final AtomicReference<String> offerResponseId = new AtomicReference<String>();
                             final Realm user2ManagementRealm = user2.getManagementRealm();
-                            looperThread.testRealms.add(user2ManagementRealm);
+                            looperThread.addTestRealm(user2ManagementRealm);
                             user2ManagementRealm.executeTransactionAsync(new Realm.Transaction() {
                                 @Override
                                 public void execute(Realm realm) {
@@ -128,7 +128,7 @@ public class ManagementRealmTests extends BaseIntegrationTest {
                                     RealmResults<PermissionOfferResponse> responses = user2ManagementRealm.where(PermissionOfferResponse.class)
                                             .equalTo("id", offerResponseId.get())
                                             .findAllAsync();
-                                    looperThread.keepStrongReference.add(responses);
+                                    looperThread.keepStrongReference(responses);
                                     responses.addChangeListener(new RealmChangeListener<RealmResults<PermissionOfferResponse>>() {
                                         @Override
                                         public void onChange(RealmResults<PermissionOfferResponse> responses) {
@@ -136,9 +136,9 @@ public class ManagementRealmTests extends BaseIntegrationTest {
                                             if (response != null && response.isSuccessful() && response.getToken().equals(offerToken)) {
                                                 // 7. Response accepted. It should now be possible for user2 to access user1's Realm
                                                 Realm realm = Realm.getInstance(config2);
-                                                looperThread.testRealms.add(realm);
+                                                looperThread.addTestRealm(realm);
                                                 RealmResults<Dog> dogs = realm.where(Dog.class).findAll();
-                                                looperThread.keepStrongReference.add(dogs);
+                                                looperThread.keepStrongReference(dogs);
                                                 dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
                                                     @Override
                                                     public void onChange(RealmResults<Dog> element) {


### PR DESCRIPTION
During the process of fixing the last couple bugs in the backlinks UTs, I discovered that the `RunInLooperThread` `Rule` was both difficult to read and, probably because of that, had fundamental threading bugs.  This PR fixes both of those problems.