### PR TITLE
Returns a schema info map in mediator

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -69,7 +69,6 @@ public class RealmProxyMediatorGenerator {
                 "java.util.Collections",
                 "java.util.HashSet",
                 "java.util.List",
-                "java.util.ArrayList",
                 "java.util.Map",
                 "java.util.HashMap",
                 "java.util.Set",
@@ -97,7 +96,7 @@ public class RealmProxyMediatorGenerator {
         writer.emitEmptyLine();
 
         emitFields(writer);
-        emitGetExpectedObjectSchemaInfoList(writer);
+        emitGetExpectedObjectSchemaInfoMap(writer);
         emitValidateTableMethod(writer);
         emitGetFieldNamesMethod(writer);
         emitGetTableNameMethod(writer);
@@ -127,18 +126,21 @@ public class RealmProxyMediatorGenerator {
         writer.emitEmptyLine();
     }
 
-    private void emitGetExpectedObjectSchemaInfoList(JavaWriter writer) throws IOException {
+    private void emitGetExpectedObjectSchemaInfoMap(JavaWriter writer) throws IOException {
         writer.emitAnnotation("Override");
         writer.beginMethod(
-                "List<OsObjectSchemaInfo>",
-                "getExpectedObjectSchemaInfoList",
+                "Map<Class<? extends RealmModel>, OsObjectSchemaInfo>",
+                "getExpectedObjectSchemaInfoMap",
                 EnumSet.of(Modifier.PUBLIC));
 
-        writer.emitStatement("List<OsObjectSchemaInfo> infoList = new ArrayList<OsObjectSchemaInfo>()");
-        for (String proxyClassName :  qualifiedProxyClasses) {
-            writer.emitStatement("infoList.add(%s.getExpectedObjectSchemaInfo())", proxyClassName);
+        writer.emitStatement(
+                "Map<Class<? extends RealmModel>, OsObjectSchemaInfo> infoMap = " +
+                        "new HashMap<Class<? extends RealmModel>, OsObjectSchemaInfo>()");
+        for (int i = 0; i < qualifiedProxyClasses.size(); i++) {
+            writer.emitStatement("infoMap.put(%s.class, %s.getExpectedObjectSchemaInfo())",
+                    qualifiedModelClasses.get(i), qualifiedProxyClasses.get(i));
         }
-        writer.emitStatement("return infoList");
+        writer.emitStatement("return infoMap");
 
         writer.endMethod();
         writer.emitEmptyLine();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -10,7 +10,6 @@ import io.realm.internal.Row;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,10 +32,11 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<OsObjectSchemaInfo> getExpectedObjectSchemaInfoList() {
-        List<OsObjectSchemaInfo> infoList = new ArrayList<OsObjectSchemaInfo>();
-        infoList.add(io.realm.AllTypesRealmProxy.getExpectedObjectSchemaInfo());
-        return infoList;
+    public Map<Class<? extends RealmModel>, OsObjectSchemaInfo> getExpectedObjectSchemaInfoMap() {
+        Map<Class<? extends RealmModel>, OsObjectSchemaInfo> infoMap =
+                    new HashMap<Class<? extends RealmModel>, OsObjectSchemaInfo>();
+        infoMap.put(some.test.AllTypes.class, io.realm.AllTypesRealmProxy.getExpectedObjectSchemaInfo());
+        return infoMap;
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -451,7 +451,7 @@ public class Realm extends BaseRealm {
             if (configuration.isSyncConfiguration()) {
                 // Update/create the schema if allowed
                 if (!configuration.isReadOnly()) {
-                    OsSchemaInfo schema = new OsSchemaInfo(mediator.getExpectedObjectSchemaInfoList());
+                    OsSchemaInfo schema = new OsSchemaInfo(mediator.getExpectedObjectSchemaInfoMap().values());
 
                     // Object Store handles all update logic
                     realm.sharedRealm.updateSchema(schema, newVersion);
@@ -465,7 +465,7 @@ public class Realm extends BaseRealm {
                     }
 
                     // Let Object Store initialize all tables
-                    OsSchemaInfo schemaInfo = new OsSchemaInfo(mediator.getExpectedObjectSchemaInfoList());
+                    OsSchemaInfo schemaInfo = new OsSchemaInfo(mediator.getExpectedObjectSchemaInfoMap().values());
                     realm.sharedRealm.updateSchema(schemaInfo, newVersion);
                     commitChanges = true;
                 }

--- a/realm/realm-library/src/main/java/io/realm/internal/OsSchemaInfo.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsSchemaInfo.java
@@ -16,8 +16,6 @@
 
 package io.realm.internal;
 
-import java.util.List;
-
 /**
  * Java wrapper for the Object Store Schema object.
  * <p>
@@ -36,10 +34,12 @@ public class OsSchemaInfo implements NativeObject {
      *
      * @param objectSchemaInfoList all the object schemas should be contained in this {@code OsObjectSchemaInfo}.
      */
-    public OsSchemaInfo(List<OsObjectSchemaInfo> objectSchemaInfoList) {
+    public OsSchemaInfo(java.util.Collection<OsObjectSchemaInfo> objectSchemaInfoList) {
         long[] schemaNativePointers = new long[objectSchemaInfoList.size()];
-        for (int i = 0; i < objectSchemaInfoList.size(); i++) {
-            schemaNativePointers[i] = objectSchemaInfoList.get(i).getNativePtr();
+        int i = 0;
+        for (OsObjectSchemaInfo info : objectSchemaInfoList) {
+            schemaNativePointers[i] = info.getNativePtr();
+            i++;
         }
         this.nativePtr = nativeCreateFromList(schemaNativePointers);
         NativeContext.dummyContext.addReference(this);

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -43,7 +43,13 @@ import io.realm.exceptions.RealmException;
  */
 public abstract class RealmProxyMediator {
 
-    public abstract List<OsObjectSchemaInfo> getExpectedObjectSchemaInfoList();
+    /**
+     * Returns a map of model classes to their schema information which are defined in this mediator. Classes which have
+     * same class name but in different packages should have different names in the {@code OsObjectSchemaInfo}.
+     *
+     * @return the map with classes and their schema information.
+     */
+    public abstract Map<Class<? extends RealmModel>, OsObjectSchemaInfo> getExpectedObjectSchemaInfoMap();
 
     /**
      * Validates the backing table in Realm for the given RealmObject class.

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -22,7 +22,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,12 +60,13 @@ public class CompositeMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<OsObjectSchemaInfo> getExpectedObjectSchemaInfoList() {
-        List<OsObjectSchemaInfo> infoList = new ArrayList<OsObjectSchemaInfo>();
+    public Map<Class<? extends RealmModel>, OsObjectSchemaInfo> getExpectedObjectSchemaInfoMap() {
+        Map<Class<? extends RealmModel>, OsObjectSchemaInfo> infoMap =
+                new HashMap<Class<? extends RealmModel>, OsObjectSchemaInfo>();
         for (RealmProxyMediator mediator : mediators.values()) {
-            infoList.addAll(mediator.getExpectedObjectSchemaInfoList());
+            infoMap.putAll(mediator.getExpectedObjectSchemaInfoMap());
         }
-        return infoList;
+        return infoMap;
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -22,9 +22,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +32,6 @@ import java.util.Set;
 
 import io.realm.Realm;
 import io.realm.RealmModel;
-import io.realm.RealmObjectSchema;
-import io.realm.RealmSchema;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.OsObjectSchemaInfo;
 import io.realm.internal.RealmObjectProxy;
@@ -51,7 +49,6 @@ public class FilterableMediator extends RealmProxyMediator {
 
     private final RealmProxyMediator originalMediator;
     private final Set<Class<? extends RealmModel>> allowedClasses;
-    private final Set<String> allowedClasseNames;
 
     /**
      * Creates a filterable {@link RealmProxyMediator}.
@@ -72,23 +69,19 @@ public class FilterableMediator extends RealmProxyMediator {
             }
         }
         this.allowedClasses = Collections.unmodifiableSet(tempAllowedClasses);
-
-        Set<String> tempAllowedClassNames = new HashSet<String>();
-        for (Class<? extends RealmModel> clazz : this.allowedClasses) {
-            tempAllowedClassNames.add(clazz.getSimpleName());
-        }
-        this.allowedClasseNames = Collections.unmodifiableSet(tempAllowedClassNames);
     }
 
     @Override
-    public List<OsObjectSchemaInfo> getExpectedObjectSchemaInfoList() {
-        List<OsObjectSchemaInfo> infoList = new ArrayList<OsObjectSchemaInfo>();
-        for (OsObjectSchemaInfo objectSchemaInfo : originalMediator.getExpectedObjectSchemaInfoList()) {
-            if (allowedClasseNames.contains(objectSchemaInfo.getClassName())) {
-                infoList.add(objectSchemaInfo);
+    public Map<Class<? extends RealmModel>, OsObjectSchemaInfo> getExpectedObjectSchemaInfoMap() {
+        Map<Class<? extends RealmModel>, OsObjectSchemaInfo> infoMap =
+                new HashMap<Class<? extends RealmModel>, OsObjectSchemaInfo>();
+        for (Map.Entry<Class<? extends RealmModel>, OsObjectSchemaInfo> entry :
+                originalMediator.getExpectedObjectSchemaInfoMap().entrySet()) {
+            if (allowedClasses.contains(entry.getKey())) {
+                infoMap.put(entry.getKey(), entry.getValue());
             }
         }
-        return infoList;
+        return infoMap;
     }
 
     @Override


### PR DESCRIPTION
Using map to avoid duplicated OsSchemaInfo in mediator, especially it is
an common case for composite mediator.
The key is the module class. Not using class name string is because of
we may want to support same name class in different packages in the
future.