### PR TITLE
Fixed @LinkingObjects notation for Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.1.5 (YYYY-MM-DD)
+
+## Bug fixes
+
+* `@LinkingObjects` annotation now also works with Kotlin (#4611).
+
+
 ## 3.1.4 (2017-05-04)
 
 ## Bug fixes

--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -46,5 +46,5 @@ android {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
-    compile 'org.jetbrains.anko:anko-sdk15:0.8.2'
+    compile 'org.jetbrains.anko:anko-sdk15:0.9.1'
 }

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
@@ -26,7 +26,7 @@ import io.realm.Sort
 import io.realm.examples.kotlin.model.Cat
 import io.realm.examples.kotlin.model.Dog
 import io.realm.examples.kotlin.model.Person
-import org.jetbrains.anko.async
+import org.jetbrains.anko.doAsync
 import org.jetbrains.anko.uiThread
 import kotlin.properties.Delegates
 
@@ -63,11 +63,10 @@ class KotlinExampleActivity : Activity() {
         basicLinkQuery(realm)
 
         // More complex operations can be executed on another thread, for example using
-        // Anko's async extension method.
-        async {
+        // Anko's doAsync extension method.
+        doAsync {
             var info = complexReadWrite()
             info += complexQuery()
-
             uiThread {
                 showStatus(info)
             }

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/model/Cat.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/model/Cat.kt
@@ -19,5 +19,5 @@ package io.realm.examples.kotlin.model
 import io.realm.RealmObject
 
 open class Cat : RealmObject() {
-    open var name: String? = null
+    var name: String? = null
 }

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/model/Dog.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/model/Dog.kt
@@ -17,7 +17,11 @@
 package io.realm.examples.kotlin.model
 
 import io.realm.RealmObject
+import io.realm.RealmResults
+import io.realm.annotations.LinkingObjects
 
 open class Dog : RealmObject() {
-    open var name: String? = null
+    var name: String? = null
+    @LinkingObjects("dog")
+    val owners: RealmResults<Person>? = null
 }

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/model/Person.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/model/Person.kt
@@ -21,8 +21,7 @@ import io.realm.RealmObject
 import io.realm.annotations.Ignore
 import io.realm.annotations.PrimaryKey
 
-// Your model has to extend RealmObject. Furthermore, the class and all of the
-// properties must be annotated with open (Kotlin classes and methods are final
+// Your model has to extend RealmObject. Furthermore, the class must be annotated with open (Kotlin classes are final
 // by default).
 open class Person(
         // You can put properties in the constructor as long as all of them are initialized with
@@ -30,20 +29,20 @@ open class Person(
         // All properties are by default persisted.
         // Properties can be annotated with PrimaryKey or Index.
         // If you use non-nullable types, properties must be initialized with non-null values.
-        @PrimaryKey open var id: Long = 0,
+        @PrimaryKey var id: Long = 0,
 
-        open var name: String = "",
+        var name: String = "",
 
-        open var age: Int = 0,
+        var age: Int = 0,
 
         // Other objects in a one-to-one relation must also subclass RealmObject
-        open var dog: Dog? = null,
+        var dog: Dog? = null,
 
         // One-to-many relations is simply a RealmList of the objects which also subclass RealmObject
-        open var cats: RealmList<Cat> = RealmList(),
+        var cats: RealmList<Cat> = RealmList(),
 
         // You can instruct Realm to ignore a field and not persist it.
-        @Ignore open var tempReference: Int = 0
+        @Ignore var tempReference: Int = 0
 
 ) : RealmObject() {
     // The Kotlin compiler generates standard getters and setters.

--- a/realm-annotations/src/main/java/io/realm/annotations/LinkingObjects.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/LinkingObjects.java
@@ -92,7 +92,7 @@ import java.lang.annotation.Target;
  * assert fido.owners.size() == 2;
  * }
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 @Target(ElementType.FIELD)
 @Beta
 public @interface LinkingObjects {


### PR DESCRIPTION
Fixes #4611 

Apparently, annotations need CLASS retention in order to work with Kotlin. I'm guessing some combination of how annotation processors work with the Kotlin compiler.

Also updated the example code to be more correct (don't need open on fields / updated Anko). And yes that should probably have been in another PR 😄 