### PR TITLE
Implement getInstanceAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ObjectServer] Added support for changing passwords through `SyncUser.changePassword()` (#4423).
 * Transient fields are now allowed in model classes, but are implicitly treated as having the `@Ignore` annotation (#4279).
 * Added `Realm.refresh()` and `DynamicRealm.refresh()` (#3476).
+* Added `Realm.getInstanceAsync()` and `DynamicRealm.getInstanceAsync()` (#2299).
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -684,6 +684,7 @@ public class DynamicRealmTests {
         DynamicRealm.getInstanceAsync(defaultConfig, new DynamicRealm.Callback() {
             @Override
             public void onSuccess(DynamicRealm realm) {
+                fail();
             }
         });
     }
@@ -695,6 +696,7 @@ public class DynamicRealmTests {
         DynamicRealm.getInstanceAsync(null, new DynamicRealm.Callback() {
             @Override
             public void onSuccess(DynamicRealm realm) {
+                fail();
             }
         });
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -678,4 +678,31 @@ public class DynamicRealmTests {
         thrown.expectMessage("Invalid query: field 'nonExisting' does not exist in table 'NoField'.");
         dynamicRealm.where(className).equalTo("nonExisting", 1);
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void getInstanceAsync_nonLooperThreadShouldThrow() {
+        DynamicRealm.getInstanceAsync(defaultConfig, new DynamicRealm.Callback() {
+            @Override
+            public void onSuccess(DynamicRealm realm) {
+            }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_nullConfigShouldThrow() {
+        thrown.expect(IllegalArgumentException.class);
+        DynamicRealm.getInstanceAsync(null, new DynamicRealm.Callback() {
+            @Override
+            public void onSuccess(DynamicRealm realm) {
+            }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_nullCallbackShouldThrow() {
+        thrown.expect(IllegalArgumentException.class);
+        DynamicRealm.getInstanceAsync(defaultConfig, null);
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
@@ -28,22 +28,29 @@ import org.junit.runner.RunWith;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.realm.entities.AllTypes;
 import io.realm.entities.StringOnly;
 import io.realm.exceptions.RealmFileException;
+import io.realm.rule.RunInLooperThread;
+import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class RealmCacheTests {
 
+    @Rule
+    public final RunInLooperThread looperThread = new RunInLooperThread();
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
 
@@ -328,6 +335,184 @@ public class RealmCacheTests {
         assertNull(realmA.sharedRealm);
         dynamicRealmA.close();
         assertNull(realmA.sharedRealm);
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_typedRealm() {
+        final RealmConfiguration configuration = looperThread.createConfiguration();
+        final AtomicBoolean realmCreated = new AtomicBoolean(false);
+        Realm.getInstanceAsync(configuration, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+                realmCreated.set(true);
+                assertEquals(1, Realm.getLocalInstanceCount(configuration));
+                realm.close();
+                looperThread.testComplete();
+            }
+        });
+        assertFalse(realmCreated.get());
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_dynamicRealm() {
+        final RealmConfiguration configuration = looperThread.createConfiguration();
+        final AtomicBoolean realmCreated = new AtomicBoolean(false);
+        DynamicRealm.getInstanceAsync(configuration, new DynamicRealm.Callback() {
+            @Override
+            public void onSuccess(DynamicRealm realm) {
+                realmCreated.set(true);
+                assertEquals(1, Realm.getLocalInstanceCount(configuration));
+                realm.close();
+                looperThread.testComplete();
+            }
+        });
+        assertFalse(realmCreated.get());
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_callbackDeliveredInFollowingEventLoopWhenLocalCacheExist() {
+        final RealmConfiguration configuration = looperThread.createConfiguration();
+        final AtomicBoolean realmCreated = new AtomicBoolean(false);
+        final Realm localRealm = Realm.getInstance(configuration);
+        Realm.getInstanceAsync(configuration, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+                realmCreated.set(true);
+                assertEquals(2, Realm.getLocalInstanceCount(configuration));
+                assertSame(realm, localRealm);
+                realm.close();
+                localRealm.close();
+                looperThread.testComplete();
+            }
+        });
+        assertFalse(realmCreated.get());
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_callbackDeliveredInFollowingEventLoopWhenGlobalCacheExist() throws InterruptedException {
+        final RealmConfiguration configuration = looperThread.createConfiguration();
+        final AtomicBoolean realmCreated = new AtomicBoolean(false);
+        final CountDownLatch globalRealmCreated = new CountDownLatch(1);
+        final CountDownLatch getAsyncFinishedLatch = new CountDownLatch(1);
+
+        final Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Realm realm = Realm.getInstance(configuration);
+                globalRealmCreated.countDown();
+                TestHelper.awaitOrFail(getAsyncFinishedLatch);
+                realm.close();
+            }
+        });
+        thread.start();
+
+        TestHelper.awaitOrFail(globalRealmCreated);
+        Realm.getInstanceAsync(configuration, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+                realmCreated.set(true);
+                assertEquals(1, Realm.getLocalInstanceCount(configuration));
+                realm.close();
+                getAsyncFinishedLatch.countDown();
+                try {
+                    thread.join();
+                } catch (InterruptedException e) {
+                    fail();
+                }
+                looperThread.testComplete();
+            }
+        });
+        assertFalse(realmCreated.get());
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_typedRealmShouldStillBeInitializedInBGIfOnlyDynamicRealmExists() {
+        final RealmConfiguration configuration = looperThread.createConfiguration();
+        final DynamicRealm dynamicRealm = DynamicRealm.getInstance(configuration);
+        final AtomicBoolean realmCreated = new AtomicBoolean(false);
+
+        Realm.getInstanceAsync(configuration, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+                realmCreated.set(false);
+                assertEquals(2, Realm.getLocalInstanceCount(configuration));
+                dynamicRealm.close();
+                realm.close();
+                looperThread.testComplete();
+            }
+        });
+        // Callback should not be called immediately since we need to create column indices cache in bg thread.
+        // Only a local dynamic Realm instance existing at this time.
+        assertFalse(realmCreated.get());
+        assertEquals(1, Realm.getLocalInstanceCount(configuration));
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_onError() {
+        final RealmConfiguration configuration =
+                looperThread.createConfigurationBuilder()
+                .assetFile("NotExistingFile")
+                .build();
+        Realm.getInstanceAsync(configuration, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+                fail();
+            }
+
+            @Override
+            public void onError(Throwable exception) {
+                assertTrue(exception instanceof RealmFileException);
+                looperThread.testComplete();
+            }
+        });
+    }
+
+    // If the async task is canceled before the posted event to create Realm instance in caller thread, the event should
+    // just be ignored.
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_cancelBeforePostShouldNotCreateRealmInstanceOnTheCallerThread() {
+        final AtomicReference<RealmAsyncTask> realmAsyncTasks = new AtomicReference<>();
+        final Runnable finishedRunnable = new Runnable() {
+            @Override
+            public void run() {
+                looperThread.testComplete();
+            }
+        };
+        final RealmConfiguration configuration = looperThread.createConfigurationBuilder()
+                .name("will_be_canceled")
+                .initialData(new Realm.Transaction() {
+                    @Override
+                    public void execute(Realm realm) {
+                        // The BG thread started to initial the first Realm instance. Post an event to the caller's
+                        // queue to cancel the task before the event to create the Realm instance in caller thread.
+                        looperThread.postRunnable(new Runnable() {
+                            @Override
+                            public void run() {
+                                assertNotNull(realmAsyncTasks.get());
+                                realmAsyncTasks.get().cancel();
+                                // Wait the async task to be terminated.
+                                TestHelper.waitRealmThreadExecutorFinish();
+                                // Finish the test.
+                                looperThread.postRunnable(finishedRunnable);
+                            }
+                        });
+                    }
+                })
+                .build();
+
+        realmAsyncTasks.set(Realm.getInstanceAsync(configuration, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+                fail();
+            }
+        }));
     }
 
     // The DynamicRealm and Realm with the same Realm path should share the same RealmCache

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3843,6 +3843,7 @@ public class RealmTests {
         Realm.getInstanceAsync(realmConfig, new Realm.Callback() {
             @Override
             public void onSuccess(Realm realm) {
+                fail();
             }
         });
     }
@@ -3854,6 +3855,7 @@ public class RealmTests {
         Realm.getInstanceAsync(null, new Realm.Callback() {
             @Override
             public void onSuccess(Realm realm) {
+                fail();
             }
         });
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -63,7 +63,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -3837,6 +3836,33 @@ public class RealmTests {
         // Tests if it works when the namedPipeDir and the named pipe files already exist.
         realmOnExternalStorage = Realm.getInstance(config);
         realmOnExternalStorage.close();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void getInstanceAsync_nonLooperThreadShouldThrow() {
+        Realm.getInstanceAsync(realmConfig, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+            }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_nullConfigShouldThrow() {
+        thrown.expect(IllegalArgumentException.class);
+        Realm.getInstanceAsync(null, new Realm.Callback() {
+            @Override
+            public void onSuccess(Realm realm) {
+            }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getInstanceAsync_nullCallbackShouldThrow() {
+        thrown.expect(IllegalArgumentException.class);
+        Realm.getInstanceAsync(realmConfig, null);
     }
 
     // Verify that the logic for waiting for the users file dir to be come available isn't totally broken

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -239,6 +239,10 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
 
     @Override
     protected void after() {
+        // Wait for all async tasks to have completed to ensure a successful deleteRealm call.
+        // If it times out, it will throw.
+        TestHelper.waitRealmThreadExecutorFinish();
+
         super.after();
 
         // probably belt *and* suspenders...

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/TestRealmConfigurationFactory.java
@@ -80,10 +80,6 @@ public class TestRealmConfigurationFactory extends TemporaryFolder {
 
     @Override
     protected void after() {
-        // Waits all async tasks done to ensure successful deleteRealm call.
-        // This will throw when timeout. And the reason of timeout needs to be solved properly.
-        TestHelper.waitRealmThreadExecutorFinish();
-
         try {
             for (RealmConfiguration configuration : configurations) {
                 Realm.deleteRealm(configuration);

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
 import io.realm.exceptions.RealmMigrationNeededException;
 import io.realm.internal.CheckedRow;
@@ -747,4 +748,86 @@ abstract class BaseRealm implements Closeable {
     }
 
     public static final ThreadLocalRealmObjectContext objectContext = new ThreadLocalRealmObjectContext();
+
+    /**
+     * The Callback used when reporting back the result of loading a Realm asynchronously using either
+     * {@link Realm#getInstanceAsync(RealmConfiguration, Realm.Callback)} or
+     * {@link DynamicRealm#getInstanceAsync(RealmConfiguration, DynamicRealm.Callback)}.
+     * <p>
+     * Before creating the first Realm instance in a process, there are some initialization work that needs to be done
+     * such as creating or validating schemas, running migration if needed,
+     * copy asset file if {@link RealmConfiguration.Builder#assetFile(String)} is supplied and execute the
+     * {@link RealmConfiguration.Builder#initialData(Realm.Transaction)} if necessary. This work may take time
+     * and block the caller thread for a while. To avoid the {@code getInstance()} call blocking the main thread, the
+     * {@code getInstanceAsync()} can be used instead which will do the initialization work in the background thread and
+     * deliver a Realm instance to the caller thread.
+     * <p>
+     * In general, this method is most useful on the UI thread since that should be blocked as little as possible. On
+     * any other Looper threads or other threads that don't support callbacks, using the standard {@code getInstance()}
+     * should be fine.
+     * <p>
+     * Here is an example of using {@code getInstanceAsync()} when the app starts the first activity:
+     * <pre>
+     * public class MainActivity extends Activity {
+     *
+     *   private Realm realm = null;
+     *   private RealmAsyncTask realmAsyncTask;
+     *
+     *   \@Override
+     *   protected void onCreate(Bundle savedInstanceState) {
+     *     super.onCreate(savedInstanceState);
+     *     setContentView(R.layout.layout_main);
+     *     realmAsyncTask = Realm.getDefaultInstanceAsync(new Callback() {
+     *         \@Override
+     *         public void onSuccess(Realm realm) {
+     *             if (isDestroyed()) {
+     *                 // If the activity is destroyed, the Realm instance should be closed immediately to avoid leaks.
+     *                 // Or you can call realmAsyncTask.cancel() in onDestroy() to stop callback delivery.
+     *                 realm.close();
+     *             } else {
+     *                 MainActivity.this.realm = realm;
+     *                 // Remove the spinner and start the real UI.
+     *             }
+     *         }
+     *     });
+     *
+     *     // Show a spinner before Realm instance returned by the callback.
+     *   }
+     *
+     *   \@Override
+     *   protected void onDestroy() {
+     *     super.onDestroy();
+     *     if (realm != null) {
+     *         realm.close();
+     *         realm = null;
+     *     } else {
+     *         // Calling cancel() on the thread where getInstanceAsync was called on to stop the callback delivery.
+     *         // Otherwise you need to check if the activity is destroyed to close in the onSuccess() properly.
+     *         realmAsyncTask.cancel();
+     *     }
+     *   }
+     * }
+     * </pre>
+     *
+     * @param <T> {@link Realm} or {@link DynamicRealm}.
+     */
+    public abstract static class InstanceCallback<T extends BaseRealm> {
+
+        /**
+         * Deliver a Realm instance to the caller thread.
+         *
+         * @param realm the Realm instance for the caller thread.
+         */
+        public abstract void onSuccess(T realm);
+
+        /**
+         * Deliver the error happens when creating the Realm instance to the caller thread. The default implementation
+         * will throw the exception on the caller thread.
+         *
+         * @param exception happened while initializing Realm on a background thread.
+         */
+        public void onError(Throwable exception) {
+            throw new RealmException("Exception happens when initializing Realm in the background thread.", exception);
+        }
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -754,15 +754,15 @@ abstract class BaseRealm implements Closeable {
      * {@link Realm#getInstanceAsync(RealmConfiguration, Realm.Callback)} or
      * {@link DynamicRealm#getInstanceAsync(RealmConfiguration, DynamicRealm.Callback)}.
      * <p>
-     * Before creating the first Realm instance in a process, there are some initialization work that needs to be done
+     * Before creating the first Realm instance in a process, there are some initialization work that need to be done
      * such as creating or validating schemas, running migration if needed,
      * copy asset file if {@link RealmConfiguration.Builder#assetFile(String)} is supplied and execute the
      * {@link RealmConfiguration.Builder#initialData(Realm.Transaction)} if necessary. This work may take time
      * and block the caller thread for a while. To avoid the {@code getInstance()} call blocking the main thread, the
-     * {@code getInstanceAsync()} can be used instead which will do the initialization work in the background thread and
+     * {@code getInstanceAsync()} can be used instead to do the initialization work in the background thread and
      * deliver a Realm instance to the caller thread.
      * <p>
-     * In general, this method is most useful on the UI thread since that should be blocked as little as possible. On
+     * In general, this method is mostly useful on the UI thread since that should be blocked as little as possible. On
      * any other Looper threads or other threads that don't support callbacks, using the standard {@code getInstance()}
      * should be fine.
      * <p>
@@ -821,8 +821,8 @@ abstract class BaseRealm implements Closeable {
         public abstract void onSuccess(T realm);
 
         /**
-         * Deliver the error happens when creating the Realm instance to the caller thread. The default implementation
-         * will throw the exception on the caller thread.
+         * Deliver an error happens when creating the Realm instance to the caller thread. The default implementation
+         * will throw an exception on the caller thread.
          *
          * @param exception happened while initializing Realm on a background thread.
          */

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -78,7 +78,7 @@ public class DynamicRealm extends BaseRealm {
      *
      * @param configuration {@link RealmConfiguration} used to open the Realm.
      * @param callback invoked to return the results.
-     * @throws IllegalArgumentException if a null {@link RealmConfiguration} is provided.
+     * @throws IllegalArgumentException if a null {@link RealmConfiguration} or a null {@link Callback} is provided.
      * @throws IllegalStateException if it is called from a non-Looper or {@link android.app.IntentService} thread.
      * @return a {@link RealmAsyncTask} representing a cancellable task.
      * @see Callback for more details.

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -71,6 +71,27 @@ public class DynamicRealm extends BaseRealm {
     }
 
     /**
+     * The creation of the first Realm instance per {@link RealmConfiguration} in a process can take some time as all
+     * initialization code need to run at that point (Setting up the Realm, validating schemas and creating initial
+     * data). This method places the initialization work in a background thread and deliver the Realm instance
+     * to the caller thread asynchronously after the initialization is finished.
+     *
+     * @param configuration {@link RealmConfiguration} used to open the Realm.
+     * @param callback invoked to return the results.
+     * @throws IllegalArgumentException if a null {@link RealmConfiguration} is provided.
+     * @throws IllegalStateException if it is called from a non-Looper or {@link android.app.IntentService} thread.
+     * @return a {@link RealmAsyncTask} representing a cancellable task.
+     * @see Callback for more details.
+     */
+    public static RealmAsyncTask getInstanceAsync(RealmConfiguration configuration,
+                                                  Callback callback) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("A non-null RealmConfiguration must be provided");
+        }
+        return RealmCache.createRealmOrGetFromCacheAsync(configuration, callback, DynamicRealm.class);
+    }
+
+    /**
      * Instantiates and adds a new object to the Realm.
      *
      * @param className the class name of the object to create.
@@ -238,6 +259,25 @@ public class DynamicRealm extends BaseRealm {
      */
     public interface Transaction {
         void execute(DynamicRealm realm);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static abstract class Callback extends InstanceCallback<DynamicRealm> {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public abstract void onSuccess(DynamicRealm realm);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onError(Throwable exception) {
+            super.onError(exception);
+        }
     }
 }
 

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -288,7 +288,7 @@ public class Realm extends BaseRealm {
 
     /**
      * The creation of the first Realm instance per {@link RealmConfiguration} in a process can take some time as all
-     * initialization code need to run at that point (Setting up the Realm, validating schemas and creating initial
+     * initialization code need to run at that point (setting up the Realm, validating schemas and creating initial
      * data). This method places the initialization work in a background thread and deliver the Realm instance
      * to the caller thread asynchronously after the initialization is finished.
      *

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -127,6 +127,8 @@ import rx.Observable;
  */
 public class Realm extends BaseRealm {
 
+    private static final String NULL_CONFIG_MSG = "A non-null RealmConfiguration must be provided";
+
     public static final String DEFAULT_REALM_NAME = RealmConfiguration.DEFAULT_REALM_NAME;
 
     private static RealmConfiguration defaultConfiguration;
@@ -279,9 +281,30 @@ public class Realm extends BaseRealm {
      */
     public static Realm getInstance(RealmConfiguration configuration) {
         if (configuration == null) {
-            throw new IllegalArgumentException("A non-null RealmConfiguration must be provided");
+            throw new IllegalArgumentException(NULL_CONFIG_MSG);
         }
         return RealmCache.createRealmOrGetFromCache(configuration, Realm.class);
+    }
+
+    /**
+     * The creation of the first Realm instance per {@link RealmConfiguration} in a process can take some time as all
+     * initialization code need to run at that point (Setting up the Realm, validating schemas and creating initial
+     * data). This method places the initialization work in a background thread and deliver the Realm instance
+     * to the caller thread asynchronously after the initialization is finished.
+     *
+     * @param configuration {@link RealmConfiguration} used to open the Realm.
+     * @param callback invoked to return the results.
+     * @throws IllegalArgumentException if a null {@link RealmConfiguration} is provided.
+     * @throws IllegalStateException if it is called from a non-Looper or {@link IntentService} thread.
+     * @return a {@link RealmAsyncTask} representing a cancellable task.
+     * @see Callback for more details.
+     */
+    public static RealmAsyncTask getInstanceAsync(RealmConfiguration configuration,
+                                                  Callback callback) {
+        if (configuration == null) {
+            throw new IllegalArgumentException(NULL_CONFIG_MSG);
+        }
+        return RealmCache.createRealmOrGetFromCacheAsync(configuration, callback, Realm.class);
     }
 
     /**
@@ -1850,6 +1873,25 @@ public class Realm extends BaseRealm {
          */
         interface OnError {
             void onError(Throwable error);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static abstract class Callback extends InstanceCallback<Realm> {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public abstract void onSuccess(Realm realm);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onError(Throwable exception) {
+            super.onError(exception);
         }
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -294,7 +294,7 @@ public class Realm extends BaseRealm {
      *
      * @param configuration {@link RealmConfiguration} used to open the Realm.
      * @param callback invoked to return the results.
-     * @throws IllegalArgumentException if a null {@link RealmConfiguration} is provided.
+     * @throws IllegalArgumentException if a null {@link RealmConfiguration} or a null {@link Callback} is provided.
      * @throws IllegalStateException if it is called from a non-Looper or {@link IntentService} thread.
      * @return a {@link RealmAsyncTask} representing a cancellable task.
      * @see Callback for more details.

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -24,16 +24,24 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.realm.exceptions.RealmFileException;
+import io.realm.internal.Capabilities;
 import io.realm.internal.ColumnIndices;
 import io.realm.internal.ObjectServerFacade;
+import io.realm.internal.RealmNotifier;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
+import io.realm.internal.android.AndroidCapabilities;
+import io.realm.internal.android.AndroidRealmNotifier;
+import io.realm.internal.async.RealmAsyncTaskImpl;
 import io.realm.log.RealmLog;
 
 
@@ -78,6 +86,88 @@ final class RealmCache {
         }
     }
 
+    private static class CreateRealmRunnable<T extends BaseRealm> implements Runnable {
+        private RealmConfiguration configuration;
+        private BaseRealm.InstanceCallback<T> callback;
+        private Class<T> realmClass;
+        private CountDownLatch createdInForegroundLatch = new CountDownLatch(1);
+        private RealmNotifier notifier;
+        // The Future this runnable belongs to.
+        private Future future;
+
+        CreateRealmRunnable(RealmNotifier notifier, RealmConfiguration configuration,
+                            BaseRealm.InstanceCallback<T> callback, Class<T> realmClass) {
+            this.configuration = configuration;
+            this.realmClass = realmClass;
+            this.callback = callback;
+            this.notifier = notifier;
+        }
+
+        public void setFuture(Future future) {
+            this.future = future;
+        }
+
+        @Override
+        public void run() {
+            T instance = null;
+            try {
+                instance = createRealmOrGetFromCache(configuration, realmClass);
+                boolean results = notifier.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        // If the RealmAsyncTask.cancel() is called before, we just return without creating the Realm
+                        // instance on the caller thread.
+                        // Thread.isInterrupted() cannot be used for checking here since CountDownLatch.await() will
+                        // will clear interrupted status.
+                        // Using the future to check which this runnable belongs to is to ensure if it is canceled from
+                        // the caller thread before, the callback will never be delivered.
+                        if (future == null || future.isCancelled()) {
+                            return;
+                        }
+                        T instanceToReturn = null;
+                        try {
+                            instanceToReturn = createRealmOrGetFromCache(configuration, realmClass);
+                        } catch (Throwable e) {
+                            callback.onError(e);
+                        } finally {
+                            createdInForegroundLatch.countDown();
+                        }
+                        if (instanceToReturn != null) {
+                            callback.onSuccess(instanceToReturn);
+                        }
+                    }
+                });
+                if (!results) {
+                    createdInForegroundLatch.countDown();
+                }
+                // There is a small chance that the posted runnable cannot be executed because of the thread terminated
+                // before the runnable gets fetched from the event queue.
+                if (!createdInForegroundLatch.await(2, TimeUnit.SECONDS)) {
+                    RealmLog.warn("Timeout for creating Realm instance in foreground thread in `CreateRealmRunnable` ");
+                }
+            } catch (InterruptedException e) {
+                RealmLog.warn(e, "`CreateRealmRunnable` has been interrupted.");
+            } catch (final Throwable e) {
+                RealmLog.error(e, "`CreateRealmRunnable` failed.");
+                notifier.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        callback.onError(e);
+                    }
+                });
+            } finally {
+                if (instance != null) {
+                    instance.close();
+                }
+            }
+        }
+    }
+
+    private static final String ASYNC_NOT_ALLOWED_MSG =
+            "Realm instances cannot be loaded asynchronously on a non-looper thread.";
+    private static final String ASYNC_CALLBACK_NULL_MSG =
+            "The callback cannot be null.";
+
     // Separated references and counters for typed Realm and dynamic Realm.
     private final EnumMap<RealmCacheType, RefAndCount> refAndCountMap;
 
@@ -117,6 +207,30 @@ final class RealmCache {
         for (RealmCacheType type : RealmCacheType.values()) {
             refAndCountMap.put(type, new RefAndCount());
         }
+    }
+
+    static <T extends BaseRealm> RealmAsyncTask createRealmOrGetFromCacheAsync(
+            RealmConfiguration configuration, BaseRealm.InstanceCallback<T> callback, Class<T> realmClass) {
+        RealmCache cache = getCache(configuration.getPath(), true);
+        return cache.doCreateRealmOrGetFromCacheAsync(configuration, callback, realmClass);
+    }
+
+    private synchronized  <T extends BaseRealm> RealmAsyncTask doCreateRealmOrGetFromCacheAsync(
+            RealmConfiguration configuration, BaseRealm.InstanceCallback<T> callback, Class<T> realmClass) {
+        Capabilities capabilities = new AndroidCapabilities();
+        capabilities.checkCanDeliverNotification(ASYNC_NOT_ALLOWED_MSG);
+        if (callback == null) {
+            throw new IllegalArgumentException(ASYNC_CALLBACK_NULL_MSG);
+        }
+
+        // Always create a Realm instance in the background thread even when there are instances existing on current
+        // thread. This to ensure that onSuccess will always be called in the following event loop but not current one.
+        CreateRealmRunnable<T> createRealmRunnable = new CreateRealmRunnable<T>(
+                new AndroidRealmNotifier(null, capabilities), configuration, callback, realmClass);
+        Future<?> future = BaseRealm.asyncTaskExecutor.submitTransaction(createRealmRunnable);
+        createRealmRunnable.setFuture(future);
+
+        return new RealmAsyncTaskImpl(future, BaseRealm.asyncTaskExecutor);
     }
 
     private static RealmCache getCache(String realmPath, boolean createIfNotExist) {
@@ -452,7 +566,7 @@ final class RealmCache {
      * @param schemaVersion requested version of the schema.
      * @return {@link ColumnIndices} instance for specified schema version. {@code null} if not found.
      */
-    public static ColumnIndices findColumnIndices(ColumnIndices[] array, long schemaVersion) {
+    static ColumnIndices findColumnIndices(ColumnIndices[] array, long schemaVersion) {
         for (int i = array.length - 1; 0 <= i; i--) {
             final ColumnIndices candidate = array[i];
             if (candidate != null && candidate.getSchemaVersion() == schemaVersion) {

--- a/realm/realm-library/src/main/java/io/realm/internal/async/RealmThreadPoolExecutor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/async/RealmThreadPoolExecutor.java
@@ -19,7 +19,6 @@ package io.realm.internal.async;
 import java.io.File;
 import java.io.FileFilter;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -111,36 +110,6 @@ public class RealmThreadPoolExecutor extends ThreadPoolExecutor {
     public Future<?> submitTransaction(Runnable task) {
         Future<?> future = super.submit(new BgPriorityRunnable(task));
         return future;
-    }
-
-    /**
-     * Submits a runnable for updating a query.
-     *
-     * @param task the task to submit
-     * @return a future representing pending completion of the task
-     */
-    public Future<?> submitQueryUpdate(Runnable task) {
-        return super.submit(new BgPriorityRunnable(task));
-    }
-
-    /**
-     * Submits a runnable for executing a query.
-     *
-     * @param task the task to submit
-     * @return a future representing pending completion of the task
-     */
-    public <T> Future<T> submitQuery(Callable<T> task) {
-        return super.submit(new BgPriorityCallable<T>(task));
-    }
-
-    /**
-     * Submits a runnable for executing a network request.
-     *
-     * @param task the task to submit
-     * @return a future representing pending completion of the task
-     */
-    public Future<?> submitNetworkRequest(Runnable task) {
-        return super.submit(new BgPriorityRunnable(task));
     }
 
     /**


### PR DESCRIPTION
Fix #2299
- Add APIs to get Realm instance asynchronously.
- Remove some useless methods.

There are some work need to be done before create the first Realm instance
in the process, like creating schema table, doing migration, etc.. Those
could block the UI thread quite badly. This commit tries to do those
initialization work in the background and hold a Realm instance in the
background until the 2nd instance created in the caller thread.

A better solution than this would be do initialization in the
background and only deliver a column indices cache to caller thread
without holding a Realm instance in the background. But that is not
possible since from the current database design, we cannot know if the
schema changes compared with the last time it was opened.

Also create a SharedGroup in the background and handover it to the
caller thread is not ideal as well. That not only requires some design
changes in the Object Store RealmCoordinator, but also is a very
special use case of SharedGroup which core is not designed for.
SharedGroup Leaking during the handover is another flaw for this
solution -- we can only rely on the GC to collect the leaked SharedGroup
during handover then.

- [x] Check and fix javadoc for `Realm.Callback` `DynamicRealm.Callback`.