### PR TITLE
Immutable RealmSchema and RealmObjectSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+* Potential crash after using `Realm.getSchema()` to change the schema of a typed Realm. `Realm.getSchema()` now returns an immutable `RealmSchema` instance.
+
 ### Internal
 
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -1007,7 +1007,7 @@ public class RealmProxyClassGenerator {
                     .beginControlFlow("if (rowIndex != Table.NO_MATCH)")
                     .beginControlFlow("try")
                     .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex)," +
-                            " realm.schema.getColumnInfo(%s.class)," +
+                            " realm.getSchema().getColumnInfo(%s.class)," +
                             " false, Collections.<String> emptyList())", qualifiedClassName)
                     .emitStatement("realmObject = new %s()", qualifiedGeneratedClassName)
                     .emitStatement("cache.put(object, (RealmObjectProxy) realmObject)")
@@ -1154,7 +1154,7 @@ public class RealmProxyClassGenerator {
 
         writer.emitStatement("Table table = realm.getTable(%s.class)", qualifiedClassName);
         writer.emitStatement("long tableNativePtr = table.getNativePtr()");
-        writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
+        writer.emitStatement("%s columnInfo = (%s) realm.getSchema().getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
 
         if (metadata.hasPrimaryKey()) {
@@ -1223,7 +1223,7 @@ public class RealmProxyClassGenerator {
 
         writer.emitStatement("Table table = realm.getTable(%s.class)", qualifiedClassName);
         writer.emitStatement("long tableNativePtr = table.getNativePtr()");
-        writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
+        writer.emitStatement("%s columnInfo = (%s) realm.getSchema().getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
         if (metadata.hasPrimaryKey()) {
             writer.emitStatement("long pkColumnIndex = table.getPrimaryKey()");
@@ -1309,7 +1309,7 @@ public class RealmProxyClassGenerator {
 
         writer.emitStatement("Table table = realm.getTable(%s.class)", qualifiedClassName);
         writer.emitStatement("long tableNativePtr = table.getNativePtr()");
-        writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
+        writer.emitStatement("%s columnInfo = (%s) realm.getSchema().getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
 
         if (metadata.hasPrimaryKey()) {
@@ -1382,7 +1382,7 @@ public class RealmProxyClassGenerator {
 
         writer.emitStatement("Table table = realm.getTable(%s.class)", qualifiedClassName);
         writer.emitStatement("long tableNativePtr = table.getNativePtr()");
-        writer.emitStatement("%s columnInfo = (%s) realm.schema.getColumnInfo(%s.class)",
+        writer.emitStatement("%s columnInfo = (%s) realm.getSchema().getColumnInfo(%s.class)",
                 columnInfoClassName(), columnInfoClassName(), qualifiedClassName);
         if (metadata.hasPrimaryKey()) {
             writer.emitStatement("long pkColumnIndex = table.getPrimaryKey()");
@@ -1901,7 +1901,7 @@ public class RealmProxyClassGenerator {
                     .emitStatement("final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get()")
                     .beginControlFlow("try")
                     .emitStatement("objectContext.set(realm, table.getUncheckedRow(rowIndex)," +
-                            " realm.schema.getColumnInfo(%s.class)," +
+                            " realm.getSchema().getColumnInfo(%s.class)," +
                             " false, Collections.<String> emptyList())", qualifiedClassName)
                     .emitStatement("obj = new %s()", qualifiedGeneratedClassName)
                     .nextControlFlow("finally")

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -548,7 +548,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             if (rowIndex != Table.NO_MATCH) {
                 final BaseRealm.RealmObjectContext objectContext = BaseRealm.objectContext.get();
                 try {
-                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false, Collections.<String> emptyList());
+                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.getSchema().getColumnInfo(some.test.AllTypes.class), false, Collections.<String> emptyList());
                     obj = new io.realm.AllTypesRealmProxy();
                 } finally {
                     objectContext.clear();
@@ -767,7 +767,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
             }
             if (rowIndex != Table.NO_MATCH) {
                 try {
-                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.schema.getColumnInfo(some.test.AllTypes.class), false, Collections.<String> emptyList());
+                    objectContext.set(realm, table.getUncheckedRow(rowIndex), realm.getSchema().getColumnInfo(some.test.AllTypes.class), false, Collections.<String> emptyList());
                     realmObject = new io.realm.AllTypesRealmProxy();
                     cache.put(object, (RealmObjectProxy) realmObject);
                 } finally {
@@ -840,7 +840,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         }
         Table table = realm.getTable(some.test.AllTypes.class);
         long tableNativePtr = table.getNativePtr();
-        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.schema.getColumnInfo(some.test.AllTypes.class);
+        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.AllTypes.class);
         long pkColumnIndex = table.getPrimaryKey();
         String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
         long rowIndex = Table.NO_MATCH;
@@ -895,7 +895,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     public static void insert(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.AllTypes.class);
         long tableNativePtr = table.getNativePtr();
-        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.schema.getColumnInfo(some.test.AllTypes.class);
+        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.AllTypes.class);
         long pkColumnIndex = table.getPrimaryKey();
         some.test.AllTypes object = null;
         while (objects.hasNext()) {
@@ -962,7 +962,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         }
         Table table = realm.getTable(some.test.AllTypes.class);
         long tableNativePtr = table.getNativePtr();
-        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.schema.getColumnInfo(some.test.AllTypes.class);
+        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.AllTypes.class);
         long pkColumnIndex = table.getPrimaryKey();
         String primaryKeyValue = ((AllTypesRealmProxyInterface) object).realmGet$columnString();
         long rowIndex = Table.NO_MATCH;
@@ -1022,7 +1022,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     public static void insertOrUpdate(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.AllTypes.class);
         long tableNativePtr = table.getNativePtr();
-        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.schema.getColumnInfo(some.test.AllTypes.class);
+        AllTypesColumnInfo columnInfo = (AllTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.AllTypes.class);
         long pkColumnIndex = table.getPrimaryKey();
         some.test.AllTypes object = null;
         while (objects.hasNext()) {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -381,7 +381,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         }
         Table table = realm.getTable(some.test.Booleans.class);
         long tableNativePtr = table.getNativePtr();
-        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.schema.getColumnInfo(some.test.Booleans.class);
+        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.getSchema().getColumnInfo(some.test.Booleans.class);
         long rowIndex = OsObject.createRow(table);
         cache.put(object, rowIndex);
         Table.nativeSetBoolean(tableNativePtr, columnInfo.doneIndex, rowIndex, ((BooleansRealmProxyInterface) object).realmGet$done(), false);
@@ -394,7 +394,7 @@ public class BooleansRealmProxy extends some.test.Booleans
     public static void insert(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.Booleans.class);
         long tableNativePtr = table.getNativePtr();
-        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.schema.getColumnInfo(some.test.Booleans.class);
+        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.getSchema().getColumnInfo(some.test.Booleans.class);
         some.test.Booleans object = null;
         while (objects.hasNext()) {
             object = (some.test.Booleans) objects.next();
@@ -420,7 +420,7 @@ public class BooleansRealmProxy extends some.test.Booleans
         }
         Table table = realm.getTable(some.test.Booleans.class);
         long tableNativePtr = table.getNativePtr();
-        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.schema.getColumnInfo(some.test.Booleans.class);
+        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.getSchema().getColumnInfo(some.test.Booleans.class);
         long rowIndex = OsObject.createRow(table);
         cache.put(object, rowIndex);
         Table.nativeSetBoolean(tableNativePtr, columnInfo.doneIndex, rowIndex, ((BooleansRealmProxyInterface) object).realmGet$done(), false);
@@ -433,7 +433,7 @@ public class BooleansRealmProxy extends some.test.Booleans
     public static void insertOrUpdate(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.Booleans.class);
         long tableNativePtr = table.getNativePtr();
-        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.schema.getColumnInfo(some.test.Booleans.class);
+        BooleansColumnInfo columnInfo = (BooleansColumnInfo) realm.getSchema().getColumnInfo(some.test.Booleans.class);
         some.test.Booleans object = null;
         while (objects.hasNext()) {
             object = (some.test.Booleans) objects.next();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1396,7 +1396,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         }
         Table table = realm.getTable(some.test.NullTypes.class);
         long tableNativePtr = table.getNativePtr();
-        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.schema.getColumnInfo(some.test.NullTypes.class);
+        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.NullTypes.class);
         long rowIndex = OsObject.createRow(table);
         cache.put(object, rowIndex);
         String realmGet$fieldStringNotNull = ((NullTypesRealmProxyInterface) object).realmGet$fieldStringNotNull();
@@ -1494,7 +1494,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     public static void insert(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.NullTypes.class);
         long tableNativePtr = table.getNativePtr();
-        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.schema.getColumnInfo(some.test.NullTypes.class);
+        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.NullTypes.class);
         some.test.NullTypes object = null;
         while (objects.hasNext()) {
             object = (some.test.NullTypes) objects.next();
@@ -1605,7 +1605,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         }
         Table table = realm.getTable(some.test.NullTypes.class);
         long tableNativePtr = table.getNativePtr();
-        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.schema.getColumnInfo(some.test.NullTypes.class);
+        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.NullTypes.class);
         long rowIndex = OsObject.createRow(table);
         cache.put(object, rowIndex);
         String realmGet$fieldStringNotNull = ((NullTypesRealmProxyInterface) object).realmGet$fieldStringNotNull();
@@ -1745,7 +1745,7 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     public static void insertOrUpdate(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.NullTypes.class);
         long tableNativePtr = table.getNativePtr();
-        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.schema.getColumnInfo(some.test.NullTypes.class);
+        NullTypesColumnInfo columnInfo = (NullTypesColumnInfo) realm.getSchema().getColumnInfo(some.test.NullTypes.class);
         some.test.NullTypes object = null;
         while (objects.hasNext()) {
             object = (some.test.NullTypes) objects.next();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -297,7 +297,7 @@ public class SimpleRealmProxy extends some.test.Simple
         }
         Table table = realm.getTable(some.test.Simple.class);
         long tableNativePtr = table.getNativePtr();
-        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.schema.getColumnInfo(some.test.Simple.class);
+        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.getSchema().getColumnInfo(some.test.Simple.class);
         long rowIndex = OsObject.createRow(table);
         cache.put(object, rowIndex);
         String realmGet$name = ((SimpleRealmProxyInterface) object).realmGet$name();
@@ -311,7 +311,7 @@ public class SimpleRealmProxy extends some.test.Simple
     public static void insert(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.Simple.class);
         long tableNativePtr = table.getNativePtr();
-        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.schema.getColumnInfo(some.test.Simple.class);
+        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.getSchema().getColumnInfo(some.test.Simple.class);
         some.test.Simple object = null;
         while (objects.hasNext()) {
             object = (some.test.Simple) objects.next();
@@ -338,7 +338,7 @@ public class SimpleRealmProxy extends some.test.Simple
         }
         Table table = realm.getTable(some.test.Simple.class);
         long tableNativePtr = table.getNativePtr();
-        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.schema.getColumnInfo(some.test.Simple.class);
+        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.getSchema().getColumnInfo(some.test.Simple.class);
         long rowIndex = OsObject.createRow(table);
         cache.put(object, rowIndex);
         String realmGet$name = ((SimpleRealmProxyInterface) object).realmGet$name();
@@ -354,7 +354,7 @@ public class SimpleRealmProxy extends some.test.Simple
     public static void insertOrUpdate(Realm realm, Iterator<? extends RealmModel> objects, Map<RealmModel,Long> cache) {
         Table table = realm.getTable(some.test.Simple.class);
         long tableNativePtr = table.getNativePtr();
-        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.schema.getColumnInfo(some.test.Simple.class);
+        SimpleColumnInfo columnInfo = (SimpleColumnInfo) realm.getSchema().getColumnInfo(some.test.Simple.class);
         some.test.Simple object = null;
         while (objects.hasNext()) {
             object = (some.test.Simple) objects.next();

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -332,22 +332,23 @@ public class RealmMigrationTests {
      * @param createBase create a schema named "MigrationPrimaryKey" instead of {@code className} if {@code true}
      */
     private void buildInitialMigrationSchema(final String className, final boolean createBase) {
-        Realm realm = Realm.getInstance(configFactory.createConfigurationBuilder().build());
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                // First, removes an existing schema.
-                realm.getSchema().remove(className);
-                // Then recreates the deleted schema or builds a base schema.
-                realm.getSchema()
-                        .create(createBase ? MigrationPrimaryKey.CLASS_NAME : className)
-                        .addField(MigrationPrimaryKey.FIELD_FIRST,   Byte.class)
-                        .addField(MigrationPrimaryKey.FIELD_SECOND,  Short.class)
-                        .addField(MigrationPrimaryKey.FIELD_PRIMARY, String.class, FieldAttribute.PRIMARY_KEY)
-                        .addField(MigrationPrimaryKey.FIELD_FOURTH,  Integer.class)
-                        .addField(MigrationPrimaryKey.FIELD_FIFTH,   Long.class);
-            }
-        });
+        RealmConfiguration config = configFactory.createConfigurationBuilder().build();
+        // Init the schema
+        Realm.getInstance(config).close();
+
+        DynamicRealm realm = DynamicRealm.getInstance(config);
+        realm.beginTransaction();
+        // First, removes an existing schema.
+        realm.getSchema().remove(className);
+        // Then recreates the deleted schema or builds a base schema.
+        realm.getSchema()
+                .create(createBase ? MigrationPrimaryKey.CLASS_NAME : className)
+                .addField(MigrationPrimaryKey.FIELD_FIRST,   Byte.class)
+                .addField(MigrationPrimaryKey.FIELD_SECOND,  Short.class)
+                .addField(MigrationPrimaryKey.FIELD_PRIMARY, String.class, FieldAttribute.PRIMARY_KEY)
+                .addField(MigrationPrimaryKey.FIELD_FOURTH,  Integer.class)
+                .addField(MigrationPrimaryKey.FIELD_FIFTH,   Long.class);
+        realm.commitTransaction();
         realm.close();
     }
 
@@ -477,14 +478,13 @@ public class RealmMigrationTests {
 
     @Test
     public void setClassName_throwOnLongClassName() {
+        RealmConfiguration config = configFactory.createConfigurationBuilder().build();
         // Creates the first version of schema.
-        Realm realm = Realm.getInstance(configFactory.createConfigurationBuilder().build());
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                realm.getSchema().create(MigrationPrimaryKey.CLASS_NAME);
-            }
-        });
+        Realm.getInstance(config).close();
+        DynamicRealm realm = DynamicRealm.getInstance(config);
+        realm.beginTransaction();
+        realm.getSchema().create(MigrationPrimaryKey.CLASS_NAME);
+        realm.commitTransaction();
         realm.close();
 
         // Gets ready for the 2nd version migration.
@@ -590,7 +590,7 @@ public class RealmMigrationTests {
         assertEquals(MigrationFieldRenamed.DEFAULT_FIELDS_COUNT, table.getColumnCount());
         assertEquals(MigrationFieldRenamed.DEFAULT_PRIMARY_INDEX, table.getPrimaryKey());
 
-        RealmObjectSchema objectSchema = realm.getSchema().getSchemaForClass(MigrationFieldRenamed.class);
+        RealmObjectSchema objectSchema = realm.getSchema().get(MigrationFieldRenamed.CLASS_NAME);
         assertFalse(objectSchema.hasField(MigrationPrimaryKey.FIELD_PRIMARY));
         assertEquals(MigrationFieldRenamed.FIELD_PRIMARY, objectSchema.getPrimaryKey());
     }
@@ -656,7 +656,7 @@ public class RealmMigrationTests {
         assertEquals(MigrationFieldTypeToInt.DEFAULT_FIELDS_COUNT, table.getColumnCount());
         assertEquals(MigrationFieldTypeToInt.DEFAULT_PRIMARY_INDEX, table.getPrimaryKey());
 
-        RealmObjectSchema objectSchema = realm.getSchema().getSchemaForClass(MigrationFieldTypeToInt.class);
+        RealmObjectSchema objectSchema = realm.getSchema().get(MigrationFieldTypeToInt.CLASS_NAME);
         assertFalse(objectSchema.hasField(MigrationPrimaryKey.FIELD_PRIMARY));
         assertEquals(MigrationFieldTypeToInt.FIELD_PRIMARY, objectSchema.getPrimaryKey());
         assertEquals(1, realm.where(MigrationFieldTypeToInt.class).count());
@@ -704,7 +704,7 @@ public class RealmMigrationTests {
         assertEquals(MigrationFieldTypeToInteger.DEFAULT_FIELDS_COUNT, table.getColumnCount());
         assertEquals(MigrationFieldTypeToInteger.DEFAULT_PRIMARY_INDEX, table.getPrimaryKey());
 
-        RealmObjectSchema objectSchema = realm.getSchema().getSchemaForClass(MigrationFieldTypeToInteger.class);
+        RealmObjectSchema objectSchema = realm.getSchema().get(MigrationFieldTypeToInteger.CLASS_NAME);
         assertFalse(objectSchema.hasField(MigrationPrimaryKey.FIELD_PRIMARY));
         assertEquals(MigrationFieldTypeToInteger.FIELD_PRIMARY, objectSchema.getPrimaryKey());
         assertEquals(2, realm.where(MigrationFieldTypeToInteger.class).count());
@@ -935,7 +935,7 @@ public class RealmMigrationTests {
                 public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
                     if (oldVersion == 0) { // 0 after initNullTypesTableExcludes
                         // No @Required for not nullable field
-                        RealmObjectSchema nullTypesSchema = realm.getSchema().getSchemaForClass(NullTypes.CLASS_NAME);
+                        RealmObjectSchema nullTypesSchema = realm.getSchema().get(NullTypes.CLASS_NAME);
                         if (field.equals(NullTypes.FIELD_STRING_NOT_NULL)) {
                             // 1 String
                             nullTypesSchema.addField(field, String.class);
@@ -1004,7 +1004,7 @@ public class RealmMigrationTests {
                 public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
                     if (oldVersion == 0) { // 0 after initNullTypesTableExcludes
                         // No @Required for not nullable field
-                        RealmObjectSchema nullTypesSchema = realm.getSchema().getSchemaForClass(NullTypes.CLASS_NAME);
+                        RealmObjectSchema nullTypesSchema = realm.getSchema().get(NullTypes.CLASS_NAME);
                         if (field.equals(NullTypes.FIELD_STRING_NULL)) {
                             // 1 String
                             nullTypesSchema.addField(field, String.class, FieldAttribute.REQUIRED);
@@ -1075,7 +1075,7 @@ public class RealmMigrationTests {
             RealmMigration migration = new RealmMigration() {
                 @Override
                 public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
-                    RealmObjectSchema schema = realm.getSchema().getSchemaForClass(clazz.getSimpleName());
+                    RealmObjectSchema schema = realm.getSchema().get(clazz.getSimpleName());
                     if (clazz == PrimaryKeyAsString.class) {
                         schema.setNullable("name", true);
                     } else {
@@ -1093,7 +1093,7 @@ public class RealmMigrationTests {
             configFactory.copyRealmFromAssets(context, "default-notnullable-primarykey.realm", Realm.DEFAULT_REALM_NAME);
             Realm.migrateRealm(realmConfig);
             realm = Realm.getInstance(realmConfig);
-            RealmObjectSchema schema = realm.getSchema().getSchemaForClass(clazz);
+            RealmObjectSchema schema = realm.getSchema().get(clazz.getSimpleName());
             assertEquals(SCHEMA_VERSION, realm.getVersion());
             assertTrue(didMigrate.get());
             if (clazz == PrimaryKeyAsString.class) {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -240,6 +240,12 @@ public class RealmObjectSchemaTests {
                 fail();
             } catch (UnsupportedOperationException ignore) {
             }
+
+            try {
+                schema.removeField("test");
+                fail();
+            } catch (UnsupportedOperationException ignore) {
+            }
             return;
         }
         for (FieldType fieldType : FieldType.values()) {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -16,8 +16,6 @@
 
 package io.realm;
 
-import android.support.test.runner.AndroidJUnit4;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -25,11 +23,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import io.realm.entities.AllJavaTypes;
+import io.realm.entities.Dog;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
@@ -38,8 +40,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 public class RealmObjectSchemaTests {
+
+    private enum ObjectSchemaType {
+        MUTABLE, IMMUTABLE
+    }
 
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
@@ -47,19 +53,43 @@ public class RealmObjectSchemaTests {
     public final ExpectedException thrown = ExpectedException.none();
 
     private RealmObjectSchema DOG_SCHEMA;
-    private DynamicRealm realm;
+    private BaseRealm realm;
     private RealmObjectSchema schema;
     private RealmSchema realmSchema;
+    private ObjectSchemaType type;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<ObjectSchemaType> data() {
+        return Arrays.asList(ObjectSchemaType.values());
+    }
+
+    public RealmObjectSchemaTests(ObjectSchemaType type) {
+        this.type = type;
+    }
 
     @Before
     public void setUp() {
         RealmConfiguration realmConfig = configFactory.createConfiguration();
         Realm.getInstance(realmConfig).close(); // Creates Schema.
+
         realm = DynamicRealm.getInstance(realmConfig);
-        realmSchema = realm.getSchema();
-        DOG_SCHEMA = realmSchema.get("Dog");
         realm.beginTransaction();
-        schema = realmSchema.create("NewClass");
+        realm.getSchema().create("NewClass");
+        realm.commitTransaction();
+        realm.close();
+
+        if (type == ObjectSchemaType.MUTABLE)  {
+            realm = DynamicRealm.getInstance(realmConfig);
+            realmSchema = realm.getSchema();
+            DOG_SCHEMA = realmSchema.get("Dog");
+            schema = realmSchema.get("NewClass");
+        } else {
+            realm = Realm.getInstance(realmConfig);
+            realmSchema = realm.getSchema();
+            DOG_SCHEMA = realmSchema.get("Dog");
+            schema = realmSchema.get("NewClass");
+        }
+        realm.beginTransaction();
     }
 
     @After
@@ -194,6 +224,24 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addRemoveField() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            try {
+                schema.addField("test", int.class);
+                fail();
+            } catch (UnsupportedOperationException ignore) {
+            }
+            try {
+                schema.addRealmObjectField("test", DOG_SCHEMA);
+                fail();
+            } catch (UnsupportedOperationException ignore) {
+            }
+            try {
+                schema.addRealmListField("test", DOG_SCHEMA);
+                fail();
+            } catch (UnsupportedOperationException ignore) {
+            }
+            return;
+        }
         for (FieldType fieldType : FieldType.values()) {
             String fieldName = "foo";
             switch (fieldType) {
@@ -222,6 +270,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addField_nameAlreadyExistsThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (SchemaFieldType schemaFieldType : SchemaFieldType.values()) {
             switch (schemaFieldType) {
                 case SIMPLE:
@@ -266,6 +317,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addField_illegalFieldNameThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String[] fieldNames = new String[] { null, "", "foo.bar", TestHelper.getRandomString(65) };
         for (SchemaFieldType schemaFieldType : SchemaFieldType.values()) {
             for (String fieldName : fieldNames) {
@@ -286,6 +340,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void requiredFieldAttribute() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (FieldType fieldType : FieldType.values()) {
             String fieldName = "foo";
             switch (fieldType) {
@@ -302,6 +359,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void indexedFieldAttribute() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (IndexFieldType fieldType : IndexFieldType.values()) {
             String fieldName = "foo";
             switch (fieldType) {
@@ -315,6 +375,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void invalidIndexedFieldAttributeThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (InvalidIndexFieldType fieldType : InvalidIndexFieldType.values()) {
             String fieldName = "foo";
             try {
@@ -327,6 +390,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void primaryKeyFieldAttribute() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
             String fieldName = "foo";
             schema.addField(fieldName, fieldType.getType(), FieldAttribute.PRIMARY_KEY);
@@ -350,6 +416,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void invalidPrimaryKeyFieldAttributeThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (InvalidPrimaryKeyFieldType fieldType : InvalidPrimaryKeyFieldType.values()) {
             String fieldName = "foo";
             try {
@@ -362,6 +431,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addPrimaryKeyFieldModifier_alreadyExistsThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
             String fieldName = "foo";
             schema.addField(fieldName, fieldType.getType());
@@ -378,6 +450,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addPrimaryKeyFieldModifier_illegalFieldTypeThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String fieldName = "foo";
         for (InvalidPrimaryKeyFieldType fieldType : InvalidPrimaryKeyFieldType.values()) {
             switch (fieldType) {
@@ -396,13 +471,16 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addPrimaryKeyFieldModifier_duplicateValues() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
             final String fieldName = "foo";
             schema.addField(fieldName, fieldType.getType());
 
             // Creates multiple objects with same values.
-            realm.createObject(schema.getClassName());
-            realm.createObject(schema.getClassName());
+            ((DynamicRealm)realm).createObject(schema.getClassName());
+            ((DynamicRealm)realm).createObject(schema.getClassName());
 
             try {
                 schema.addPrimaryKey(fieldName);
@@ -417,6 +495,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addIndexFieldModifier_illegalFieldTypeThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String fieldName = "foo";
         for (InvalidIndexFieldType fieldType : InvalidIndexFieldType.values()) {
             switch (fieldType) {
@@ -435,6 +516,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void addIndexFieldModifier_alreadyIndexedThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (IndexFieldType fieldType : IndexFieldType.values()) {
             String fieldName = "foo";
             schema.addField(fieldName, fieldType.getType());
@@ -450,6 +534,11 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void setRemoveNullable() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            thrown.expect(UnsupportedOperationException.class);
+            schema.setNullable("test", true);
+            return;
+        }
         for (FieldType fieldType : FieldType.values()) {
             String fieldName = "foo";
             switch (fieldType) {
@@ -486,6 +575,11 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void setRemoveRequired() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            thrown.expect(UnsupportedOperationException.class);
+            schema.setRequired("test", true);
+            return;
+        }
         for (FieldType fieldType : FieldType.values()) {
             String fieldName = "foo";
             switch (fieldType) {
@@ -524,6 +618,9 @@ public class RealmObjectSchemaTests {
     // according to the field type.
     @Test
     public void setRequired_nullValueBecomesDefaultValue() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (FieldType fieldType : FieldType.values()) {
             String fieldName = fieldType.name();
             switch (fieldType) {
@@ -537,7 +634,7 @@ public class RealmObjectSchemaTests {
                         break;
                     }
                     schema.addField(fieldName, fieldType.getType());
-                    DynamicRealmObject object = realm.createObject(schema.getClassName());
+                    DynamicRealmObject object = ((DynamicRealm)realm).createObject(schema.getClassName());
                     assertTrue(object.isNull(fieldName));
                     schema.setRequired(fieldName, true);
                     assertFalse(object.isNull(fieldName));
@@ -563,6 +660,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void setRequired_true_onPrimaryKeyField_containsNullValues_shouldThrow() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
             String className = fieldType.getType().getSimpleName() + "Class";
             String fieldName = "primaryKey";
@@ -571,7 +671,7 @@ public class RealmObjectSchemaTests {
                 continue;
             }
             schema.addField(fieldName, fieldType.getType(), FieldAttribute.PRIMARY_KEY);
-            DynamicRealmObject object = realm.createObject(schema.getClassName(), null);
+            DynamicRealmObject object = ((DynamicRealm)realm).createObject(schema.getClassName(), null);
             assertTrue(object.isNull(fieldName));
             try {
                 schema.setRequired(fieldName, true);
@@ -597,8 +697,8 @@ public class RealmObjectSchemaTests {
             } else {
                 schema.addField(fieldName, fieldType.getType(), FieldAttribute.PRIMARY_KEY, FieldAttribute.REQUIRED);
             }
-            realm.createObject(schema.getClassName(), "1");
-            realm.createObject(schema.getClassName(), "2");
+            ((DynamicRealm)realm).createObject(schema.getClassName(), "1");
+            ((DynamicRealm)realm).createObject(schema.getClassName(), "2");
             assertTrue(schema.hasPrimaryKey());
             assertTrue(schema.hasIndex(fieldName));
 
@@ -606,7 +706,7 @@ public class RealmObjectSchemaTests {
             assertTrue(schema.hasPrimaryKey());
             assertTrue(schema.hasIndex(fieldName));
 
-            RealmResults<DynamicRealmObject> results = realm.where(className).findAllSorted(fieldName);
+            RealmResults<DynamicRealmObject> results = ((DynamicRealm)realm).where(className).findAllSorted(fieldName);
             assertEquals(2, results.size());
             if (fieldType == PrimaryKeyFieldType.STRING) {
                 assertEquals("1", results.get(0).getString(fieldName));
@@ -621,11 +721,17 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void setRequired_true_onPrimaryKeyField() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         setRequired_onPrimaryKeyField(true);
     }
 
     @Test
     public void setRequired_false_onPrimaryKeyField() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         setRequired_onPrimaryKeyField(false);
     }
 
@@ -649,16 +755,36 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void setRequired_true_onIndexedField() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         setRequired_onIndexedField(true);
     }
 
     @Test
     public void setRequired_false_onIndexedField() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         setRequired_onIndexedField(false);
     }
 
     @Test
     public void setRemovePrimaryKey() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            try {
+                schema.addPrimaryKey("test");
+                fail();
+            } catch (UnsupportedOperationException ignore){
+
+            }
+            try {
+                schema.removePrimaryKey();
+                fail();
+            } catch (UnsupportedOperationException ignore){
+            }
+            return;
+        }
         for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
             String fieldName = "foo";
             schema.addField(fieldName, fieldType.getType());
@@ -676,6 +802,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void removeNonExistingPrimaryKeyThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String fieldName = "foo";
         schema.addField(fieldName, String.class);
 
@@ -685,6 +814,19 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void setRemoveIndex() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            try {
+                schema.addIndex("test");
+                fail();
+            } catch (UnsupportedOperationException ignore) {
+            }
+            try {
+                schema.removeIndex("test");
+                fail();
+            } catch (UnsupportedOperationException ignore) {
+            }
+            return;
+        }
         for (IndexFieldType fieldType : IndexFieldType.values()) {
             String fieldName = "foo";
             schema.addField(fieldName, fieldType.getType(), FieldAttribute.INDEXED);
@@ -697,6 +839,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void removeNonExistingIndexThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String fieldName = "foo";
         schema.addField(fieldName, String.class);
 
@@ -706,6 +851,11 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void removeField() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            thrown.expect(UnsupportedOperationException.class);
+            DOG_SCHEMA.removeField(Dog.FIELD_HEIGHT);
+            return;
+        }
         String fieldName = "foo";
         schema.addField(fieldName, String.class);
         assertTrue(schema.hasField(fieldName));
@@ -715,6 +865,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void removeField_withPrimaryKey() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String fieldName = "foo";
         schema.addField(fieldName, String.class, FieldAttribute.PRIMARY_KEY);
         assertTrue(schema.hasField(fieldName));
@@ -726,6 +879,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void removeField_nonExistingFieldThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String fieldName = "foo";
 
         thrown.expect(IllegalStateException.class);
@@ -734,6 +890,11 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void renameField() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            thrown.expect(UnsupportedOperationException.class);
+            schema.renameField("test", "test1");
+            return;
+        }
         String oldFieldName = "old";
         String newFieldName = "new";
         schema.addField(oldFieldName, String.class);
@@ -746,6 +907,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void renameField_nonExistingFieldThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String oldFieldName = "old";
         String newFieldName = "new";
 
@@ -755,6 +919,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void renameField_toIllegalNameThrows() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String oldFieldName = "old";
         String newFieldName = "";
         schema.addField(oldFieldName, String.class);
@@ -765,6 +932,9 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void renameField_withPrimaryKey() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String fieldName = "foo";
         schema.addField(fieldName, String.class, FieldAttribute.PRIMARY_KEY);
         assertTrue(schema.hasField(fieldName));
@@ -781,17 +951,31 @@ public class RealmObjectSchemaTests {
     public void setGetClassName() {
         assertEquals("Dog", DOG_SCHEMA.getClassName());
         String newClassName = "Darby";
-        DOG_SCHEMA.setClassName(newClassName);
-        assertEquals(newClassName, DOG_SCHEMA.getClassName());
-        assertTrue(realmSchema.contains(newClassName));
+        if (type == ObjectSchemaType.MUTABLE) {
+            DOG_SCHEMA.setClassName(newClassName);
+            assertEquals(newClassName, DOG_SCHEMA.getClassName());
+            assertTrue(realmSchema.contains(newClassName));
+        } else {
+            thrown.expect(UnsupportedOperationException.class);
+            DOG_SCHEMA.setClassName(newClassName);
+        }
     }
 
     @Test
     public void transform() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            thrown.expect(UnsupportedOperationException.class);
+            DOG_SCHEMA.transform(new RealmObjectSchema.Function() {
+                @Override
+                public void apply(DynamicRealmObject obj) {
+                }
+            });
+            return;
+        }
         String className = DOG_SCHEMA.getClassName();
-        DynamicRealmObject dog1 = realm.createObject(className);
+        DynamicRealmObject dog1 = ((DynamicRealm)realm).createObject(className);
         dog1.setInt("age", 1);
-        DynamicRealmObject dog2 = realm.createObject(className);
+        DynamicRealmObject dog2 = ((DynamicRealm)realm).createObject(className);
         dog2.setInt("age", 2);
 
         DOG_SCHEMA.transform(new RealmObjectSchema.Function() {
@@ -800,25 +984,28 @@ public class RealmObjectSchemaTests {
                 obj.setInt("age", obj.getInt("age") + 1);
             }
         });
-        assertEquals(5, realm.where("Dog").sum("age").intValue());
+        assertEquals(5, ((DynamicRealm)realm).where("Dog").sum("age").intValue());
     }
 
     @Test
     public void transformObjectReferences() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         String className = DOG_SCHEMA.getClassName();
-        DynamicRealmObject dog1 = realm.createObject(className);
+        DynamicRealmObject dog1 = ((DynamicRealm)realm).createObject(className);
         dog1.setInt("age", 1);
 
         DOG_SCHEMA.transform(new RealmObjectSchema.Function() {
             @Override
             public void apply(DynamicRealmObject dog) {
-                DynamicRealmObject owner = realm.createObject("Owner");
+                DynamicRealmObject owner = ((DynamicRealm)realm).createObject("Owner");
                 owner.setString("name", "John");
                 dog.setObject("owner", owner);
             }
         });
         //noinspection ConstantConditions
-        assertEquals("John", realm.where("Dog").findFirst().getObject("owner").getString("name"));
+        assertEquals("John", ((DynamicRealm)realm).where("Dog").findFirst().getObject("owner").getString("name"));
     }
 
     @Test
@@ -836,7 +1023,7 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void getFieldType() {
-        schema = realmSchema.getSchemaForClass("AllJavaTypes");
+        schema = realmSchema.get("AllJavaTypes");
         assertEquals(RealmFieldType.STRING, schema.getFieldType(AllJavaTypes.FIELD_STRING));
         assertEquals(RealmFieldType.BINARY, schema.getFieldType(AllJavaTypes.FIELD_BINARY));
         assertEquals(RealmFieldType.BOOLEAN, schema.getFieldType(AllJavaTypes.FIELD_BOOLEAN));

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -1314,7 +1314,7 @@ public class RealmObjectTests {
                 .migration(new RealmMigration() {
                     @Override
                     public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
-                        final Table table = realm.schema.getTable(StringAndInt.class);
+                        final Table table = realm.getSchema().getTable(StringAndInt.class);
                         final long strIndex = table.getColumnIndex("str");
                         final long numberIndex = table.getColumnIndex("number");
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
@@ -16,15 +16,15 @@
 
 package io.realm;
 
-import android.support.test.runner.AndroidJUnit4;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,19 +42,41 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 public class RealmSchemaTests {
+
+    private enum SchemaType {
+        MUTABLE(MutableRealmObjectSchema.class),
+        IMMUTABLE(ImmutableRealmObjectSchema.class);
+
+        final Class<? extends RealmObjectSchema> objectSchemaClass;
+
+        SchemaType(Class<? extends RealmObjectSchema> objectSchemaClass) {
+            this.objectSchemaClass = objectSchemaClass;
+        }
+    }
 
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    private DynamicRealm realm;
+    private BaseRealm realm;
     private RealmSchema realmSchema;
+    private SchemaType type;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<SchemaType> data() {
+        return Arrays.asList(SchemaType.values());
+    }
+
+    public RealmSchemaTests(SchemaType type) {
+        this.type = type;
+    }
 
     @Before
     public void setUp() {
@@ -63,7 +85,11 @@ public class RealmSchemaTests {
                         DogPrimaryKey.class)
                 .build();
         Realm.getInstance(realmConfig).close(); // create Schema
-        realm = DynamicRealm.getInstance(realmConfig);
+        if (type == SchemaType.MUTABLE) {
+            realm = DynamicRealm.getInstance(realmConfig);
+        } else {
+            realm = Realm.getInstance(realmConfig);
+        }
         realmSchema = this.realm.getSchema();
         realm.beginTransaction();
     }
@@ -82,6 +108,7 @@ public class RealmSchemaTests {
         List<String> expectedTables = Arrays.asList(
                 AllJavaTypes.CLASS_NAME, "Owner", "Cat", "Dog", "DogPrimaryKey", "PrimaryKeyAsString");
         for (RealmObjectSchema objectSchema : objectSchemas) {
+            assertThat(objectSchema, CoreMatchers.instanceOf(type.objectSchemaClass));
             if (!expectedTables.contains(objectSchema.getClassName())) {
                 fail(objectSchema.getClassName() + " was not found");
             }
@@ -90,12 +117,21 @@ public class RealmSchemaTests {
 
     @Test
     public void create() {
-        realmSchema.create("Foo");
-        assertTrue(realmSchema.contains("Foo"));
+        if (type == SchemaType.MUTABLE) {
+            realmSchema.create("Foo");
+            assertTrue(realmSchema.contains("Foo"));
+        } else {
+            thrown.expect(UnsupportedOperationException.class);
+            realmSchema.create("Foo");
+        }
     }
 
     @Test
     public void create_invalidNameThrows() {
+        if (type == SchemaType.IMMUTABLE) {
+            return;
+        }
+
         String[] names = { null, "", TestHelper.getRandomString(57) };
 
         for (String name : names) {
@@ -109,6 +145,10 @@ public class RealmSchemaTests {
 
     @Test
     public void create_duplicatedNameThrows() {
+        if (type == SchemaType.IMMUTABLE) {
+            return;
+        }
+
         realmSchema.create("Foo");
         thrown.expect(IllegalArgumentException.class);
         realmSchema.create("Foo");
@@ -119,6 +159,7 @@ public class RealmSchemaTests {
         RealmObjectSchema objectSchema = realmSchema.get(AllJavaTypes.CLASS_NAME);
         assertNotNull(objectSchema);
         assertEquals(AllJavaTypes.CLASS_NAME, objectSchema.getClassName());
+        assertThat(objectSchema, CoreMatchers.instanceOf(type.objectSchemaClass));
     }
 
     @Test
@@ -128,13 +169,22 @@ public class RealmSchemaTests {
 
     @Test
     public void rename() {
-        realmSchema.rename("Owner", "Owner2");
-        assertFalse(realmSchema.contains("Owner"));
-        assertTrue(realmSchema.contains("Owner2"));
+        if (type == SchemaType.MUTABLE) {
+            realmSchema.rename("Owner", "Owner2");
+            assertFalse(realmSchema.contains("Owner"));
+            assertTrue(realmSchema.contains("Owner2"));
+        } else {
+            thrown.expect(UnsupportedOperationException.class);
+            realmSchema.rename("Owner", "Owner2");
+        }
     }
 
     @Test
     public void rename_invalidArgumentThrows() {
+        if (type == SchemaType.IMMUTABLE) {
+            return;
+        }
+
         String[] illegalNames = new String[] { null, "" };
 
         // Tests as first parameter.
@@ -158,12 +208,16 @@ public class RealmSchemaTests {
 
     @Test
     public void rename_shouldChangeInfoInPKTable() {
+        if (type == SchemaType.IMMUTABLE) {
+            return;
+        }
+
         final String NEW_NAME = "NewPrimaryKeyAsString";
         assertTrue(realmSchema.contains(PrimaryKeyAsString.CLASS_NAME));
         realmSchema.rename(PrimaryKeyAsString.CLASS_NAME, NEW_NAME);
         assertFalse(realmSchema.contains(PrimaryKeyAsString.CLASS_NAME));
         assertTrue(realmSchema.contains(NEW_NAME));
-        RealmObjectSchema objectSchema = realmSchema.getSchemaForClass(NEW_NAME);
+        RealmObjectSchema objectSchema = realmSchema.get(NEW_NAME);
 
         assertEquals(PrimaryKeyAsString.FIELD_PRIMARY_KEY, objectSchema.getPrimaryKey());
 
@@ -184,12 +238,21 @@ public class RealmSchemaTests {
 
     @Test
     public void remove() {
-        realmSchema.remove(AllJavaTypes.CLASS_NAME);
-        assertFalse(realmSchema.contains(AllJavaTypes.CLASS_NAME));
+        if (type == SchemaType.MUTABLE) {
+            realmSchema.remove(AllJavaTypes.CLASS_NAME);
+            assertFalse(realmSchema.contains(AllJavaTypes.CLASS_NAME));
+        } else {
+            thrown.expect(UnsupportedOperationException.class);
+            realmSchema.remove(AllJavaTypes.CLASS_NAME);
+        }
     }
 
     @Test
     public void remove_invalidArgumentThrows() {
+        if (type == SchemaType.IMMUTABLE) {
+            return;
+        }
+
         try {
             realmSchema.remove("Foo");
             fail();
@@ -207,6 +270,10 @@ public class RealmSchemaTests {
     // class. This also include transitive dependencies.
     @Test
     public void remove_classWithReferencesThrows() {
+        if (type == SchemaType.IMMUTABLE) {
+            return;
+        }
+
         try {
             realmSchema.remove("Cat");
             fail();
@@ -223,6 +290,10 @@ public class RealmSchemaTests {
 
     @Test
     public void remove_shouldRemoveInfoFromPKTable() {
+        if (type == SchemaType.IMMUTABLE) {
+            return;
+        }
+
         assertTrue(realmSchema.contains(PrimaryKeyAsString.CLASS_NAME));
         realmSchema.remove(PrimaryKeyAsString.CLASS_NAME);
         assertFalse(realmSchema.contains(PrimaryKeyAsString.CLASS_NAME));

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
@@ -238,12 +238,12 @@ public class RealmSchemaTests {
 
     @Test
     public void remove() {
-        if (type == SchemaType.MUTABLE) {
-            realmSchema.remove(AllJavaTypes.CLASS_NAME);
-            assertFalse(realmSchema.contains(AllJavaTypes.CLASS_NAME));
-        } else {
+        if (type == SchemaType.IMMUTABLE) {
             thrown.expect(UnsupportedOperationException.class);
             realmSchema.remove(AllJavaTypes.CLASS_NAME);
+        } else {
+            realmSchema.remove(AllJavaTypes.CLASS_NAME);
+            assertFalse(realmSchema.contains(AllJavaTypes.CLASS_NAME));
         }
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -3885,7 +3885,7 @@ public class RealmTests {
 
         // get the pre-update index for the "name" column.
         CatRealmProxy.CatColumnInfo catColumnInfo
-                = (CatRealmProxy.CatColumnInfo) realm.schema.getColumnInfo(Cat.class);
+                = (CatRealmProxy.CatColumnInfo) realm.getSchema().getColumnInfo(Cat.class);
         final long nameIndex = catColumnInfo.nameIndex;
 
         // Change the index of the column "name".
@@ -3908,7 +3908,7 @@ public class RealmTests {
         assertNotEquals(nameIndex, nameIndexNew);
 
         // Verify that the index in the ColumnInfo has been updated.
-        catColumnInfo = (CatRealmProxy.CatColumnInfo) realm.schema.getColumnInfo(Cat.class);
+        catColumnInfo = (CatRealmProxy.CatColumnInfo) realm.getSchema().getColumnInfo(Cat.class);
         assertEquals(nameIndexNew.get(), catColumnInfo.nameIndex);
         assertEquals(nameIndexNew.get(), (long) catColumnInfo.getColumnIndex(Cat.FIELD_NAME));
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SchemaTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SchemaTests.java
@@ -49,7 +49,6 @@ public class SchemaTests {
 
     @After
     public void tearDown() throws Exception {
-        Realm.deleteRealm(config);
     }
 
     @Test
@@ -74,7 +73,10 @@ public class SchemaTests {
 
     @Test
     public void disallow_removeClass() {
-        Realm realm = Realm.getInstance(config);
+        // Init schema
+        Realm.getInstance(config).close();
+
+        DynamicRealm realm = DynamicRealm.getInstance(config);
         String className = "StringOnly";
         realm.beginTransaction();
         assertTrue(realm.getSchema().contains(className));
@@ -90,7 +92,7 @@ public class SchemaTests {
 
     @Test
     public void allow_createClass() {
-        Realm realm = Realm.getInstance(config);
+        DynamicRealm realm = DynamicRealm.getInstance(config);
         String className = "Dogplace";
         realm.beginTransaction();
         realm.getSchema().create("Dogplace");
@@ -101,7 +103,10 @@ public class SchemaTests {
 
     @Test
     public void disallow_renameClass() {
-        Realm realm = Realm.getInstance(config);
+        // Init schema
+        Realm.getInstance(config).close();
+
+        DynamicRealm realm = DynamicRealm.getInstance(config);
         String className = "StringOnly";
         realm.beginTransaction();
         try {
@@ -117,7 +122,10 @@ public class SchemaTests {
 
     @Test
     public void disallow_removeField() {
-        Realm realm = Realm.getInstance(config);
+        // Init schema
+        Realm.getInstance(config).close();
+
+        DynamicRealm realm = DynamicRealm.getInstance(config);
         String className = "StringOnly";
         String fieldName = "chars";
         realm.beginTransaction();
@@ -134,9 +142,11 @@ public class SchemaTests {
 
     @Test
     public void allow_addField() {
+        // Init schema
+        Realm.getInstance(config).close();
         String className = "StringOnly";
-        Realm realm = Realm.getInstance(config);
 
+        DynamicRealm realm = DynamicRealm.getInstance(config);
         realm.beginTransaction();
         realm.getSchema().get(className).addField("foo", String.class);
         realm.commitTransaction();

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
@@ -279,17 +279,18 @@ public class SyncedRealmMigrationTests {
                 .build();
 
         // Initialize schema
-        Realm realm = Realm.getInstance(config);
-        realm.beginTransaction();
-        RealmObjectSchema objectSchema = realm.getSchema().getSchemaForClass(StringOnly.class);
+        Realm.getInstance(config).close();
+        DynamicRealm dynamicRealm = DynamicRealm.getInstance(config);
+        dynamicRealm.beginTransaction();
+        RealmObjectSchema objectSchema = dynamicRealm.getSchema().get(StringOnly.CLASS_NAME);
         // Add one extra field which doesn't exist in the typed Realm.
         objectSchema.addField("oneMoreField", int.class);
-        realm.commitTransaction();
+        dynamicRealm.commitTransaction();
         // Clear column indices cache.
-        realm.close();
+        dynamicRealm.close();
 
         // Verify schema again.
-        realm = Realm.getInstance(config);
+        Realm realm = Realm.getInstance(config);
         realm.close();
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -49,12 +49,16 @@ import rx.Observable;
  */
 public class DynamicRealm extends BaseRealm {
 
+    private final RealmSchema schema;
+
     private DynamicRealm(RealmCache cache) {
         super(cache);
+        this.schema = new MutableRealmSchema(this);
     }
 
     private DynamicRealm(RealmConfiguration configuration) {
         super(configuration);
+        this.schema = new MutableRealmSchema(this);
     }
 
     /**
@@ -253,6 +257,16 @@ public class DynamicRealm extends BaseRealm {
     @Override
     public Observable<DynamicRealm> asObservable() {
         return configuration.getRxFactory().from(this);
+    }
+
+    /**
+     * Returns the mutable schema for this Realm.
+     *
+     * @return The {@link RealmSchema} for this Realm.
+     */
+    @Override
+    public RealmSchema getSchema() {
+        return schema;
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/ImmutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/ImmutableRealmObjectSchema.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import io.realm.internal.ColumnInfo;
+import io.realm.internal.Table;
+
+/**
+ * Immutable {@link RealmObjectSchema}.
+ */
+class ImmutableRealmObjectSchema extends RealmObjectSchema {
+
+    private static final String SCHEMA_IMMUTABLE_EXCEPTION_MSG = "This 'RealmObjectSchema' is immutable." +
+            " Please use 'DynamicRealm.getSchema() to get a mutable instance.";
+
+    ImmutableRealmObjectSchema(BaseRealm realm, RealmSchema schema, Table table, ColumnInfo columnInfo) {
+        super(realm, schema, table, columnInfo);
+    }
+
+    ImmutableRealmObjectSchema(BaseRealm realm, RealmSchema schema, Table table) {
+        super(realm, schema, table, new DynamicColumnIndices(table));
+    }
+
+    @Override
+    public RealmObjectSchema setClassName(String className) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema addField(String fieldName, Class<?> fieldType, FieldAttribute... attributes) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema addRealmObjectField(String fieldName, RealmObjectSchema objectSchema) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema addRealmListField(String fieldName, RealmObjectSchema objectSchema) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema removeField(String fieldName) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema renameField(String currentFieldName, String newFieldName) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema addIndex(String fieldName) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema removeIndex(String fieldName) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema addPrimaryKey(String fieldName) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema removePrimaryKey() {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema setRequired(String fieldName, boolean required) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema setNullable(String fieldName, boolean nullable) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema transform(Function function) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/ImmutableRealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/ImmutableRealmSchema.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import io.realm.internal.Table;
+
+/**
+ * Immutable {@link RealmSchema}.
+ */
+class ImmutableRealmSchema extends RealmSchema {
+
+    private static final String SCHEMA_IMMUTABLE_EXCEPTION_MSG = "This 'RealmSchema' is immutable." +
+            " Please use 'DynamicRealm.getSchema() to get a mutable instance.";
+
+    ImmutableRealmSchema(BaseRealm realm) {
+        super(realm);
+    }
+
+    @Override
+    public RealmObjectSchema get(String className) {
+        checkEmpty(className, EMPTY_STRING_MSG);
+
+        String internalClassName = Table.getTableNameForClass(className);
+        if (!realm.getSharedRealm().hasTable(internalClassName)) { return null; }
+        Table table = realm.getSharedRealm().getTable(internalClassName);
+        return new ImmutableRealmObjectSchema(realm, this, table, getColumnInfo(className));
+    }
+
+    @Override
+    public RealmObjectSchema create(String className) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public void remove(String className) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
+    @Override
+    public RealmObjectSchema rename(String oldClassName, String newClassName) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import java.util.Locale;
+
+import io.realm.internal.Table;
+
+/**
+ * Mutable {@link RealmObjectSchema}.
+ */
+class MutableRealmObjectSchema extends RealmObjectSchema {
+
+    /**
+     * Creates a mutable schema object for a given Realm class.
+     *
+     * @param realm Realm holding the objects.
+     * @param table table representation of the Realm class
+     */
+    MutableRealmObjectSchema(BaseRealm realm, RealmSchema schema, Table table) {
+        super(realm, schema, table, new DynamicColumnIndices(table));
+    }
+
+    @Override
+    public RealmObjectSchema setClassName(String className) {
+        realm.checkNotInSync(); // renaming a table is not permitted
+        checkEmpty(className);
+        String internalTableName = Table.getTableNameForClass(className);
+        if (internalTableName.length() > Table.TABLE_MAX_LENGTH) {
+            throw new IllegalArgumentException("Class name is too long. Limit is 56 characters: \'" + className + "\' (" + Integer.toString(className.length()) + ")");
+        }
+        if (realm.sharedRealm.hasTable(internalTableName)) {
+            throw new IllegalArgumentException("Class already exists: " + className);
+        }
+        // in case this table has a primary key, we need to transfer it after renaming the table.
+        String oldTableName = null;
+        String pkField = null;
+        if (table.hasPrimaryKey()) {
+            oldTableName = table.getName();
+            pkField = getPrimaryKey();
+            table.setPrimaryKey(null);
+        }
+        realm.sharedRealm.renameTable(table.getName(), internalTableName);
+        if (pkField != null && !pkField.isEmpty()) {
+            try {
+                table.setPrimaryKey(pkField);
+            } catch (Exception e) {
+                // revert the table name back when something goes wrong
+                realm.sharedRealm.renameTable(table.getName(), oldTableName);
+                throw e;
+            }
+        }
+        return this;
+    }
+
+    private void checkEmpty(String str) {
+        if (str == null || str.isEmpty()) {
+            throw new IllegalArgumentException("Null or empty class names are not allowed");
+        }
+    }
+
+    @Override
+    public RealmObjectSchema addField(String fieldName, Class<?> fieldType, FieldAttribute... attributes) {
+        FieldMetaData metadata = SUPPORTED_SIMPLE_FIELDS.get(fieldType);
+        if (metadata == null) {
+            if (SUPPORTED_LINKED_FIELDS.containsKey(fieldType)) {
+                throw new IllegalArgumentException("Use addRealmObjectField() instead to add fields that link to other RealmObjects: " + fieldName);
+            } else {
+                throw new IllegalArgumentException(String.format(Locale.US,
+                        "Realm doesn't support this field type: %s(%s)",
+                        fieldName, fieldType));
+            }
+        }
+
+        checkNewFieldName(fieldName);
+        boolean nullable = metadata.defaultNullable;
+        if (containsAttribute(attributes, FieldAttribute.REQUIRED)) {
+            nullable = false;
+        }
+
+        long columnIndex = table.addColumn(metadata.realmType, fieldName, nullable);
+        try {
+            addModifiers(fieldName, attributes);
+        } catch (Exception e) {
+            // Modifiers have been removed by the addModifiers method()
+            table.removeColumn(columnIndex);
+            throw e;
+        }
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema addRealmObjectField(String fieldName, RealmObjectSchema objectSchema) {
+        checkLegalName(fieldName);
+        checkFieldNameIsAvailable(fieldName);
+        table.addColumnLink(RealmFieldType.OBJECT, fieldName, realm.sharedRealm.getTable(Table.getTableNameForClass(objectSchema.getClassName())));
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema addRealmListField(String fieldName, RealmObjectSchema objectSchema) {
+        checkLegalName(fieldName);
+        checkFieldNameIsAvailable(fieldName);
+        table.addColumnLink(RealmFieldType.LIST, fieldName, realm.sharedRealm.getTable(Table.getTableNameForClass(objectSchema.getClassName())));
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema removeField(String fieldName) {
+        realm.checkNotInSync(); // destructive modification of a schema is not permitted
+        checkLegalName(fieldName);
+        if (!hasField(fieldName)) {
+            throw new IllegalStateException(fieldName + " does not exist.");
+        }
+        long columnIndex = getColumnIndex(fieldName);
+        if (table.getPrimaryKey() == columnIndex) {
+            table.setPrimaryKey(null);
+        }
+        table.removeColumn(columnIndex);
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema renameField(String currentFieldName, String newFieldName) {
+        realm.checkNotInSync(); // destructive modification of a schema is not permitted
+        checkLegalName(currentFieldName);
+        checkFieldExists(currentFieldName);
+        checkLegalName(newFieldName);
+        checkFieldNameIsAvailable(newFieldName);
+        long columnIndex = getColumnIndex(currentFieldName);
+        table.renameColumn(columnIndex, newFieldName);
+
+        // ATTENTION: We don't need to re-set the PK table here since the column index won't be changed when renaming.
+
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema addIndex(String fieldName) {
+        checkLegalName(fieldName);
+        checkFieldExists(fieldName);
+        long columnIndex = getColumnIndex(fieldName);
+        if (table.hasSearchIndex(columnIndex)) {
+            throw new IllegalStateException(fieldName + " already has an index.");
+        }
+        table.addSearchIndex(columnIndex);
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema removeIndex(String fieldName) {
+        realm.checkNotInSync(); // Destructive modifications are not permitted.
+        checkLegalName(fieldName);
+        checkFieldExists(fieldName);
+        long columnIndex = getColumnIndex(fieldName);
+        if (!table.hasSearchIndex(columnIndex)) {
+            throw new IllegalStateException("Field is not indexed: " + fieldName);
+        }
+        table.removeSearchIndex(columnIndex);
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema addPrimaryKey(String fieldName) {
+        checkLegalName(fieldName);
+        checkFieldExists(fieldName);
+        if (table.hasPrimaryKey()) {
+            throw new IllegalStateException("A primary key is already defined");
+        }
+        table.setPrimaryKey(fieldName);
+        long columnIndex = getColumnIndex(fieldName);
+        if (!table.hasSearchIndex(columnIndex)) {
+            // No exception will be thrown since adding PrimaryKey implies the column has an index.
+            table.addSearchIndex(columnIndex);
+        }
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema removePrimaryKey() {
+        realm.checkNotInSync(); // Destructive modifications are not permitted.
+        if (!table.hasPrimaryKey()) {
+            throw new IllegalStateException(getClassName() + " doesn't have a primary key.");
+        }
+        long columnIndex = table.getPrimaryKey();
+        if (table.hasSearchIndex(columnIndex)) {
+            table.removeSearchIndex(columnIndex);
+        }
+        table.setPrimaryKey("");
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema setRequired(String fieldName, boolean required) {
+        long columnIndex = table.getColumnIndex(fieldName);
+        boolean currentColumnRequired = isRequired(fieldName);
+        RealmFieldType type = table.getColumnType(columnIndex);
+
+        if (type == RealmFieldType.OBJECT) {
+            throw new IllegalArgumentException("Cannot modify the required state for RealmObject references: " + fieldName);
+        }
+        if (type == RealmFieldType.LIST) {
+            throw new IllegalArgumentException("Cannot modify the required state for RealmList references: " + fieldName);
+        }
+        if (required && currentColumnRequired) {
+            throw new IllegalStateException("Field is already required: " + fieldName);
+        }
+        if (!required && !currentColumnRequired) {
+            throw new IllegalStateException("Field is already nullable: " + fieldName);
+        }
+
+        if (required) {
+            table.convertColumnToNotNullable(columnIndex);
+        } else {
+            table.convertColumnToNullable(columnIndex);
+        }
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema setNullable(String fieldName, boolean nullable) {
+        setRequired(fieldName, !nullable);
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema transform(Function function) {
+        if (function != null) {
+            long size = table.size();
+            for (long i = 0; i < size; i++) {
+                function.apply(new DynamicRealmObject(realm, table.getCheckedRow(i)));
+            }
+        }
+
+        return this;
+    }
+
+    // Invariant: Field was just added. This method is responsible for cleaning up attributes if it fails.
+    private void addModifiers(String fieldName, FieldAttribute[] attributes) {
+        boolean indexAdded = false;
+        try {
+            if (attributes != null && attributes.length > 0) {
+                if (containsAttribute(attributes, FieldAttribute.INDEXED)) {
+                    addIndex(fieldName);
+                    indexAdded = true;
+                }
+
+                if (containsAttribute(attributes, FieldAttribute.PRIMARY_KEY)) {
+                    // Note : adding primary key implies application of FieldAttribute.INDEXED attribute.
+                    addPrimaryKey(fieldName);
+                    indexAdded = true;
+                }
+
+                // REQUIRED is being handled when adding the column using addField through the nullable parameter.
+            }
+        } catch (Exception e) {
+            // If something went wrong, revert all attributes.
+            long columnIndex = getColumnIndex(fieldName);
+            if (indexAdded) {
+                table.removeSearchIndex(columnIndex);
+            }
+            throw (RuntimeException) e;
+        }
+    }
+
+    private boolean containsAttribute(FieldAttribute[] attributeList, FieldAttribute attribute) {
+        if (attributeList == null || attributeList.length == 0) {
+            return false;
+        }
+        for (FieldAttribute anAttributeList : attributeList) {
+            if (anAttributeList == attribute) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void checkNewFieldName(String fieldName) {
+        checkLegalName(fieldName);
+        checkFieldNameIsAvailable(fieldName);
+    }
+
+    private void checkFieldNameIsAvailable(String fieldName) {
+        if (table.getColumnIndex(fieldName) != Table.NO_MATCH) {
+            throw new IllegalArgumentException("Field already exists in '" + getClassName() + "': " + fieldName);
+        }
+    }
+
+}

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm;
+
+import io.realm.internal.Table;
+
+/**
+ * Mutable {@link RealmSchema}.
+ */
+class MutableRealmSchema extends RealmSchema {
+
+    MutableRealmSchema(BaseRealm realm) {
+        super(realm);
+    }
+
+    @Override
+    public RealmObjectSchema get(String className) {
+        checkEmpty(className, EMPTY_STRING_MSG);
+
+        String internalClassName = Table.getTableNameForClass(className);
+        if (!realm.getSharedRealm().hasTable(internalClassName)) { return null; }
+        Table table = realm.getSharedRealm().getTable(internalClassName);
+        return new MutableRealmObjectSchema(realm, this, table);
+    }
+
+    @Override
+    public RealmObjectSchema create(String className) {
+        // Adding a class is always permitted.
+        checkEmpty(className, EMPTY_STRING_MSG);
+
+        String internalTableName = Table.getTableNameForClass(className);
+        if (internalTableName.length() > Table.TABLE_MAX_LENGTH) {
+            throw new IllegalArgumentException("Class name is too long. Limit is 56 characters: " + className.length());
+        }
+        return new MutableRealmObjectSchema(realm, this, realm.getSharedRealm().createTable(internalTableName));
+    }
+
+    @Override
+    public void remove(String className) {
+        realm.checkNotInSync(); // Destructive modifications are not permitted.
+        checkEmpty(className, EMPTY_STRING_MSG);
+        String internalTableName = Table.getTableNameForClass(className);
+        checkHasTable(className, "Cannot remove class because it is not in this Realm: " + className);
+        Table table = getTable(className);
+        if (table.hasPrimaryKey()) {
+            table.setPrimaryKey(null);
+        }
+        realm.getSharedRealm().removeTable(internalTableName);
+    }
+
+    @Override
+    public RealmObjectSchema rename(String oldClassName, String newClassName) {
+        realm.checkNotInSync(); // Destructive modifications are not permitted.
+        checkEmpty(oldClassName, "Class names cannot be empty or null");
+        checkEmpty(newClassName, "Class names cannot be empty or null");
+        String oldInternalName = Table.getTableNameForClass(oldClassName);
+        String newInternalName = Table.getTableNameForClass(newClassName);
+        checkHasTable(oldClassName, "Cannot rename class because it doesn't exist in this Realm: " + oldClassName);
+        if (realm.getSharedRealm().hasTable(newInternalName)) {
+            throw new IllegalArgumentException(oldClassName + " cannot be renamed because the new class already exists: " + newClassName);
+        }
+
+        // Checks if there is a primary key defined for the old class.
+        Table oldTable = getTable(oldClassName);
+        String pkField = null;
+        if (oldTable.hasPrimaryKey()) {
+            pkField = oldTable.getColumnName(oldTable.getPrimaryKey());
+            oldTable.setPrimaryKey(null);
+        }
+
+        realm.getSharedRealm().renameTable(oldInternalName, newInternalName);
+        Table table = realm.getSharedRealm().getTable(newInternalName);
+
+        // Sets the primary key for the new class if necessary.
+        if (pkField != null) {
+            table.setPrimaryKey(pkField);
+        }
+
+        return new MutableRealmObjectSchema(realm, this, table);
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -138,6 +138,7 @@ public class Realm extends BaseRealm {
     private static final Object defaultConfigurationLock = new Object();
     // guarded by `defaultConfigurationLock`
     private static RealmConfiguration defaultConfiguration;
+    private final RealmSchema schema;
 
     /**
      * The constructor is private to enforce the use of the static one.
@@ -147,6 +148,7 @@ public class Realm extends BaseRealm {
      */
     private Realm(RealmCache cache) {
         super(cache);
+        schema = new ImmutableRealmSchema(this);
     }
 
     /**
@@ -155,6 +157,16 @@ public class Realm extends BaseRealm {
     @Override
     public Observable<Realm> asObservable() {
         return configuration.getRxFactory().from(this);
+    }
+
+    /**
+     * Returns the immutable schema for this Realm.
+     *
+     * @return The {@link RealmSchema} for this Realm.
+     */
+    @Override
+    public RealmSchema getSchema() {
+        return schema;
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -160,7 +160,10 @@ public class Realm extends BaseRealm {
     }
 
     /**
-     * Returns the immutable schema for this Realm.
+     * Returns the schema for this Realm. The schema is immutable.
+     * Any attempt to modify it will result in an {@link UnsupportedOperationException}.
+     * <p>
+     * The schema can only be modified using {@link DynamicRealm#getSchema()} or through an migration.
      *
      * @return The {@link RealmSchema} for this Realm.
      */

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -356,7 +356,7 @@ final class RealmCache {
 
             if (realmClass == Realm.class && refAndCount.globalCount == 0) {
                 // Stores a copy of local ColumnIndices as a global cache.
-                RealmCache.storeColumnIndices(typedColumnIndicesArray, realm.schema.getImmutableColumnIndicies());
+                RealmCache.storeColumnIndices(typedColumnIndicesArray, realm.getSchema().getImmutableColumnIndicies());
             }
             // This is the first instance in current thread, increase the global count.
             refAndCount.globalCount++;

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -1,4 +1,3 @@
-package io.realm;
 /*
  * Copyright 2017 Realm Inc.
  *
@@ -15,6 +14,7 @@ package io.realm;
  * limitations under the License.
  */
 
+package io.realm;
 
 import java.util.Collections;
 import java.util.Date;
@@ -31,14 +31,17 @@ import io.realm.internal.fields.FieldDescriptor;
 
 
 /**
- * Class for interacting with the schema for a given RealmObject class. This makes it possible to
+ * Class for interacting with the schema for a given RealmObject class. This makes it possible to inspect,
  * add, delete or change the fields for given class.
+ * <p>
+ * If this {@link RealmObjectSchema} is retrieved from an immutable {@link RealmSchema}, this {@link RealmObjectSchema}
+ * will be immutable as well.
  *
  * @see io.realm.RealmMigration
  */
-public class RealmObjectSchema {
+public abstract class RealmObjectSchema {
 
-    private static final Map<Class<?>, FieldMetaData> SUPPORTED_SIMPLE_FIELDS;
+    static final Map<Class<?>, FieldMetaData> SUPPORTED_SIMPLE_FIELDS;
 
     static {
         Map<Class<?>, FieldMetaData> m = new HashMap<>();
@@ -62,7 +65,7 @@ public class RealmObjectSchema {
         SUPPORTED_SIMPLE_FIELDS = Collections.unmodifiableMap(m);
     }
 
-    private static final Map<Class<?>, FieldMetaData> SUPPORTED_LINKED_FIELDS;
+    static final Map<Class<?>, FieldMetaData> SUPPORTED_LINKED_FIELDS;
 
     static {
         Map<Class<?>, FieldMetaData> m = new HashMap<>();
@@ -71,20 +74,10 @@ public class RealmObjectSchema {
         SUPPORTED_LINKED_FIELDS = Collections.unmodifiableMap(m);
     }
 
-    private final RealmSchema schema;
-    private final BaseRealm realm;
+    final RealmSchema schema;
+    final BaseRealm realm;
+    final Table table;
     private final ColumnInfo columnInfo;
-    private final Table table;
-
-    /**
-     * Creates a dynamic schema object for a given Realm class.
-     *
-     * @param realm Realm holding the objects.
-     * @param table table representation of the Realm class
-     */
-    RealmObjectSchema(BaseRealm realm, RealmSchema schema, Table table) {
-        this(realm, schema, table, new DynamicColumnIndices(table));
-    }
 
     /**
      * Creates a schema object for a given Realm class.
@@ -127,38 +120,10 @@ public class RealmObjectSchema {
      * @param className the new name for this class.
      * @throws IllegalArgumentException if className is {@code null} or an empty string, or its length exceeds 56
      * characters.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      * @see RealmSchema#rename(String, String)
      */
-    public RealmObjectSchema setClassName(String className) {
-        realm.checkNotInSync(); // renaming a table is not permitted
-        checkEmpty(className);
-        String internalTableName = Table.getTableNameForClass(className);
-        if (internalTableName.length() > Table.TABLE_MAX_LENGTH) {
-            throw new IllegalArgumentException("Class name is too long. Limit is 56 characters: \'" + className + "\' (" + Integer.toString(className.length()) + ")");
-        }
-        if (realm.sharedRealm.hasTable(internalTableName)) {
-            throw new IllegalArgumentException("Class already exists: " + className);
-        }
-        // in case this table has a primary key, we need to transfer it after renaming the table.
-        String oldTableName = null;
-        String pkField = null;
-        if (table.hasPrimaryKey()) {
-            oldTableName = table.getName();
-            pkField = getPrimaryKey();
-            table.setPrimaryKey(null);
-        }
-        realm.sharedRealm.renameTable(table.getName(), internalTableName);
-        if (pkField != null && !pkField.isEmpty()) {
-            try {
-                table.setPrimaryKey(pkField);
-            } catch (Exception e) {
-                // revert the table name back when something goes wrong
-                realm.sharedRealm.renameTable(table.getName(), oldTableName);
-                throw e;
-            }
-        }
-        return this;
-    }
+    public abstract RealmObjectSchema setClassName(String className);
 
     /**
      * Adds a new simple field to the RealmObject class. The type must be one supported by Realm. See
@@ -174,36 +139,10 @@ public class RealmObjectSchema {
      * @param attributes set of attributes for this field.
      * @return the updated schema.
      * @throws IllegalArgumentException if the type isn't supported, field name is illegal or a field with that name
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      * already exists.
      */
-    public RealmObjectSchema addField(String fieldName, Class<?> fieldType, FieldAttribute... attributes) {
-        FieldMetaData metadata = SUPPORTED_SIMPLE_FIELDS.get(fieldType);
-        if (metadata == null) {
-            if (SUPPORTED_LINKED_FIELDS.containsKey(fieldType)) {
-                throw new IllegalArgumentException("Use addRealmObjectField() instead to add fields that link to other RealmObjects: " + fieldName);
-            } else {
-                throw new IllegalArgumentException(String.format(Locale.US,
-                        "Realm doesn't support this field type: %s(%s)",
-                        fieldName, fieldType));
-            }
-        }
-
-        checkNewFieldName(fieldName);
-        boolean nullable = metadata.defaultNullable;
-        if (containsAttribute(attributes, FieldAttribute.REQUIRED)) {
-            nullable = false;
-        }
-
-        long columnIndex = table.addColumn(metadata.realmType, fieldName, nullable);
-        try {
-            addModifiers(fieldName, attributes);
-        } catch (Exception e) {
-            // Modifiers have been removed by the addModifiers method()
-            table.removeColumn(columnIndex);
-            throw e;
-        }
-        return this;
-    }
+    public abstract RealmObjectSchema addField(String fieldName, Class<?> fieldType, FieldAttribute... attributes);
 
     /**
      * Adds a new field that references another {@link RealmObject}.
@@ -212,13 +151,9 @@ public class RealmObjectSchema {
      * @param objectSchema schema for the Realm type being referenced.
      * @return the updated schema.
      * @throws IllegalArgumentException if field name is illegal or a field with that name already exists.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema addRealmObjectField(String fieldName, RealmObjectSchema objectSchema) {
-        checkLegalName(fieldName);
-        checkFieldNameIsAvailable(fieldName);
-        table.addColumnLink(RealmFieldType.OBJECT, fieldName, realm.sharedRealm.getTable(Table.getTableNameForClass(objectSchema.getClassName())));
-        return this;
-    }
+    public abstract RealmObjectSchema addRealmObjectField(String fieldName, RealmObjectSchema objectSchema);
 
     /**
      * Adds a new field that references a {@link RealmList}.
@@ -227,13 +162,9 @@ public class RealmObjectSchema {
      * @param objectSchema schema for the Realm type being referenced.
      * @return the updated schema.
      * @throws IllegalArgumentException if the field name is illegal or a field with that name already exists.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema addRealmListField(String fieldName, RealmObjectSchema objectSchema) {
-        checkLegalName(fieldName);
-        checkFieldNameIsAvailable(fieldName);
-        table.addColumnLink(RealmFieldType.LIST, fieldName, realm.sharedRealm.getTable(Table.getTableNameForClass(objectSchema.getClassName())));
-        return this;
-    }
+    public abstract RealmObjectSchema addRealmListField(String fieldName, RealmObjectSchema objectSchema);
 
     /**
      * Removes a field from the class.
@@ -241,20 +172,9 @@ public class RealmObjectSchema {
      * @param fieldName field name to remove.
      * @return the updated schema.
      * @throws IllegalArgumentException if field name doesn't exist.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema removeField(String fieldName) {
-        realm.checkNotInSync(); // destructive modification of a schema is not permitted
-        checkLegalName(fieldName);
-        if (!hasField(fieldName)) {
-            throw new IllegalStateException(fieldName + " does not exist.");
-        }
-        long columnIndex = getColumnIndex(fieldName);
-        if (table.getPrimaryKey() == columnIndex) {
-            table.setPrimaryKey(null);
-        }
-        table.removeColumn(columnIndex);
-        return this;
-    }
+    public abstract RealmObjectSchema removeField(String fieldName);
 
     /**
      * Renames a field from one name to another.
@@ -263,20 +183,9 @@ public class RealmObjectSchema {
      * @param newFieldName the new field name.
      * @return the updated schema.
      * @throws IllegalArgumentException if field name doesn't exist or if the new field name already exists.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema renameField(String currentFieldName, String newFieldName) {
-        realm.checkNotInSync(); // destructive modification of a schema is not permitted
-        checkLegalName(currentFieldName);
-        checkFieldExists(currentFieldName);
-        checkLegalName(newFieldName);
-        checkFieldNameIsAvailable(newFieldName);
-        long columnIndex = getColumnIndex(currentFieldName);
-        table.renameColumn(columnIndex, newFieldName);
-
-        // ATTENTION: We don't need to re-set the PK table here since the column index won't be changed when renaming.
-
-        return this;
-    }
+    public abstract RealmObjectSchema renameField(String currentFieldName, String newFieldName);
 
     /**
      * Tests if the class has field defined with the given name.
@@ -296,17 +205,9 @@ public class RealmObjectSchema {
      * @return the updated schema.
      * @throws IllegalArgumentException if field name doesn't exist, the field cannot be indexed or it already has a
      * index defined.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema addIndex(String fieldName) {
-        checkLegalName(fieldName);
-        checkFieldExists(fieldName);
-        long columnIndex = getColumnIndex(fieldName);
-        if (table.hasSearchIndex(columnIndex)) {
-            throw new IllegalStateException(fieldName + " already has an index.");
-        }
-        table.addSearchIndex(columnIndex);
-        return this;
-    }
+    public abstract RealmObjectSchema addIndex(String fieldName);
 
     /**
      * Checks if a given field has an index defined.
@@ -328,18 +229,9 @@ public class RealmObjectSchema {
      * @param fieldName field to remove index from.
      * @return the updated schema.
      * @throws IllegalArgumentException if field name doesn't exist or the field doesn't have an index.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema removeIndex(String fieldName) {
-        realm.checkNotInSync(); // Destructive modifications are not permitted.
-        checkLegalName(fieldName);
-        checkFieldExists(fieldName);
-        long columnIndex = getColumnIndex(fieldName);
-        if (!table.hasSearchIndex(columnIndex)) {
-            throw new IllegalStateException("Field is not indexed: " + fieldName);
-        }
-        table.removeSearchIndex(columnIndex);
-        return this;
-    }
+    public abstract RealmObjectSchema removeIndex(String fieldName);
 
     /**
      * Adds a primary key to a given field. This is the same as adding the {@link io.realm.annotations.PrimaryKey}
@@ -350,21 +242,9 @@ public class RealmObjectSchema {
      * @return the updated schema.
      * @throws IllegalArgumentException if field name doesn't exist, the field cannot be a primary key or it already
      * has a primary key defined.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema addPrimaryKey(String fieldName) {
-        checkLegalName(fieldName);
-        checkFieldExists(fieldName);
-        if (table.hasPrimaryKey()) {
-            throw new IllegalStateException("A primary key is already defined");
-        }
-        table.setPrimaryKey(fieldName);
-        long columnIndex = getColumnIndex(fieldName);
-        if (!table.hasSearchIndex(columnIndex)) {
-            // No exception will be thrown since adding PrimaryKey implies the column has an index.
-            table.addSearchIndex(columnIndex);
-        }
-        return this;
-    }
+    public abstract RealmObjectSchema addPrimaryKey(String fieldName);
 
     /**
      * Removes the primary key from this class. This is the same as removing the {@link io.realm.annotations.PrimaryKey}
@@ -373,19 +253,9 @@ public class RealmObjectSchema {
      *
      * @return the updated schema.
      * @throws IllegalArgumentException if the class doesn't have a primary key defined.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema removePrimaryKey() {
-        realm.checkNotInSync(); // Destructive modifications are not permitted.
-        if (!table.hasPrimaryKey()) {
-            throw new IllegalStateException(getClassName() + " doesn't have a primary key.");
-        }
-        long columnIndex = table.getPrimaryKey();
-        if (table.hasSearchIndex(columnIndex)) {
-            table.removeSearchIndex(columnIndex);
-        }
-        table.setPrimaryKey("");
-        return this;
-    }
+    public abstract RealmObjectSchema removePrimaryKey();
 
     /**
      * Sets a field to be required i.e., it is not allowed to hold {@code null} values. This is equivalent to switching
@@ -396,33 +266,10 @@ public class RealmObjectSchema {
      * @return the updated schema.
      * @throws IllegalArgumentException if the field name doesn't exist, cannot have the {@link Required} annotation or
      * the field already have been set as required.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      * @see Required
      */
-    public RealmObjectSchema setRequired(String fieldName, boolean required) {
-        long columnIndex = table.getColumnIndex(fieldName);
-        boolean currentColumnRequired = isRequired(fieldName);
-        RealmFieldType type = table.getColumnType(columnIndex);
-
-        if (type == RealmFieldType.OBJECT) {
-            throw new IllegalArgumentException("Cannot modify the required state for RealmObject references: " + fieldName);
-        }
-        if (type == RealmFieldType.LIST) {
-            throw new IllegalArgumentException("Cannot modify the required state for RealmList references: " + fieldName);
-        }
-        if (required && currentColumnRequired) {
-            throw new IllegalStateException("Field is already required: " + fieldName);
-        }
-        if (!required && !currentColumnRequired) {
-            throw new IllegalStateException("Field is already nullable: " + fieldName);
-        }
-
-        if (required) {
-            table.convertColumnToNotNullable(columnIndex);
-        } else {
-            table.convertColumnToNullable(columnIndex);
-        }
-        return this;
-    }
+    public abstract RealmObjectSchema setRequired(String fieldName, boolean required);
 
     /**
      * Sets a field to be nullable i.e., it should be able to hold {@code null} values. This is equivalent to switching
@@ -432,11 +279,9 @@ public class RealmObjectSchema {
      * @param nullable {@code true} if field should be nullable, {@code false} otherwise.
      * @return the updated schema.
      * @throws IllegalArgumentException if the field name doesn't exist, or cannot be set as nullable.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema setNullable(String fieldName, boolean nullable) {
-        setRequired(fieldName, !nullable);
-        return this;
-    }
+    public abstract RealmObjectSchema setNullable(String fieldName, boolean nullable);
 
     /**
      * Checks if a given field is required i.e., it is not allowed to contain {@code null} values.
@@ -519,17 +364,9 @@ public class RealmObjectSchema {
      * as a {@link DynamicRealmObject}.
      *
      * @return this schema.
+     * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema transform(Function function) {
-        if (function != null) {
-            long size = table.size();
-            for (long i = 0; i < size; i++) {
-                function.apply(new DynamicRealmObject(realm, table.getCheckedRow(i)));
-            }
-        }
-
-        return this;
-    }
+    public abstract RealmObjectSchema transform(Function function);
 
     /**
      * Returns the type used by the underlying storage engine to represent this field.
@@ -607,52 +444,7 @@ public class RealmObjectSchema {
         return columnInfo.getColumnIndex(fieldName);
     }
 
-    // Invariant: Field was just added. This method is responsible for cleaning up attributes if it fails.
-    private void addModifiers(String fieldName, FieldAttribute[] attributes) {
-        boolean indexAdded = false;
-        try {
-            if (attributes != null && attributes.length > 0) {
-                if (containsAttribute(attributes, FieldAttribute.INDEXED)) {
-                    addIndex(fieldName);
-                    indexAdded = true;
-                }
-
-                if (containsAttribute(attributes, FieldAttribute.PRIMARY_KEY)) {
-                    // Note : adding primary key implies application of FieldAttribute.INDEXED attribute.
-                    addPrimaryKey(fieldName);
-                    indexAdded = true;
-                }
-
-                // REQUIRED is being handled when adding the column using addField through the nullable parameter.
-            }
-        } catch (Exception e) {
-            // If something went wrong, revert all attributes.
-            long columnIndex = getColumnIndex(fieldName);
-            if (indexAdded) {
-                table.removeSearchIndex(columnIndex);
-            }
-            throw (RuntimeException) e;
-        }
-    }
-
-    private boolean containsAttribute(FieldAttribute[] attributeList, FieldAttribute attribute) {
-        if (attributeList == null || attributeList.length == 0) {
-            return false;
-        }
-        for (FieldAttribute anAttributeList : attributeList) {
-            if (anAttributeList == attribute) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void checkNewFieldName(String fieldName) {
-        checkLegalName(fieldName);
-        checkFieldNameIsAvailable(fieldName);
-    }
-
-    private void checkLegalName(String fieldName) {
+    void checkLegalName(String fieldName) {
         if (fieldName == null || fieldName.isEmpty()) {
             throw new IllegalArgumentException("Field name can not be null or empty");
         }
@@ -661,19 +453,13 @@ public class RealmObjectSchema {
         }
     }
 
-    private void checkFieldNameIsAvailable(String fieldName) {
-        if (table.getColumnIndex(fieldName) != Table.NO_MATCH) {
-            throw new IllegalArgumentException("Field already exists in '" + getClassName() + "': " + fieldName);
-        }
-    }
-
-    private void checkFieldExists(String fieldName) {
+    void checkFieldExists(String fieldName) {
         if (table.getColumnIndex(fieldName) == Table.NO_MATCH) {
             throw new IllegalArgumentException("Field name doesn't exist on object '" + getClassName() + "': " + fieldName);
         }
     }
 
-    private long getColumnIndex(String fieldName) {
+    long getColumnIndex(String fieldName) {
         long columnIndex = table.getColumnIndex(fieldName);
         if (columnIndex == -1) {
             throw new IllegalArgumentException(
@@ -685,13 +471,7 @@ public class RealmObjectSchema {
         return columnIndex;
     }
 
-    private void checkEmpty(String str) {
-        if (str == null || str.isEmpty()) {
-            throw new IllegalArgumentException("Null or empty class names are not allowed");
-        }
-    }
-
-    private static final class DynamicColumnIndices extends ColumnInfo {
+    static final class DynamicColumnIndices extends ColumnInfo {
         private final Table table;
 
         DynamicColumnIndices(Table table) {
@@ -732,7 +512,7 @@ public class RealmObjectSchema {
     }
 
     // Tuple containing data about each supported Java type.
-    private static final class FieldMetaData {
+    static final class FieldMetaData {
         final RealmFieldType realmType;
         final boolean defaultNullable;
 

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -29,14 +29,17 @@ import io.realm.internal.util.Pair;
 
 
 /**
- * Class for interacting with the Realm schema using a dynamic API. This makes it possible
- * to add, delete and change the classes in the Realm.
+ * Class for interacting with the Realm schema. This makes it possible to inspect, add, delete and change the classes in
+ * the Realm.
+ * <p>
+ * {@link Realm#getSchema()} returns an immutable {@code RealmSchema} which can only be used for inspecting. Use
+ * {@link DynamicRealm#getSchema()} to get a mutable schema.
  * <p>
  * All changes must happen inside a write transaction for the particular Realm.
  *
  * @see RealmMigration
  */
-public class RealmSchema {
+public abstract class RealmSchema {
     static final String EMPTY_STRING_MSG = "Null or empty class names are not allowed";
 
     // Caches Dynamic Class objects given as Strings to Realm Tables
@@ -48,7 +51,7 @@ public class RealmSchema {
     // Caches Class Strings to their Schema object
     private final Map<String, RealmObjectSchema> dynamicClassToSchema = new HashMap<>();
 
-    private final BaseRealm realm;
+    final BaseRealm realm;
     // Cached field look up
     private ColumnIndices columnIndices;
 
@@ -67,22 +70,18 @@ public class RealmSchema {
     }
 
     /**
-     * Returns the Realm schema for a given class.
+     * Returns the {@link RealmObjectSchema} for a given class. If this {@link RealmSchema} is immutable, an immutable
+     * {@link RealmObjectSchema} will be returned. Otherwise, it returns an mutable {@link RealmObjectSchema}.
      *
      * @param className name of the class
      * @return schema object for that class or {@code null} if the class doesn't exists.
      */
-    public RealmObjectSchema get(String className) {
-        checkEmpty(className, EMPTY_STRING_MSG);
-
-        String internalClassName = Table.getTableNameForClass(className);
-        if (!realm.getSharedRealm().hasTable(internalClassName)) { return null; }
-        Table table = realm.getSharedRealm().getTable(internalClassName);
-        return new RealmObjectSchema(realm, this, table);
-    }
+    public abstract RealmObjectSchema get(String className);
 
     /**
-     * Returns the {@link RealmObjectSchema}s for all RealmObject classes that can be saved in this Realm.
+     * Returns the {@link RealmObjectSchema}s for all RealmObject classes that can be saved in this Realm. If this
+     * {@link RealmSchema} is immutable, an immutable {@link RealmObjectSchema} set will be returned. Otherwise, it
+     * returns an mutable {@link RealmObjectSchema} set.
      *
      * @return the set of all classes in this Realm or no RealmObject classes can be saved in the Realm.
      */
@@ -90,11 +89,10 @@ public class RealmSchema {
         int tableCount = (int) realm.getSharedRealm().size();
         Set<RealmObjectSchema> schemas = new LinkedHashSet<>(tableCount);
         for (int i = 0; i < tableCount; i++) {
-            String tableName = realm.getSharedRealm().getTableName(i);
-            if (!Table.isModelTable(tableName)) {
-                continue;
+            RealmObjectSchema objectSchema = get(realm.getSharedRealm().getTableName(i));
+            if (objectSchema != null) {
+                schemas.add(objectSchema);
             }
-            schemas.add(new RealmObjectSchema(realm, this, realm.getSharedRealm().getTable(tableName)));
         }
         return schemas;
     }
@@ -104,35 +102,18 @@ public class RealmSchema {
      *
      * @param className name of the class.
      * @return a Realm schema object for that class.
+     * @throws UnsupportedOperationException if this {@link RealmSchema} is immutable.
      */
-    public RealmObjectSchema create(String className) {
-        // Adding a class is always permitted.
-        checkEmpty(className, EMPTY_STRING_MSG);
-
-        String internalTableName = Table.getTableNameForClass(className);
-        if (internalTableName.length() > Table.TABLE_MAX_LENGTH) {
-            throw new IllegalArgumentException("Class name is too long. Limit is 56 characters: " + className.length());
-        }
-        return new RealmObjectSchema(realm, this, realm.getSharedRealm().createTable(internalTableName));
-    }
+    public abstract RealmObjectSchema create(String className);
 
     /**
      * Removes a class from the Realm. All data will be removed. Removing a class while other classes point
      * to it will throw an {@link IllegalStateException}. Removes those classes or fields first.
      *
      * @param className name of the class to remove.
+     * @throws UnsupportedOperationException if this {@link RealmSchema} is immutable.
      */
-    public void remove(String className) {
-        realm.checkNotInSync(); // Destructive modifications are not permitted.
-        checkEmpty(className, EMPTY_STRING_MSG);
-        String internalTableName = Table.getTableNameForClass(className);
-        checkHasTable(className, "Cannot remove class because it is not in this Realm: " + className);
-        Table table = getTable(className);
-        if (table.hasPrimaryKey()) {
-            table.setPrimaryKey(null);
-        }
-        realm.getSharedRealm().removeTable(internalTableName);
-    }
+    public abstract void remove(String className);
 
     /**
      * Renames a class already in the Realm.
@@ -140,36 +121,9 @@ public class RealmSchema {
      * @param oldClassName old class name.
      * @param newClassName new class name.
      * @return a schema object for renamed class.
+     * @throws UnsupportedOperationException if this {@link RealmSchema} is immutable.
      */
-    public RealmObjectSchema rename(String oldClassName, String newClassName) {
-        realm.checkNotInSync(); // Destructive modifications are not permitted.
-        checkEmpty(oldClassName, "Class names cannot be empty or null");
-        checkEmpty(newClassName, "Class names cannot be empty or null");
-        String oldInternalName = Table.getTableNameForClass(oldClassName);
-        String newInternalName = Table.getTableNameForClass(newClassName);
-        checkHasTable(oldClassName, "Cannot rename class because it doesn't exist in this Realm: " + oldClassName);
-        if (realm.getSharedRealm().hasTable(newInternalName)) {
-            throw new IllegalArgumentException(oldClassName + " cannot be renamed because the new class already exists: " + newClassName);
-        }
-
-        // Checks if there is a primary key defined for the old class.
-        Table oldTable = getTable(oldClassName);
-        String pkField = null;
-        if (oldTable.hasPrimaryKey()) {
-            pkField = oldTable.getColumnName(oldTable.getPrimaryKey());
-            oldTable.setPrimaryKey(null);
-        }
-
-        realm.getSharedRealm().renameTable(oldInternalName, newInternalName);
-        Table table = realm.getSharedRealm().getTable(newInternalName);
-
-        // Sets the primary key for the new class if necessary.
-        if (pkField != null) {
-            table.setPrimaryKey(pkField);
-        }
-
-        return new RealmObjectSchema(realm, this, table);
-    }
+    public abstract RealmObjectSchema rename(String oldClassName, String newClassName);
 
     /**
      * Checks if a given class already exists in the schema.
@@ -181,13 +135,13 @@ public class RealmSchema {
         return realm.getSharedRealm().hasTable(Table.getTableNameForClass(className));
     }
 
-    private void checkEmpty(String str, String error) {
+    void checkEmpty(String str, String error) {
         if (str == null || str.isEmpty()) {
             throw new IllegalArgumentException(error);
         }
     }
 
-    private void checkHasTable(String className, String errorMsg) {
+    void checkHasTable(String className, String errorMsg) {
         String internalTableName = Table.getTableNameForClass(className);
         if (!realm.getSharedRealm().hasTable(internalTableName)) {
             throw new IllegalArgumentException(errorMsg);
@@ -226,6 +180,7 @@ public class RealmSchema {
         return table;
     }
 
+    // Returns an immutable RealmObjectSchema for internal usage only.
     RealmObjectSchema getSchemaForClass(Class<? extends RealmModel> clazz) {
         RealmObjectSchema classSchema = classToSchema.get(clazz);
         if (classSchema != null) { return classSchema; }
@@ -237,7 +192,7 @@ public class RealmSchema {
         }
         if (classSchema == null) {
             Table table = getTable(clazz);
-            classSchema = new RealmObjectSchema(realm, this, table, getColumnInfo(originalClass));
+            classSchema = new ImmutableRealmObjectSchema(realm, this, table, getColumnInfo(originalClass));
             classToSchema.put(originalClass, classSchema);
         }
         if (isProxyClass(originalClass, clazz)) {
@@ -248,6 +203,7 @@ public class RealmSchema {
         return classSchema;
     }
 
+    // Returns an immutable RealmObjectSchema for internal usage only.
     RealmObjectSchema getSchemaForClass(String className) {
         String tableName = Table.getTableNameForClass(className);
         RealmObjectSchema dynamicSchema = dynamicClassToSchema.get(tableName);
@@ -255,7 +211,7 @@ public class RealmSchema {
             if (!realm.getSharedRealm().hasTable(tableName)) {
                 throw new IllegalArgumentException("The class " + className + " doesn't exist in this Realm.");
             }
-            dynamicSchema = new RealmObjectSchema(realm, this, realm.getSharedRealm().getTable(tableName));
+            dynamicSchema = new ImmutableRealmObjectSchema(realm, this, realm.getSharedRealm().getTable(tableName));
             dynamicClassToSchema.put(tableName, dynamicSchema);
         }
         return dynamicSchema;
@@ -298,7 +254,7 @@ public class RealmSchema {
         columnIndices.copyFrom(schemaVersion);
     }
 
-    final boolean isProxyClass(Class<? extends RealmModel> modelClass, Class<? extends RealmModel> testee) {
+    private boolean isProxyClass(Class<? extends RealmModel> modelClass, Class<? extends RealmModel> testee) {
         return modelClass.equals(testee);
     }
 


### PR DESCRIPTION
Before this change, Realm.getSchema() and DynamicRealm.getSchema() both
return a mutable version RealmSchema object. That would cause issue when
changing the typed Realm's schema then continue to use typed inferface
to access the Realm where the column indices might be changed already
and had not been refreshed before the transaction commited.

After this change:
Realm.getSchema() returns an immutable RealmSchema object. And all
RealmObjectSchema objects retrieved from that will be immutable as
well.