### PR TITLE
Update Kotlin to 1.1.2

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.1.2-2'
     repositories {
         jcenter()
         mavenCentral()

--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.1'
+    ext.kotlin_version = '1.1.2'
     repositories {
         jcenter()
         mavenCentral()


### PR DESCRIPTION
@realm/java 

Android Gradle Plugin 2.4.0(-alpha) requires Kotlin 1.1.2 plugin.
