### PR TITLE
Fix merge conflict resulting in duplicate error code

### DIFF
--- a/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
@@ -113,9 +113,6 @@ public enum ErrorCode {
     NOT_EXTENDED(510),
     NETWORK_AUTHENTICATION_REQUIRED(511),
 
-    // user lookup endpoint returns 404 in case it couldn't honor the query
-    NOT_FOUND(404),
-
     // Realm Authentication Server response errors (600 - 699)
     INVALID_PARAMETERS(601),
     MISSING_PARAMETERS(602),


### PR DESCRIPTION
Happened because another feature was merged into `master` that also added this code. The automatic merge could not detect this.