### PR TITLE
Make the proxy toString methods reveal themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 3.1.5 (YYYY-MM-DD)
 
+## Enhancements
+
+* The `toString()` methods for the standard and dynamic proxies now print "proxy", or "dynamic" before the left bracket enclosing the data.
+
 ## Bug fixes
 
 * `@LinkingObjects` annotation now also works with Kotlin (#4611).

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -1732,7 +1732,7 @@ public class RealmProxyClassGenerator {
                 .beginControlFlow("if (!RealmObject.isValid(this))")
                 .emitStatement("return \"Invalid object\"")
                 .endControlFlow();
-        writer.emitStatement("StringBuilder stringBuilder = new StringBuilder(\"%s = [\")", simpleClassName);
+        writer.emitStatement("StringBuilder stringBuilder = new StringBuilder(\"%s = proxy[\")", simpleClassName);
 
         Collection<VariableElement> fields = metadata.getFields();
         int i = fields.size() - 1;

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -1223,7 +1223,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         if (!RealmObject.isValid(this)) {
             return "Invalid object";
         }
-        StringBuilder stringBuilder = new StringBuilder("AllTypes = [");
+        StringBuilder stringBuilder = new StringBuilder("AllTypes = proxy[");
         stringBuilder.append("{columnString:");
         stringBuilder.append(realmGet$columnString() != null ? realmGet$columnString() : "null");
         stringBuilder.append("}");

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -496,7 +496,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         if (!RealmObject.isValid(this)) {
             return "Invalid object";
         }
-        StringBuilder stringBuilder = new StringBuilder("Booleans = [");
+        StringBuilder stringBuilder = new StringBuilder("Booleans = proxy[");
         stringBuilder.append("{done:");
         stringBuilder.append(realmGet$done());
         stringBuilder.append("}");

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -2059,7 +2059,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         if (!RealmObject.isValid(this)) {
             return "Invalid object";
         }
-        StringBuilder stringBuilder = new StringBuilder("NullTypes = [");
+        StringBuilder stringBuilder = new StringBuilder("NullTypes = proxy[");
         stringBuilder.append("{fieldStringNotNull:");
         stringBuilder.append(realmGet$fieldStringNotNull());
         stringBuilder.append("}");

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -1220,7 +1220,7 @@ public class DynamicRealmObjectTests {
         // Checks that toString() doesn't crash, and does simple formatting checks. We cannot compare to a set String as
         // eg. the byte array will be allocated each time it is accessed.
         String str = dObjTyped.toString();
-        assertTrue(str.startsWith("AllJavaTypes = dyn["));
+        assertTrue(str.startsWith("AllJavaTypes = dynamic["));
         assertTrue(str.endsWith("}]"));
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -1220,7 +1220,7 @@ public class DynamicRealmObjectTests {
         // Checks that toString() doesn't crash, and does simple formatting checks. We cannot compare to a set String as
         // eg. the byte array will be allocated each time it is accessed.
         String str = dObjTyped.toString();
-        assertTrue(str.startsWith("AllJavaTypes = ["));
+        assertTrue(str.startsWith("AllJavaTypes = dyn["));
         assertTrue(str.endsWith("}]"));
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -456,8 +456,9 @@ public class RealmObjectTests {
         realm.beginTransaction();
         CyclicType foo = createCyclicData();
         realm.commitTransaction();
-        String expected = "CyclicType = [{id:0},{name:Foo},{date:null},{object:CyclicType},{otherObject:null},{objects:RealmList<CyclicType>[0]}]";
-        assertEquals(expected, foo.toString());
+        assertEquals(
+                "CyclicType = proxy[{id:0},{name:Foo},{date:null},{object:CyclicType},{otherObject:null},{objects:RealmList<CyclicType>[0]}]",
+                foo.toString());
     }
 
     @Test

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -873,7 +873,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
         }
 
         final String className = Table.tableNameToClassName(proxyState.getRow$realm().getTable().getName());
-        StringBuilder sb = new StringBuilder(className + " = dyn[");
+        StringBuilder sb = new StringBuilder(className + " = dynamic[");
         String[] fields = getFieldNames();
         for (String field : fields) {
             long columnIndex = proxyState.getRow$realm().getColumnIndex(field);

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -873,7 +873,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
         }
 
         final String className = Table.tableNameToClassName(proxyState.getRow$realm().getTable().getName());
-        StringBuilder sb = new StringBuilder(className + " = [");
+        StringBuilder sb = new StringBuilder(className + " = dyn[");
         String[] fields = getFieldNames();
         for (String field : fields) {
             long columnIndex = proxyState.getRow$realm().getColumnIndex(field);
@@ -918,9 +918,9 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                     sb.append("?");
                     break;
             }
-            sb.append("}, ");
+            sb.append("},");
         }
-        sb.replace(sb.length() - 2, sb.length(), "");
+        sb.replace(sb.length() - 1, sb.length(), "");
         sb.append("]");
         return sb.toString();
     }


### PR DESCRIPTION
Make the `toString` methods in the DynamicObject Proxy and the Realm Proxy more up-front about who  they are.