### PR TITLE
PermissionWrapper unit test helper methods

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -157,7 +157,7 @@ public class TestHelper {
     public static String getRandomEmail() {
         StringBuilder sb = new StringBuilder(UUID.randomUUID().toString().toLowerCase());
         sb.append('@');
-        sb.append("realm.io");
+        sb.append("androidtest.realm.io");
         return sb.toString();
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TestHelper.java
@@ -39,6 +39,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -151,6 +152,13 @@ public class TestHelper {
         byte[] key = new byte[64];
         RANDOM.nextBytes(key);
         return key;
+    }
+
+    public static String getRandomEmail() {
+        StringBuilder sb = new StringBuilder(UUID.randomUUID().toString().toLowerCase());
+        sb.append('@');
+        sb.append("realm.io");
+        return sb.toString();
     }
 
     // Returns a random key from the given seed. Used by encrypted Realms.

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/PermissionManagerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/PermissionManagerTests.java
@@ -52,13 +52,7 @@ public class PermissionManagerTests extends BaseIntegrationTest {
 
     @Before
     public void setUpTest() {
-        user = UserFactory.createUniqueUser(Constants.AUTH_URL);
-        looperThread.runAfterTest(new Runnable() {
-            @Override
-            public void run() {
-                user.logout();
-            }
-        });
+        user = createUniqueUserForTest();
     }
 
     @Test
@@ -279,6 +273,28 @@ public class PermissionManagerTests extends BaseIntegrationTest {
 
         // Create dummy task that can trigger the error reporting
         runTask(pm, callback);
+    }
+
+    private SyncUser createUniqueUserForTest() {
+        final SyncUser user = UserFactory.createUniqueUser();
+        looperThread.runAfterTest(new Runnable() {
+            @Override
+            public void run() {
+                user.logout();
+            }
+        });
+        return user;
+    }
+
+    private SyncUser createUserForTest(String username) {
+        final SyncUser user = UserFactory.createUser(username);
+        looperThread.runAfterTest(new Runnable() {
+            @Override
+            public void run() {
+                user.logout();
+            }
+        });
+        return user;
     }
 
     private void setRealmError(PermissionManager pm, String fieldName, ObjectServerError error) throws NoSuchFieldException,

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -46,11 +46,27 @@ public class UserFactory {
         return SyncUser.login(credentials, authUrl);
     }
 
+    /**
+     * Create a unique user, using the standard authentification URL used by the test server.
+     */
+    public static SyncUser createUniqueUser() {
+        return createUniqueUser(Constants.AUTH_URL);
+    }
+
+    public static SyncUser createUser(String username) {
+        return createUser(username, Constants.AUTH_URL);
+    }
+
     public static SyncUser createUniqueUser(String authUrl) {
         String uniqueName = UUID.randomUUID().toString();
-        SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, PASSWORD, true);
+        return createUser(uniqueName);
+    }
+
+    private static SyncUser createUser(String username, String authUrl) {
+        SyncCredentials credentials = SyncCredentials.usernamePassword(username, PASSWORD, true);
         return SyncUser.login(credentials, authUrl);
     }
+
 
     public SyncUser createDefaultUser(String authUrl) {
         SyncCredentials credentials = SyncCredentials.usernamePassword(userName, PASSWORD, true);
@@ -101,4 +117,5 @@ public class UserFactory {
         RealmLog.debug("UserFactory.getInstance, the default user is " + instance.userName + " .");
         return instance;
     }
+
 }


### PR DESCRIPTION
This PR adds a few helper methods required for the PermissionManager unit tests in #4731 