### PR TITLE
Fix class name length check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 
 * Potential crash after using `Realm.getSchema()` to change the schema of a typed Realm. `Realm.getSchema()` now returns an immutable `RealmSchema` instance.
-* `RealmSchema.create(String)` and `RealmObjectSchema.setClassName(String)` did not accept class name whose length was 51 to 56.
+* `RealmSchema.create(String)` and `RealmObjectSchema.setClassName(String)` did not accept class name whose length was 51 to 57.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 * Potential crash after using `Realm.getSchema()` to change the schema of a typed Realm. `Realm.getSchema()` now returns an immutable `RealmSchema` instance.
+* `RealmSchema.create(String)` and `RealmObjectSchema.setClassName(String)` did not accept class name whose length was 51 to 56.
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -491,10 +491,11 @@ public class RealmMigrationTests {
         RealmMigration migration = new RealmMigration() {
             @Override
             public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+                final String tooLongClassName = "MigrationNameIsLongerThan57Char_ThisShouldThrowAnException";
+                assertEquals(58, tooLongClassName.length());
                 realm.getSchema()
                         .get(MigrationPrimaryKey.CLASS_NAME)
-                        // 57 characters
-                        .setClassName("MigrationNameIsLongerThan56CharThisShouldThrowAnException");
+                        .setClassName(tooLongClassName);
             }
         };
         RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Date;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.realm.entities.AllTypes;
