### PR TITLE
Fix logging for RunTestInLooperThreadTests integration tests.

### DIFF
--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
@@ -17,25 +17,42 @@
 package io.realm;
 
 import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.UiThreadTestRule;
 import android.util.Log;
 
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import io.realm.internal.Util;
 import io.realm.log.LogLevel;
 import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.HttpUtils;
+import io.realm.rule.RunInLooperThread;
+import io.realm.rule.TestSyncConfigurationFactory;
+
 
 public class BaseIntegrationTest {
 
     private static int originalLogLevel;
+
+    @Rule
+    public final TestSyncConfigurationFactory configurationFactory = new TestSyncConfigurationFactory();
+
+    @Rule
+    public RunInLooperThread looperThread = new RunInLooperThread();
+
+    @Rule
+    public final UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @BeforeClass
     public static void setUp () throws Exception {
@@ -82,7 +99,18 @@ public class BaseIntegrationTest {
 
     @After
     public void tearDownTest() throws IOException {
-        RealmLog.setLevel(originalLogLevel);
+        if (looperThread.isTestComplete()) {
+            // Non-looper tests can reset here
+            RealmLog.setLevel(originalLogLevel);
+        } else {
+            // Otherwise we need to wait for the test to complete
+            looperThread.runAfterTest(new Runnable() {
+                @Override
+                public void run() {
+                    RealmLog.setLevel(originalLogLevel);
+                }
+            });
+        }
     }
 
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
@@ -44,9 +44,6 @@ public class SSLConfigurationTests extends BaseIntegrationTest {
     @Rule
     public Timeout globalTimeout = Timeout.seconds(10);
 
-    @Rule
-    public final TestSyncConfigurationFactory configurationFactory = new TestSyncConfigurationFactory();
-
     @Test
     public void trustedRootCA() throws InterruptedException {
         String username = UUID.randomUUID().toString();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
@@ -19,10 +19,8 @@ package io.realm;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.test.annotation.UiThreadTest;
-import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,9 +35,7 @@ import io.realm.entities.StringOnly;
 import io.realm.exceptions.DownloadingRealmInterruptedException;
 import io.realm.exceptions.RealmMigrationNeededException;
 import io.realm.objectserver.utils.Constants;
-import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
-import io.realm.rule.TestSyncConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -51,15 +47,6 @@ import static org.junit.Assert.fail;
  */
 @RunWith(AndroidJUnit4.class)
 public class SyncedRealmTests extends BaseIntegrationTest {
-
-    @Rule
-    public RunInLooperThread looperThread = new RunInLooperThread();
-
-    @Rule
-    public final UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
-
-    @Rule
-    public final TestSyncConfigurationFactory configurationFactory = new TestSyncConfigurationFactory();
 
     @Test
     @UiThreadTest

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -5,9 +5,7 @@ import android.os.Looper;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.net.MalformedURLException;
@@ -27,7 +25,6 @@ import io.realm.SyncSession;
 import io.realm.SyncUser;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.UserFactory;
-import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 
 import static junit.framework.Assert.assertEquals;
@@ -38,11 +35,6 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(AndroidJUnit4.class)
 public class AuthTests extends BaseIntegrationTest {
-    @Rule
-    public RunInLooperThread looperThread = new RunInLooperThread();
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void login_userNotExist() {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
@@ -2,7 +2,6 @@ package io.realm.objectserver;
 
 import android.os.SystemClock;
 
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,19 +25,15 @@ import io.realm.exceptions.RealmFileException;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.StringOnlyModule;
 import io.realm.objectserver.utils.UserFactory;
-import io.realm.rule.TestSyncConfigurationFactory;
-import io.realm.util.SyncTestUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class EncryptedSynchronizedRealmTests extends BaseIntegrationTest {
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10);
 
     @Rule
-    public final TestSyncConfigurationFactory configurationFactory = new TestSyncConfigurationFactory();
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     // Make sure the encryption is local, i.e after deleting a synced Realm
     // re-open it again with no (or different) key, should be possible.

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ManagementRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ManagementRealmTests.java
@@ -51,9 +51,6 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class ManagementRealmTests extends BaseIntegrationTest {
 
-    @Rule
-    public RunInLooperThread looperThread = new RunInLooperThread();
-
     // This is primarily a test making sure that an admin user actually connects correctly to ROS.
     // See https://github.com/realm/realm-java/issues/4750
     @Test

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -19,7 +19,6 @@ package io.realm.objectserver;
 import android.os.Looper;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,11 +37,9 @@ import io.realm.objectserver.model.TestObject;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.RemoteIntegrationTestService;
 import io.realm.objectserver.utils.UserFactory;
-import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.RunTestWithRemoteService;
 import io.realm.rule.RunWithRemoteService;
-import io.realm.rule.TestSyncConfigurationFactory;
 import io.realm.services.RemoteTestService;
 
 import static org.junit.Assert.assertEquals;
@@ -52,16 +49,7 @@ import static org.junit.Assert.assertEquals;
 public class ProcessCommitTests extends BaseIntegrationTest {
 
     @Rule
-    public RunInLooperThread looperThread = new RunInLooperThread();
-    @Rule
     public RunWithRemoteService remoteService = new RunWithRemoteService();
-    @Rule
-    public TestSyncConfigurationFactory configFactory = new TestSyncConfigurationFactory();
-
-    @Before
-    public void before() throws Exception {
-        UserFactory.resetInstance();
-    }
 
     public static class SimpleCommitRemoteService extends RemoteIntegrationTestService {
         private static SyncUser user;
@@ -114,7 +102,7 @@ public class ProcessCommitTests extends BaseIntegrationTest {
 
         final SyncUser user = UserFactory.getInstance().createDefaultUser(Constants.AUTH_URL);
         String realmUrl = Constants.SYNC_SERVER_URL;
-        final SyncConfiguration syncConfig = configFactory.createSyncConfigurationBuilder(user, realmUrl).build();
+        final SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, realmUrl).build();
         final Realm realm = Realm.getInstance(syncConfig);
         final RealmResults<ProcessInfo> all = realm.where(ProcessInfo.class).findAll();
         looperThread.keepStrongReference(all);
@@ -189,7 +177,7 @@ public class ProcessCommitTests extends BaseIntegrationTest {
 
         final SyncUser user = UserFactory.getInstance().createDefaultUser(Constants.AUTH_URL);
         String realmUrl = Constants.SYNC_SERVER_URL;
-        final SyncConfiguration syncConfig = configFactory.createSyncConfigurationBuilder(user, realmUrl).build();
+        final SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, realmUrl).build();
         final Realm realm = Realm.getInstance(syncConfig);
         final RealmResults<TestObject> all = realm.where(TestObject.class).findAllSorted("intProp");
         looperThread.keepStrongReference(all);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -19,6 +19,7 @@ package io.realm.objectserver;
 import android.os.Looper;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +51,11 @@ public class ProcessCommitTests extends BaseIntegrationTest {
 
     @Rule
     public RunWithRemoteService remoteService = new RunWithRemoteService();
+
+    @Before
+    public void before() throws Exception {
+        UserFactory.resetInstance();
+    }
 
     public static class SimpleCommitRemoteService extends RemoteIntegrationTestService {
         private static SyncUser user;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -38,9 +38,11 @@ import io.realm.objectserver.model.TestObject;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.RemoteIntegrationTestService;
 import io.realm.objectserver.utils.UserFactory;
+import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.RunTestWithRemoteService;
 import io.realm.rule.RunWithRemoteService;
+import io.realm.rule.TestSyncConfigurationFactory;
 import io.realm.services.RemoteTestService;
 
 import static org.junit.Assert.assertEquals;
@@ -49,6 +51,8 @@ import static org.junit.Assert.assertEquals;
 @RunWith(AndroidJUnit4.class)
 public class ProcessCommitTests extends BaseIntegrationTest {
 
+    @Rule
+    public RunInLooperThread looperThread = new RunInLooperThread();
     @Rule
     public RunWithRemoteService remoteService = new RunWithRemoteService();
 


### PR DESCRIPTION
Logging was not reset correct when running integration tests with @RunTestInLooperThread. Also clean up all subclasses of `BaseIntegrationTest`