### PR TITLE
Fixing isNull() for link queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-* Fixed a bug related to link queries (#4856).
+* Fixed a bug in `isNull()`, `isNotNull()`, `isEmpty()`, and `isNotEmpty()` when queries involve nullable fields in link queries (#4856).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed a bug related to link queries (#4856).
+
 ### Internal
 
 * Removed `Table#Table()`, `Table#addEmptyRow()`, `Table#addEmptyRows()`, `Table#add(Object...)`, `Table#pivot(long,long,PivotType)` and `Table#createnative()`.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
@@ -534,6 +534,9 @@ public class RealmLinkTests {
 
         RealmResults<Owner> owners2 = testRealm.where(Owner.class).isNull("cat").findAll();
         assertEquals(1, owners2.size());
+
+        RealmResults<Owner> owners3 = testRealm.where(Owner.class).isNull("dogs.birthday").findAll();
+        assertEquals(0, owners3.size());
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmLinkTests.java
@@ -550,6 +550,27 @@ public class RealmLinkTests {
 
         RealmResults<Owner> owners2 = testRealm.where(Owner.class).isNotNull("cat").findAll();
         assertEquals(0, owners2.size());
+
+        RealmResults<Owner> owners3 = testRealm.where(Owner.class).isNotNull("dogs.birthday").findAll();
+        assertEquals(1, owners3.size());
+    }
+
+    @Test
+    public void isEmpty() {
+        RealmResults<Owner> owners1 = testRealm.where(Owner.class).isEmpty("cat.name").findAll();
+        assertEquals(0, owners1.size());
+
+        RealmResults<Owner> owners2 = testRealm.where(Owner.class).isEmpty("dogs.name").findAll();
+        assertEquals(0, owners2.size());
+    }
+
+    @Test
+    public void isNotEmpty() {
+        RealmResults<Owner> owners1 = testRealm.where(Owner.class).isNotEmpty("cat.name").findAll();
+        assertEquals(1, owners1.size());
+
+        RealmResults<Owner> owners2 = testRealm.where(Owner.class).isNotEmpty("dogs.name").findAll();
+        assertEquals(1, owners2.size());
     }
 
     @Test

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -1510,7 +1510,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(JNIEnv* en
         }
 
         TableRef src_table_ref = getTableForLinkQuery(nativeQueryPtr, table_arr, index_arr);
-        int col_type = src_table_ref->get_column_type(S(column_idx));
+        DataType col_type = src_table_ref->get_column_type(S(column_idx));
         if (arr_len == 1) {
             switch (col_type) {
                 case type_Link:
@@ -1635,7 +1635,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull(JNIEnv*
 
         TableRef src_table_ref = getTableForLinkQuery(nativeQueryPtr, table_arr, index_arr);
 
-        int col_type = src_table_ref->get_column_type(S(column_idx));
+        DataType col_type = src_table_ref->get_column_type(S(column_idx));
         if (arr_len == 1) {
             switch (col_type) {
                 case type_Link:
@@ -1718,7 +1718,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsEmpty(JNIEnv* e
             return;
         }
 
-        int col_type = src_table_ref->get_column_type(column_idx);
+        DataType col_type = src_table_ref->get_column_type(column_idx);
         if (arr_len == 1) {
             // Field queries
             switch (col_type) {
@@ -1788,7 +1788,7 @@ Java_io_realm_internal_TableQuery_nativeIsNotEmpty(JNIEnv *env, jobject, jlong n
             return;
         }
 
-        int col_type = src_table_ref->get_column_type(column_idx);
+        DataType col_type = src_table_ref->get_column_type(column_idx);
         if (arr_len == 1) {
             // Field queries
             switch (col_type) {

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -1510,7 +1510,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNull(JNIEnv* en
         }
 
         TableRef src_table_ref = getTableForLinkQuery(nativeQueryPtr, table_arr, index_arr);
-        DataType col_type = src_table_ref->get_column_type(S(column_idx));
+        DataType col_type = table_ref->get_column_type(S(column_idx));
         if (arr_len == 1) {
             switch (col_type) {
                 case type_Link:
@@ -1635,7 +1635,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsNotNull(JNIEnv*
 
         TableRef src_table_ref = getTableForLinkQuery(nativeQueryPtr, table_arr, index_arr);
 
-        DataType col_type = src_table_ref->get_column_type(S(column_idx));
+        DataType col_type = table_ref->get_column_type(S(column_idx));
         if (arr_len == 1) {
             switch (col_type) {
                 case type_Link:
@@ -1718,7 +1718,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeIsEmpty(JNIEnv* e
             return;
         }
 
-        DataType col_type = src_table_ref->get_column_type(column_idx);
+        TableRef table_ref = getTableByArray(nativeQueryPtr, table_arr, index_arr);
+        DataType col_type = table_ref->get_column_type(column_idx);
         if (arr_len == 1) {
             // Field queries
             switch (col_type) {
@@ -1788,7 +1789,8 @@ Java_io_realm_internal_TableQuery_nativeIsNotEmpty(JNIEnv *env, jobject, jlong n
             return;
         }
 
-        DataType col_type = src_table_ref->get_column_type(column_idx);
+        TableRef table_ref = getTableByArray(nativeQueryPtr, table_arr, index_arr);
+        DataType col_type = table_ref->get_column_type(column_idx);
         if (arr_len == 1) {
             // Field queries
             switch (col_type) {


### PR DESCRIPTION
If the link query is on a nullable field, it seems to query the wrong field.

This is embarrassing bug, and the solution is simple: Follow links between tables and not queries links.

Fixes #4856 