### PR TITLE
Options in AndroidManifest for attaching debugger

### DIFF
--- a/realm/realm-library/src/androidTest/AndroidManifest.xml
+++ b/realm/realm-library/src/androidTest/AndroidManifest.xml
@@ -7,12 +7,14 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.SET_DEBUG_APP"/>
 
     <uses-sdk
         android:minSdkVersion="9"
         android:targetSdkVersion="22"/>
 
-    <application>
+    <application
+        android:debuggable="true">
         <uses-library android:name="android.test.runner"/>
         <service
             android:name=".services.RemoteProcessService"


### PR DESCRIPTION
android.permission.SET_DEBUG_APP and android:debuggable="true" are
needed for attaching debugger on some devices (eg.: Huawei device).