### PR TITLE
Fix flaky emptyChangeSet_findAllAsync

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedCollectionChangeSetTests.java
@@ -413,6 +413,7 @@ public class OrderedCollectionChangeSetTests {
         Realm realm = looperThread.getRealm();
         populateData(realm, 10);
         final RealmResults<Dog> results = realm.where(Dog.class).findAllSortedAsync(Dog.FIELD_AGE);
+        looperThread.keepStrongReference(results);
         results.addChangeListener(new OrderedRealmCollectionChangeListener<RealmResults<Dog>>() {
             @Override
             public void onChange(RealmResults<Dog> collection, OrderedCollectionChangeSet changeSet) {


### PR DESCRIPTION
There is no guarantee that async query will be finished later after the
transaction. So the original assertEquals(9, collection.size()) might
not be true always.
Just remove the object deletion logic since it has nothing to do with
the test purpose.