### PR TITLE
Explicitly specify Locale for String.format() instead of implicit current Locale

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import java.util.Locale;
+
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
 import io.realm.internal.CheckedRow;
@@ -105,7 +107,8 @@ public class DynamicRealm extends BaseRealm {
         Table table = schema.getTable(className);
         // Check and throw the exception earlier for a better exception message.
         if (table.hasPrimaryKey()) {
-            throw new RealmException(String.format("'%s' has a primary key, use" +
+            throw new RealmException(String.format(Locale.ENGLISH,
+                    "'%s' has a primary key, use" +
                     " 'createObject(String, Object)' instead.", className));
         }
 

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -107,7 +107,7 @@ public class DynamicRealm extends BaseRealm {
         Table table = schema.getTable(className);
         // Check and throw the exception earlier for a better exception message.
         if (table.hasPrimaryKey()) {
-            throw new RealmException(String.format(Locale.ENGLISH,
+            throw new RealmException(String.format(Locale.US,
                     "'%s' has a primary key, use" +
                     " 'createObject(String, Object)' instead.", className));
         }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -454,7 +454,8 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                     value = JsonUtils.stringToDate(strValue);
                     break;
                 default:
-                    throw new IllegalArgumentException(String.format("Field %s is not a String field, " +
+                    throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                            "Field %s is not a String field, " +
                             "and the provide value could not be automatically converted: %s. Use a typed" +
                             "setter instead", fieldName, value));
             }
@@ -679,7 +680,8 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             Table table = proxyState.getRow$realm().getTable().getLinkTarget(columnIndex);
             Table inputTable = value.proxyState.getRow$realm().getTable();
             if (!table.hasSameSchema(inputTable)) {
-                throw new IllegalArgumentException(String.format("Type of object is wrong. Was %s, expected %s",
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        "Type of object is wrong. Was %s, expected %s",
                         inputTable.getName(), table.getName()));
             }
             proxyState.getRow$realm().setLink(columnIndex, value.proxyState.getRow$realm().getIndex());
@@ -803,7 +805,8 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             if (columnType == RealmFieldType.INTEGER || columnType == RealmFieldType.OBJECT) {
                 columnTypeIndefiniteVowel = "n";
             }
-            throw new IllegalArgumentException(String.format("'%s' is not a%s '%s', but a%s '%s'.",
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                    "'%s' is not a%s '%s', but a%s '%s'.",
                     fieldName, expectedIndefiniteVowel, expectedType, columnTypeIndefiniteVowel, columnType));
         }
     }
@@ -910,7 +913,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                     break;
                 case LIST:
                     String targetClassName = proxyState.getRow$realm().getTable().getLinkTarget(columnIndex).getClassName();
-                    sb.append(String.format("RealmList<%s>[%s]", targetClassName, proxyState.getRow$realm().getLinkList(columnIndex).size()));
+                    sb.append(String.format(Locale.ENGLISH, "RealmList<%s>[%s]", targetClassName, proxyState.getRow$realm().getLinkList(columnIndex).size()));
                     break;
                 case UNSUPPORTED_TABLE:
                 case UNSUPPORTED_MIXED:
@@ -984,7 +987,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
     private void checkIsPrimaryKey(String fieldName) {
         RealmObjectSchema objectSchema = proxyState.getRealm$realm().getSchema().getSchemaForClass(getType());
         if (objectSchema.hasPrimaryKey() && objectSchema.getPrimaryKey().equals(fieldName)) {
-            throw new IllegalArgumentException(String.format(
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                     "Primary key field '%s' cannot be changed after object was created.", fieldName));
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -454,7 +454,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                     value = JsonUtils.stringToDate(strValue);
                     break;
                 default:
-                    throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                    throw new IllegalArgumentException(String.format(Locale.US,
                             "Field %s is not a String field, " +
                             "and the provide value could not be automatically converted: %s. Use a typed" +
                             "setter instead", fieldName, value));
@@ -680,7 +680,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             Table table = proxyState.getRow$realm().getTable().getLinkTarget(columnIndex);
             Table inputTable = value.proxyState.getRow$realm().getTable();
             if (!table.hasSameSchema(inputTable)) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         "Type of object is wrong. Was %s, expected %s",
                         inputTable.getName(), table.getName()));
             }
@@ -718,7 +718,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             String listType = list.className != null ? list.className
                     : proxyState.getRealm$realm().getSchema().getTable(list.clazz).getClassName();
             if (!linkTargetTableName.equals(listType)) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         "The elements in the list are not the proper type. " +
                                 "Was %s expected %s.", listType, linkTargetTableName));
             }