@@ -487,11 +488,12 @@ public class RealmMigrationTests {
         realm.commitTransaction();
         realm.close();
 
+        final String tooLongClassName = "MigrationNameIsLongerThan57Char_ThisShouldThrowAnException";
+
         // Gets ready for the 2nd version migration.
         RealmMigration migration = new RealmMigration() {
             @Override
             public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
-                final String tooLongClassName = "MigrationNameIsLongerThan57Char_ThisShouldThrowAnException";
                 assertEquals(58, tooLongClassName.length());
                 realm.getSchema()
                         .get(MigrationPrimaryKey.CLASS_NAME)
@@ -508,7 +510,12 @@ public class RealmMigrationTests {
             Realm.getInstance(realmConfig);
             fail();
         } catch (IllegalArgumentException expected) {
-            assertEquals("Class name is too long. Limit is 56 characters: 'MigrationNameIsLongerThan56CharThisShouldThrowAnException' (57)",
+            assertEquals(
+                    String.format(Locale.US,
+                            "Class name is too long. Limit is %1$d characters: '%2$s' (%3$d)",
+                            tooLongClassName.length() - 1,
+                            tooLongClassName,
+                            tooLongClassName.length()),
                     expected.getMessage());
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -489,12 +489,12 @@ public class RealmMigrationTests {
         realm.close();
 
         final String tooLongClassName = "MigrationNameIsLongerThan57Char_ThisShouldThrowAnException";
+        assertEquals(58, tooLongClassName.length());
 
         // Gets ready for the 2nd version migration.
         RealmMigration migration = new RealmMigration() {
             @Override
             public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
-                assertEquals(58, tooLongClassName.length());
                 realm.getSchema()
                         .get(MigrationPrimaryKey.CLASS_NAME)
                         .setClassName(tooLongClassName);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import io.realm.entities.AllJavaTypes;
 import io.realm.entities.Dog;
+import io.realm.internal.Table;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
@@ -955,15 +956,23 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void setGetClassName() {
-        assertEquals("Dog", DOG_SCHEMA.getClassName());
-        String newClassName = "Darby";
-        if (type == ObjectSchemaType.MUTABLE) {
-            DOG_SCHEMA.setClassName(newClassName);
-            assertEquals(newClassName, DOG_SCHEMA.getClassName());
-            assertTrue(realmSchema.contains(newClassName));
-        } else {
+        final String[] validClassNames = {
+                TestHelper.getRandomString(1),
+                "Darby",
+                TestHelper.getRandomString(Table.CLASS_NAME_MAX_LENGTH)
+        };
+
+        if (type == ObjectSchemaType.IMMUTABLE) {
             thrown.expect(UnsupportedOperationException.class);
-            DOG_SCHEMA.setClassName(newClassName);
+            DOG_SCHEMA.setClassName(validClassNames[0]);
+            return;
+        }
+
+        assertEquals("Dog", DOG_SCHEMA.getClassName());
+        for (String validClassName : validClassNames) {
+            DOG_SCHEMA.setClassName(validClassName);
+            assertEquals(validClassName, DOG_SCHEMA.getClassName());
+            assertTrue(realmSchema.contains(validClassName));
         }
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
@@ -36,6 +36,7 @@ import io.realm.entities.Dog;
 import io.realm.entities.DogPrimaryKey;
 import io.realm.entities.Owner;
 import io.realm.entities.PrimaryKeyAsString;
+import io.realm.internal.Table;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
@@ -117,12 +118,21 @@ public class RealmSchemaTests {
 
     @Test
     public void create() {
-        if (type == SchemaType.MUTABLE) {
-            realmSchema.create("Foo");
-            assertTrue(realmSchema.contains("Foo"));
-        } else {
+        final String[] validClassNames = {
+                TestHelper.getRandomString(1),
+                "Darby",
+                TestHelper.getRandomString(Table.CLASS_NAME_MAX_LENGTH)
+        };
+
+        if (type == SchemaType.IMMUTABLE) {
             thrown.expect(UnsupportedOperationException.class);
-            realmSchema.create("Foo");
+            realmSchema.create(validClassNames[0]);
+            return;
+        }
+
+        for (String validClassName : validClassNames) {
+            realmSchema.create(validClassName);
+            assertTrue(realmSchema.contains(validClassName));
         }
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmSchemaTests.java
@@ -142,11 +142,12 @@ public class RealmSchemaTests {
             return;
         }
 
-        String[] names = { null, "", TestHelper.getRandomString(57) };
+        String[] names = { null, "", TestHelper.getRandomString(58) };
 
         for (String name : names) {
             try {
                 realmSchema.create(name);
+                fail();
             } catch (IllegalArgumentException ignored) {
             }
             assertFalse(String.format("'%s' failed", name), realmSchema.contains(name));

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
@@ -40,8 +40,10 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
         realm.checkNotInSync(); // renaming a table is not permitted
         checkEmpty(className);
         String internalTableName = Table.getTableNameForClass(className);
-        if (internalTableName.length() > Table.TABLE_MAX_LENGTH) {
-            throw new IllegalArgumentException("Class name is too long. Limit is 56 characters: \'" + className + "\' (" + Integer.toString(className.length()) + ")");
+        if (className.length() > Table.CLASS_NAME_MAX_LENGTH) {
+            throw new IllegalArgumentException(String.format(Locale.US,
+                    "Class name is too long. Limit is %1$d characters: \'%2$s\' (%3$d)",
+                    Table.CLASS_NAME_MAX_LENGTH, className, className.length()));
         }
         if (realm.sharedRealm.hasTable(internalTableName)) {
             throw new IllegalArgumentException("Class already exists: " + className);

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
@@ -45,11 +45,11 @@ class MutableRealmSchema extends RealmSchema {
         checkNotEmpty(className, EMPTY_STRING_MSG);
 
         String internalTableName = Table.getTableNameForClass(className);
-        if (internalTableName.length() > Table.TABLE_MAX_LENGTH) {
+        if (className.length() > Table.CLASS_NAME_MAX_LENGTH) {
             throw new IllegalArgumentException(
                     String.format(Locale.US,
                             "Class name is too long. Limit is %1$d characters: %2$s",
-                            Table.TABLE_MAX_LENGTH,
+                            Table.CLASS_NAME_MAX_LENGTH,
                             className.length()));
         }
         return new MutableRealmObjectSchema(realm, this, realm.getSharedRealm().createTable(internalTableName));

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -30,13 +30,14 @@ import io.realm.exceptions.RealmPrimaryKeyConstraintException;
  */
 public class Table implements TableSchema, NativeObject {
 
-    public static final int TABLE_MAX_LENGTH = 56; // Max length of class names without prefix
+    private static final String TABLE_PREFIX = Util.getTablePrefix();
+    public static final int TABLE_NAME_MAX_LENGTH = 62; // Max length of table names
+    public static final int CLASS_NAME_MAX_LENGTH = TABLE_NAME_MAX_LENGTH - TABLE_PREFIX.length(); // Max length of class names
     public static final long INFINITE = -1;
     public static final boolean NULLABLE = true;
     public static final boolean NOT_NULLABLE = false;
     public static final int NO_MATCH = -1;
 
-    private static final String TABLE_PREFIX = Util.getTablePrefix();
     private static final String PRIMARY_KEY_TABLE_NAME = "pk";
     private static final String PRIMARY_KEY_CLASS_COLUMN_NAME = "pk_table";
     private static final long PRIMARY_KEY_CLASS_COLUMN_INDEX = 0;

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -31,7 +31,7 @@ import io.realm.exceptions.RealmPrimaryKeyConstraintException;
 public class Table implements TableSchema, NativeObject {
 
     private static final String TABLE_PREFIX = Util.getTablePrefix();
-    public static final int TABLE_NAME_MAX_LENGTH = 62; // Max length of table names
+    private static final int TABLE_NAME_MAX_LENGTH = 63; // Max length of table names
     public static final int CLASS_NAME_MAX_LENGTH = TABLE_NAME_MAX_LENGTH - TABLE_PREFIX.length(); // Max length of class names
     public static final long INFINITE = -1;
     public static final boolean NULLABLE = true;


### PR DESCRIPTION
`RealmSchema.create(String)` and `RealmObjectSchema.setClassName(String)` did not accept class name whose length was 51 to ~56~ 57.
