### PR TITLE
migrate to sdkmanager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,10 @@ RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
 RUN sdkmanager --list
 RUN sdkmanager --update
-RUN sdkmanager platform-tools;26.0.0
-RUN sdkmanager build-tools;25.0.3
-RUN sdkmanager extras;android;m2repository
-RUN sdkmanager platforms;android-25
+RUN sdkmanager 'platform-tools;26.0.0'
+RUN sdkmanager 'build-tools;25.0.3'
+RUN sdkmanager 'extras;android;m2repository'
+RUN sdkmanager 'platforms;android-25'
 
 # Install the NDK
 RUN mkdir /opt/android-ndk-tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV ANDROID_HOME /opt/android-sdk-linux
 # Need by cmake
 ENV ANDROID_NDK_HOME /opt/android-ndk
 ENV ANDROID_NDK /opt/android-ndk
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 ENV PATH ${PATH}:${NDK_HOME}
 ENV NDK_CCACHE /usr/bin/ccache
 ENV NDK_LCACHE /usr/bin/lcache
@@ -49,11 +49,12 @@ RUN cd /opt && \
 # Grab what's needed in the SDK
 RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
-RUN ${ANDROID_HOME}/bin/sdkmanager "tools;26.0.2"
-RUN ${ANDROID_HOME}/bin/sdkmanager "platform-tools;26.0.0"
-RUN ${ANDROID_HOME}/bin/sdkmanager "build-tools;25.0.3"
-RUN ${ANDROID_HOME}/bin/sdkmanager "extras;android;m2repository"
-RUN ${ANDROID_HOME}/bin/sdkmanager "platforms;android-25"
+RUN ls ${ANDROID_HOME}
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager "tools;26.0.2"
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager "platform-tools;26.0.0"
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;25.0.3"
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager "extras;android;m2repository"
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-25"
 
 # Install the NDK
 RUN mkdir /opt/android-ndk-tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,12 +48,12 @@ RUN cd /opt && \
 
 # Grab what's needed in the SDK
 RUN mkdir "${ANDROID_HOME}/licenses" && \
-    echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license" && \
-RUN sdkmanager 'tools;26.0.2'
-RUN sdkmanager 'platform-tools;26.0.0'
-RUN sdkmanager 'build-tools;25.0.3'
-RUN sdkmanager 'extras;android;m2repository'
-RUN sdkmanager 'platforms;android-25'
+    echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
+RUN sdkmanager "tools;26.0.2"
+RUN sdkmanager "platform-tools;26.0.0"
+RUN sdkmanager "build-tools;25.0.3"
+RUN sdkmanager "extras;android;m2repository"
+RUN sdkmanager "platforms;android-25"
 
 # Install the NDK
 RUN mkdir /opt/android-ndk-tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,11 @@ RUN cd /opt && \
 # Grab what's needed in the SDK
 RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
-RUN sdkmanager "tools;26.0.2"
-RUN sdkmanager "platform-tools;26.0.0"
-RUN sdkmanager "build-tools;25.0.3"
-RUN sdkmanager "extras;android;m2repository"
-RUN sdkmanager "platforms;android-25"
+RUN ${ANDROID_HOME}/bin/sdkmanager "tools;26.0.2"
+RUN ${ANDROID_HOME}/bin/sdkmanager "platform-tools;26.0.0"
+RUN ${ANDROID_HOME}/bin/sdkmanager "build-tools;25.0.3"
+RUN ${ANDROID_HOME}/bin/sdkmanager "extras;android;m2repository"
+RUN ${ANDROID_HOME}/bin/sdkmanager "platforms;android-25"
 
 # Install the NDK
 RUN mkdir /opt/android-ndk-tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,8 @@ RUN cd /opt && \
 # Grab what's needed in the SDK
 RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
-RUN sdkmanager --list
 RUN sdkmanager --update
-RUN sdkmanager 'platform-tools;26.0.0'
+RUN sdkmanager 'platform-tools'
 RUN sdkmanager 'build-tools;25.0.3'
 RUN sdkmanager 'extras;android;m2repository'
 RUN sdkmanager 'platforms;android-25'

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,10 @@ RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
 RUN sdkmanager --list
 RUN sdkmanager --update
-RUN sdkmanager "platform-tools;26.0.0"
-RUN sdkmanager "build-tools;25.0.3"
-RUN sdkmanager "extras;android;m2repository"
-RUN sdkmanager "platforms;android-25"
+RUN sdkmanager platform-tools;26.0.0
+RUN sdkmanager build-tools;25.0.3
+RUN sdkmanager extras;android;m2repository
+RUN sdkmanager platforms;android-25
 
 # Install the NDK
 RUN mkdir /opt/android-ndk-tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,12 @@ RUN cd /opt && \
 # Grab what's needed in the SDK
 RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
-RUN ls ${ANDROID_HOME}
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager "tools;26.0.2"
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager "platform-tools;26.0.0"
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;25.0.3"
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager "extras;android;m2repository"
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-25"
+RUN sdkmanager --list
+RUN sdkmanager "tools;26.0.2"
+RUN sdkmanager "platform-tools;26.0.0"
+RUN sdkmanager "build-tools;25.0.3"
+RUN sdkmanager "extras;android;m2repository"
+RUN sdkmanager "platforms;android-25"
 
 # Install the NDK
 RUN mkdir /opt/android-ndk-tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN cd /opt && \
 RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
 RUN sdkmanager --list
-RUN sdkmanager "tools;26.0.2"
+RUN sdkmanager --update
 RUN sdkmanager "platform-tools;26.0.0"
 RUN sdkmanager "build-tools;25.0.3"
 RUN sdkmanager "extras;android;m2repository"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,20 +42,18 @@ RUN DEBIAN_FRONTEND=noninteractive dpkg --add-architecture i386 \
 
 # Install the Android SDK
 RUN cd /opt && \
-    wget -q https://dl.google.com/android/repository/tools_r25.1.7-linux.zip -O android-tools-linux.zip && \
+    wget -q https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip -O android-tools-linux.zip && \
     unzip android-tools-linux.zip -d ${ANDROID_HOME} && \
     rm -f android-tools-linux.zip
 
 # Grab what's needed in the SDK
-# ↓ updates tools to at least 25.1.7, but that prints 'Nothing was installed' (so I don't check the outputs).
 RUN mkdir "${ANDROID_HOME}/licenses" && \
     echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license" && \
-    echo -en "\nd23d63a1f23e25e2c7a316e29eb60396e7924281" > "${ANDROID_HOME}/licenses/android-sdk-preview-license"
-RUN echo y | android update sdk --no-ui --all --filter tools > /dev/null
-RUN echo y | android update sdk --no-ui --all --filter platform-tools | grep 'package installed'
-RUN echo y | android update sdk --no-ui --all --filter build-tools-25.0.3 | grep 'package installed'
-RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository | grep 'package installed'
-RUN echo y | android update sdk --no-ui --all --filter android-25 | grep 'package installed'
+RUN sdkmanager 'tools;26.0.2'
+RUN sdkmanager 'platform-tools;26.0.0'
+RUN sdkmanager 'build-tools;25.0.3'
+RUN sdkmanager 'extras;android;m2repository'
+RUN sdkmanager 'platforms;android-25'
 
 # Install the NDK
 RUN mkdir /opt/android-ndk-tmp && \


### PR DESCRIPTION
Migrated CI environment to `sdkmanager` command from deprecate `android` command.
