### PR TITLE
PermissionManger should not return same instance for different users

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -44,6 +44,7 @@ import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.util.SyncTestUtils;
 
+import static io.realm.util.SyncTestUtils.createNamedTestUser;
 import static io.realm.util.SyncTestUtils.createTestAdminUser;
 import static io.realm.util.SyncTestUtils.createTestUser;
 import static junit.framework.Assert.assertEquals;
@@ -370,5 +371,35 @@ public class SyncUserTests {
         pm1.close();
         assertTrue(pm1.isClosed());
         looperThread.testComplete();
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void getPermissionManger_instanceUniqueToUser() {
+        SyncUser user1 = createNamedTestUser("user1");
+        SyncUser user2 = createNamedTestUser("user2");
+        PermissionManager pm1 = user1.getPermissionManager();
+        PermissionManager pm2 = user2.getPermissionManager();
+
+        try {
+            assertFalse(pm1 == pm2);
+            assertFalse(pm1.equals(pm2));
+            looperThread.testComplete();
+        } finally {
+            pm1.close();
+            pm2.close();
+            user1.logout();
+            user2.logout();
+        }
+    }
+
+    @Test
+    public void getPermissionManager_throwOnNonLooperThread() {
+        SyncUser user = createTestUser();
+        try {
+            user.getPermissionManager();
+            fail();
+        } catch (IllegalStateException e) {
+        }
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/PermissionManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/PermissionManager.java
@@ -62,8 +62,12 @@ public class PermissionManager implements Closeable {
             String userId = syncUser.getIdentity();
             ThreadLocal<Cache> threadLocalCache = cache.get(userId);
             if (threadLocalCache == null) {
-                threadLocalCache = new ThreadLocal<>();
-                threadLocalCache.set(new Cache());
+                threadLocalCache = new ThreadLocal<Cache>() {
+                    @Override
+                    protected Cache initialValue() {
+                        return new Cache();
+                    }
+                };
                 cache.put(userId, threadLocalCache);
             }
             Cache c = threadLocalCache.get();
@@ -322,7 +326,7 @@ public class PermissionManager implements Closeable {
         }
         closed = true;
     }
-    
+
     /**
      * Checks if this PermissionManager is closed or not. If it is closed, all methods will report back an error.
      *

--- a/realm/realm-library/src/objectServer/java/io/realm/PermissionManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/PermissionManager.java
@@ -24,8 +24,10 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import io.realm.internal.permissions.ManagementModule;
 import io.realm.internal.permissions.PermissionModule;
@@ -40,19 +42,14 @@ import io.realm.log.RealmLog;
 public class PermissionManager implements Closeable {
 
     // Reference counted cache equivalent to how Realm instances work.
-    private static ThreadLocal<PermissionManager> permissionManager = new ThreadLocal<PermissionManager>() {
-        @Override
-        protected PermissionManager initialValue() {
-            return null;
-        }
-    };
+    private static Map<String, ThreadLocal<Cache>> cache = new HashMap<>();
 
-    private static ThreadLocal<Integer> permissionManagerInstanceCounter = new ThreadLocal<Integer>() {
-        @Override
-        protected Integer initialValue() {
-            return 0;
-        }
-    };
+    private static class Cache {
+        public PermissionManager pm = null;
+        public Integer instanceCounter = Integer.valueOf(0);
+    }
+
+    private static final Object cacheLock = new Object();
 
     /**
      * Return a thread confined, reference counted instance of the PermissionManager.
@@ -60,14 +57,22 @@ public class PermissionManager implements Closeable {
      * @param syncUser user to create the PermissionManager for.
      * @return a thread confined PermissionManager instance for the provided user.
      */
-    static synchronized PermissionManager getInstance(SyncUser syncUser) {
-        PermissionManager pm = permissionManager.get();
-        if (pm == null) {
-            pm = new PermissionManager(syncUser);
-            permissionManager.set(pm);
+    static PermissionManager getInstance(SyncUser syncUser) {
+        synchronized (cacheLock) {
+            String userId = syncUser.getIdentity();
+            ThreadLocal<Cache> threadLocalCache = cache.get(userId);
+            if (threadLocalCache == null) {
+                threadLocalCache = new ThreadLocal<>();
+                threadLocalCache.set(new Cache());
+                cache.put(userId, threadLocalCache);
+            }
+            Cache c = threadLocalCache.get();
+            if (c.instanceCounter == 0) {
+                c.pm = new PermissionManager(syncUser);
+            }
+            c.instanceCounter++;
+            return c.pm;
         }
-        permissionManagerInstanceCounter.set(permissionManagerInstanceCounter.get() + 1);
-        return pm;
     }
 
     private enum RealmType {
@@ -285,15 +290,17 @@ public class PermissionManager implements Closeable {
         checkIfValidThread();
 
         // Multiple instances open, just decrement the reference count
-        Integer instanceCount = permissionManagerInstanceCounter.get();
-        if (instanceCount > 1) {
-            permissionManagerInstanceCounter.set(instanceCount - 1);
-            return;
-        }
+        synchronized (cacheLock) {
+            Cache cache = PermissionManager.cache.get(user.getIdentity()).get();
+            if (cache.instanceCounter > 1) {
+                cache.instanceCounter--;
+                return;
+            }
 
-        // Only one instance open. Do a full close
-        permissionManagerInstanceCounter.set(0);
-        permissionManager.set(null);
+            // Only one instance open. Do a full close
+            cache.instanceCounter = 0;
+            cache.pm = null;
+        }
         delayedTasks.clear();
 
         // If Realms are still being opened, abort that task
@@ -315,7 +322,7 @@ public class PermissionManager implements Closeable {
         }
         closed = true;
     }
-
+    
     /**
      * Checks if this PermissionManager is closed or not. If it is closed, all methods will report back an error.
      *

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -531,6 +531,7 @@ public class SyncUser {
      * @return
      */
     public PermissionManager getPermissionManager() {
+        new AndroidCapabilities().checkCanDeliverNotification("The PermissionManager can only opened on a Looper thread.");
         return PermissionManager.getInstance(this);
     }
 


### PR DESCRIPTION
Discovered this embarrassing bug while writing unit tests for #4731 ... apparently caching is hard.

I modified the cache to be per user. 