### PR TITLE
Explicitly specify Locale for String.format() in our annotation processor

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Backlink.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Backlink.java
@@ -131,7 +131,8 @@ final class Backlink {
     public boolean validateSource() {
         // A @LinkingObjects cannot be @Required
         if (backlink.getAnnotation(Required.class) != null) {
-            Utils.error(String.format(Locale.US,
+            Utils.error(String.format(
+                    Locale.US,
                     "The @LinkingObjects field \"%s.%s\" cannot be @Required.",
                     targetClass,
                     targetField));
@@ -140,7 +141,8 @@ final class Backlink {
 
         // The annotation must have an argument, identifying the linked field
         if ((sourceField == null) || sourceField.equals("")) {
-            Utils.error(String.format(Locale.US,
+            Utils.error(String.format(
+                    Locale.US,
                     "The @LinkingObjects annotation for the field \"%s.%s\" must have a parameter identifying the link target.",
                     targetClass,
                     targetField));
@@ -149,7 +151,8 @@ final class Backlink {
 
         // Using link syntax to try to reference a linked field is not possible.
         if (sourceField.contains(".")) {
-            Utils.error(String.format(Locale.US,
+            Utils.error(String.format(
+                    Locale.US,
                     "The parameter to the @LinkingObjects annotation for the field \"%s.%s\" contains a '.'.  The use of '.' to specify fields in referenced classes is not supported.",
                     targetClass,
                     targetField));
@@ -158,7 +161,8 @@ final class Backlink {
 
         // The annotated element must be a RealmResult
         if (!Utils.isRealmResults(backlink)) {
-            Utils.error(String.format(Locale.US,
+            Utils.error(String.format(
+                    Locale.US,
                     "The field \"%s.%s\" is a \"%s\". Fields annotated with @LinkingObjects must be RealmResults.",
                     targetClass,
                     targetField,
@@ -167,7 +171,8 @@ final class Backlink {
         }
 
         if (sourceClass == null) {
-            Utils.error(String.format(Locale.US,
+            Utils.error(String.format(
+                    Locale.US,
                     "\"The field \"%s.%s\", annotated with @LinkingObjects, must specify a generic type.",
                     targetClass,
                     targetField));
@@ -176,7 +181,8 @@ final class Backlink {
 
         // A @LinkingObjects field must be final
         if (!backlink.getModifiers().contains(Modifier.FINAL)) {
-            Utils.error(String.format(Locale.US,
+            Utils.error(String.format(
+                    Locale.US,
                     "A @LinkingObjects field \"%s.%s\" must be final.",
                     targetClass,
                     targetField));

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Backlink.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Backlink.java
@@ -16,6 +16,8 @@
 
 package io.realm.processor;
 
+import java.util.Locale;
+
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
 
@@ -87,7 +89,7 @@ final class Backlink {
 
     public Backlink(ClassMetaData clazz, VariableElement backlink) {
         if ((null == clazz) || (null == backlink)) {
-            throw new NullPointerException(String.format("null parameter: %s, %s", clazz, backlink));
+            throw new NullPointerException(String.format(Locale.US, "null parameter: %s, %s", clazz, backlink));
         }
 
         this.backlink = backlink;
@@ -129,7 +131,7 @@ final class Backlink {
     public boolean validateSource() {
         // A @LinkingObjects cannot be @Required
         if (backlink.getAnnotation(Required.class) != null) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "The @LinkingObjects field \"%s.%s\" cannot be @Required.",
                     targetClass,
                     targetField));
@@ -138,7 +140,7 @@ final class Backlink {
 
         // The annotation must have an argument, identifying the linked field
         if ((sourceField == null) || sourceField.equals("")) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "The @LinkingObjects annotation for the field \"%s.%s\" must have a parameter identifying the link target.",
                     targetClass,
                     targetField));
@@ -147,7 +149,7 @@ final class Backlink {
 
         // Using link syntax to try to reference a linked field is not possible.
         if (sourceField.contains(".")) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "The parameter to the @LinkingObjects annotation for the field \"%s.%s\" contains a '.'.  The use of '.' to specify fields in referenced classes is not supported.",
                     targetClass,
                     targetField));
@@ -156,7 +158,7 @@ final class Backlink {
 
         // The annotated element must be a RealmResult
         if (!Utils.isRealmResults(backlink)) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "The field \"%s.%s\" is a \"%s\". Fields annotated with @LinkingObjects must be RealmResults.",
                     targetClass,
                     targetField,
@@ -165,7 +167,7 @@ final class Backlink {
         }
 
         if (sourceClass == null) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "\"The field \"%s.%s\", annotated with @LinkingObjects, must specify a generic type.",
                     targetClass,
                     targetField));
@@ -174,7 +176,7 @@ final class Backlink {
 
         // A @LinkingObjects field must be final
         if (!backlink.getModifiers().contains(Modifier.FINAL)) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "A @LinkingObjects field \"%s.%s\" must be final.",
                     targetClass,
                     targetField));
@@ -188,7 +190,7 @@ final class Backlink {
         VariableElement field = clazz.getDeclaredField(sourceField);
 
         if (field == null) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "Field \"%s\", the target of the @LinkedObjects annotation on field \"%s.%s\", does not exist in class \"%s\".",
                     sourceField,
                     targetClass,
@@ -199,7 +201,7 @@ final class Backlink {
 
         String fieldType = field.asType().toString();
         if (!(targetClass.equals(fieldType) || targetClass.equals(Utils.getRealmListType(field)))) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "Field \"%s.%s\", the target of the @LinkedObjects annotation on field \"%s.%s\", has type \"%s\" instead of \"%3$s\".",
                     sourceClass,
                     sourceField,

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -266,7 +267,7 @@ public class ClassMetaData {
         }
 
         if (fields.size() == 0) {
-            Utils.error(String.format("Class \"%s\" must contain at least 1 persistable field.", className));
+            Utils.error(String.format(Locale.US, "Class \"%s\" must contain at least 1 persistable field.", className));
         }
 
         return true;
@@ -320,7 +321,7 @@ public class ClassMetaData {
     // Report if the default constructor is missing
     private boolean checkDefaultConstructor() {
         if (!hasDefaultConstructor) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "Class \"%s\" must declare a public constructor with no arguments if it contains custom constructors.",
                     className));
             return false;
@@ -332,7 +333,7 @@ public class ClassMetaData {
     private boolean checkForFinalFields() {
         for (VariableElement field : fields) {
             if (field.getModifiers().contains(Modifier.FINAL)) {
-                Utils.error(String.format(
+                Utils.error(String.format(Locale.US,
                         "Class \"%s\" contains illegal final field \"%s\".", className, field.getSimpleName().toString()));
                 return false;
             }
@@ -343,7 +344,7 @@ public class ClassMetaData {
     private boolean checkForVolatileFields() {
         for (VariableElement field : fields) {
             if (field.getModifiers().contains(Modifier.VOLATILE)) {
-                Utils.error(String.format(
+                Utils.error(String.format(Locale.US,
                         "Class \"%s\" contains illegal volatile field \"%s\".",
                         className,
                         field.getSimpleName().toString()));
@@ -410,22 +411,22 @@ public class ClassMetaData {
             }
         }
 
-        Utils.error(String.format("Field \"%s\" of type \"%s\" cannot be an @Index.", element, element.asType()));
+        Utils.error(String.format(Locale.US, "Field \"%s\" of type \"%s\" cannot be an @Index.", element, element.asType()));
         return false;
     }
 
     // The field has the @Required annotation
     private void categorizeRequiredField(Element element, VariableElement variableElement) {
         if (Utils.isPrimitiveType(variableElement)) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "@Required annotation is unnecessary for primitive field \"%s\".", element));
         } else if (Utils.isRealmList(variableElement) || Utils.isRealmModel(variableElement)) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "Field \"%s\" with type \"%s\" cannot be @Required.", element, element.asType()));
         } else {
             // Should never get here - user should remove @Required
             if (nullableFields.contains(variableElement)) {
-                Utils.error(String.format(
+                Utils.error(String.format(Locale.US,
                         "Field \"%s\" with type \"%s\" appears to be nullable. Consider removing @Required.",
                         element,
                         element.asType()));
@@ -437,7 +438,7 @@ public class ClassMetaData {
     // String, short, int, long and must only be present one time
     private boolean categorizePrimaryKeyField(VariableElement variableElement) {
         if (primaryKey != null) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "A class cannot have more than one @PrimaryKey. Both \"%s\" and \"%s\" are annotated as @PrimaryKey.",
                     primaryKey.getSimpleName().toString(),
                     variableElement.getSimpleName().toString()));
@@ -446,7 +447,7 @@ public class ClassMetaData {
 
         TypeMirror fieldType = variableElement.asType();
         if (!isValidPrimaryKeyType(fieldType)) {
-            Utils.error(String.format(
+            Utils.error(String.format(Locale.US,
                     "Field \"%s\" with type \"%s\" cannot be used as primary key. See @PrimaryKey for legal types.",
                     variableElement.getSimpleName().toString(),
                     fieldType));

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/DefaultModuleGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/DefaultModuleGenerator.java
@@ -22,6 +22,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -44,7 +45,7 @@ public class DefaultModuleGenerator {
     }
 
     public void generate() throws IOException {
-        String qualifiedGeneratedClassName = String.format("%s.%s", Constants.REALM_PACKAGE_NAME, Constants.DEFAULT_MODULE_CLASS_NAME);
+        String qualifiedGeneratedClassName = String.format(Locale.US, "%s.%s", Constants.REALM_PACKAGE_NAME, Constants.DEFAULT_MODULE_CLASS_NAME);
         JavaFileObject sourceFile = env.getFiler().createSourceFile(qualifiedGeneratedClassName);
         JavaWriter writer = new JavaWriter(new BufferedWriter(sourceFile.openWriter()));
         writer.setIndent("    ");

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmJsonTypeHelper.java
@@ -20,6 +20,7 @@ import com.squareup.javawriter.JavaWriter;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 
@@ -187,8 +188,8 @@ public class RealmJsonTypeHelper {
             // Only throw exception for primitive types.
             // For boxed types and String, exception will be thrown in the setter.
             String statementSetNullOrThrow = Utils.isPrimitiveType(fieldType) ?
-                    String.format(Constants.STATEMENT_EXCEPTION_ILLEGAL_NULL_VALUE, fieldName) :
-                    String.format("((%s) obj).%s(null)", interfaceName, setter);
+                    String.format(Locale.US, Constants.STATEMENT_EXCEPTION_ILLEGAL_NULL_VALUE, fieldName) :
+                    String.format(Locale.US, "((%s) obj).%s(null)", interfaceName, setter);
             // @formatter:off
             writer
                 .beginControlFlow("if (json.has(\"%s\"))", fieldName)
@@ -211,8 +212,8 @@ public class RealmJsonTypeHelper {
             // Only throw exception for primitive types. For boxed types and String, exception will be thrown in
             // the setter.
             String statementSetNullOrThrow = (Utils.isPrimitiveType(fieldType)) ?
-                    String.format(Constants.STATEMENT_EXCEPTION_ILLEGAL_NULL_VALUE, fieldName) :
-                    String.format("((%s) obj).%s(null)", interfaceName, setter);
+                    String.format(Locale.US, Constants.STATEMENT_EXCEPTION_ILLEGAL_NULL_VALUE, fieldName) :
+                    String.format(Locale.US, "((%s) obj).%s(null)", interfaceName, setter);
             // @formatter:off
             writer
                 .beginControlFlow("if (reader.peek() == JsonToken.NULL)")

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -85,7 +86,7 @@ public class RealmProxyClassGenerator {
         this.simpleClassName = metadata.getSimpleClassName();
         this.qualifiedClassName = metadata.getFullyQualifiedClassName();
         this.interfaceName = Utils.getProxyInterfaceName(simpleClassName);
-        this.qualifiedGeneratedClassName = String.format("%s.%s",
+        this.qualifiedGeneratedClassName = String.format(Locale.US, "%s.%s",
                 Constants.REALM_PACKAGE_NAME, Utils.getProxyClassName(simpleClassName));
 
         // See the configuration for the debug build type,
@@ -278,7 +279,7 @@ public class RealmProxyClassGenerator {
             } else if (Utils.isRealmList(field)) {
                 emitRealmList(writer, field, fieldName, fieldTypeCanonicalName);
             } else {
-                throw new UnsupportedOperationException(String.format(
+                throw new UnsupportedOperationException(String.format(Locale.US,
                         "Field \"%s\" of type \"%s\" is not supported.", fieldName, fieldTypeCanonicalName));
             }
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyInterfaceGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyInterfaceGenerator.java
@@ -20,6 +20,7 @@ import com.squareup.javawriter.JavaWriter;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.Locale;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
@@ -42,7 +43,7 @@ public class RealmProxyInterfaceGenerator {
 
     public void generate() throws IOException {
         String qualifiedGeneratedInterfaceName =
-                String.format("%s.%s", Constants.REALM_PACKAGE_NAME, Utils.getProxyInterfaceName(className));
+                String.format(Locale.US, "%s.%s", Constants.REALM_PACKAGE_NAME, Utils.getProxyInterfaceName(className));
         JavaFileObject sourceFile = processingEnvironment.getFiler().createSourceFile(qualifiedGeneratedInterfaceName);
         JavaWriter writer = new JavaWriter(new BufferedWriter(sourceFile.openWriter()));
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -55,7 +56,7 @@ public class RealmProxyMediatorGenerator {
     }
 
     public void generate() throws IOException {
-        String qualifiedGeneratedClassName = String.format("%s.%sMediator", REALM_PACKAGE_NAME, className);
+        String qualifiedGeneratedClassName = String.format(Locale.US, "%s.%sMediator", REALM_PACKAGE_NAME, className);
         JavaFileObject sourceFile = processingEnvironment.getFiler().createSourceFile(qualifiedGeneratedClassName);
         JavaWriter writer = new JavaWriter(new BufferedWriter(sourceFile.openWriter()));
         writer.setIndent("    ");

--- a/realm/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
+++ b/realm/realm-annotations-processor/src/test/java/io/realm/processor/RealmProcessorTest.java
@@ -69,6 +69,7 @@ public class RealmProcessorTest {
     private JavaFileObject backlinksNotFound = JavaFileObjects.forResource("some/test/Backlinks_NotFound.java");
     private JavaFileObject backlinksNonFinalField = JavaFileObjects.forResource("some/test/Backlinks_NotFinal.java");
     private JavaFileObject backlinksWrongType = JavaFileObjects.forResource("some/test/Backlinks_WrongType.java");
+    private JavaFileObject nonLatinName = JavaFileObjects.forResource("some/test/ÁrvíztűrőTükörfúrógép.java");
 
     @Test
     public void compileSimpleFile() {
@@ -563,5 +564,13 @@ public class RealmProcessorTest {
                 .processedWith(new RealmProcessor())
                 .failsToCompile()
                 .withErrorContaining("instead of");
+    }
+
+    @Test
+    public void compareNonLatinName() throws Exception {
+        ASSERT.about(javaSource())
+                .that(nonLatinName)
+                .processedWith(new RealmProcessor())
+                .compilesWithoutError();
     }
 }

--- a/realm/realm-annotations-processor/src/test/resources/some/test/ÁrvíztűrőTükörfúrógép.java
+++ b/realm/realm-annotations-processor/src/test/resources/some/test/ÁrvíztűrőTükörfúrógép.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package some.test;
+
+import io.realm.RealmObject;
+
+
+/**
+ * A model class to test non latin class name.
+ */
+public class ÁrvíztűrőTükörfúrógép extends RealmObject {
+    public String name;
+    public long 델타;
+    public long Δέλτα;
+    public float 貸借対照表;
+}


### PR DESCRIPTION
Explicitly specify Locale for String.format() in our annotation processor.
And also added a test for non-latin model name and field names.