@@ -734,7 +734,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                 throw new IllegalArgumentException("Each element in 'list' must belong to the same Realm instance.");
             }
             if (!typeValidated && !linkTargetTable.hasSameSchema(obj.realmGet$proxyState().getRow$realm().getTable())) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         "Element at index %d is not the proper type. " +
                                 "Was '%s' expected '%s'.",
                         i,
@@ -805,7 +805,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             if (columnType == RealmFieldType.INTEGER || columnType == RealmFieldType.OBJECT) {
                 columnTypeIndefiniteVowel = "n";
             }
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+            throw new IllegalArgumentException(String.format(Locale.US,
                     "'%s' is not a%s '%s', but a%s '%s'.",
                     fieldName, expectedIndefiniteVowel, expectedType, columnTypeIndefiniteVowel, columnType));
         }
@@ -913,7 +913,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                     break;
                 case LIST:
                     String targetClassName = proxyState.getRow$realm().getTable().getLinkTarget(columnIndex).getClassName();
-                    sb.append(String.format(Locale.ENGLISH, "RealmList<%s>[%s]", targetClassName, proxyState.getRow$realm().getLinkList(columnIndex).size()));
+                    sb.append(String.format(Locale.US, "RealmList<%s>[%s]", targetClassName, proxyState.getRow$realm().getLinkList(columnIndex).size()));
                     break;
                 case UNSUPPORTED_TABLE:
                 case UNSUPPORTED_MIXED:
@@ -963,7 +963,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
 
         final RealmFieldType fieldType = realmObjectSchema.getFieldType(srcFieldName); // throws IAE if not found
         if (fieldType != RealmFieldType.OBJECT && fieldType != RealmFieldType.LIST) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+            throw new IllegalArgumentException(String.format(Locale.US,
                     "Unexpected field type: %1$s. Field type should be either %2$s.%3$s or %2$s.%4$s.",
                     fieldType.name(),
                     RealmFieldType.class.getSimpleName(),
@@ -987,7 +987,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
     private void checkIsPrimaryKey(String fieldName) {
         RealmObjectSchema objectSchema = proxyState.getRealm$realm().getSchema().getSchemaForClass(getType());
         if (objectSchema.hasPrimaryKey() && objectSchema.getPrimaryKey().equals(fieldName)) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+            throw new IllegalArgumentException(String.format(Locale.US,
                     "Primary key field '%s' cannot be changed after object was created.", fieldName));
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
@@ -247,7 +247,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
         }
         long columnIndex = collection.getTable().getColumnIndex(fieldName);
         if (columnIndex < 0) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Field '%s' does not exist.", fieldName));
+            throw new IllegalArgumentException(String.format(Locale.US, "Field '%s' does not exist.", fieldName));
         }
         return columnIndex;
     }

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
@@ -5,6 +5,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.ListIterator;
+import java.util.Locale;
 
 import io.realm.internal.Collection;
 import io.realm.internal.InvalidRow;
@@ -246,7 +247,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
         }
         long columnIndex = collection.getTable().getColumnIndex(fieldName);
         if (columnIndex < 0) {
-            throw new IllegalArgumentException(String.format("Field '%s' does not exist.", fieldName));
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Field '%s' does not exist.", fieldName));
         }
         return columnIndex;
     }

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionSnapshot.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionSnapshot.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import java.util.Locale;
+
 import io.realm.internal.Collection;
 import io.realm.internal.UncheckedRow;
 
@@ -128,7 +130,7 @@ public class OrderedRealmCollectionSnapshot<E extends RealmModel> extends Ordere
 
     private UnsupportedOperationException getUnsupportedException(String methodName) {
         return new UnsupportedOperationException(
-                String.format("'%s()' is not supported by OrderedRealmCollectionSnapshot. " +
+                String.format(Locale.ENGLISH, "'%s()' is not supported by OrderedRealmCollectionSnapshot. " +
                         "Call '%s()' on the original 'RealmCollection' instead.", methodName, methodName));
     }
 

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionSnapshot.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionSnapshot.java
@@ -130,7 +130,7 @@ public class OrderedRealmCollectionSnapshot<E extends RealmModel> extends Ordere
 
     private UnsupportedOperationException getUnsupportedException(String methodName) {
         return new UnsupportedOperationException(
-                String.format(Locale.ENGLISH, "'%s()' is not supported by OrderedRealmCollectionSnapshot. " +
+                String.format(Locale.US, "'%s()' is not supported by OrderedRealmCollectionSnapshot. " +
                         "Call '%s()' on the original 'RealmCollection' instead.", methodName, methodName));
     }
 

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
@@ -407,12 +408,12 @@ public class Realm extends BaseRealm {
                     realm.doClose();
                     throw new RealmMigrationNeededException(
                             configuration.getPath(),
-                            String.format("Realm on disk need to migrate from v%s to v%s", currentVersion, requiredVersion));
+                            String.format(Locale.ENGLISH, "Realm on disk need to migrate from v%s to v%s", currentVersion, requiredVersion));
                 }
                 if (requiredVersion < currentVersion) {
                     realm.doClose();
                     throw new IllegalArgumentException(
-                            String.format("Realm on disk is newer than the one specified: v%s vs. v%s", currentVersion, requiredVersion));
+                            String.format(Locale.ENGLISH, "Realm on disk is newer than the one specified: v%s vs. v%s", currentVersion, requiredVersion));
                 }
             }
 
