### PR TITLE
Fix reference table overflow when logging from the sync thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-* Fixed a bug in `isNull()`, `isNotNull()`, `isEmpty()`, and `isNotEmpty()` when queries involve nullable fields in link queries (#4856).
+* Bug in `isNull()`, `isNotNull()`, `isEmpty()`, and `isNotEmpty()` when queries involve nullable fields in link queries (#4856).
+* Rare crash in `RealmLog` when log level was set to `LogLevel.DEBUG`.   
 
 ### Internal
 

--- a/realm/realm-library/src/main/cpp/jni_util/log.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.cpp
@@ -19,6 +19,7 @@
 #include <realm/util/assert.hpp>
 
 #include "jni_util/log.hpp"
+#include "jni_util/java_local_ref.hpp"
 
 using namespace realm;
 using namespace realm::jni_util;
@@ -91,8 +92,9 @@ void JavaLogger::log(Log::Level level, const char* tag, jthrowable throwable, co
     // "JNI called with pending exception". This is something that should be avoided when printing log in JNI --
     // Always
     // print log before calling env->ThrowNew. Doing env->ExceptionCheck() here creates overhead for normal cases.
-    env->CallVoidMethod(m_java_logger, m_log_method, level, env->NewStringUTF(tag), throwable,
-                        env->NewStringUTF(message));
+    JavaLocalRef<jstring> java_tag(env, env->NewStringUTF(tag));
+    JavaLocalRef<jstring> java_error_message(env, env->NewStringUTF(message));
+    env->CallVoidMethod(m_java_logger, m_log_method, level, java_tag.get(), throwable, java_error_message.get());
 }
 
 bool JavaLogger::is_same_object(JNIEnv* env, jobject java_logger)


### PR DESCRIPTION
I discovered this while debugging our unstable integration tests.
I haven't found a way to reproduce this in a unit test since it depends on the logging happening from a non-java thread (like the Sync thread).

Error was this one:
```
06-30 06:33:51.053 11311 13305 I REALM_SYNC: Connection[12]: Session[29]: Sending: UNBIND
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115] JNI ERROR (app bug): local reference table overflow (max=512)
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115] local reference table dump:
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]   Last 10 entries (of 512):
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       511: 0x1329bac0 java.lang.String "REALM_SYNC"
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       510: 0x13840760 java.lang.String "Closing Realm fi... (136 chars)
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       509: 0x1329ba90 java.lang.String "REALM_SYNC"
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       508: 0x12dcc4e0 java.lang.String "Connection[12]: ... (164 chars)
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       507: 0x1329ba60 java.lang.String "REALM_SYNC"
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       506: 0x12d37880 java.lang.String "Using already op... (147 chars)
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       505: 0x1329ba30 java.lang.String "REALM_SYNC"
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       504: 0x12d37740 java.lang.String "Using already op... (147 chars)
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       503: 0x1329ba00 java.lang.String "REALM_SYNC"
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       502: 0x13130c20 java.lang.String "Connection[12]: ... (238 chars)
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]   Summary:
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115]       512 of java.lang.String (512 unique instances)
06-30 06:33:51.054 11311 13305 F art     : art/runtime/indirect_reference_table.cc:115] 
06-30 06:33:51.230 11311 13305 F art     : art/runtime/barrier.cc:90] Check failed: count_ == 0 (count_=-1, 0=0) Attempted to destroy barrier with non zero count
06-30 06:33:51.230 11311 13305 F art     : art/runtime/runtime.cc:366] Runtime aborting --- recursively, so no thread-specific detail!
06-30 06:33:51.230 11311 13305 F art     : art/runtime/runtime.cc:366] 
06-30 06:33:51.230 11311 13305 F libc    : Fatal signal 6 (SIGABRT), code -6 in tid 13305 (Thread-801)
06-30 06:33:51.332   101   101 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
06-30 06:33:51.332   101   101 F DEBUG   : Build fingerprint: 'Android/vbox86p/vbox86p:6.0/MRA58K/genymotion08241314:userdebug/test-keys'
06-30 06:33:51.332   101   101 F DEBUG   : Revision: '0'
06-30 06:33:51.332   101   101 F DEBUG   : ABI: 'x86'
06-30 06:33:51.332   101   101 F DEBUG   : pid: 11311, tid: 13305, name: Thread-801  >>> io.realm.test <<<
06-30 06:33:51.332   101   101 F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
06-30 06:33:51.337   101   101 F DEBUG   : Abort message: 'art/runtime/indirect_reference_table.cc:115] JNI ERROR (app bug): local reference table overflow (max=512)'
06-30 06:33:51.337   101   101 F DEBUG   :     eax 00000000  ebx 00002c2f  ecx 000033f9  edx 00000006
06-30 06:33:51.337   101   101 F DEBUG   :     esi da3f0980  edi 00000000
06-30 06:33:51.337   101   101 F DEBUG   :     xcs 00000023  xds 0000002b  xes 0000002b  xfs 000000cf  xss 0000002b
06-30 06:33:51.337   101   101 F DEBUG   :     eip f72c6e66  ebp 000033f9  esp da3efdf0  flags 00200202
06-30 06:33:51.341   101   101 F DEBUG   : 
06-30 06:33:51.341   101   101 F DEBUG   : backtrace:
06-30 06:33:51.341   101   101 F DEBUG   :     #00 pc 00083e66  /system/lib/libc.so (tgkill+22)
06-30 06:33:51.341   101   101 F DEBUG   :     #01 pc 00081348  /system/lib/libc.so (pthread_kill+70)
06-30 06:33:51.341   101   101 F DEBUG   :     #02 pc 00027205  /system/lib/libc.so (raise+36)
06-30 06:33:51.341   101   101 F DEBUG   :     #03 pc 000209e4  /system/lib/libc.so (abort+80)
06-30 06:33:51.341   101   101 F DEBUG   :     #04 pc 005167ab  /system/lib/libart.so (art::Runtime::Abort()+377)
06-30 06:33:51.341   101   101 F DEBUG   :     #05 pc 0014d9f3  /system/lib/libart.so (art::LogMessage::~LogMessage()+1343)
06-30 06:33:51.341   101   101 F DEBUG   :     #06 pc 00147f36  /system/lib/libart.so (art::Barrier::~Barrier()+966)
06-30 06:33:51.341   101   101 F DEBUG   :     #07 pc 0055f4ef  /system/lib/libart.so (art::ThreadList::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&)+271)
06-30 06:33:51.341   101   101 F DEBUG   :     #08 pc 00516928  /system/lib/libart.so (art::Runtime::Abort()+758)
06-30 06:33:51.341   101   101 F DEBUG   :     #09 pc 0014d9f3  /system/lib/libart.so (art::LogMessage::~LogMessage()+1343)
06-30 06:33:51.341   101   101 F DEBUG   :     #10 pc 002e6fac  /system/lib/libart.so (art::IndirectReferenceTable::Add(unsigned int, art::mirror::Object*)+860)
06-30 06:33:51.341   101   101 F DEBUG   :     #11 pc 00408b0a  /system/lib/libart.so (art::JNI::NewStringUTF(_JNIEnv*, char const*)+570)
06-30 06:33:51.341   101   101 F DEBUG   :     #12 pc 0017c545  /system/lib/libart.so (art::CheckJNI::NewStringUTF(_JNIEnv*, char const*)+632)
06-30 06:33:51.341   101   101 F DEBUG   :     #13 pc 000ea4ff  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (JavaLogger::log(realm::jni_util::Log::Level, char const*, _jthrowable*, char const*)+97)
06-30 06:33:51.341   101   101 F DEBUG   :     #14 pc 000ea76d  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (realm::jni_util::Log::log(realm::jni_util::Log::Level, char const*, _jthrowable*, char const*)+115)
06-30 06:33:51.341   101   101 F DEBUG   :     #15 pc 000eba6b  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (realm::jni_util::CoreLoggerBridge::do_log(realm::util::Logger::Level, std::string)+281)
06-30 06:33:51.341   101   101 F DEBUG   :     #16 pc 0006385e  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (realm::util::PrefixLogger::do_log(realm::util::Logger::Level, std::string)+100)
06-30 06:33:51.341   101   101 F DEBUG   :     #17 pc 0006385e  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (realm::util::PrefixLogger::do_log(realm::util::Logger::Level, std::string)+100)
06-30 06:33:51.341   101   101 F DEBUG   :     #18 pc 000e3c71  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (void realm::util::Logger::do_log<>(realm::util::Logger::Level, char const*)+649)
06-30 06:33:51.341   101   101 F DEBUG   :     #19 pc 0016f545  /data/app/io.realm.test-2/lib/x86/librealm-jni.so ((anonymous namespace)::Connection::send_next_message()+455)
06-30 06:33:51.341   101   101 F DEBUG   :     #20 pc 00173217  /data/app/io.realm.test-2/lib/x86/librealm-jni.so ((anonymous namespace)::ClientImpl::stop_and_start_sessions()+265)
06-30 06:33:51.342   101   101 F DEBUG   :     #21 pc 001746b7  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (realm::sync::Client::run()+157)
06-30 06:33:51.342   101   101 F DEBUG   :     #22 pc 0015418b  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (_ZNSt6thread5_ImplISt12_Bind_simpleIFZN5realm5_impl10SyncClientC4ESt10unique_ptrINS2_4util6LoggerESt14default_deleteIS7_EENS2_4sync6Client13ReconnectModeEEUlvE_vEEE6_M_runEv+75)
06-30 06:33:51.342   101   101 F DEBUG   :     #23 pc 00395b9e  /data/app/io.realm.test-2/lib/x86/librealm-jni.so (execute_native_thread_routine+46)
06-30 06:33:51.342   101   101 F DEBUG   :     #24 pc 000807f3  /system/lib/libc.so (__pthread_start(void*)+56)
06-30 06:33:51.343   101   101 F DEBUG   :     #25 pc 00021952  /system/lib/libc.so (__start_thread+25)
06-30 06:33:51.343   101   101 F DEBUG   :     #26 pc 000170b6  /system/lib/libc.so (__bionic_clone+70)
06-30 06:33:51.482   101   101 F DEBUG   : 
```