### PR TITLE
Correctly reset integration tests.

### DIFF
--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -3,6 +3,7 @@
 var winston = require('winston'); //logging
 const temp = require('temp');
 const spawn = require('child_process').spawn;
+const exec = require('child_process').exec;
 var http = require('http');
 var dispatcher = require('httpdispatcher');
 
@@ -64,9 +65,15 @@ function stopRealmObjectServer() {
     if (syncServerChildProcess) {
         syncServerChildProcess.kill();
         syncServerChildProcess = null;
+        exec('rm -r ' + 'realm-object-server', function (err, stdout, stderr) {
+            if (err) {
+                winston.err(err)
+            } else {
+                winston.info("realm-object-server directory deleted")
+            }
+        });
     }
 }
-
 
 // start sync server
 dispatcher.onGet("/start", function(req, res) {


### PR DESCRIPTION
According to @mrackwitz, we need to delete the `realm-object-server` directory between each integration test to correctly reset ROS ( https://github.com/realm/realm-object-server/issues/1225#issuecomment-308216359 ) .

This error caused #4655 to be extremely flaky. After this change, it seems to run consistently.