### PR TITLE
fix ambiguous method calls warned by Java 8 compiler

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -953,11 +953,11 @@ public class DynamicRealmObjectTests {
                         break;
                     case FLOAT:
                         dObj.set(AllJavaTypes.FIELD_FLOAT, 1.23f);
-                        assertEquals(Float.parseFloat("1.23"), dObj.get(AllJavaTypes.FIELD_FLOAT), Float.MIN_NORMAL);
+                        assertEquals(Float.parseFloat("1.23"), dObj.<Float> get(AllJavaTypes.FIELD_FLOAT), Float.MIN_NORMAL);
                         break;
                     case DOUBLE:
                         dObj.set(AllJavaTypes.FIELD_DOUBLE, 1.234d);
-                        assertEquals(Double.parseDouble("1.234"), dObj.get(AllJavaTypes.FIELD_DOUBLE), Double.MIN_NORMAL);
+                        assertEquals(Double.parseDouble("1.234"), dObj.<Double>get(AllJavaTypes.FIELD_DOUBLE), Double.MIN_NORMAL);
                         break;
                     case STRING:
                         dObj.set(AllJavaTypes.FIELD_STRING, "str");

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -937,27 +937,27 @@ public class DynamicRealmObjectTests {
                         break;
                     case SHORT:
                         dObj.set(AllJavaTypes.FIELD_SHORT, (short) 42);
-                        assertEquals(Long.parseLong("42"), dObj.get(AllJavaTypes.FIELD_SHORT));
+                        assertEquals(Long.parseLong("42"), dObj.<Long> get(AllJavaTypes.FIELD_SHORT).longValue());
                         break;
                     case INT:
                         dObj.set(AllJavaTypes.FIELD_INT, 42);
-                        assertEquals(Long.parseLong("42"), dObj.get(AllJavaTypes.FIELD_INT));
+                        assertEquals(Long.parseLong("42"), dObj.<Long> get(AllJavaTypes.FIELD_INT).longValue());
                         break;
                     case LONG:
                         dObj.set(AllJavaTypes.FIELD_LONG, 42L);
-                        assertEquals(Long.parseLong("42"), dObj.get(AllJavaTypes.FIELD_LONG));
+                        assertEquals(Long.parseLong("42"), dObj.<Long> get(AllJavaTypes.FIELD_LONG).longValue());
                         break;
                     case BYTE:
                         dObj.set(AllJavaTypes.FIELD_BYTE, (byte) 4);
-                        assertEquals(Long.parseLong("4"), dObj.get(AllJavaTypes.FIELD_BYTE));
+                        assertEquals(Long.parseLong("4"), dObj.<Long> get(AllJavaTypes.FIELD_BYTE).longValue());
                         break;
                     case FLOAT:
                         dObj.set(AllJavaTypes.FIELD_FLOAT, 1.23f);
-                        assertEquals(Float.parseFloat("1.23"), dObj.get(AllJavaTypes.FIELD_FLOAT));
+                        assertEquals(Float.parseFloat("1.23"), dObj.get(AllJavaTypes.FIELD_FLOAT), Float.MIN_NORMAL);
                         break;
                     case DOUBLE:
                         dObj.set(AllJavaTypes.FIELD_DOUBLE, 1.234d);
-                        assertEquals(Double.parseDouble("1.234"), dObj.get(AllJavaTypes.FIELD_DOUBLE));
+                        assertEquals(Double.parseDouble("1.234"), dObj.get(AllJavaTypes.FIELD_DOUBLE), Double.MIN_NORMAL);
                         break;
                     case STRING:
                         dObj.set(AllJavaTypes.FIELD_STRING, "str");

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -476,27 +476,27 @@ public class DynamicRealmTests {
             @Override
             public void onChange(RealmResults<DynamicRealmObject> object) {
                 assertEquals("data 0", realmResults1.get(0).get(AllTypes.FIELD_STRING));
-                assertEquals(3L, realmResults1.get(0).get(AllTypes.FIELD_LONG));
+                assertEquals(3L, realmResults1.get(0).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 0", realmResults1.get(1).get(AllTypes.FIELD_STRING));
-                assertEquals(2L, realmResults1.get(1).get(AllTypes.FIELD_LONG));
+                assertEquals(2L, realmResults1.get(1).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 0", realmResults1.get(2).get(AllTypes.FIELD_STRING));
-                assertEquals(0L, realmResults1.get(2).get(AllTypes.FIELD_LONG));
+                assertEquals(0L, realmResults1.get(2).<Long> get(AllTypes.FIELD_LONG).longValue());
 
                 assertEquals("data 1", realmResults1.get(3).get(AllTypes.FIELD_STRING));
-                assertEquals(4L, realmResults1.get(3).get(AllTypes.FIELD_LONG));
+                assertEquals(4L, realmResults1.get(3).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 1", realmResults1.get(4).get(AllTypes.FIELD_STRING));
-                assertEquals(3L, realmResults1.get(4).get(AllTypes.FIELD_LONG));
+                assertEquals(3L, realmResults1.get(4).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 1", realmResults1.get(5).get(AllTypes.FIELD_STRING));
-                assertEquals(1L, realmResults1.get(5).get(AllTypes.FIELD_LONG));
+                assertEquals(1L, realmResults1.get(5).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 1", realmResults1.get(6).get(AllTypes.FIELD_STRING));
-                assertEquals(0L, realmResults1.get(6).get(AllTypes.FIELD_LONG));
+                assertEquals(0L, realmResults1.get(6).<Long> get(AllTypes.FIELD_LONG).longValue());
 
                 assertEquals("data 2", realmResults1.get(7).get(AllTypes.FIELD_STRING));
-                assertEquals(4L, realmResults1.get(7).get(AllTypes.FIELD_LONG));
+                assertEquals(4L, realmResults1.get(7).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 2", realmResults1.get(8).get(AllTypes.FIELD_STRING));
-                assertEquals(2L, realmResults1.get(8).get(AllTypes.FIELD_LONG));
+                assertEquals(2L, realmResults1.get(8).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 2", realmResults1.get(9).get(AllTypes.FIELD_STRING));
-                assertEquals(1L, realmResults1.get(9).get(AllTypes.FIELD_LONG));
+                assertEquals(1L, realmResults1.get(9).<Long> get(AllTypes.FIELD_LONG).longValue());
 
                 signalCallbackDone.run();
             }
@@ -506,27 +506,27 @@ public class DynamicRealmTests {
             @Override
             public void onChange(RealmResults<DynamicRealmObject> object) {
                 assertEquals("data 2", realmResults2.get(0).get(AllTypes.FIELD_STRING));
-                assertEquals(1L, realmResults2.get(0).get(AllTypes.FIELD_LONG));
+                assertEquals(1L, realmResults2.get(0).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 2", realmResults2.get(1).get(AllTypes.FIELD_STRING));
-                assertEquals(2L, realmResults2.get(1).get(AllTypes.FIELD_LONG));
+                assertEquals(2L, realmResults2.get(1).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 2", realmResults2.get(2).get(AllTypes.FIELD_STRING));
-                assertEquals(4L, realmResults2.get(2).get(AllTypes.FIELD_LONG));
+                assertEquals(4L, realmResults2.get(2).<Long> get(AllTypes.FIELD_LONG).longValue());
 
                 assertEquals("data 1", realmResults2.get(3).get(AllTypes.FIELD_STRING));
-                assertEquals(0L, realmResults2.get(3).get(AllTypes.FIELD_LONG));
+                assertEquals(0L, realmResults2.get(3).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 1", realmResults2.get(4).get(AllTypes.FIELD_STRING));
-                assertEquals(1L, realmResults2.get(4).get(AllTypes.FIELD_LONG));
+                assertEquals(1L, realmResults2.get(4).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 1", realmResults2.get(5).get(AllTypes.FIELD_STRING));
-                assertEquals(3L, realmResults2.get(5).get(AllTypes.FIELD_LONG));
+                assertEquals(3L, realmResults2.get(5).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 1", realmResults2.get(6).get(AllTypes.FIELD_STRING));
-                assertEquals(4L, realmResults2.get(6).get(AllTypes.FIELD_LONG));
+                assertEquals(4L, realmResults2.get(6).<Long> get(AllTypes.FIELD_LONG).longValue());
 
                 assertEquals("data 0", realmResults2.get(7).get(AllTypes.FIELD_STRING));
-                assertEquals(0L, realmResults2.get(7).get(AllTypes.FIELD_LONG));
+                assertEquals(0L, realmResults2.get(7).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 0", realmResults2.get(8).get(AllTypes.FIELD_STRING));
-                assertEquals(2L, realmResults2.get(8).get(AllTypes.FIELD_LONG));
+                assertEquals(2L, realmResults2.get(8).<Long> get(AllTypes.FIELD_LONG).longValue());
                 assertEquals("data 0", realmResults2.get(9).get(AllTypes.FIELD_STRING));
-                assertEquals(3L, realmResults2.get(9).get(AllTypes.FIELD_LONG));
+                assertEquals(3L, realmResults2.get(9).<Long> get(AllTypes.FIELD_LONG).longValue());
 
                 signalCallbackDone.run();
             }

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIQueryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIQueryTest.java
@@ -69,7 +69,7 @@ public class JNIQueryTest extends TestCase {
         assertEquals(14+16, cnt);
 
         double avg = query.averageInt(0);
-        assertEquals(15.0, avg);
+        assertEquals(15.0, avg, Double.MIN_NORMAL);
 
         // TODO: Add tests with all parameters
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIRowTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIRowTest.java
@@ -48,8 +48,8 @@ public class JNIRowTest extends TestCase {
 
         assertEquals("abc", row.getString(0));
         assertEquals(3, row.getLong(1));
-        assertEquals((float) 1.2, row.getFloat(2), 0.0001);
-        assertEquals(1.3, row.getDouble(3));
+        assertEquals(1.2F, row.getFloat(2), Float.MIN_NORMAL);
+        assertEquals(1.3, row.getDouble(3), Double.MIN_NORMAL);
         assertEquals(true, row.getBoolean(4));
         assertEquals(new Date(0), row.getDate(5));
         MoreAsserts.assertEquals(data, row.getBinaryByteArray(6));
@@ -67,8 +67,8 @@ public class JNIRowTest extends TestCase {
 
         assertEquals("a", row.getString(0));
         assertEquals(1, row.getLong(1));
-        assertEquals((float) 8.8, row.getFloat(2), 0.0001);
-        assertEquals(9.9, row.getDouble(3));
+        assertEquals(8.8F, row.getFloat(2), Float.MIN_NORMAL);
+        assertEquals(9.9, row.getDouble(3), Double.MIN_NORMAL);
         assertEquals(false, row.getBoolean(4));
         assertEquals(new Date(10000), row.getDate(5));
         MoreAsserts.assertEquals(newData, row.getBinaryByteArray(6));


### PR DESCRIPTION
When I compiled Realm java with Java 8 compiler, I got some warnings.
This PR fixes those warnings in advance.

@realm/java 