### PR TITLE
Don't strip debug symbols for debug build!

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -92,6 +92,9 @@ android {
     packagingOptions {
         exclude 'META-INF/NOTICE.txt'
         exclude 'META-INF/LICENSE.txt'
+        // We did strip with cmake for release build.
+        // Please, Gradle, you are not that smart! Pleas DO NOT strip debug symbols for debug build!
+        doNotStrip "*/*/*.so"
     }
 
     lintOptions {


### PR DESCRIPTION
From Android Plugin Version 2.2.0, it tries to strip debug symbols of
native libs for all build types (even debug build!!??).
I don't like something try to be smart, so just let our cmake handler
stripping and backup the unstripped libs.