### PR TITLE
Fix multi-processes tests

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunTestWithRemoteService.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunTestWithRemoteService.java
@@ -30,5 +30,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 public @interface RunTestWithRemoteService {
-    Class<? extends RemoteTestService> value();
+    Class<? extends RemoteTestService> remoteService();
+    boolean onLooperThread();
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -103,9 +103,10 @@ public class ProcessCommitTests extends BaseIntegrationTest {
     // A. Open the same sync Realm and add one object.
     // 2. Get the notification, check if the change in A is received.
     @Test
-    @RunTestWithRemoteService(SimpleCommitRemoteService.class)
     @RunTestInLooperThread
+    @RunTestWithRemoteService(remoteService = SimpleCommitRemoteService.class, onLooperThread = true)
     public void expectSimpleCommit() {
+        looperThread.runAfterTest(remoteService.afterRunnable);
         remoteService.createHandler(Looper.myLooper());
 
         final SyncUser user = UserFactory.getInstance().createDefaultUser(Constants.AUTH_URL);
@@ -178,9 +179,10 @@ public class ProcessCommitTests extends BaseIntegrationTest {
     // 2. Check if the 100 objects are received.
     // #. Repeat B/2 10 times.
     @Test
-    @RunTestWithRemoteService(ALotCommitsRemoteService.class)
+    @RunTestWithRemoteService(remoteService = ALotCommitsRemoteService.class, onLooperThread = true)
     @RunTestInLooperThread
     public void expectALot() throws Throwable {
+        looperThread.runAfterTest(remoteService.afterRunnable);
         remoteService.createHandler(Looper.myLooper());
 
         final SyncUser user = UserFactory.getInstance().createDefaultUser(Constants.AUTH_URL);


### PR DESCRIPTION
When running remote service test, the remote service is killed in after
function. It is too early when running it together with looper thread
test.