### PR TITLE
Add comment about GC to all relevant change listeners

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -914,9 +914,9 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      *     protected void onCreate(Bundle savedInstanceState) {
      *       super.onCreate(savedInstanceState);
      *       dogs = realm.where(Person.class).findFirst().getDogs();
-     *       dogs.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<Dog>>() {
+     *       dogs.addChangeListener(new OrderedRealmCollectionChangeListener<RealmList<Dog>>() {
      *           \@Override
-     *           public void onChange(RealmResults<Dog> dogs, OrderedCollectionChangeSet changeSet) {
+     *           public void onChange(RealmList<Dog> dogs, OrderedCollectionChangeSet changeSet) {
      *               // React to change
      *           }
      *       });
@@ -965,9 +965,9 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      *     protected void onCreate(Bundle savedInstanceState) {
      *       super.onCreate(savedInstanceState);
      *       dogs = realm.where(Person.class).findFirst().getDogs();
-     *       dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
+     *       dogs.addChangeListener(new RealmChangeListener<RealmList<Dog>>() {
      *           \@Override
-     *           public void onChange(RealmResults<Dog> dogs) {
+     *           public void onChange(RealmList<Dog> dogs) {
      *               // React to change
      *           }
      *       });

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -899,6 +899,31 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
 
     /**
      * Adds a change listener to this {@link RealmList}.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmList from being garbage collected.
+     * If the RealmList is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private RealmList<Dog> dogs; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       dogs = realm.where(Person.class).findFirst().getDogs();
+     *       dogs.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<Dog>>() {
+     *           \@Override
+     *           public void onChange(RealmResults<Dog> dogs, OrderedCollectionChangeSet changeSet) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null}.
@@ -925,6 +950,31 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
 
     /**
      * Adds a change listener to this {@link RealmList}.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmList from being garbage collected.
+     * If the RealmList is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private RealmList<Dog> dogs; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       dogs = realm.where(Person.class).findFirst().getDogs();
+     *       dogs.addChangeListener(new RealmChangeListener<RealmResults<Dog>>() {
+     *           \@Override
+     *           public void onChange(RealmResults<Dog> dogs) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null}.

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -316,6 +316,31 @@ public abstract class RealmObject implements RealmModel {
      * Adds a change listener to this RealmObject to get detailed information about changes. The listener will be
      * triggered if any value field or referenced RealmObject field is changed, or the RealmList field itself is
      * changed.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmObject from being garbage collected.
+     * If the RealmObject is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private Person person; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       person = realm.where(Person.class).findFirst();
+     *       person.addChangeListener(new RealmObjectChangeListener<Person>() {
+     *           \@Override
+     *           public void onChange(Person person, ObjectChangeSet changeSet) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null} or the object is an unmanaged object.
@@ -330,6 +355,31 @@ public abstract class RealmObject implements RealmModel {
     /**
      * Adds a change listener to this RealmObject that will be triggered if any value field or referenced RealmObject
      * field is changed, or the RealmList field itself is changed.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmObject from being garbage collected.
+     * If the RealmObject is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private Person person; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       person = realm.where(Person.class).findFirst();
+     *       person.addChangeListener(new RealmChangeListener<Person>() {
+     *           \@Override
+     *           public void onChange(Person person) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null} or the object is an unmanaged object.
@@ -345,6 +395,32 @@ public abstract class RealmObject implements RealmModel {
      * Adds a change listener to a RealmObject to get detailed information about the changes. The listener will be
      * triggered if any value field or referenced RealmObject field is changed, or the RealmList field itself is
      * changed.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmObject from being garbage collected.
+     * If the RealmObject is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private Person person; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       person = realm.where(Person.class).findFirst();
+     *       person.addChangeListener(new RealmObjectChangeListener<Person>() {
+     *           \@Override
+     *           public void onChange(Person person, ObjectChangeSet changeSet) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
+     *
      *
      * @param object RealmObject to add listener to.
      * @param listener the change listener to be notified.
@@ -375,6 +451,31 @@ public abstract class RealmObject implements RealmModel {
     /**
      * Adds a change listener to a RealmObject that will be triggered if any value field or referenced RealmObject field
      * is changed, or the RealmList field itself is changed.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmObject from being garbage collected.
+     * If the RealmObject is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private Person person; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       person = realm.where(Person.class).findFirst();
+     *       person.addChangeListener(new RealmChangeListener<Person>() {
+     *           \@Override
+     *           public void onChange(Person person) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
      *
      * @param object RealmObject to add listener to.
      * @param listener the change listener to be notified.

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -125,6 +125,31 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
 
     /**
      * Adds a change listener to this {@link RealmResults}.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmResults from being garbage collected.
+     * If the RealmResults is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private RealmResults<Person> results; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       results = realm.where(Person.class).findAllAsync();
+     *       results.addChangeListener(new RealmChangeListener<RealmResults<Person>>() {
+     *           \@Override
+     *           public void onChange(RealmResults<Person> persons) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null}.
@@ -138,6 +163,31 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
 
     /**
      * Adds a change listener to this {@link RealmResults}.
+     * <p>
+     * Registering a change listener will not prevent the underlying RealmResults from being garbage collected.
+     * If the RealmResults is garbage collected, the change listener will stop being triggered. To avoid this, keep a
+     * strong reference for as long as appropriate e.g. in a class variable.
+     * <p>
+     * <pre>
+     * {@code
+     * public class MyActivity extends Activity {
+     *
+     *     private RealmResults<Person> results; // Strong reference to keep listeners alive
+     *
+     *     \@Override
+     *     protected void onCreate(Bundle savedInstanceState) {
+     *       super.onCreate(savedInstanceState);
+     *       results = realm.where(Person.class).findAllAsync();
+     *       results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<Person>>() {
+     *           \@Override
+     *           public void onChange(RealmResults<Person> persons, OrderedCollectionChangeSet changeSet) {
+     *               // React to change
+     *           }
+     *       });
+     *     }
+     * }
+     * }
+     * </pre>
      *
      * @param listener the change listener to be notified.
      * @throws IllegalArgumentException if the change listener is {@code null}.


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/4626
Closes https://github.com/realm/realm-java/issues/4472

This adds a mention about the GC to all relevant listeners. Note, the subtle differences in the code samples ;)

Also, this has not been added to the `Realm` change listeners as our internal `RealmCache` keeps a strong reference to them while they are open.