### PR TITLE
Suppress warnings in generated code.

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -124,7 +124,7 @@ import io.realm.annotations.RealmModule;
         "io.realm.annotations.RealmModule",
         "io.realm.annotations.Required"
 })
-@SupportedOptions(value = {"debug"})
+@SupportedOptions(value = {"realm.suppressWarnings"})
 public class RealmProcessor extends AbstractProcessor {
 
     // Don't consume annotations. This allows 3rd party annotation processors to run.

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -123,7 +124,9 @@ import io.realm.annotations.RealmModule;
         "io.realm.annotations.RealmModule",
         "io.realm.annotations.Required"
 })
+@SupportedOptions(value = {"debug"})
 public class RealmProcessor extends AbstractProcessor {
+
     // Don't consume annotations. This allows 3rd party annotation processors to run.
     private static final boolean CONSUME_ANNOTATIONS = false;
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -36,6 +36,7 @@ import javax.tools.JavaFileObject;
 
 
 public class RealmProxyClassGenerator {
+    private static final String OPTION_DEBUG = "debug";
     private static final String BACKLINKS_FIELD_EXTENSION = "Backlinks";
 
     private final ProcessingEnvironment processingEnvironment;
@@ -44,6 +45,7 @@ public class RealmProxyClassGenerator {
     private final String qualifiedClassName;
     private final String interfaceName;
     private final String qualifiedGeneratedClassName;
+    private final boolean debugging;
 
     public RealmProxyClassGenerator(ProcessingEnvironment processingEnvironment, ClassMetaData metadata) {
         this.processingEnvironment = processingEnvironment;
@@ -53,6 +55,8 @@ public class RealmProxyClassGenerator {
         this.interfaceName = Utils.getProxyInterfaceName(simpleClassName);
         this.qualifiedGeneratedClassName = String.format("%s.%s",
                 Constants.REALM_PACKAGE_NAME, Utils.getProxyClassName(simpleClassName));
+
+        debugging = Boolean.parseBoolean(processingEnvironment.getOptions().get(OPTION_DEBUG));
     }
 
     public void generate() throws IOException, UnsupportedOperationException {
@@ -101,7 +105,10 @@ public class RealmProxyClassGenerator {
                 .emitEmptyLine();
 
         // Begin the class definition
-        writer.emitAnnotation("SuppressWarnings(\"all\")")
+        if (!debugging) {
+            writer.emitAnnotation("SuppressWarnings(\"all\")");
+        }
+        writer
                 .beginType(
                 qualifiedGeneratedClassName, // full qualified name of the item to generate
                 "class",                     // the type of the item

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -56,6 +56,8 @@ public class RealmProxyClassGenerator {
         this.qualifiedGeneratedClassName = String.format("%s.%s",
                 Constants.REALM_PACKAGE_NAME, Utils.getProxyClassName(simpleClassName));
 
+        // See the configuration for the debug build type, in the realm-library project
+        // for an example of how to set this flag.
         debugging = Boolean.parseBoolean(processingEnvironment.getOptions().get(OPTION_DEBUG));
     }
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -36,7 +36,7 @@ import javax.tools.JavaFileObject;
 
 
 public class RealmProxyClassGenerator {
-    private static final String OPTION_DEBUG = "debug";
+    private static final String OPTION_SUPPRESS_WARNINGS = "realm.suppressWarnings";
     private static final String BACKLINKS_FIELD_EXTENSION = "Backlinks";
 
     private final ProcessingEnvironment processingEnvironment;
@@ -45,7 +45,7 @@ public class RealmProxyClassGenerator {
     private final String qualifiedClassName;
     private final String interfaceName;
     private final String qualifiedGeneratedClassName;
-    private final boolean debugging;
+    private final boolean suppressWarnings;
 
     public RealmProxyClassGenerator(ProcessingEnvironment processingEnvironment, ClassMetaData metadata) {
         this.processingEnvironment = processingEnvironment;
@@ -56,9 +56,9 @@ public class RealmProxyClassGenerator {
         this.qualifiedGeneratedClassName = String.format("%s.%s",
                 Constants.REALM_PACKAGE_NAME, Utils.getProxyClassName(simpleClassName));
 
-        // See the configuration for the debug build type, in the realm-library project
-        // for an example of how to set this flag.
-        debugging = Boolean.parseBoolean(processingEnvironment.getOptions().get(OPTION_DEBUG));
+        // See the configuration for the debug build type,
+        //  in the realm-library project, for an example of how to set this flag.
+        this.suppressWarnings = !"false".equalsIgnoreCase(processingEnvironment.getOptions().get(OPTION_SUPPRESS_WARNINGS));
     }
 
     public void generate() throws IOException, UnsupportedOperationException {
@@ -107,7 +107,7 @@ public class RealmProxyClassGenerator {
                 .emitEmptyLine();
 
         // Begin the class definition
-        if (!debugging) {
+        if (suppressWarnings) {
             writer.emitAnnotation("SuppressWarnings(\"all\")");
         }
         writer

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -101,7 +101,8 @@ public class RealmProxyClassGenerator {
                 .emitEmptyLine();
 
         // Begin the class definition
-        writer.beginType(
+        writer.emitAnnotation("SuppressWarnings(\"all\")")
+                .beginType(
                 qualifiedGeneratedClassName, // full qualified name of the item to generate
                 "class",                     // the type of the item
                 EnumSet.of(Modifier.PUBLIC), // modifiers to apply

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -30,6 +30,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("all")
 public class AllTypesRealmProxy extends some.test.AllTypes
         implements RealmObjectProxy, AllTypesRealmProxyInterface {
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -29,6 +29,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("all")
 public class BooleansRealmProxy extends some.test.Booleans
         implements RealmObjectProxy, BooleansRealmProxyInterface {
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -29,6 +29,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("all")
 public class NullTypesRealmProxy extends some.test.NullTypes
         implements RealmObjectProxy, NullTypesRealmProxyInterface {
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -29,6 +29,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@SuppressWarnings("all")
 public class SimpleRealmProxy extends some.test.Simple
         implements RealmObjectProxy, SimpleRealmProxyInterface {
 

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -70,7 +70,7 @@ android {
             debug {
                 javaCompileOptions {
                     annotationProcessorOptions {
-                        arguments = [ debug : 'true' ]
+                        arguments += [ 'realm.suppressWarnings' : 'false' ]
                     }
                 }
             }

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -65,6 +65,16 @@ android {
                 }
             }
         }
+
+        buildTypes {
+            debug {
+                javaCompileOptions {
+                    annotationProcessorOptions {
+                        arguments = [ debug : 'true' ]
+                    }
+                }
+            }
+        }
     }
 
     externalNativeBuild {


### PR DESCRIPTION
There is no reason that generated code, in production, should ever generate a warning.

We may decide for any of a number of reasons, that we wish to generated code that would otherwise generate a warning.  We may also decide to pay attention to some warnings, an eliminate them.

The user, who can *never* do anything about warnings in the generated code, though, should never, ever see them.