### PR TITLE
winston.err did not exist

### DIFF
--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -79,9 +79,9 @@ function stopRealmObjectServer() {
         syncServerChildProcess = null;
         exec('rm -r ' + 'realm-object-server', function (err, stdout, stderr) {
             if (err) {
-                winston.err(err)
+                winston.error(err);
             } else {
-                winston.info("realm-object-server directory deleted")
+                winston.info("realm-object-server directory deleted");
             }
         });
     }


### PR DESCRIPTION
Used the wrong method for error reporting which crashed the Integration Test Server. Ups.
