### PR TITLE
Use shorthand for generic arguments for better AS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added `Realm.refresh()` and `DynamicRealm.refresh()` (#3476).
 * Added `Realm.getInstanceAsync()` and `DynamicRealm.getInstanceAsync()` (#2299).
 * Added `DynamicRealmObject#linkingObjects(String,String)` to support linking objects on `DynamicRealm` (#4492).
+* Changelisteners will now auto-expand variable names to be more descriptive when using Android Studio.
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionChangeListener.java
@@ -32,9 +32,9 @@ public interface OrderedRealmCollectionChangeListener<T> {
     /**
      * This will be called when the async query is finished the first time or the collection of objects has changed.
      *
-     * @param collection the collection this listener is registered to.
+     * @param t the collection this listener is registered to.
      * @param changeSet object with information about which rows in the collection were added, removed or modified.
      * {@code null} is returned the first time an async query is completed.
      */
-    void onChange(T collection, OrderedCollectionChangeSet changeSet);
+    void onChange(T t, OrderedCollectionChangeSet changeSet);
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
@@ -42,6 +42,6 @@ public interface RealmChangeListener<T> {
     /**
      * Called when a transaction is committed.
      */
-    void onChange(T element);
+    void onChange(T t);
 
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectChangeListener.java
@@ -51,8 +51,8 @@ public interface RealmObjectChangeListener<T extends RealmModel> {
      * <p>
      * Changes to {@link LinkingObjects} annotated {@link RealmResults} fields will not be monitored, nor reported
      * through this change listener.
-     * @param object the {@code RealmObject} this listener is registered to.
+     * @param t the {@code RealmObject} this listener is registered to.
      * @param changeSet the detailed information about the changes.
      */
-    void onChange(T object, ObjectChangeSet changeSet);
+    void onChange(T t, ObjectChangeSet changeSet);
 }


### PR DESCRIPTION
By using a shorthand for the generic argument when creating Changelisteners, IntelliJ (and Android Studio) will expand that automatically to be a camel-cased version of the generic argument. This makes the code more readable with minimal effort. Existing code will not be affected.

Example:
```
// Before
RealmResults<Permission> permissions = realm.where(Permission.class).findAll();
permissions.addChangeListener(new RealmChangeListener<RealmResults<Permission>>() {
  @Override
  public void onChange(RealmResults<Permission> element) {
     // user forced to manually rename `element` to something more descriptive
  }
});

// Now 
permissions.addChangeListener(new RealmChangeListener<RealmResults<Permission>>() {
  @Override
  public void onChange(RealmResults<Permission> permissions) {
     // IntelliJ will automatically rename the variable to 'permissions' even though it is really named 't'.
  }
});
```