### PR TITLE
Fix bug while downloading server changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * [ObjectServer] Fixed a crash when an authentication error happend (#4726).
+* [ObjectServer] Fixed race condition with `waitForInitialRemoteData` that could result in `RealmMigrationNeededExceptions` to be thrown.
 
 ### Internal
 

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -303,6 +303,9 @@ final class RealmCache {
                 if (!fileExists) {
                     try {
                         ObjectServerFacade.getSyncFacadeIfPossible().downloadRemoteChanges(configuration);
+                        // Data is downloaded on background thread, so we need to make sure to advance
+                        // to latest version before continuing.
+                        sharedRealm.refresh();
                     } catch (Throwable t) {
                         // If an error happened while downloading initial data, we need to reset the file so we can
                         // download it again on the next attempt.


### PR DESCRIPTION
Fixing bug experienced #4655 and discovered by @nhachicha 

Note this should be covered by this unit test: https://github.com/realm/realm-java/blob/79ca7666432a7a17b0dc29a1dfa7185f27b4f216/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java#L218

And I still need to uncover why this doesn't fail :/