### PR TITLE
Local ref needs to be cleaned on client thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Bug Fixes
 
-* [ObjectServer] Fixed a bug which may crash when the JNI local reference limitation reached on sync client thread.
+* [ObjectServer] Fixed a bug which may crash when the JNI local reference limitation was reached on sync client thread.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Bug Fixes
 
+* [ObjectServer] Fixed a bug which may crash when the JNI local reference limitation reached on sync client thread.
+
 ### Internal
 
 * Upgraded to Realm Sync 1.10.1


### PR DESCRIPTION
- Add support for null JavaLocalRef.
- Clean the local ref after notifyAllChangesDownloaded.