### PR TITLE
Better control of ROS instance used by the integration tests

### DIFF
--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -32,6 +32,7 @@ function handleRequest(request, response) {
 }
 
 var syncServerChildProcess = null;
+var syncServerDir = null;
 
 function startRealmObjectServer(done) {
     // Hack for checking the ROS is fully initialized.
@@ -40,50 +41,65 @@ function startRealmObjectServer(done) {
     // https://github.com/realm/realm-object-server/issues/1297
     var logFindingCounter = 2
 
-    stopRealmObjectServer();
-    temp.mkdir('ros', function(err, path) {
-        if (!err) {
-            winston.info("Starting sync server in ", path);
-            var env = Object.create( process.env );
-            winston.info(env.NODE_ENV);
-            env.NODE_ENV = 'development';
-            syncServerChildProcess = spawn('realm-object-server',
-                    ['--root', path,
-                    '--configuration', '/configuration.yml'],
-                    { env: env});
-            // local config:
-            syncServerChildProcess.stdout.on('data', (data) => {
-                if (logFindingCounter != 0 && /client: Closing Realm file: .*__auth.realm/.test(data)) {
-                    if (logFindingCounter == 1) {
-                        done()
-                    }
-                    logFindingCounter--
-                }
-                winston.info(`stdout: ${data}`);
-            });
-
-            syncServerChildProcess.stderr.on('data', (data) => {
-                winston.info(`stderr: ${data}`);
-            });
-
-            syncServerChildProcess.on('close', (code) => {
-                winston.info(`child process exited with code ${code}`);
-            });
+    stopRealmObjectServer(function(err) {
+        if(err) {
+          return;
         }
+        temp.mkdir('ros', function(err, path) {
+            if (!err) {
+                var oldCwd = process.cwd();
+                process.chdir(path);
+                syncServerDir = path;
+                winston.info("Starting sync server in ", path);
+                var env = Object.create( process.env );
+                winston.info(env.NODE_ENV);
+                env.NODE_ENV = 'development';
+                syncServerChildProcess = spawn('realm-object-server',
+                        ['--root', path,
+                        '--configuration', '/configuration.yml'],
+                        { env: env});
+                // local config:
+                syncServerChildProcess.stdout.on('data', (data) => {
+                    if (logFindingCounter != 0 && /client: Closing Realm file: .*__auth.realm/.test(data)) {
+                        if (logFindingCounter == 1) {
+                            done()
+                        }
+                        logFindingCounter--
+                    }
+                    winston.info(`stdout: ${data}`);
+                });
+
+                syncServerChildProcess.stderr.on('data', (data) => {
+                    winston.info(`stderr: ${data}`);
+                });
+
+                syncServerChildProcess.on('close', (code) => {
+                    winston.info(`child process exited with code ${code}`);
+                });
+                process.chdir(oldCwd);
+            }
+        });
     });
 }
 
-function stopRealmObjectServer() {
+function stopRealmObjectServer(callback) {
     if (syncServerChildProcess) {
-        syncServerChildProcess.kill();
-        syncServerChildProcess = null;
-        exec('rm -r ' + 'realm-object-server', function (err, stdout, stderr) {
-            if (err) {
-                winston.error(err);
-            } else {
-                winston.info("realm-object-server directory deleted");
-            }
+        syncServerChildProcess.on('exit', function() {
+            syncServerChildProcess = null;
+            exec('rm -r ' + syncServerDir, function (err, stdout, stderr) {
+                if (err) {
+                    winston.error(err);
+                    callback(err);
+                } else {
+                    winston.info("realm-object-server directory deleted");
+                    syncServerDir = null;
+                    callback();
+                }
+            });
         });
+        syncServerChildProcess.kill();
+    } else {
+        callback();
     }
 }
 
@@ -98,10 +114,11 @@ dispatcher.onGet("/start", function(req, res) {
 
 // stop a previously started sync server
 dispatcher.onGet("/stop", function(req, res) {
-    stopRealmObjectServer();
-    winston.info("Sync server stopped");
-    res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.end('Stopping the server');
+    stopRealmObjectServer(function() {
+      winston.info("Sync server stopped");
+      res.writeHead(200, {'Content-Type': 'text/plain'});
+      res.end('Stopping the server');
+    });
 });
 
 //Create and start the Http server

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -32,7 +32,6 @@ function handleRequest(request, response) {
 }
 
 var syncServerChildProcess = null;
-var syncServerDir = null;
 
 function startRealmObjectServer(done) {
     // Hack for checking the ROS is fully initialized.
@@ -47,7 +46,6 @@ function startRealmObjectServer(done) {
         }
         temp.mkdir('ros', function(err, path) {
             if (!err) {
-                syncServerDir = path;
                 winston.info("Starting sync server in ", path);
                 var env = Object.create( process.env );
                 winston.info(env.NODE_ENV);
@@ -83,16 +81,7 @@ function stopRealmObjectServer(callback) {
     if (syncServerChildProcess) {
         syncServerChildProcess.on('exit', function() {
             syncServerChildProcess = null;
-            exec('rm -r ' + syncServerDir, function (err, stdout, stderr) {
-                if (err) {
-                    winston.error(err);
-                    callback(err);
-                } else {
-                    winston.info("realm-object-server directory deleted");
-                    syncServerDir = null;
-                    callback();
-                }
-            });
+            callback();
         });
         syncServerChildProcess.kill();
     } else {

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -47,8 +47,6 @@ function startRealmObjectServer(done) {
         }
         temp.mkdir('ros', function(err, path) {
             if (!err) {
-                var oldCwd = process.cwd();
-                process.chdir(path);
                 syncServerDir = path;
                 winston.info("Starting sync server in ", path);
                 var env = Object.create( process.env );
@@ -57,7 +55,7 @@ function startRealmObjectServer(done) {
                 syncServerChildProcess = spawn('realm-object-server',
                         ['--root', path,
                         '--configuration', '/configuration.yml'],
-                        { env: env});
+                        { env: env, cwd: path});
                 // local config:
                 syncServerChildProcess.stdout.on('data', (data) => {
                     if (logFindingCounter != 0 && /client: Closing Realm file: .*__auth.realm/.test(data)) {
@@ -76,7 +74,6 @@ function startRealmObjectServer(done) {
                 syncServerChildProcess.on('close', (code) => {
                     winston.info(`child process exited with code ${code}`);
                 });
-                process.chdir(oldCwd);
             }
         });
     });


### PR DESCRIPTION
Courtesy of @alebsack.

This fixes a bunch of flaky integration tests. Mostly seen during the development of #4558 , but could also be the root cause for a bunch of other stability issues we have seen lately with integration tests timing out.