### PR TITLE
Rename Context to NativeContext

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -33,7 +33,7 @@ public class CheckedRow extends UncheckedRow {
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private UncheckedRow originalRow;
 
-    private CheckedRow(Context context, Table parent, long nativePtr) {
+    private CheckedRow(RealmContext context, Table parent, long nativePtr) {
         super(context, parent, nativePtr);
     }
 
@@ -50,7 +50,7 @@ public class CheckedRow extends UncheckedRow {
      * @param index the index of the row.
      * @return an instance of Row for the table and index specified.
      */
-    public static CheckedRow get(Context context, Table table, long index) {
+    public static CheckedRow get(RealmContext context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.getNativePtr(), index);
         return new CheckedRow(context, table, nativeRowPointer);
     }
@@ -63,7 +63,7 @@ public class CheckedRow extends UncheckedRow {
      * @param index the index of the row.
      * @return a checked instance of {@link Row} for the {@link LinkView} and index specified.
      */
-    public static CheckedRow get(Context context, LinkView linkView, long index) {
+    public static CheckedRow get(RealmContext context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.getNativePtr(), index);
         return new CheckedRow(context, linkView.getTargetTable(), nativeRowPointer);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -33,7 +33,7 @@ public class CheckedRow extends UncheckedRow {
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private UncheckedRow originalRow;
 
-    private CheckedRow(RealmContext context, Table parent, long nativePtr) {
+    private CheckedRow(NativeContext context, Table parent, long nativePtr) {
         super(context, parent, nativePtr);
     }
 
@@ -50,7 +50,7 @@ public class CheckedRow extends UncheckedRow {
      * @param index the index of the row.
      * @return an instance of Row for the table and index specified.
      */
-    public static CheckedRow get(RealmContext context, Table table, long index) {
+    public static CheckedRow get(NativeContext context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.getNativePtr(), index);
         return new CheckedRow(context, table, nativeRowPointer);
     }
@@ -63,7 +63,7 @@ public class CheckedRow extends UncheckedRow {
      * @param index the index of the row.
      * @return a checked instance of {@link Row} for the {@link LinkView} and index specified.
      */
-    public static CheckedRow get(RealmContext context, LinkView linkView, long index) {
+    public static CheckedRow get(NativeContext context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.getNativePtr(), index);
         return new CheckedRow(context, linkView.getTargetTable(), nativeRowPointer);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/Collection.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Collection.java
@@ -259,7 +259,7 @@ public class Collection implements NativeObject {
     private final long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
     private final SharedRealm sharedRealm;
-    private final RealmContext context;
+    private final NativeContext context;
     private final Table table;
     private boolean loaded;
     private boolean isSnapshot = false;

--- a/realm/realm-library/src/main/java/io/realm/internal/Collection.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Collection.java
@@ -259,7 +259,7 @@ public class Collection implements NativeObject {
     private final long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
     private final SharedRealm sharedRealm;
-    private final Context context;
+    private final RealmContext context;
     private final Table table;
     private boolean loaded;
     private boolean isSnapshot = false;

--- a/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
@@ -44,7 +44,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
 
     public CollectionChangeSet(long nativePtr) {
         this.nativePtr = nativePtr;
-        Context.dummyContext.addReference(this);
+        RealmContext.dummyContext.addReference(this);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
@@ -44,7 +44,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
 
     public CollectionChangeSet(long nativePtr) {
         this.nativePtr = nativePtr;
-        RealmContext.dummyContext.addReference(this);
+        NativeContext.dummyContext.addReference(this);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
@@ -24,13 +24,13 @@ import io.realm.RealmFieldType;
  */
 public class LinkView implements NativeObject {
 
-    private final RealmContext context;
+    private final NativeContext context;
     final Table parent;
     final long columnIndexInParent;
     private final long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
 
-    public LinkView(RealmContext context, Table parent, long columnIndexInParent, long nativeLinkViewPtr) {
+    public LinkView(NativeContext context, Table parent, long columnIndexInParent, long nativeLinkViewPtr) {
         this.context = context;
         this.parent = parent;
         this.columnIndexInParent = columnIndexInParent;

--- a/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/LinkView.java
@@ -24,13 +24,13 @@ import io.realm.RealmFieldType;
  */
 public class LinkView implements NativeObject {
 
-    private final Context context;
+    private final RealmContext context;
     final Table parent;
     final long columnIndexInParent;
     private final long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
 
-    public LinkView(Context context, Table parent, long columnIndexInParent, long nativeLinkViewPtr) {
+    public LinkView(RealmContext context, Table parent, long columnIndexInParent, long nativeLinkViewPtr) {
         this.context = context;
         this.parent = parent;
         this.columnIndexInParent = columnIndexInParent;

--- a/realm/realm-library/src/main/java/io/realm/internal/NativeContext.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/NativeContext.java
@@ -21,16 +21,16 @@ import java.lang.ref.ReferenceQueue;
 
 // Currently we free native objects in two threads, the SharedGroup is freed in the caller thread, others are freed in
 // RealmFinalizingDaemon thread. And the destruction in both threads are locked by the corresponding context.
-// The purpose of locking on RealmContext is:
+// The purpose of locking on NativeContext is:
 // Destruction of SharedGroup (and hence Group and Table) is currently not thread-safe with respect to destruction of
 // other accessors, you have to ensure mutual exclusion. This is also illustrated by the use of locks in the test
 // test_destructor_thread_safety.cpp. Explicit call of SharedGroup::close() or Table::detach() is also not thread-safe
 // with respect to destruction of other accessors.
-public class RealmContext {
+public class NativeContext {
     private final static ReferenceQueue<NativeObject> referenceQueue = new ReferenceQueue<NativeObject>();
     private final static Thread finalizingThread = new Thread(new FinalizerRunnable(referenceQueue));
     // Dummy context which will be used by native objects which's destructors are always thread safe.
-    final static RealmContext dummyContext = new RealmContext();
+    final static NativeContext dummyContext = new NativeContext();
 
     static {
         finalizingThread.setName("RealmFinalizingDaemon");

--- a/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
@@ -63,13 +63,13 @@ final class NativeObjectReference extends PhantomReference<NativeObject> {
     private final long nativePtr;
     // The pointer to the native finalize function
     private final long nativeFinalizerPtr;
-    private final RealmContext context;
+    private final NativeContext context;
     private NativeObjectReference prev;
     private NativeObjectReference next;
 
     private static ReferencePool referencePool = new ReferencePool();
 
-    NativeObjectReference(RealmContext context,
+    NativeObjectReference(NativeContext context,
             NativeObject referent,
             ReferenceQueue<? super NativeObject> referenceQueue) {
         super(referent, referenceQueue);

--- a/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/NativeObjectReference.java
@@ -63,13 +63,13 @@ final class NativeObjectReference extends PhantomReference<NativeObject> {
     private final long nativePtr;
     // The pointer to the native finalize function
     private final long nativeFinalizerPtr;
-    private final Context context;
+    private final RealmContext context;
     private NativeObjectReference prev;
     private NativeObjectReference next;
 
     private static ReferencePool referencePool = new ReferencePool();
 
-    NativeObjectReference(Context context,
+    NativeObjectReference(RealmContext context,
             NativeObject referent,
             ReferenceQueue<? super NativeObject> referenceQueue) {
         super(referent, referenceQueue);

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmContext.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmContext.java
@@ -21,16 +21,16 @@ import java.lang.ref.ReferenceQueue;
 
 // Currently we free native objects in two threads, the SharedGroup is freed in the caller thread, others are freed in
 // RealmFinalizingDaemon thread. And the destruction in both threads are locked by the corresponding context.
-// The purpose of locking on Context is:
+// The purpose of locking on RealmContext is:
 // Destruction of SharedGroup (and hence Group and Table) is currently not thread-safe with respect to destruction of
 // other accessors, you have to ensure mutual exclusion. This is also illustrated by the use of locks in the test
 // test_destructor_thread_safety.cpp. Explicit call of SharedGroup::close() or Table::detach() is also not thread-safe
 // with respect to destruction of other accessors.
-public class Context {
+public class RealmContext {
     private final static ReferenceQueue<NativeObject> referenceQueue = new ReferenceQueue<NativeObject>();
     private final static Thread finalizingThread = new Thread(new FinalizerRunnable(referenceQueue));
     // Dummy context which will be used by native objects which's destructors are always thread safe.
-    final static Context dummyContext = new Context();
+    final static RealmContext dummyContext = new RealmContext();
 
     static {
         finalizingThread.setName("RealmFinalizingDaemon");

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -177,7 +177,7 @@ public final class SharedRealm implements Closeable, NativeObject {
     private final RealmConfiguration configuration;
 
     final private long nativePtr;
-    final Context context;
+    final RealmContext context;
     private long lastSchemaVersion;
     private final SchemaVersionListener schemaChangeListener;
 
@@ -193,7 +193,7 @@ public final class SharedRealm implements Closeable, NativeObject {
         this.capabilities = capabilities;
         this.realmNotifier = realmNotifier;
         this.schemaChangeListener = schemaVersionListener;
-        context = new Context();
+        context = new RealmContext();
         context.addReference(this);
         this.lastSchemaVersion = schemaVersionListener == null ? -1L : getSchemaVersion();
         nativeSetAutoRefresh(nativePtr, capabilities.canDeliverNotification());

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -177,7 +177,7 @@ public final class SharedRealm implements Closeable, NativeObject {
     private final RealmConfiguration configuration;
 
     final private long nativePtr;
-    final RealmContext context;
+    final NativeContext context;
     private long lastSchemaVersion;
     private final SchemaVersionListener schemaChangeListener;
 
@@ -193,7 +193,7 @@ public final class SharedRealm implements Closeable, NativeObject {
         this.capabilities = capabilities;
         this.realmNotifier = realmNotifier;
         this.schemaChangeListener = schemaVersionListener;
-        context = new RealmContext();
+        context = new NativeContext();
         context.addReference(this);
         this.lastSchemaVersion = schemaVersionListener == null ? -1L : getSchemaVersion();
         nativeSetAutoRefresh(nativePtr, capabilities.canDeliverNotification());

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -60,7 +60,7 @@ public class Table implements TableSchema, NativeObject {
 
     private long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
-    final Context context;
+    final RealmContext context;
     private final SharedRealm sharedRealm;
     private long cachedPrimaryKeyColumnIndex = NO_MATCH;
 
@@ -69,7 +69,7 @@ public class Table implements TableSchema, NativeObject {
      * allowed only for empty tables. It creates a native reference of the object and keeps a reference to it.
      */
     public Table() {
-        this.context = new Context();
+        this.context = new RealmContext();
         // Native methods work will be initialized here. Generated classes will
         // have nothing to do with the native functions. Generated Java Table
         // classes will work as a wrapper on top of table.

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -60,7 +60,7 @@ public class Table implements TableSchema, NativeObject {
 
     private long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
-    final RealmContext context;
+    final NativeContext context;
     private final SharedRealm sharedRealm;
     private long cachedPrimaryKeyColumnIndex = NO_MATCH;
 
@@ -69,7 +69,7 @@ public class Table implements TableSchema, NativeObject {
      * allowed only for empty tables. It creates a native reference of the object and keeps a reference to it.
      */
     public Table() {
-        this.context = new RealmContext();
+        this.context = new NativeContext();
         // Native methods work will be initialized here. Generated classes will
         // have nothing to do with the native functions. Generated Java Table
         // classes will work as a wrapper on top of table.

--- a/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
@@ -28,7 +28,7 @@ public class TableQuery implements NativeObject {
     protected long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
     protected final Table table;
-    private final RealmContext context;
+    private final NativeContext context;
 
     // All actions (find(), findAll(), sum(), etc.) must call validateQuery() before performing
     // the actual action. The other methods must set queryValidated to false in order to enforce
@@ -36,7 +36,7 @@ public class TableQuery implements NativeObject {
     private boolean queryValidated = true;
 
     // TODO: Can we protect this?
-    public TableQuery(RealmContext context, Table table, long nativeQueryPtr) {
+    public TableQuery(NativeContext context, Table table, long nativeQueryPtr) {
         if (DEBUG) {
             System.err.println("++++++ new TableQuery, ptr= " + nativeQueryPtr);
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
@@ -28,7 +28,7 @@ public class TableQuery implements NativeObject {
     protected long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
     protected final Table table;
-    private final Context context;
+    private final RealmContext context;
 
     // All actions (find(), findAll(), sum(), etc.) must call validateQuery() before performing
     // the actual action. The other methods must set queryValidated to false in order to enforce
@@ -36,7 +36,7 @@ public class TableQuery implements NativeObject {
     private boolean queryValidated = true;
 
     // TODO: Can we protect this?
-    public TableQuery(Context context, Table table, long nativeQueryPtr) {
+    public TableQuery(RealmContext context, Table table, long nativeQueryPtr) {
         if (DEBUG) {
             System.err.println("++++++ new TableQuery, ptr= " + nativeQueryPtr);
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
@@ -33,11 +33,11 @@ import io.realm.RealmFieldType;
 public class UncheckedRow implements NativeObject, Row {
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
 
-    private final RealmContext context; // This is only kept because for now it's needed by the constructor of LinkView
+    private final NativeContext context; // This is only kept because for now it's needed by the constructor of LinkView
     private final Table parent;
     private final long nativePtr;
 
-    UncheckedRow(RealmContext context, Table parent, long nativePtr) {
+    UncheckedRow(NativeContext context, Table parent, long nativePtr) {
         this.context = context;
         this.parent = parent;
         this.nativePtr = nativePtr;
@@ -71,7 +71,7 @@ public class UncheckedRow implements NativeObject, Row {
      * @param index the index of the row.
      * @return an instance of Row for the table and index specified.
      */
-    static UncheckedRow getByRowIndex(RealmContext context, Table table, long index) {
+    static UncheckedRow getByRowIndex(NativeContext context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.getNativePtr(), index);
         return new UncheckedRow(context, table, nativeRowPointer);
     }
@@ -84,7 +84,7 @@ public class UncheckedRow implements NativeObject, Row {
      * @param nativeRowPointer pointer of a row.
      * @return an instance of Row for the table and row specified.
      */
-    static UncheckedRow getByRowPointer(RealmContext context, Table table, long nativeRowPointer) {
+    static UncheckedRow getByRowPointer(NativeContext context, Table table, long nativeRowPointer) {
         return new UncheckedRow(context, table, nativeRowPointer);
     }
 
@@ -96,7 +96,7 @@ public class UncheckedRow implements NativeObject, Row {
      * @param index the index of the row.
      * @return an instance of Row for the LinkView and index specified.
      */
-    static UncheckedRow getByRowIndex(RealmContext context, LinkView linkView, long index) {
+    static UncheckedRow getByRowIndex(NativeContext context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.getNativePtr(), index);
         return new UncheckedRow(context, linkView.getTargetTable(), nativeRowPointer);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
@@ -33,11 +33,11 @@ import io.realm.RealmFieldType;
 public class UncheckedRow implements NativeObject, Row {
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
 
-    private final Context context; // This is only kept because for now it's needed by the constructor of LinkView
+    private final RealmContext context; // This is only kept because for now it's needed by the constructor of LinkView
     private final Table parent;
     private final long nativePtr;
 
-    UncheckedRow(Context context, Table parent, long nativePtr) {
+    UncheckedRow(RealmContext context, Table parent, long nativePtr) {
         this.context = context;
         this.parent = parent;
         this.nativePtr = nativePtr;
@@ -71,7 +71,7 @@ public class UncheckedRow implements NativeObject, Row {
      * @param index the index of the row.
      * @return an instance of Row for the table and index specified.
      */
-    static UncheckedRow getByRowIndex(Context context, Table table, long index) {
+    static UncheckedRow getByRowIndex(RealmContext context, Table table, long index) {
         long nativeRowPointer = table.nativeGetRowPtr(table.getNativePtr(), index);
         return new UncheckedRow(context, table, nativeRowPointer);
     }
@@ -84,7 +84,7 @@ public class UncheckedRow implements NativeObject, Row {
      * @param nativeRowPointer pointer of a row.
      * @return an instance of Row for the table and row specified.
      */
-    static UncheckedRow getByRowPointer(Context context, Table table, long nativeRowPointer) {
+    static UncheckedRow getByRowPointer(RealmContext context, Table table, long nativeRowPointer) {
         return new UncheckedRow(context, table, nativeRowPointer);
     }
 
@@ -96,7 +96,7 @@ public class UncheckedRow implements NativeObject, Row {
      * @param index the index of the row.
      * @return an instance of Row for the LinkView and index specified.
      */
-    static UncheckedRow getByRowIndex(Context context, LinkView linkView, long index) {
+    static UncheckedRow getByRowIndex(RealmContext context, LinkView linkView, long index) {
         long nativeRowPointer = linkView.nativeGetRow(linkView.getNativePtr(), index);
         return new UncheckedRow(context, linkView.getTargetTable(), nativeRowPointer);
     }


### PR DESCRIPTION
Renames `io.realm.internal.Context` to `io.realm.internal.NativeContext` (started out as RealmContext) to avoid confusion with `android.content.Context`