### PR TITLE
Add missing sync error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed a bug in how to resolve field names when querying `@LinkingObjects` as the last field (#4864).
 * Rare crash in `RealmLog` when log level was set to `LogLevel.DEBUG`.
 * [ObjectServer] Fixed a bug related to the behaviour of `SyncUser#logout` and the use of invalid `SyncUser` with `SyncConfiguration` (#4822).
+* [ObjectServer] Not all error codes from the server were recognized correctly, resulting in UNKNOWN being reported instead.
 
 ### Internal
 

--- a/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
@@ -23,7 +23,8 @@ import java.net.ConnectException;
  */
 public enum ErrorCode {
 
-    // See https://github.com/realm/realm-sync/blob/master/doc/protocol_16.md
+    // See https://github.com/realm/realm-sync/blob/master/doc/protocol_17.md
+    // See https://github.com/realm/realm-object-server/blob/master/object-server/doc/problems.md
 
     // Realm Java errors (0-49)
     UNKNOWN(-1),                                // Catch-all
@@ -65,6 +66,52 @@ public enum ErrorCode {
     DISABLED_SESSION(213),                          // Disabled session
 
     // 300 - 599 Reserved for Standard HTTP error codes
+    MULTIPLE_CHOICES(300),
+    MOVED_PERMANENTLY(301),
+    FOUND(302),
+    SEE_OTHER(303),
+    NOT_MODIFIED(304),
+    USE_PROXY(305),
+    TEMPORARY_REDIRECT(307),
+    PERMANENT_REDIRECT(308),
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    PAYMENT_REQUIRED(402),
+    FORBIDDEN(403),
+    NOT_FOUND(404),
+    METHOD_NOT_ALLOWED(405),
+    NOT_ACCEPTABLE(406),
+    PROXY_AUTHENTICATION_REQUIRED(407),
+    REQUEST_TIMEOUT(408),
+    CONFLICT(409),
+    GONE(410),
+    LENGTH_REQUIRED(411),
+    PRECONDITION_FAILED(412),
+    PAYLOAD_TOO_LARGE(413),
+    URI_TOO_LONG(414),
+    UNSUPPORTED_MEDIA_TYPE(415),
+    RANGE_NOT_SATISFIABLE(416),
+    EXPECTATION_FAILED(417),
+    MISDIRECTED_REQUEST(421),
+    UNPROCESSABLE_ENTITY(422),
+    LOCKED(423),
+    FAILED_DEPENDENCY(424),
+    UPGRADE_REQUIRED(426),
+    PRECONDITION_REQUIRED(428),
+    TOO_MANY_REQUESTS(429),
+    REQUEST_HEADER_FIELDS_TOO_LARGE(431),
+    UNAVAILABLE_FOR_LEGAL_REASONS(451),
+    INTERNAL_SERVER_ERROR(500),
+    NOT_IMPLEMENTED(501),
+    BAD_GATEWAY(502),
+    SERVICE_UNAVAILABLE(503),
+    GATEWAY_TIMEOUT(504),
+    HTTP_VERSION_NOT_SUPPORTED(505),
+    VARIANT_ALSO_NEGOTIATES(506),
+    INSUFFICIENT_STORAGE(507),
+    LOOP_DETECTED(508),
+    NOT_EXTENDED(510),
+    NETWORK_AUTHENTICATION_REQUIRED(511),
 
     // Realm Authentication Server response errors (600 - 699)
     INVALID_PARAMETERS(601),
@@ -73,7 +120,14 @@ public enum ErrorCode {
     UNKNOWN_ACCOUNT(612),
     EXISTING_ACCOUNT(613),
     ACCESS_DENIED(614),
-    EXPIRED_REFRESH_TOKEN(615);
+    EXPIRED_REFRESH_TOKEN(615),
+    INVALID_HOST(616),
+
+    // Other Realm Object Server response errors
+    EXPIRED_PERMISSION_OFFER(701),
+    AMBIGUOUS_PERMISSION_OFFER_TOKEN(702),
+    FILE_MAY_NOT_BE_SHARED(703),
+    SERVER_MISCONFIGURATION(801);
 
     private final int code;
     private final Category category;


### PR DESCRIPTION
Discovered while adding tests for #4871 

This PR adds support for all known error codes coming from ROS, including standard HTTP error codes. All names are just capitalized versions of this list https://github.com/realm/realm-object-server/blob/master/object-server/doc/problems.md