### PR TITLE
Fix test case with missing linking object schema

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/BulkInsertTests.java
@@ -505,7 +505,7 @@ public class BulkInsertTests {
     public void insert_emptyListWithFilterableMediator() {
         //noinspection unchecked
         final RealmConfiguration config = configFactory.createConfigurationBuilder()
-                .schema(CatOwner.class, Cat.class)
+                .schema(CatOwner.class, Cat.class, Owner.class, DogPrimaryKey.class, Dog.class)
                 .name("filterable.realm")
                 .build();
         Realm.deleteRealm(config);
@@ -601,7 +601,7 @@ public class BulkInsertTests {
     public void insertOrUpdate_emptyListWithFilterableMediator() {
         //noinspection unchecked
         final RealmConfiguration config = configFactory.createConfigurationBuilder()
-                .schema(CatOwner.class, Cat.class)
+                .schema(CatOwner.class, Cat.class, Owner.class, DogPrimaryKey.class, Dog.class)
                 .name("filterable.realm")
                 .build();
         Realm.deleteRealm(config);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -43,6 +43,8 @@ import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.HumanModule;
 import io.realm.entities.Owner;
+import io.realm.entities.StringAndInt;
+import io.realm.entities.StringOnly;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
 import io.realm.exceptions.RealmMigrationNeededException;
@@ -229,7 +231,7 @@ public class RealmConfigurationTests {
         RealmConfiguration config = new RealmConfiguration.Builder(context)
                 .directory(configFactory.getRoot())
                 .schemaVersion(42)
-                .schema(Dog.class)
+                .schema(StringOnly.class)
                 .build();
         Realm.getInstance(config).close();
 
@@ -238,7 +240,7 @@ public class RealmConfigurationTests {
             config = new RealmConfiguration.Builder(context)
                     .directory(configFactory.getRoot())
                     .schemaVersion(42)
-                    .schema(AllTypesPrimaryKey.class)
+                    .schema(StringAndInt.class)
                     .build();
             realm = Realm.getInstance(config);
             fail("A migration should be required");
@@ -337,26 +339,26 @@ public class RealmConfigurationTests {
         // Populates v0 of a Realm with an object.
         RealmConfiguration config = new RealmConfiguration.Builder(context)
                 .directory(configFactory.getRoot())
-                .schema(Dog.class)
+                .schema(StringOnly.class)
                 .schemaVersion(0)
                 .build();
         Realm.deleteRealm(config);
         realm = Realm.getInstance(config);
         realm.beginTransaction();
-        realm.copyToRealm(new Dog("Foo"));
+        realm.copyToRealm(new StringOnly());
         realm.commitTransaction();
-        assertEquals(1, realm.where(Dog.class).count());
+        assertEquals(1, realm.where(StringOnly.class).count());
         realm.close();
 
         // Changes schema and verifies that Realm has been cleared.
         config = new RealmConfiguration.Builder(context)
                 .directory(configFactory.getRoot())
-                .schema(Owner.class, Dog.class)
+                .schema(StringOnly.class, StringAndInt.class)
                 .schemaVersion(1)
                 .deleteRealmIfMigrationNeeded()
                 .build();
         realm = Realm.getInstance(config);
-        assertEquals(0, realm.where(Dog.class).count());
+        assertEquals(0, realm.where(StringOnly.class).count());
     }
 
     @Test
@@ -526,11 +528,11 @@ public class RealmConfigurationTests {
     public void schema_differentSchemasThrows() {
         RealmConfiguration config1 = new RealmConfiguration.Builder(context)
                 .directory(configFactory.getRoot())
-                .schema(AllTypes.class)
+                .schema(StringOnly.class)
                 .build();
         RealmConfiguration config2 = new RealmConfiguration.Builder(context)
                 .directory(configFactory.getRoot())
-                .schema(CyclicType.class).build();
+                .schema(StringAndInt.class).build();
 
         Realm realm1 = Realm.getInstance(config1);
         try {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -121,7 +121,7 @@ public class RealmMigrationTests {
         // V1 config
         RealmConfiguration v1Config = configFactory.createConfigurationBuilder()
                 .name(MIGRATED_REALM)
-                .schema(AllTypes.class)
+                .schema(StringOnly.class)
                 .schemaVersion(1)
                 .build();
         Realm oldRealm = Realm.getInstance(v1Config);
@@ -140,7 +140,7 @@ public class RealmMigrationTests {
 
         RealmConfiguration v2Config = configFactory.createConfigurationBuilder()
                 .name(MIGRATED_REALM)
-                .schema(AllTypes.class, FieldOrder.class)
+                .schema(StringOnly.class, FieldOrder.class)
                 .schemaVersion(2)
                 .migration(migration)
                 .build();
@@ -151,7 +151,7 @@ public class RealmMigrationTests {
         RealmConfiguration newConfig = configFactory.createConfigurationBuilder()
                 .name(NEW_REALM)
                 .schemaVersion(2)
-                .schema(AllTypes.class, FieldOrder.class)
+                .schema(StringOnly.class, FieldOrder.class)
                 .build();
         Realm newRealm = Realm.getInstance(newConfig);
         newRealm.close();
@@ -166,7 +166,7 @@ public class RealmMigrationTests {
 
         // Creates v0 of the Realm.
         RealmConfiguration originalConfig = configFactory.createConfigurationBuilder()
-                .schema(AllTypes.class)
+                .schema(StringOnly.class)
                 .build();
         Realm.getInstance(originalConfig).close();
 
@@ -184,7 +184,7 @@ public class RealmMigrationTests {
 
         RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()
                 .schemaVersion(1)
-                .schema(AllTypes.class, AnnotationTypes.class)
+                .schema(StringOnly.class, AnnotationTypes.class)
                 .migration(migration)
                 .build();
         try {
@@ -718,7 +718,7 @@ public class RealmMigrationTests {
     public void settingPrimaryKeyWithObjectSchema() {
         // Creates v0 of the Realm.
         RealmConfiguration originalConfig = configFactory.createConfigurationBuilder()
-                .schema(AllTypes.class)
+                .schema(StringOnly.class)
                 .build();
         Realm.getInstance(originalConfig).close();
 
@@ -738,7 +738,7 @@ public class RealmMigrationTests {
         // Creates v1 of the Realm.
         RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()
                 .schemaVersion(1)
-                .schema(AllTypes.class, AnnotationTypes.class)
+                .schema(StringOnly.class, AnnotationTypes.class)
                 .migration(migration)
                 .build();
 
@@ -789,7 +789,7 @@ public class RealmMigrationTests {
 
         // Creates v0 of the Realm.
         RealmConfiguration originalConfig = configFactory.createConfigurationBuilder()
-                .schema(AllTypes.class)
+                .schema(StringOnly.class)
                 .build();
         Realm.getInstance(originalConfig).close();
 
@@ -806,7 +806,7 @@ public class RealmMigrationTests {
 
         RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()
                 .schemaVersion(1)
-                .schema(AllTypes.class, AnnotationTypes.class)
+                .schema(StringOnly.class, AnnotationTypes.class)
                 .migration(migration)
                 .build();
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
@@ -31,6 +31,9 @@ import java.util.List;
 import java.util.Set;
 
 import io.realm.entities.AllJavaTypes;
+import io.realm.entities.Cat;
+import io.realm.entities.Dog;
+import io.realm.entities.DogPrimaryKey;
 import io.realm.entities.Owner;
 import io.realm.entities.PrimaryKeyAsString;
 import io.realm.rule.TestRealmConfigurationFactory;
@@ -56,7 +59,8 @@ public class RealmSchemaTests {
     @Before
     public void setUp() {
         RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()
-                .schema(AllJavaTypes.class, Owner.class, PrimaryKeyAsString.class)
+                .schema(AllJavaTypes.class, Owner.class, PrimaryKeyAsString.class, Cat.class, Dog.class,
+                        DogPrimaryKey.class)
                 .build();
         Realm.getInstance(realmConfig).close(); // create Schema
         realm = DynamicRealm.getInstance(realmConfig);

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AnimalModule.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AnimalModule.java
@@ -18,6 +18,6 @@ package io.realm.entities;
 
 import io.realm.annotations.RealmModule;
 
-@RealmModule(classes = {Dog.class, Cat.class})
+@RealmModule(classes = {Dog.class, Cat.class, DogPrimaryKey.class})
 public class AnimalModule {
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/HumanModule.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/HumanModule.java
@@ -18,6 +18,6 @@ package io.realm.entities;
 
 import io.realm.annotations.RealmModule;
 
-@RealmModule(classes = {CatOwner.class})
+@RealmModule(classes = {CatOwner.class, Owner.class})
 public class HumanModule {
 }


### PR DESCRIPTION
Those tests pass with current schema implementation since currently it
will create extra object schemas which are not in the module. This
behaviour is not right and will fail those tests in the future schema
refactor.

So always define all the needed object schemas in the module.

This is needed for #4674