### PR TITLE
Fix queries not working on proguarded Realms model classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## 3.2.1 (2017-05-19)
+## 3.2.2 (YYYY-MM-DD)
 
-### Deprecated
+### Bug Fixes
+
+* Queries on proguarded Realm model classes, failed with "Table not found" (#4673).
+
+
+## 3.2.1 (2017-05-19)
 
 ### Enhancements
 

--- a/examples/moduleExample/app/build.gradle
+++ b/examples/moduleExample/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false // FIXME Why is this suddenly broken?
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }

--- a/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
+++ b/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
@@ -128,7 +128,7 @@ public class ModulesExampleActivity extends Activity {
             }
         });
 
-        showStatus("Number of pigs on the farm : " + farmRealm.where(Pig.class).count());
+        showStatus("Number of unnamed pigs on the farm : " + farmRealm.where(Pig.class).isNull("name").count());
 
         // Each Realm is restricted to only accept the classes in their schema.
         showStatus("Trying to add an unsupported class");

--- a/realm/realm-library/src/androidTest/java/io/realm/ColumnIndicesTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ColumnIndicesTests.java
@@ -32,6 +32,7 @@ import io.realm.entities.Dog;
 import io.realm.internal.ColumnIndices;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.RealmProxyMediator;
+import io.realm.internal.util.Pair;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static junit.framework.Assert.assertEquals;
@@ -70,11 +71,13 @@ public class ColumnIndicesTests {
         final DogRealmProxy.DogColumnInfo dogColumnInfo;
         catColumnInfo = (CatRealmProxy.CatColumnInfo) mediator.validateTable(Cat.class, realm.sharedRealm, false);
         dogColumnInfo = (DogRealmProxy.DogColumnInfo) mediator.validateTable(Dog.class, realm.sharedRealm, false);
-
+        Pair<Class<? extends RealmModel>, String> catDesc = Pair.<Class<? extends RealmModel>, String>create(Cat.class, "Cat");
+        Pair<Class<? extends RealmModel>, String> dogDesc = Pair.<Class<? extends RealmModel>, String>create(Dog.class, "Dog");
         return new ColumnIndices(schemaVersion,
-                ImmutableMap.<Class<? extends RealmModel>, ColumnInfo>of(
-                        Cat.class, catColumnInfo,
-                        Dog.class, dogColumnInfo));
+                ImmutableMap.<Pair<Class<? extends RealmModel>, String>, ColumnInfo>of(
+                        catDesc, catColumnInfo,
+                        dogDesc, dogColumnInfo)
+        );
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/ColumnIndicesTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ColumnIndicesTests.java
@@ -74,7 +74,7 @@ public class ColumnIndicesTests {
         Pair<Class<? extends RealmModel>, String> catDesc = Pair.<Class<? extends RealmModel>, String>create(Cat.class, "Cat");
         Pair<Class<? extends RealmModel>, String> dogDesc = Pair.<Class<? extends RealmModel>, String>create(Dog.class, "Dog");
         return new ColumnIndices(schemaVersion,
-                ImmutableMap.<Pair<Class<? extends RealmModel>, String>, ColumnInfo>of(
+                ImmutableMap.of(
                         catDesc, catColumnInfo,
                         dogDesc, dogColumnInfo)
         );

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -60,6 +60,7 @@ import io.realm.internal.RealmProxyMediator;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
 import io.realm.internal.async.RealmAsyncTaskImpl;
+import io.realm.internal.util.Pair;
 import io.realm.log.RealmLog;
 import rx.Observable;
 
@@ -441,9 +442,11 @@ public class Realm extends BaseRealm {
             }
 
             // Now that they have all been created, validate them.
-            final Map<Class<? extends RealmModel>, ColumnInfo> columnInfoMap = new HashMap<>(modelClasses.size());
+            final Map<Pair<Class<? extends RealmModel>, String>, ColumnInfo> columnInfoMap = new HashMap<>(modelClasses.size());
             for (Class<? extends RealmModel> modelClass : modelClasses) {
-                columnInfoMap.put(modelClass, mediator.validateTable(modelClass, realm.sharedRealm, false));
+                String className = Table.getClassNameForTable(mediator.getTableName(modelClass));
+                Pair<Class<? extends RealmModel>, String> key = Pair.<Class<? extends RealmModel>, String>create(modelClass, className);
+                columnInfoMap.put(key, mediator.validateTable(modelClass, realm.sharedRealm, false));
             }
 
             realm.getSchema().setInitialColumnIndices(
@@ -507,9 +510,11 @@ public class Realm extends BaseRealm {
             }
 
             // Validate the schema in the file
-            final Map<Class<? extends RealmModel>, ColumnInfo> columnInfoMap = new HashMap<>(modelClasses.size());
+            final Map<Pair<Class<? extends RealmModel>, String>, ColumnInfo> columnInfoMap = new HashMap<>(modelClasses.size());
             for (Class<? extends RealmModel> modelClass : modelClasses) {
-                columnInfoMap.put(modelClass, mediator.validateTable(modelClass, realm.sharedRealm, false));
+                String className = Table.getClassNameForTable(mediator.getTableName(modelClass));
+                Pair<Class<? extends RealmModel>, String> key = Pair.<Class<? extends RealmModel>, String>create(modelClass, className);
+                columnInfoMap.put(key, mediator.validateTable(modelClass, realm.sharedRealm, false));
             }
             realm.getSchema().setInitialColumnIndices((unversioned) ? newVersion : currentVersion, columnInfoMap);
 
@@ -1773,7 +1778,7 @@ public class Realm extends BaseRealm {
 
             // Not found in global cache. create it.
             final Set<Class<? extends RealmModel>> modelClasses = mediator.getModelClasses();
-            final Map<Class<? extends RealmModel>, ColumnInfo> map;
+            final Map<Pair<Class<? extends RealmModel>, String>, ColumnInfo> map;
             map = new HashMap<>(modelClasses.size());
 
 
@@ -1782,7 +1787,9 @@ public class Realm extends BaseRealm {
             try {
                 for (Class<? extends RealmModel> clazz : modelClasses) {
                     final ColumnInfo columnInfo = mediator.validateTable(clazz, sharedRealm, true);
-                    map.put(clazz, columnInfo);
+                    String className = Table.getClassNameForTable(mediator.getTableName(clazz));
+                    Pair<Class<? extends RealmModel>, String> key = Pair.<Class<? extends RealmModel>, String>create(clazz, className);
+                    map.put(key, columnInfo);
                 }
             } catch (RealmMigrationNeededException e) {
                 throw e;

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import io.realm.internal.ColumnIndices;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.Table;
+import io.realm.internal.util.Pair;
 
 
 /**
@@ -114,7 +115,7 @@ public abstract class RealmSchema {
      * @param version the schema version
      * @param columnInfoMap the column info map
      */
-    final void setInitialColumnIndices(long version, Map<Class<? extends RealmModel>, ColumnInfo> columnInfoMap) {
+    final void setInitialColumnIndices(long version, Map<Pair<Class<? extends RealmModel>, String>, ColumnInfo> columnInfoMap) {
         if (this.columnIndices != null) {
             throw new IllegalStateException("An instance of ColumnIndices is already set.");
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
@@ -79,11 +79,10 @@ public final class ColumnIndices {
         this(other.schemaVersion, new HashMap<Pair<Class<? extends RealmModel>, String>, ColumnInfo>(other.classesToColumnInfo.size()), mutable);
         for (Map.Entry<Pair<Class<? extends RealmModel>, String>, ColumnInfo> entry : other.classesToColumnInfo.entrySet()) {
             ColumnInfo columnInfo = entry.getValue().copy(mutable);
-            Pair<Class<? extends RealmModel>, String> oldKey = entry.getKey();
-            Pair<Class<? extends RealmModel>, String> newKey = Pair.<Class<? extends RealmModel>, String>create(oldKey.first, oldKey.second);
-            this.classes.put(newKey.first, columnInfo);
-            this.classesByName.put(newKey.second, columnInfo);
-            this.classesToColumnInfo.put(newKey, columnInfo);
+            Pair<Class<? extends RealmModel>, String> key = entry.getKey();
+            this.classes.put(key.first, columnInfo);
+            this.classesByName.put(key.second, columnInfo);
+            this.classesToColumnInfo.put(key, columnInfo);
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
@@ -64,13 +64,13 @@ public final class ColumnIndices {
                 throw new IllegalArgumentException("ColumnInfo mutability does not match ColumnIndices");
             }
             Pair<Class<? extends RealmModel>, String> classDescription = entry.getKey();
-            this.classes.put(classDescription.first, entry.getValue());
-            this.classesByName.put(classDescription.second, entry.getValue());
+            this.classes.put(classDescription.first, columnInfo);
+            this.classesByName.put(classDescription.second, columnInfo);
         }
     }
 
     /**
-     * Create a copy of the passed ColumnIndices with the specified mutablity.
+     * Create a copy of the passed ColumnIndices with the specified mutability.
      *
      * @param other the ColumnIndices object to copy
      * @param mutable if false the object is effectively final.
@@ -79,8 +79,11 @@ public final class ColumnIndices {
         this(other.schemaVersion, new HashMap<Pair<Class<? extends RealmModel>, String>, ColumnInfo>(other.classesToColumnInfo.size()), mutable);
         for (Map.Entry<Pair<Class<? extends RealmModel>, String>, ColumnInfo> entry : other.classesToColumnInfo.entrySet()) {
             ColumnInfo columnInfo = entry.getValue().copy(mutable);
-            this.classes.put(entry.getKey().first, columnInfo);
-            this.classesByName.put(entry.getKey().second, columnInfo);
+            Pair<Class<? extends RealmModel>, String> oldKey = entry.getKey();
+            Pair<Class<? extends RealmModel>, String> newKey = Pair.<Class<? extends RealmModel>, String>create(oldKey.first, oldKey.second);
+            this.classes.put(newKey.first, columnInfo);
+            this.classesByName.put(newKey.second, columnInfo);
+            this.classesToColumnInfo.put(newKey, columnInfo);
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.realm.RealmModel;
+import io.realm.internal.util.Pair;
 
 
 /**
@@ -30,7 +31,7 @@ import io.realm.RealmModel;
  * <li>the {@code copyFrom} method</li>
  * <li>mutating one of the ColumnInfo object to which this instance holds a reference</li>
  * </ul>
- * Immutable instances of this class protect against the first possiblity by throwing on calls
+ * Immutable instances of this class protect against the first possibility by throwing on calls
  * to {@code copyFrom}.  {@see ColumnInfo} for its mutability contract.
  *
  * There are two, redundant, lookup methods, for schema members: by Class and by String.
@@ -39,8 +40,12 @@ import io.realm.RealmModel;
  * class lookup is very fast and on a hot path, so we maintain the redundant table.
  */
 public final class ColumnIndices {
+    // MultiKeyMap of <Class, String> -> ColumnInfo
+    // Right now we maintain 3 copies. One public and 2 internal ones.
+    private final Map<Pair<Class<? extends RealmModel>, String>, ColumnInfo> classesToColumnInfo;
     private final Map<Class<? extends RealmModel>, ColumnInfo> classes;
     private final Map<String, ColumnInfo> classesByName;
+
     private final boolean mutable;
     private long schemaVersion;
 
@@ -48,17 +53,19 @@ public final class ColumnIndices {
      * Create a mutable ColumnIndices initialized with the ColumnInfo objects in the passed map.
      *
      * @param schemaVersion the schema version
-     * @param classes a map of table classes to their column info
+     * @param classesMap a map of table classes to their column info
      * @throws IllegalArgumentException if any of the ColumnInfo object is immutable.
      */
-    public ColumnIndices(long schemaVersion, Map<Class<? extends RealmModel>, ColumnInfo> classes) {
-        this(schemaVersion, new HashMap<>(classes), true);
-        for (Map.Entry<Class<? extends RealmModel>, ColumnInfo> entry : classes.entrySet()) {
+    public ColumnIndices(long schemaVersion, Map<Pair<Class<? extends RealmModel>, String>, ColumnInfo> classesMap) {
+        this(schemaVersion, new HashMap<>(classesMap), true);
+        for (Map.Entry<Pair<Class<? extends RealmModel>, String>, ColumnInfo> entry : classesMap.entrySet()) {
             ColumnInfo columnInfo = entry.getValue();
             if (mutable != columnInfo.isMutable()) {
                 throw new IllegalArgumentException("ColumnInfo mutability does not match ColumnIndices");
             }
-            this.classesByName.put(entry.getKey().getSimpleName(), entry.getValue());
+            Pair<Class<? extends RealmModel>, String> classDescription = entry.getKey();
+            this.classes.put(classDescription.first, entry.getValue());
+            this.classesByName.put(classDescription.second, entry.getValue());
         }
     }
 
@@ -69,19 +76,20 @@ public final class ColumnIndices {
      * @param mutable if false the object is effectively final.
      */
     public ColumnIndices(ColumnIndices other, boolean mutable) {
-        this(other.schemaVersion, new HashMap<Class<? extends RealmModel>, ColumnInfo>(other.classes.size()), mutable);
-        for (Map.Entry<Class<? extends RealmModel>, ColumnInfo> entry : other.classes.entrySet()) {
+        this(other.schemaVersion, new HashMap<Pair<Class<? extends RealmModel>, String>, ColumnInfo>(other.classesToColumnInfo.size()), mutable);
+        for (Map.Entry<Pair<Class<? extends RealmModel>, String>, ColumnInfo> entry : other.classesToColumnInfo.entrySet()) {
             ColumnInfo columnInfo = entry.getValue().copy(mutable);
-            this.classes.put(entry.getKey(), columnInfo);
-            this.classesByName.put(entry.getKey().getSimpleName(), columnInfo);
+            this.classes.put(entry.getKey().first, columnInfo);
+            this.classesByName.put(entry.getKey().second, columnInfo);
         }
     }
 
-    private ColumnIndices(long schemaVersion, Map<Class<? extends RealmModel>, ColumnInfo> classes, boolean mutable) {
+    private ColumnIndices(long schemaVersion, Map<Pair<Class<? extends RealmModel>, String>, ColumnInfo> classesMap, boolean mutable) {
         this.schemaVersion = schemaVersion;
-        this.classes = classes;
+        this.classesToColumnInfo = classesMap;
         this.mutable = mutable;
-        this.classesByName = new HashMap<>(classes.size());
+        this.classes = new HashMap<>(classesMap.size());
+        this.classesByName = new HashMap<>(classesMap.size());
     }
 
     /**
@@ -164,9 +172,9 @@ public final class ColumnIndices {
         buf.append(mutable).append(",");
         if (classes != null) {
             boolean commaNeeded = false;
-            for (Map.Entry<Class<? extends RealmModel>, ColumnInfo> entry : classes.entrySet()) {
+            for (Map.Entry<String, ColumnInfo> entry : classesByName.entrySet()) {
                 if (commaNeeded) { buf.append(","); }
-                buf.append(entry.getKey().getSimpleName()).append("->").append(entry.getValue());
+                buf.append(entry.getKey()).append("->").append(entry.getValue());
                 commaNeeded = true;
             }
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/util/Pair.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/util/Pair.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.util;
+
+/**
+ * Copy from the Android framework to avoid the dependency on Android classes + slight adjustment
+ * to support older versions of Android.
+ *
+ * Original source: https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/util/Pair.java
+ *
+ * Container to ease passing around a tuple of two objects. This object provides a sensible
+ * implementation of equals(), returning true if equals() is true on each of the contained
+ * objects.
+ */
+public class Pair<F, S> {
+    public F first;
+    public S second;
+
+    /**
+     * Constructor for a Pair.
+     *
+     * @param first the first object in the Pair.
+     * @param second the second object in the pair.
+     */
+    public Pair(F first, S second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    /**
+     * Checks the two objects for equality by delegating to their respective
+     * {@link Object#equals(Object)} methods.
+     *
+     * @param o the {@link Pair} to which this one is to be checked for equality.
+     * @return true if the underlying objects of the Pair are both considered
+     *         equal.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Pair)) {
+            return false;
+        }
+        Pair<?, ?> p = (Pair<?, ?>) o;
+        return equals(p.first, first) && (equals(p.second, second));
+    }
+
+    private boolean equals(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    }
+
+    /**
+     * Compute a hash code using the hash codes of the underlying objects.
+     *
+     * @return a hashcode of the Pair.
+     */
+    @Override
+    public int hashCode() {
+        return (first == null ? 0 : first.hashCode()) ^ (second == null ? 0 : second.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "Pair{" + String.valueOf(first) + " " + String.valueOf(second) + "}";
+    }
+
+    /**
+     * Convenience method for creating an appropriately typed pair.
+     *
+     * @param a the first object in the Pair.
+     * @param b the second object in the pair.
+     * @return a Pair that is templatized with the types of a and b.
+     */
+    public static <A, B> Pair <A, B> create(A a, B b) {
+        return new Pair<A, B>(a, b);
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/internal/util/Pair.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/util/Pair.java
@@ -27,8 +27,8 @@ package io.realm.internal.util;
  * objects.
  */
 public class Pair<F, S> {
-    public F first;
-    public S second;
+    public final F first;
+    public final S second;
 
     /**
      * Constructor for a Pair.


### PR DESCRIPTION
Fixes #4673 

The new ColumnIndices wrapper cached names using `class.getSimpleName()` which breaks when the class is obfuscated (We should really have caught this in code review 😢 )

I modified it so a pair consisting of `<class, realSimpleName>` is now being passed around instead. It complicated the internals of `ColumnIndices` a little more than I would like (We could really use a MultiKeyMap implementation).

Creating/Copying this class is now also more expensive as we have to go through the mediator for the proper non-obfuscated name, but given how rarely this happens, it is probably acceptable for now.

We have an example `moduleExample/app` that used a proguarded Realm and we test the Release build as part of the release process, but unfortunately, that example didn't use any query methods that triggered the bug.

It is apparently possible to run unit tests with ProGuard: https://stackoverflow.com/questions/26482119/android-unit-tests-with-proguard-enabled so I'll be creating an issue for enabling that going forward.

For now, I modified the example to use a query that will catch this bug.