### PR TITLE
Clean up SharedRealm source

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -128,6 +128,7 @@ public final class SharedRealm implements Closeable, NativeObject {
 
         @Override
         public int compareTo(@SuppressWarnings("NullableProblems") VersionID another) {
+            //noinspection ConstantConditions
             if (another == null) {
                 throw new IllegalArgumentException("Version cannot be compared to a null value.");
             }
@@ -214,17 +215,18 @@ public final class SharedRealm implements Closeable, NativeObject {
         String syncRealmUrl = syncUserConf[1];
         String syncRealmAuthUrl = syncUserConf[2];
         String syncRefreshToken = syncUserConf[3];
-        boolean enable_caching = false; // Handled in Java currently
-        boolean disableFormatUpgrade = false; // TODO Double negatives :/
+
+        final boolean enableCaching = false; // Handled in Java currently
+        final boolean enableFormatUpgrade = true;
 
         long nativeConfigPtr = nativeCreateConfig(
                 config.getPath(),
                 config.getEncryptionKey(),
                 syncRealmUrl != null ? SchemaMode.SCHEMA_MODE_ADDITIVE.getNativeValue() : SchemaMode.SCHEMA_MODE_MANUAL.getNativeValue(),
                 config.getDurability() == Durability.MEM_ONLY,
-                enable_caching,
+                enableCaching,
                 config.getSchemaVersion(),
-                disableFormatUpgrade,
+                enableFormatUpgrade,
                 autoChangeNotifications,
                 syncRealmUrl,
                 syncRealmAuthUrl,
@@ -312,10 +314,6 @@ public final class SharedRealm implements Closeable, NativeObject {
     public SharedRealm.VersionID getVersionID() {
         long[] versionId = nativeGetVersionID(nativePtr);
         return new SharedRealm.VersionID(versionId[0], versionId[1]);
-    }
-
-    public long getLastSnapshotVersion() {
-        return nativeGetSnapshotVersion(nativePtr);
     }
 
     public boolean isClosed() {
@@ -463,7 +461,9 @@ public final class SharedRealm implements Closeable, NativeObject {
 
     // Keep last session as an 'object' to avoid any reference to sync code
     private static native long nativeCreateConfig(String realmPath, byte[] key, byte schemaMode, boolean inMemory,
-            boolean cache, long schemaVersion, boolean disableFormatUpgrade,
+            boolean cache,
+            long schemaVersion,
+            boolean enabledFormatUpgrade,
             boolean autoChangeNotification,
             String syncServerURL,
             String syncServerAuthURL,
@@ -487,8 +487,6 @@ public final class SharedRealm implements Closeable, NativeObject {
     private static native boolean nativeIsInTransaction(long nativeSharedRealmPtr);
 
     private static native long nativeGetVersion(long nativeSharedRealmPtr);
-
-    private static native long nativeGetSnapshotVersion(long nativeSharedRealmPtr);
 
     private static native void nativeSetVersion(long nativeSharedRealmPtr, long version);
 


### PR DESCRIPTION
- Remove unused methods.
- Fix double negatives.
- Use auto& to avoid creating temp objects.