@@ -998,7 +999,7 @@ public class Realm extends BaseRealm {
         Table table = schema.getTable(clazz);
         // Checks and throws the exception earlier for a better exception message.
         if (table.hasPrimaryKey()) {
-            throw new RealmException(String.format("'%s' has a primary key, use" +
+            throw new RealmException(String.format(Locale.ENGLISH, "'%s' has a primary key, use" +
                     " 'createObject(Class<E>, Object)' instead.", table.getClassName()));
         }
         return configuration.getSchemaMediator().newInstance(clazz, this,

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -408,12 +408,12 @@ public class Realm extends BaseRealm {
                     realm.doClose();
                     throw new RealmMigrationNeededException(
                             configuration.getPath(),
-                            String.format(Locale.ENGLISH, "Realm on disk need to migrate from v%s to v%s", currentVersion, requiredVersion));
+                            String.format(Locale.US, "Realm on disk need to migrate from v%s to v%s", currentVersion, requiredVersion));
                 }
                 if (requiredVersion < currentVersion) {
                     realm.doClose();
                     throw new IllegalArgumentException(
-                            String.format(Locale.ENGLISH, "Realm on disk is newer than the one specified: v%s vs. v%s", currentVersion, requiredVersion));
+                            String.format(Locale.US, "Realm on disk is newer than the one specified: v%s vs. v%s", currentVersion, requiredVersion));
                 }
             }
 
@@ -999,7 +999,7 @@ public class Realm extends BaseRealm {
         Table table = schema.getTable(clazz);
         // Checks and throws the exception earlier for a better exception message.
         if (table.hasPrimaryKey()) {
-            throw new RealmException(String.format(Locale.ENGLISH, "'%s' has a primary key, use" +
+            throw new RealmException(String.format(Locale.US, "'%s' has a primary key, use" +
                     " 'createObject(Class<E>, Object)' instead.", table.getClassName()));
         }
         return configuration.getSchemaMediator().newInstance(clazz, this,

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import io.realm.annotations.RealmModule;
@@ -322,7 +323,7 @@ public class RealmConfiguration {
     private static RealmProxyMediator getModuleMediator(String fullyQualifiedModuleClassName) {
         String[] moduleNameParts = fullyQualifiedModuleClassName.split("\\.");
         String moduleSimpleName = moduleNameParts[moduleNameParts.length - 1];
-        String mediatorName = String.format("io.realm.%s%s", moduleSimpleName, "Mediator");
+        String mediatorName = String.format(Locale.ENGLISH, "io.realm.%s%s", moduleSimpleName, "Mediator");
         Class<?> clazz;
         //noinspection TryWithIdenticalCatches
         try {
@@ -500,7 +501,8 @@ public class RealmConfiguration {
                 throw new IllegalArgumentException("A non-null key must be provided");
             }
             if (key.length != KEY_LENGTH) {
-                throw new IllegalArgumentException(String.format("The provided key must be %s bytes. Yours was: %s",
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        "The provided key must be %s bytes. Yours was: %s",
                         KEY_LENGTH, key.length));
             }
             this.key = Arrays.copyOf(key, key.length);

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -323,7 +323,7 @@ public class RealmConfiguration {
     private static RealmProxyMediator getModuleMediator(String fullyQualifiedModuleClassName) {
         String[] moduleNameParts = fullyQualifiedModuleClassName.split("\\.");
         String moduleSimpleName = moduleNameParts[moduleNameParts.length - 1];
-        String mediatorName = String.format(Locale.ENGLISH, "io.realm.%s%s", moduleSimpleName, "Mediator");
+        String mediatorName = String.format(Locale.US, "io.realm.%s%s", moduleSimpleName, "Mediator");
         Class<?> clazz;
         //noinspection TryWithIdenticalCatches
         try {
@@ -501,7 +501,7 @@ public class RealmConfiguration {
                 throw new IllegalArgumentException("A non-null key must be provided");
             }
             if (key.length != KEY_LENGTH) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         "The provided key must be %s bytes. Yours was: %s",
                         KEY_LENGTH, key.length));
             }

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -255,7 +255,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
                         return object;
                     } else {
                         // Different target table
-                        throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        throw new IllegalArgumentException(String.format(Locale.US,
                                 "The object has a different type from list's." +
                                 " Type of the list is '%s', type of object is '%s'.", listClassName, objectClassName));
                     }

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 
 import io.realm.internal.InvalidRow;
@@ -254,7 +255,8 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
                         return object;
                     } else {
                         // Different target table
-                        throw new IllegalArgumentException(String.format("The object has a different type from list's." +
+                        throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                "The object has a different type from list's." +
                                 " Type of the list is '%s', type of object is '%s'.", listClassName, objectClassName));
                     }
                 } else if (realm.threadId == proxy.realmGet$proxyState().getRealm$realm().threadId) {

--- a/realm/realm-library/src/main/java/io/realm/RealmMigration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmMigration.java
@@ -42,7 +42,7 @@ package io.realm;
  *     }
  *
  *     if (oldVersion < newVersion) {
- *         throw new IllegalStateException(String.format("Migration missing from v%d to v%d", oldVersion, newVersion));
+ *         throw new IllegalStateException(String.format(Locale.ENGLISH, "Migration missing from v%d to v%d", oldVersion, newVersion));
  *     }
  *   }
  * }

--- a/realm/realm-library/src/main/java/io/realm/RealmMigration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmMigration.java
@@ -42,7 +42,7 @@ package io.realm;
  *     }
  *
  *     if (oldVersion < newVersion) {
- *         throw new IllegalStateException(String.format(Locale.ENGLISH, "Migration missing from v%d to v%d", oldVersion, newVersion));
+ *         throw new IllegalStateException(String.format(Locale.US, "Migration missing from v%d to v%d", oldVersion, newVersion));
  *     }
  *   }
  * }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1601,7 +1601,7 @@ public class RealmQuery<E extends RealmModel> {
             case DOUBLE:
                 return query.sumDouble(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
@@ -1628,7 +1628,7 @@ public class RealmQuery<E extends RealmModel> {
             case FLOAT:
                 return query.averageFloat(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
@@ -1654,7 +1654,7 @@ public class RealmQuery<E extends RealmModel> {
             case DOUBLE:
                 return this.query.minimumDouble(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
@@ -1696,7 +1696,7 @@ public class RealmQuery<E extends RealmModel> {
             case DOUBLE:
                 return this.query.maximumDouble(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -19,6 +19,7 @@ package io.realm;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.Locale;
 
 import io.realm.annotations.Required;
 import io.realm.internal.Collection;
@@ -1600,7 +1601,8 @@ public class RealmQuery<E extends RealmModel> {
             case DOUBLE:
                 return query.sumDouble(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(TYPE_MISMATCH, fieldName, "int, float or double"));
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
 
@@ -1626,7 +1628,8 @@ public class RealmQuery<E extends RealmModel> {
             case FLOAT:
                 return query.averageFloat(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(TYPE_MISMATCH, fieldName, "int, float or double"));
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
 
@@ -1651,7 +1654,8 @@ public class RealmQuery<E extends RealmModel> {
             case DOUBLE:
                 return this.query.minimumDouble(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(TYPE_MISMATCH, fieldName, "int, float or double"));
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
 
@@ -1692,7 +1696,8 @@ public class RealmQuery<E extends RealmModel> {
             case DOUBLE:
                 return this.query.maximumDouble(columnIndex);
             default:
-                throw new IllegalArgumentException(String.format(TYPE_MISMATCH, fieldName, "int, float or double"));
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        TYPE_MISMATCH, fieldName, "int, float or double"));
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/StandardRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/StandardRealmObjectSchema.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -176,7 +177,8 @@ class StandardRealmObjectSchema extends RealmObjectSchema {
             if (SUPPORTED_LINKED_FIELDS.containsKey(fieldType)) {
                 throw new IllegalArgumentException("Use addRealmObjectField() instead to add fields that link to other RealmObjects: " + fieldName);
             } else {
-                throw new IllegalArgumentException(String.format("Realm doesn't support this field type: %s(%s)",
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        "Realm doesn't support this field type: %s(%s)",
                         fieldName, fieldType));
             }
         }
@@ -678,7 +680,8 @@ class StandardRealmObjectSchema extends RealmObjectSchema {
         long columnIndex = table.getColumnIndex(fieldName);
         if (columnIndex == -1) {
             throw new IllegalArgumentException(
-                    String.format("Field name '%s' does not exist on schema for '%s'",
+                    String.format(Locale.ENGLISH,
+                            "Field name '%s' does not exist on schema for '%s'",
                             fieldName, getClassName()
                     ));
         }

--- a/realm/realm-library/src/main/java/io/realm/StandardRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/StandardRealmObjectSchema.java
@@ -177,7 +177,7 @@ class StandardRealmObjectSchema extends RealmObjectSchema {
             if (SUPPORTED_LINKED_FIELDS.containsKey(fieldType)) {
                 throw new IllegalArgumentException("Use addRealmObjectField() instead to add fields that link to other RealmObjects: " + fieldName);
             } else {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         "Realm doesn't support this field type: %s(%s)",
                         fieldName, fieldType));
             }
@@ -680,7 +680,7 @@ class StandardRealmObjectSchema extends RealmObjectSchema {
         long columnIndex = table.getColumnIndex(fieldName);
         if (columnIndex == -1) {
             throw new IllegalArgumentException(
-                    String.format(Locale.ENGLISH,
+                    String.format(Locale.US,
                             "Field name '%s' does not exist on schema for '%s'",
                             fieldName, getClassName()
                     ));

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
@@ -120,6 +120,6 @@ public class RealmFileException extends RuntimeException {
 
     @Override
     public String toString() {
-        return String.format(Locale.ENGLISH, "%s Kind: %s.", super.toString(), kind);
+        return String.format(Locale.US, "%s Kind: %s.", super.toString(), kind);
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
@@ -15,6 +15,8 @@
  */
 package io.realm.exceptions;
 
+import java.util.Locale;
+
 import io.realm.internal.Keep;
 import io.realm.internal.SharedRealm;
 
@@ -118,6 +120,6 @@ public class RealmFileException extends RuntimeException {
 
     @Override
     public String toString() {
-        return String.format("%s Kind: %s.", super.toString(), kind);
+        return String.format(Locale.ENGLISH, "%s Kind: %s.", super.toString(), kind);
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
@@ -19,6 +19,7 @@ package io.realm.internal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import io.realm.RealmFieldType;
@@ -103,7 +104,7 @@ public class SortDescriptor {
     // could do this in the field descriptor, but this provides a better error message
     private static void checkFieldType(FieldDescriptor descriptor, Set<RealmFieldType> legalTerminalTypes, String message, String fieldDescriptions) {
         if (!legalTerminalTypes.contains(descriptor.getFinalColumnType())) {
-            throw new IllegalArgumentException(String.format(
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                     "%s on '%s' field '%s' in '%s'.", message, descriptor.getFinalColumnType(), descriptor.getFinalColumnName(), fieldDescriptions));
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
@@ -104,7 +104,7 @@ public class SortDescriptor {
     // could do this in the field descriptor, but this provides a better error message
     private static void checkFieldType(FieldDescriptor descriptor, Set<RealmFieldType> legalTerminalTypes, String message, String fieldDescriptions) {
         if (!legalTerminalTypes.contains(descriptor.getFinalColumnType())) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+            throw new IllegalArgumentException(String.format(Locale.US,
                     "%s on '%s' field '%s' in '%s'.", message, descriptor.getFinalColumnType(), descriptor.getFinalColumnName(), fieldDescriptions));
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
@@ -16,6 +16,7 @@ package io.realm.internal.fields;
  */
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import io.realm.RealmFieldType;
@@ -69,13 +70,13 @@ class CachedFieldDescriptor extends FieldDescriptor {
             tableInfo = schema.getColumnInfo(currentTable);
             if (tableInfo == null) {
                 throw new IllegalArgumentException(
-                        String.format("Invalid query: table '%s' not found in this schema.", currentTable));
+                        String.format(Locale.ENGLISH, "Invalid query: table '%s' not found in this schema.", currentTable));
             }
 
             columnIndex = tableInfo.getColumnIndex(columnName);
             if (columnIndex < 0) {
                 throw new IllegalArgumentException(
-                        String.format("Invalid query: field '%s' not found in table '%s'.", columnName, currentTable));
+                        String.format(Locale.ENGLISH, "Invalid query: field '%s' not found in table '%s'.", columnName, currentTable));
             }
 
             columnType = tableInfo.getColumnType(columnName);

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
@@ -70,13 +70,13 @@ class CachedFieldDescriptor extends FieldDescriptor {
             tableInfo = schema.getColumnInfo(currentTable);
             if (tableInfo == null) {
                 throw new IllegalArgumentException(
-                        String.format(Locale.ENGLISH, "Invalid query: table '%s' not found in this schema.", currentTable));
+                        String.format(Locale.US, "Invalid query: table '%s' not found in this schema.", currentTable));
             }
 
             columnIndex = tableInfo.getColumnIndex(columnName);
             if (columnIndex < 0) {
                 throw new IllegalArgumentException(
-                        String.format(Locale.ENGLISH, "Invalid query: field '%s' not found in table '%s'.", columnName, currentTable));
+                        String.format(Locale.US, "Invalid query: field '%s' not found in table '%s'.", columnName, currentTable));
             }
 
             columnType = tableInfo.getColumnType(columnName);

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/DynamicFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/DynamicFieldDescriptor.java
@@ -16,6 +16,7 @@ package io.realm.internal.fields;
  */
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import io.realm.RealmFieldType;
@@ -64,7 +65,7 @@ class DynamicFieldDescriptor extends FieldDescriptor {
             columnIndex = currentTable.getColumnIndex(columnName);
             if (columnIndex < 0) {
                 throw new IllegalArgumentException(
-                        String.format("Invalid query: field '%s' not found in table '%s'.", columnName, tableName));
+                        String.format(Locale.ENGLISH, "Invalid query: field '%s' not found in table '%s'.", columnName, tableName));
             }
 
             columnType = currentTable.getColumnType(columnIndex);

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/DynamicFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/DynamicFieldDescriptor.java
@@ -65,7 +65,7 @@ class DynamicFieldDescriptor extends FieldDescriptor {
             columnIndex = currentTable.getColumnIndex(columnName);
             if (columnIndex < 0) {
                 throw new IllegalArgumentException(
-                        String.format(Locale.ENGLISH, "Invalid query: field '%s' not found in table '%s'.", columnName, tableName));
+                        String.format(Locale.US, "Invalid query: field '%s' not found in table '%s'.", columnName, tableName));
             }
 
             columnType = currentTable.getColumnType(columnIndex);

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/FieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/FieldDescriptor.java
@@ -274,7 +274,7 @@ public abstract class FieldDescriptor {
 
     private void verifyColumnType(String tableName, String columnName, RealmFieldType columnType, Set<RealmFieldType> validTypes) {
         if (!validTypes.contains(columnType)) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+            throw new IllegalArgumentException(String.format(Locale.US,
                     "Invalid query: field '%s' in table '%s' is of invalid type '%s'.",
                     columnName, tableName, columnType.toString()));
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/FieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/FieldDescriptor.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import io.realm.RealmFieldType;
@@ -273,7 +274,7 @@ public abstract class FieldDescriptor {
 
     private void verifyColumnType(String tableName, String columnName, RealmFieldType columnType, Set<RealmFieldType> validTypes) {
         if (!validTypes.contains(columnType)) {
-            throw new IllegalArgumentException(String.format(
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                     "Invalid query: field '%s' in table '%s' is of invalid type '%s'.",
                     columnName, tableName, columnType.toString()));
         }

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
@@ -18,6 +18,8 @@ package io.realm.log;
 
 import android.util.Log;
 
+import java.util.Locale;
+
 
 /**
  * Global logger used by all Realm components.
@@ -275,7 +277,7 @@ public final class RealmLog {
 
         StringBuilder stringBuilder = new StringBuilder();
         if (args != null && args.length > 0) {
-            message = String.format(message, args);
+            message = String.format(Locale.ENGLISH, message, args);
         }
         if (throwable != null) {
             stringBuilder.append(Log.getStackTraceString(throwable));

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
@@ -277,7 +277,7 @@ public final class RealmLog {
 
         StringBuilder stringBuilder = new StringBuilder();
         if (args != null && args.length > 0) {
-            message = String.format(Locale.ENGLISH, message, args);
+            message = String.format(Locale.US, message, args);
         }
         if (throwable != null) {
             stringBuilder.append(Log.getStackTraceString(throwable));

--- a/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
@@ -118,7 +118,7 @@ public enum ErrorCode {
         return category;
     }
 
-    public static ErrorCode fromInt(int errorCode) {1
+    public static ErrorCode fromInt(int errorCode) {
         ErrorCode[] errorCodes = values();
         for (int i = 0; i < errorCodes.length; i++) {
             ErrorCode error = errorCodes[i];

--- a/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
@@ -118,7 +118,7 @@ public enum ErrorCode {
         return category;
     }
 
-    public static ErrorCode fromInt(int errorCode) {
+    public static ErrorCode fromInt(int errorCode) {1
         ErrorCode[] errorCodes = values();
         for (int i = 0; i < errorCodes.length; i++) {
             ErrorCode error = errorCodes[i];

--- a/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
@@ -51,11 +51,11 @@ class ObjectServer {
                 File dir = File.createTempFile("remote_sync_", "_" + android.os.Process.myPid(),
                         context.getFilesDir());
                 if (!dir.delete()) {
-                    throw new IllegalStateException(String.format(Locale.ENGLISH,
+                    throw new IllegalStateException(String.format(Locale.US,
                             "Temp file '%s' cannot be deleted.", dir.getPath()));
                 }
                 if (!dir.mkdir()) {
-                    throw new IllegalStateException(String.format(Locale.ENGLISH,
+                    throw new IllegalStateException(String.format(Locale.US,
                             "Directory '%s' for SyncManager cannot be created. ",
                             dir.getPath()));
                 }

--- a/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ObjectServer.java
@@ -21,6 +21,7 @@ import android.content.pm.PackageInfo;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 
 import io.realm.internal.Keep;
 
@@ -50,10 +51,12 @@ class ObjectServer {
                 File dir = File.createTempFile("remote_sync_", "_" + android.os.Process.myPid(),
                         context.getFilesDir());
                 if (!dir.delete()) {
-                    throw new IllegalStateException(String.format("Temp file '%s' cannot be deleted.", dir.getPath()));
+                    throw new IllegalStateException(String.format(Locale.ENGLISH,
+                            "Temp file '%s' cannot be deleted.", dir.getPath()));
                 }
                 if (!dir.mkdir()) {
-                    throw new IllegalStateException(String.format("Directory '%s' for SyncManager cannot be created. ",
+                    throw new IllegalStateException(String.format(Locale.ENGLISH,
+                            "Directory '%s' for SyncManager cannot be created. ",
                             dir.getPath()));
                 }
                 SyncManager.nativeInitializeSyncManager(dir.getPath());

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -27,6 +27,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -511,7 +512,8 @@ public class SyncConfiguration extends RealmConfiguration {
                 throw new IllegalArgumentException("A non-null key must be provided");
             }
             if (key.length != KEY_LENGTH) {
-                throw new IllegalArgumentException(String.format("The provided key must be %s bytes. Yours was: %s",
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        "The provided key must be %s bytes. Yours was: %s",
                         KEY_LENGTH, key.length));
             }
             this.key = Arrays.copyOf(key, key.length);
@@ -720,7 +722,7 @@ public class SyncConfiguration extends RealmConfiguration {
                 byte[] buf = digest.digest(in.getBytes("UTF-8"));
                 StringBuilder builder = new StringBuilder();
                 for (byte b : buf) {
-                    builder.append(String.format("%02X", b));
+                    builder.append(String.format(Locale.ENGLISH, "%02X", b));
                 }
                 return builder.toString();
             } catch (NoSuchAlgorithmException e) {
@@ -799,14 +801,16 @@ public class SyncConfiguration extends RealmConfiguration {
                     realmFileDirectory = new File(rootDir, user.getIdentity());
                     fullPathName = realmFileDirectory.getAbsolutePath() + File.pathSeparator + realmFileName;
                     if (fullPathName.length() > MAX_FULL_PATH_LENGTH) { // we are out of ideas
-                        throw new IllegalStateException(String.format("Full path name must not exceed %d characters: %s",
+                        throw new IllegalStateException(String.format(Locale.ENGLISH,
+                                "Full path name must not exceed %d characters: %s",
                                 MAX_FULL_PATH_LENGTH, fullPathName));
                     }
                 }
             }
 
             if (realmFileName.length() > MAX_FILE_NAME_LENGTH) {
-                throw new IllegalStateException(String.format("File name exceed %d characters: %d", MAX_FILE_NAME_LENGTH,
+                throw new IllegalStateException(String.format(Locale.ENGLISH,
+                        "File name exceed %d characters: %d", MAX_FILE_NAME_LENGTH,
                         realmFileName.length()));
             }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -512,7 +512,7 @@ public class SyncConfiguration extends RealmConfiguration {
                 throw new IllegalArgumentException("A non-null key must be provided");
             }
             if (key.length != KEY_LENGTH) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                throw new IllegalArgumentException(String.format(Locale.US,
                         "The provided key must be %s bytes. Yours was: %s",
                         KEY_LENGTH, key.length));
             }
@@ -722,7 +722,7 @@ public class SyncConfiguration extends RealmConfiguration {
                 byte[] buf = digest.digest(in.getBytes("UTF-8"));
                 StringBuilder builder = new StringBuilder();
                 for (byte b : buf) {
-                    builder.append(String.format(Locale.ENGLISH, "%02X", b));
+                    builder.append(String.format(Locale.US, "%02X", b));
                 }
                 return builder.toString();
             } catch (NoSuchAlgorithmException e) {
@@ -801,7 +801,7 @@ public class SyncConfiguration extends RealmConfiguration {
                     realmFileDirectory = new File(rootDir, user.getIdentity());
                     fullPathName = realmFileDirectory.getAbsolutePath() + File.pathSeparator + realmFileName;
                     if (fullPathName.length() > MAX_FULL_PATH_LENGTH) { // we are out of ideas
-                        throw new IllegalStateException(String.format(Locale.ENGLISH,
+                        throw new IllegalStateException(String.format(Locale.US,
                                 "Full path name must not exceed %d characters: %s",
                                 MAX_FULL_PATH_LENGTH, fullPathName));
                     }
@@ -809,7 +809,7 @@ public class SyncConfiguration extends RealmConfiguration {
             }
 
             if (realmFileName.length() > MAX_FILE_NAME_LENGTH) {
-                throw new IllegalStateException(String.format(Locale.ENGLISH,
+                throw new IllegalStateException(String.format(Locale.US,
                         "File name exceed %d characters: %d", MAX_FILE_NAME_LENGTH,
                         realmFileName.length()));
             }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -82,7 +82,7 @@ public class SyncManager {
                 return;
             }
 
-            String errorMsg = String.format(Locale.ENGLISH, "Session Error[%s]: %s",
+            String errorMsg = String.format(Locale.US, "Session Error[%s]: %s",
                     session.getConfiguration().getServerUrl(),
                     error.toString());
             switch (error.getErrorCode().getCategory()) {

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -16,6 +16,7 @@
 
 package io.realm;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,7 +82,7 @@ public class SyncManager {
                 return;
             }
 
-            String errorMsg = String.format("Session Error[%s]: %s",
+            String errorMsg = String.format(Locale.ENGLISH, "Session Error[%s]: %s",
                     session.getConfiguration().getServerUrl(),
                     error.toString());
             switch (error.getErrorCode().getCategory()) {

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -635,7 +636,8 @@ public class SyncSession {
          */
         public void throwExceptionIfNeeded() {
             if (resultReceived && errorCode != null) {
-                throw new ObjectServerError(ErrorCode.UNKNOWN, String.format("Internal error (%d): %s", errorCode, errorMessage));
+                throw new ObjectServerError(ErrorCode.UNKNOWN,
+                        String.format(Locale.ENGLISH, "Internal error (%d): %s", errorCode, errorMessage));
             }
         }
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -637,7 +637,7 @@ public class SyncSession {
         public void throwExceptionIfNeeded() {
             if (resultReceived && errorCode != null) {
                 throw new ObjectServerError(ErrorCode.UNKNOWN,
-                        String.format(Locale.ENGLISH, "Internal error (%d): %s", errorCode, errorMessage));
+                        String.format(Locale.US, "Internal error (%d): %s", errorCode, errorMessage));
             }
         }
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -75,7 +76,8 @@ public class SyncUser {
                                 if (error.getErrorCode() == ErrorCode.CLIENT_RESET) {
                                     RealmLog.error("Client Reset required for user's management Realm: " + user.toString());
                                 } else {
-                                    RealmLog.error(String.format("Unexpected error with %s's management Realm: %s",
+                                    RealmLog.error(String.format(Locale.ENGLISH,
+                                            "Unexpected error with %s's management Realm: %s",
                                             user.getIdentity(),
                                             error.toString()));
                                 }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -76,7 +76,7 @@ public class SyncUser {
                                 if (error.getErrorCode() == ErrorCode.CLIENT_RESET) {
                                     RealmLog.error("Client Reset required for user's management Realm: " + user.toString());
                                 } else {
-                                    RealmLog.error(String.format(Locale.ENGLISH,
+                                    RealmLog.error(String.format(Locale.US,
                                             "Unexpected error with %s's management Realm: %s",
                                             user.getIdentity(),
                                             error.toString()));

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
@@ -20,6 +20,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
@@ -132,14 +133,14 @@ public class AuthenticateResponse extends AuthServerResponse {
             if (accessToken == null) {
                 message = "accessToken = null";
             } else {
-                message = String.format("Identity %s; Path %s", accessToken.identity(), accessToken.path());
+                message = String.format(Locale.ENGLISH, "Identity %s; Path %s", accessToken.identity(), accessToken.path());
             }
         } catch (JSONException ex) {
             accessToken = null;
             refreshToken = null;
             //noinspection ThrowableInstanceNeverThrown
             error = new ObjectServerError(ErrorCode.JSON_EXCEPTION, ex);
-            message = String.format("Error %s", error.getErrorMessage());
+            message = String.format(Locale.ENGLISH, "Error %s", error.getErrorMessage());
         }
         RealmLog.debug("AuthenticateResponse. " + message);
         setError(error);

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticateResponse.java
@@ -133,14 +133,14 @@ public class AuthenticateResponse extends AuthServerResponse {
             if (accessToken == null) {
                 message = "accessToken = null";
             } else {
-                message = String.format(Locale.ENGLISH, "Identity %s; Path %s", accessToken.identity(), accessToken.path());
+                message = String.format(Locale.US, "Identity %s; Path %s", accessToken.identity(), accessToken.path());
             }
         } catch (JSONException ex) {
             accessToken = null;
             refreshToken = null;
             //noinspection ThrowableInstanceNeverThrown
             error = new ObjectServerError(ErrorCode.JSON_EXCEPTION, ex);
-            message = String.format(Locale.ENGLISH, "Error %s", error.getErrorMessage());
+            message = String.format(Locale.US, "Error %s", error.getErrorMessage());
         }
         RealmLog.debug("AuthenticateResponse. " + message);
         setError(error);


### PR DESCRIPTION
Added explicit Locale information to follow `lint`s advice.