### PR TITLE
Fix ErrorProne warnings

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -750,7 +750,7 @@ public class DynamicRealmObjectTests {
                             .setObject(AllJavaTypes.FIELD_OBJECT, dObjDynamic);
                     fail();
                 } catch (IllegalArgumentException expected) {
-                    assertEquals(expected.getMessage(), "Cannot add an object from another Realm instance.");
+                    assertEquals("Cannot add an object from another Realm instance.", expected.getMessage());
                 }
 
                 dynamicRealm.cancelTransaction();
@@ -861,8 +861,7 @@ public class DynamicRealmObjectTests {
                     dynamicRealm.where(AllJavaTypes.CLASS_NAME).findFirst().setList(AllJavaTypes.FIELD_LIST, list);
                     fail();
                 } catch (IllegalArgumentException expected) {
-                    assertEquals(expected.getMessage(),
-                            "Each element in 'list' must belong to the same Realm instance.");
+                    assertEquals("Each element in 'list' must belong to the same Realm instance.", expected.getMessage());
                 }
 
                 dynamicRealm.cancelTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmTests.java
@@ -332,7 +332,7 @@ public class DynamicRealmTests {
             });
         } catch (RuntimeException ignored) {
             // Ensures that we pass a valuable error message to the logger for developers.
-            assertEquals(testLogger.message, "Could not cancel transaction, not currently in a transaction.");
+            assertEquals("Could not cancel transaction, not currently in a transaction.", testLogger.message);
         } finally {
             RealmLog.remove(testLogger);
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmCacheTests.java
@@ -115,7 +115,7 @@ public class RealmCacheTests {
             Realm.getInstance(configB); // Tries to open with key 2.
             fail();
         } catch (RealmFileException expected) {
-            assertEquals(expected.getKind(), RealmFileException.Kind.ACCESS_ERROR);
+            assertEquals(RealmFileException.Kind.ACCESS_ERROR, expected.getKind());
             // Deletes Realm so key 2 works. This should work as a Realm shouldn't be cached
             // if initialization failed.
             assertTrue(Realm.deleteRealm(configA));
@@ -164,7 +164,7 @@ public class RealmCacheTests {
             Realm.getInstance(wrongConfig);
             fail();
         } catch (RealmFileException expected) {
-            assertEquals(expected.getKind(), RealmFileException.Kind.ACCESS_ERROR);
+            assertEquals(RealmFileException.Kind.ACCESS_ERROR, expected.getKind());
         }
 
         // Tries again with proper key.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -905,7 +905,7 @@ public class RealmConfigurationTests {
             Realm.getInstance(configuration);
             fail();
         } catch (RealmFileException expected) {
-            assertEquals(expected.getKind(), RealmFileException.Kind.ACCESS_ERROR);
+            assertEquals(RealmFileException.Kind.ACCESS_ERROR, expected.getKind());
         }
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmInMemoryTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmInMemoryTest.java
@@ -81,14 +81,14 @@ public class RealmInMemoryTest {
         dog.setName("DinoDog");
         testRealm.commitTransaction();
 
-        assertEquals(testRealm.where(Dog.class).count(), 1);
-        assertEquals(testRealm.where(Dog.class).findFirst().getName(), "DinoDog");
+        assertEquals(1, testRealm.where(Dog.class).count());
+        assertEquals("DinoDog", testRealm.where(Dog.class).findFirst().getName());
 
         testRealm.close();
         // After all references to the in-mem-realm closed,
         // in-mem-realm with same identifier should create a fresh new instance.
         testRealm = Realm.getInstance(inMemConf);
-        assertEquals(testRealm.where(Dog.class).count(), 0);
+        assertEquals(0, testRealm.where(Dog.class).count());
     }
 
     // Two in-memory Realms with different names should not affect each other.
@@ -110,12 +110,12 @@ public class RealmInMemoryTest {
         dog2.setName("UFODog");
         testRealm2.commitTransaction();
 
-        assertEquals(testRealm.where(Dog.class).count(), 1);
+        assertEquals(1, testRealm.where(Dog.class).count());
         //noinspection ConstantConditions
-        assertEquals(testRealm.where(Dog.class).findFirst().getName(), "DinoDog");
-        assertEquals(testRealm2.where(Dog.class).count(), 1);
+        assertEquals("DinoDog", testRealm.where(Dog.class).findFirst().getName());
+        assertEquals(1, testRealm2.where(Dog.class).count());
         //noinspection ConstantConditions
-        assertEquals(testRealm2.where(Dog.class).findFirst().getName(), "UFODog");
+        assertEquals("UFODog", testRealm2.where(Dog.class).findFirst().getName());
 
         testRealm2.close();
     }
@@ -161,13 +161,13 @@ public class RealmInMemoryTest {
         // Tests a normal Realm file.
         testRealm.writeCopyTo(new File(configFactory.getRoot(), fileName));
         Realm onDiskRealm = Realm.getInstance(conf);
-        assertEquals(onDiskRealm.where(Dog.class).count(), 1);
+        assertEquals(1, onDiskRealm.where(Dog.class).count());
         onDiskRealm.close();
 
         // Tests a encrypted Realm file.
         testRealm.writeEncryptedCopyTo(new File(configFactory.getRoot(), encFileName), key);
         onDiskRealm = Realm.getInstance(encConf);
-        assertEquals(onDiskRealm.where(Dog.class).count(), 1);
+        assertEquals(1, onDiskRealm.where(Dog.class).count());
         onDiskRealm.close();
         // Tests with a wrong key to see if it fails as expected.
         try {
@@ -178,7 +178,7 @@ public class RealmInMemoryTest {
             Realm.getInstance(wrongKeyConf);
             fail("Realm.getInstance should fail with RealmFileException");
         } catch (RealmFileException expected) {
-            assertEquals(expected.getKind(), RealmFileException.Kind.ACCESS_ERROR);
+            assertEquals(RealmFileException.Kind.ACCESS_ERROR, expected.getKind());
         }
     }
 
@@ -207,7 +207,7 @@ public class RealmInMemoryTest {
                 realm.commitTransaction();
 
                 try {
-                    assertEquals(realm.where(Dog.class).count(), 1);
+                    assertEquals(1, realm.where(Dog.class).count());
                 } catch (AssertionFailedError afe) {
                     threadError[0] = afe;
                     realm.close();
@@ -237,7 +237,7 @@ public class RealmInMemoryTest {
 
         // Refreshes will be ran in the next loop, manually refreshes it here.
         testRealm.waitForChange();
-        assertEquals(testRealm.where(Dog.class).count(), 1);
+        assertEquals(1, testRealm.where(Dog.class).count());
 
         // Step 3.
         // Releases the main thread Realm reference, and the worker thread holds the reference still.
@@ -246,7 +246,7 @@ public class RealmInMemoryTest {
         // Step 4.
         // Creates a new Realm reference in main thread and checks the data.
         testRealm = Realm.getInstance(inMemConf);
-        assertEquals(testRealm.where(Dog.class).count(), 1);
+        assertEquals(1, testRealm.where(Dog.class).count());
         testRealm.close();
 
         // Let the worker thread continue.
@@ -258,6 +258,6 @@ public class RealmInMemoryTest {
 
         // Since all previous Realm instances has been closed before, below will create a fresh new in-mem-realm instance.
         testRealm = Realm.getInstance(inMemConf);
-        assertEquals(testRealm.where(Dog.class).count(), 0);
+        assertEquals(0, testRealm.where(Dog.class).count());
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmInterprocessTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmInterprocessTest.java
@@ -282,7 +282,7 @@ public class RealmInterprocessTest extends AndroidTestCase {
             public void run() {
                 // Step 1
                 testRealm = Realm.getInstance(new RealmConfiguration.Builder(getContext()).build());
-                assertEquals(testRealm.where(AllTypes.class).count(), 0);
+                assertEquals(0, testRealm.where(AllTypes.class).count());
                 testRealm.beginTransaction();
                 testRealm.createObject(AllTypes.class);
                 testRealm.commitTransaction();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -213,7 +213,7 @@ public class RealmTests {
                     .build());
             fail();
         } catch (RealmFileException expected) {
-            assertEquals(expected.getKind(), RealmFileException.Kind.PERMISSION_DENIED);
+            assertEquals(RealmFileException.Kind.PERMISSION_DENIED, expected.getKind());
         }
     }
 
@@ -230,7 +230,7 @@ public class RealmTests {
             Realm.getInstance(new RealmConfiguration.Builder(context).directory(folder).name(REALM_FILE).build());
             fail();
         } catch (RealmFileException expected) {
-            assertEquals(expected.getKind(), RealmFileException.Kind.PERMISSION_DENIED);
+            assertEquals(RealmFileException.Kind.PERMISSION_DENIED, expected.getKind());
         }
     }
 
@@ -708,7 +708,7 @@ public class RealmTests {
             });
         } catch (RuntimeException ignored) {
             // Ensures that we pass a valuable error message to the logger for developers.
-            assertEquals(testLogger.message, "Could not cancel transaction, not currently in a transaction.");
+            assertEquals("Could not cancel transaction, not currently in a transaction.", testLogger.message);
         } finally {
             RealmLog.remove(testLogger);
         }

--- a/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/TypeBasedNotificationsTests.java
@@ -877,7 +877,7 @@ public class TypeBasedNotificationsTests {
                     looperThread.postRunnable(new Runnable() {
                         @Override
                         public void run() {
-                            assertEquals(typebasedCommitInvocations.get(), 1);
+                            assertEquals(1, typebasedCommitInvocations.get());
                             looperThread.testComplete();
                         }
                     });

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/Thread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/Thread.java
@@ -18,6 +18,7 @@ package io.realm.entities;
 
 import io.realm.RealmObject;
 
+@SuppressWarnings("JavaLangClash")
 public class Thread extends RealmObject {
     private String name;
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/conflict/String.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/conflict/String.java
@@ -19,6 +19,7 @@ package io.realm.entities.conflict;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 
+@SuppressWarnings("JavaLangClash")
 public class String extends RealmObject {
     public String str;
     public RealmList<String> strList;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/CollectionTests.java
@@ -135,10 +135,10 @@ public class CollectionTests {
         SortDescriptor distinctDescriptor = SortDescriptor.getInstanceForDistinct(null, table, "firstName");
         Collection collection = new Collection(sharedRealm, table.where(), null, distinctDescriptor);
 
-        assertEquals(collection.size(), 3);
-        assertEquals(collection.getUncheckedRow(0).getString(0), "John");
-        assertEquals(collection.getUncheckedRow(1).getString(0), "Erik");
-        assertEquals(collection.getUncheckedRow(2).getString(0), "Henry");
+        assertEquals(3, collection.size());
+        assertEquals("John", collection.getUncheckedRow(0).getString(0));
+        assertEquals("Erik", collection.getUncheckedRow(1).getString(0));
+        assertEquals("Henry", collection.getUncheckedRow(2).getString(0));
     }
 
 
@@ -192,8 +192,8 @@ public class CollectionTests {
         assertEquals(2, collection.size());
         assertEquals(2, collection2.size());
 
-        assertEquals(collection2.getUncheckedRow(0).getLong(2), 3);
-        assertEquals(collection2.getUncheckedRow(1).getLong(2), 4);
+        assertEquals(3, collection2.getUncheckedRow(0).getLong(2));
+        assertEquals(4, collection2.getUncheckedRow(1).getLong(2));
     }
 
     @Test
@@ -366,7 +366,7 @@ public class CollectionTests {
 
         final Collection collection = new Collection(sharedRealm, table.where());
         looperThread.keepStrongReference(collection);
-        assertEquals(collection.size(), 4); // Trigger the query to run.
+        assertEquals(4, collection.size()); // Trigger the query to run.
         collection.addListener(collection, new RealmChangeListener<Collection>() {
             @Override
             public void onChange(Collection collection1) {

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/JNIRowTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/JNIRowTest.java
@@ -134,7 +134,7 @@ public class JNIRowTest {
         UncheckedRow row = table.getUncheckedRow(rowIndex);
 
         row.setString(colStringIndex, "test");
-        assertEquals(row.getString(colStringIndex), "test");
+        assertEquals("test", row.getString(colStringIndex));
         row.setNull(colStringIndex);
         assertNull(row.getString(colStringIndex));
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/ObserverPairListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/ObserverPairListTests.java
@@ -39,8 +39,8 @@ import static junit.framework.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class ObserverPairListTests {
 
-    private static class TestListener<Integer> {
-        void onChange(Integer integer) {
+    private static class TestListener<T> {
+        void onChange(T integer) {
         }
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/android/JsonUtilsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/android/JsonUtilsTest.java
@@ -48,7 +48,7 @@ public class JsonUtilsTest extends AndroidTestCase {
         String jsonDate = "/Date(1198908717056)/"; // 2007-12-27T23:11:57.056
         Date output = JsonUtils.stringToDate(jsonDate);
 
-        assertEquals(output.getTime(), 1198908717056L);
+        assertEquals(1198908717056L, output.getTime());
     }
 
     public void testNegativeLongDate() {

--- a/realm/realm-library/src/main/java/io/realm/internal/OutOfMemoryError.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OutOfMemoryError.java
@@ -21,7 +21,7 @@ package io.realm.internal;
  * Can be thrown when Realm runs out of memory.
  * A JVM that catches this will be able to cleanup, e.g. release other resources to avoid also running out of memory.
  */
-@SuppressWarnings("serial")
+@SuppressWarnings({"serial", "JavaLangClash"})
 @Keep
 public class OutOfMemoryError extends Error {
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -52,8 +52,6 @@ import static org.junit.Assert.assertEquals;
 public class ProcessCommitTests extends BaseIntegrationTest {
 
     @Rule
-    public RunInLooperThread looperThread = new RunInLooperThread();
-    @Rule
     public RunWithRemoteService remoteService = new RunWithRemoteService();
 
     @Before


### PR DESCRIPTION
Fixes a lot of warnings reported by ErrorProne. Mostly it looks like ErrorProne suddenly check our unit test files as well.