### PR TITLE
Fix flaky tests caused by half inited ROS

### DIFF
--- a/tools/sync_test_server/Dockerfile
+++ b/tools/sync_test_server/Dockerfile
@@ -12,12 +12,12 @@ RUN apt-get update -qq \
 RUN npm init -y
 RUN npm install winston temp httpdispatcher@1.0.0
 
-COPY keys/public.pem keys/private.pem keys/127_0_0_1-server.key.pem keys/127_0_0_1-chain.crt.pem configuration.yml /
-COPY ros-testing-server.js /usr/bin/
-
 # Install realm object server
 RUN apt-get update -qq \
     && apt-get install -y realm-object-server-developer=$ROS_DE_VERSION \
     && apt-get clean
+
+COPY keys/public.pem keys/private.pem keys/127_0_0_1-server.key.pem keys/127_0_0_1-chain.crt.pem configuration.yml /
+COPY ros-testing-server.js /usr/bin/
 
 CMD /usr/bin/ros-testing-server.js /tmp/ros-testing-server.log

--- a/tools/sync_test_server/configuration.yml
+++ b/tools/sync_test_server/configuration.yml
@@ -154,7 +154,7 @@ proxy:
     ## The address/interface on which the HTTP proxy module should listen. This defaults
     ## to 127.0.0.1. If you wish to listen on all available interfaces,
     ## uncomment the following line.
-    listen_address: '::'
+    listen_address: '0.0.0.0'
 
     ## The port that the HTTP proxy module should bind to.
     # listen_port: 9080
@@ -175,7 +175,7 @@ proxy:
     ## The address/interface on which the HTTPS proxy module should listen. This defaults
     ## to 127.0.0.1. If you wish to listen on all available interfaces,
     ## uncomment the following line.
-    listen_address: '::'
+    listen_address: '0.0.0.0'
 
     ## The port that the HTTPS proxy module should bind to.
     listen_port: 9443

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -33,7 +33,13 @@ function handleRequest(request, response) {
 
 var syncServerChildProcess = null;
 
-function startRealmObjectServer() {
+function startRealmObjectServer(done) {
+    // Hack for checking the ROS is fully initialized.
+    // Consider the ROS is initialized fully only if log below shows twice
+    // "client: Closing Realm file: /tmp/ros117521-7-1eiqt7a/internal_data/permission/__auth.realm"
+    // https://github.com/realm/realm-object-server/issues/1297
+    var logFindingCounter = 2
+
     stopRealmObjectServer();
     temp.mkdir('ros', function(err, path) {
         if (!err) {
@@ -44,9 +50,15 @@ function startRealmObjectServer() {
             syncServerChildProcess = spawn('realm-object-server',
                     ['--root', path,
                     '--configuration', '/configuration.yml'],
-                    { env: env });
+                    { env: env});
             // local config:
             syncServerChildProcess.stdout.on('data', (data) => {
+                if (logFindingCounter != 0 && /client: Closing Realm file: .*__auth.realm/.test(data)) {
+                    if (logFindingCounter == 1) {
+                        done()
+                    }
+                    logFindingCounter--
+                }
                 winston.info(`stdout: ${data}`);
             });
 
@@ -75,11 +87,13 @@ function stopRealmObjectServer() {
     }
 }
 
+
 // start sync server
 dispatcher.onGet("/start", function(req, res) {
-    startRealmObjectServer();
-    res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.end('Starting a server');
+    startRealmObjectServer(() => {
+        res.writeHead(200, {'Content-Type': 'text/plain'});
+        res.end('Starting a server');
+    })
 });
 
 // stop a previously started sync server


### PR DESCRIPTION
- Hack for detecting if the ROS is fully initialized in the docker
  sided.
- Dockerfile optimization.
- Use "0.0.0.0" instead of "::" to solve dns issues inside docker.