### PR TITLE
Standardize test timeouts

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -1126,20 +1126,16 @@ public class RealmAsyncQueryTests {
         new Thread() {
             @Override
             public void run() {
-                try {
-                    queriesCompleted.await();
-                    Realm bgRealm = Realm.getInstance(realm.getConfiguration());
+                TestHelper.awaitOrFail(queriesCompleted);
+                Realm bgRealm = Realm.getInstance(realm.getConfiguration());
 
-                    bgRealm.beginTransaction();
-                    bgRealm.createObject(AllTypes.class);
-                    bgRealm.createObject(AnnotationIndexTypes.class);
-                    bgRealm.commitTransaction();
+                bgRealm.beginTransaction();
+                bgRealm.createObject(AllTypes.class);
+                bgRealm.createObject(AnnotationIndexTypes.class);
+                bgRealm.commitTransaction();
 
-                    bgRealm.close();
-                    bgRealmClosedLatch.countDown();
-                } catch (InterruptedException e) {
-                    fail(e.getMessage());
-                }
+                bgRealm.close();
+                bgRealmClosedLatch.countDown();
             }
         }.start();
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
@@ -255,7 +255,7 @@ public class RealmCacheTests {
         });
         thread.start();
 
-        closeLatch.await();
+        TestHelper.awaitOrFail(closeLatch);
         RealmCache.invokeWithGlobalRefCount(defaultConfig, new TestHelper.ExpectedCountCallback(1));
         realmA.close();
         RealmCache.invokeWithGlobalRefCount(defaultConfig, new TestHelper.ExpectedCountCallback(0));

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmInMemoryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmInMemoryTest.java
@@ -217,7 +217,7 @@ public class RealmInMemoryTest {
 
                 // Waits until Realm instance closed in main thread.
                 try {
-                    realmInMainClosedLatch.await(3, TimeUnit.SECONDS);
+                    realmInMainClosedLatch.await(TestHelper.SHORT_WAIT_SECS, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     threadError[0] = new AssertionFailedError("Worker thread was interrupted.");
                     realm.close();
@@ -232,7 +232,7 @@ public class RealmInMemoryTest {
 
 
         // Waits until the worker thread started.
-        workerCommittedLatch.await(3, TimeUnit.SECONDS);
+        workerCommittedLatch.await(TestHelper.SHORT_WAIT_SECS, TimeUnit.SECONDS);
         if (threadError[0] != null) { throw threadError[0]; }
 
         // Refreshes will be ran in the next loop, manually refreshes it here.
@@ -253,7 +253,7 @@ public class RealmInMemoryTest {
         realmInMainClosedLatch.countDown();
 
         // Waits until the worker thread finished.
-        workerClosedLatch.await(3, TimeUnit.SECONDS);
+        workerClosedLatch.await(TestHelper.SHORT_WAIT_SECS, TimeUnit.SECONDS);
         if (threadError[0] != null) { throw threadError[0]; }
 
         // Since all previous Realm instances has been closed before, below will create a fresh new in-mem-realm instance.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -714,10 +714,7 @@ public class RealmObjectTests {
                 realm.commitTransaction();
 
                 createLatch.countDown();
-                try {
-                    testEndLatch.await();
-                } catch (InterruptedException ignored) {
-                }
+                TestHelper.awaitOrFail(testEndLatch);
 
                 // 3. Closes Realm in this thread and finishes.
                 realm.close();
@@ -725,7 +722,7 @@ public class RealmObjectTests {
         };
         thread.start();
 
-        createLatch.await();
+        TestHelper.awaitOrFail(createLatch);
         // 2. Sets created object to target.
         realm.beginTransaction();
         try {
@@ -869,10 +866,7 @@ public class RealmObjectTests {
                 realm.commitTransaction();
 
                 createLatch.countDown();
-                try {
-                    testEndLatch.await();
-                } catch (InterruptedException ignored) {
-                }
+                TestHelper.awaitOrFail(testEndLatch);
 
                 // 3. Close Realm in this thread and finishes.
                 realm.close();
@@ -880,7 +874,7 @@ public class RealmObjectTests {
         };
         thread.start();
 
-        createLatch.await();
+        TestHelper.awaitOrFail(createLatch);
         // 2. Sets created object to target.
         realm.beginTransaction();
         try {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -70,12 +70,12 @@ public class RealmQueryTests {
     @Rule
     public final RunInLooperThread looperThread = new RunInLooperThread();
 
-    protected final static int TEST_DATA_SIZE = 10;
-    protected final static int TEST_NO_PRIMARY_KEY_NULL_TYPES_SIZE = 200;
+    private final static int TEST_DATA_SIZE = 10;
+    private final static int TEST_NO_PRIMARY_KEY_NULL_TYPES_SIZE = 200;
 
     private final static long DECADE_MILLIS = 10 * TimeUnit.DAYS.toMillis(365);
 
-    protected Realm realm;
+    private Realm realm;
 
     @Before
     public void setUp() throws Exception {
@@ -2624,7 +2624,7 @@ public class RealmQueryTests {
             thread.start();
         }
 
-        latch.await();
+        TestHelper.awaitOrFail(latch);
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -67,6 +66,10 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.fail;
 
 public class TestHelper {
+    public static final int VERY_SHORT_WAIT_SECS = 1;
+    public static final int SHORT_WAIT_SECS = 10;
+    public static final int STANDARD_WAIT_SECS = 100;
+    public static final int LONG_WAIT_SECS = 1000;
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
     private static final Random RANDOM = new Random();
@@ -779,14 +782,14 @@ public class TestHelper {
     }
 
     public static void awaitOrFail(CountDownLatch latch) {
-        awaitOrFail(latch, 300);
+        awaitOrFail(latch, STANDARD_WAIT_SECS);
     }
 
     public static void awaitOrFail(CountDownLatch latch, int numberOfSeconds) {
         try {
             if (android.os.Debug.isDebuggerConnected()) {
-                // If we are debugging the tests, just waits without a timeout. In case we are stopping at a break point
-                // and timeout happens.
+                // If we are debugging the tests, just waits without a timeout.
+                // Don't want a timeout while we are stopped at a break point.
                 latch.await();
             } else if (!latch.await(numberOfSeconds, TimeUnit.SECONDS)) {
                 fail("Test took longer than " + numberOfSeconds + " seconds");

--- a/realm/realm-library/src/androidTest/java/io/realm/util/RealmBackgroundTask.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/util/RealmBackgroundTask.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
+import io.realm.TestHelper;
+
 
 /**
  * Utility class for running a task on a non-looper background thread.
@@ -62,7 +64,7 @@ public abstract class RealmBackgroundTask {
         }, "RealmBackgroundTask").start();
 
         try {
-            if (!jobDone.await(10, TimeUnit.SECONDS)) {
+            if (!jobDone.await(TestHelper.STANDARD_WAIT_SECS, TimeUnit.SECONDS)) {
                 exceptionHolder.setError("Job timed out!");
             }
         } catch (InterruptedException e) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
@@ -18,9 +18,11 @@ package io.realm.objectserver.utils;
 
 public class Constants {
 
-    public static String SYNC_SERVER_URL = "realm://127.0.0.1/tests";
-    public static String SYNC_SERVER_URL_2 = "realm://127.0.0.1/tests2";
+    public static final String SYNC_SERVER_URL = "realm://127.0.0.1/tests";
+    public static final String SYNC_SERVER_URL_2 = "realm://127.0.0.1/tests2";
 
-    public static String AUTH_SERVER_URL = "http://127.0.0.1:9080/";
-    public static String AUTH_URL = AUTH_SERVER_URL + "auth";
+    public static final String AUTH_SERVER_URL = "http://127.0.0.1:9080/";
+    public static final String AUTH_URL = AUTH_SERVER_URL + "auth";
+
+    public static final long TEST_TIMEOUT_SECS = 300;
 }


### PR DESCRIPTION
Make sure that all `await()`s have timeouts, and standardize their lengths.