### PR TITLE
Revert "Options in AndroidManifest for attaching debugger"

### DIFF
--- a/realm/realm-library/src/androidTest/AndroidManifest.xml
+++ b/realm/realm-library/src/androidTest/AndroidManifest.xml
@@ -7,14 +7,12 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.SET_DEBUG_APP"/>
 
     <uses-sdk
         android:minSdkVersion="9"
         android:targetSdkVersion="22"/>
 
-    <application
-        android:debuggable="true">
+    <application>
         <uses-library android:name="android.test.runner"/>
         <service
             android:name=".services.RemoteProcessService"


### PR DESCRIPTION
This reverts commit 790f225bf1820ddca2b6d52fa997466e078afef8.
That commit triggered a stange crash in JNI when Running RealmTest, it
failed with a native crash on test compactOnLaunch_shouldNotCompact:

JNI DETECTED ERROR IN APPLICATION:
can't call boolean
io.realm.DefaultCompactOnLaunchCallback.shouldCompact(long, long) on instance of
io.realm.RealmTests$6'

Looks very much like a bug in Android.