### PR TITLE
Remove onSuccess callback before calling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added missing row validation check in certain cases on invalidated/deleted objects (#4540).
 * Initializing Realm is now more resilient if `Context.getFilesDir()` isn't working correctly (#4493).
 * `OrderedRealmCollectionSnapshot.get()` returned a wrong object (#4554).
+* `onSuccess` callback got triggered infinitely if a synced transaction was committed in the async transaction's `onSuccess` callback (#4594).
 
 ## 3.1.3 (2017-04-20)
 

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
@@ -99,13 +99,14 @@ public abstract class RealmNotifier implements Closeable {
     void didChange() {
         realmObserverPairs.foreach(onChangeCallBack);
 
-        Iterator<Runnable> it = transactionCallbacks.iterator();
-        while (it.hasNext()) {
-            Runnable runnable = it.next();
-            // The callback needs to be removed from list before calling to avoid sync transactions in the callback
+        if (!transactionCallbacks.isEmpty()) {
+            // The callback list needs to be cleared before calling to avoid sync transactions in the callback
             // triggers it recursively.
-            it.remove();
-            runnable.run();
+            List<Runnable> callbacks = transactionCallbacks;
+            transactionCallbacks = new ArrayList<Runnable>();
+            for (Runnable runnable : callbacks) {
+                runnable.run();
+            }
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
@@ -18,7 +18,6 @@ package io.realm.internal;
 
 import java.io.Closeable;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import io.realm.RealmChangeListener;
@@ -100,7 +99,7 @@ public abstract class RealmNotifier implements Closeable {
         realmObserverPairs.foreach(onChangeCallBack);
 
         if (!transactionCallbacks.isEmpty()) {
-            // The callback list needs to be cleared before calling to avoid sync transactions in the callback
+            // The callback list needs to be cleared before calling to avoid synchronized transactions in the callback
             // triggers it recursively.
             List<Runnable> callbacks = transactionCallbacks;
             transactionCallbacks = new ArrayList<Runnable>();


### PR DESCRIPTION
Otherwise it will cause infinite recursion if a transaction is committed
in the callback.
Fix #4595