### PR TITLE
Fix Transformer warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.2 (YYYY-MM-DD)
+
+### Bug Fixes
+
+* Fixed Realm Transformer warnings when using Build Tools 3.0.0 (#4659).
+
+
 ## 3.2.1 (2017-05-19)
 
 ### Deprecated

--- a/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/RealmTransformer.groovy
@@ -66,8 +66,17 @@ class RealmTransformer extends Transform {
 
     @Override
     Set<Scope> getReferencedScopes() {
-        return Sets.immutableEnumSet(Scope.EXTERNAL_LIBRARIES, Scope.PROJECT_LOCAL_DEPS,
-                Scope.SUB_PROJECTS, Scope.SUB_PROJECTS_LOCAL_DEPS, Scope.TESTED_CODE)
+        // Some scopes were deprecated in Build Tools 3.0
+        def localDepsDeprecated = Scope.class
+                .getField(Scope.PROJECT_LOCAL_DEPS.name())
+                .isAnnotationPresent(Deprecated.class);
+        def scopes = Sets.newHashSet(Scope.EXTERNAL_LIBRARIES, Scope.SUB_PROJECTS, Scope.TESTED_CODE)
+        if (!localDepsDeprecated) {
+            scopes.add(Scope.PROJECT_LOCAL_DEPS)
+            scopes.add(Scope.SUB_PROJECTS_LOCAL_DEPS)
+        }
+
+        return Sets.immutableEnumSet(scopes)
     }
 
     @Override


### PR DESCRIPTION
Fixes #4659 

Hacky fix for the Transformer warnings that appeared with Build Tools `3.0.0-alpha1`

Manual testing verified this removes the warnings, but I don't know what other implications there might be.