### PR TITLE
    Wait for async tasks finish to solve flaky test

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -440,15 +440,6 @@ public class RealmAsyncQueryTests {
             @Override
             public void execute(Realm realm) {
                 realm.createObject(AllTypes.class);
-                // Delay to post this to ensure the async transaction posted callback will arrive first.
-                looperThread.postRunnableDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        // Manually call refresh, so the did_change will be triggered.
-                        foregroundRealm.sharedRealm.refresh();
-                        foregroundRealm.setAutoRefresh(true);
-                    }
-                }, 50);
             }
         }, new Realm.Transaction.OnSuccess() {
             @Override
@@ -456,6 +447,17 @@ public class RealmAsyncQueryTests {
                 // This will be called 2nd and only once
                 assertEquals(1, callbackCounter.getAndIncrement());
                 looperThread.testComplete();
+            }
+        });
+
+        // Wait for all async tasks finish to ensure the async transaction posted callback will arrive first.
+        TestHelper.waitRealmThreadExecutorFinish();
+        looperThread.postRunnable(new Runnable() {
+            @Override
+            public void run() {
+                // Manually call refresh, so the did_change will be triggered.
+                foregroundRealm.sharedRealm.refresh();
+                foregroundRealm.setAutoRefresh(true);
             }
         });
     }


### PR DESCRIPTION
Apparently waiting some random millisecond is never a good idea.
