### PR TITLE
Update kotlin to 1.1.2-5

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.2-4'
+    ext.kotlin_version = '1.1.2-5'
     repositories {
         jcenter()
         mavenCentral()
@@ -45,6 +45,6 @@ android {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlin_version}"
     compile 'org.jetbrains.anko:anko-sdk15:0.9.1'
 }

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.2-4'
+    ext.kotlin_version = '1.1.2-5'
     repositories {
         mavenLocal()
         jcenter()


### PR DESCRIPTION
Updated kotlin to `1.1.2-5`.
And now example project uses `kotlin-stdlib-jre7` instead of `kotlin-stdlib`.

Chnagelog of kotlin 1.1.2-5 is https://github.com/JetBrains/kotlin/blob/1.1.2/ChangeLog.md#112-5