### PR TITLE
copyToRealmOrUpdate cause dup values in list field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 * Potential crash after using `Realm.getSchema()` to change the schema of a typed Realm. `Realm.getSchema()` now returns an immutable `RealmSchema` instance.
+* `Realm.copyToRealmOrUpdate()` might result a `RealmList` field contains duplicated elements (#4957).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 
 * Potential crash after using `Realm.getSchema()` to change the schema of a typed Realm. `Realm.getSchema()` now returns an immutable `RealmSchema` instance.
-* `Realm.copyToRealmOrUpdate()` might result a `RealmList` field contains duplicated elements (#4957).
+* `Realm.copyToRealmOrUpdate()` might cause a `RealmList` field to contain duplicated elements (#4957).
 
 ### Internal
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -1580,6 +1580,8 @@ public class RealmProxyClassGenerator {
                         .beginControlFlow("if (%sList != null)", fieldName)
                             .emitStatement("RealmList<%s> %sRealmList = realmObjectCopy.%s()",
                                 genericType, fieldName, getter)
+                             // Clear is needed. See bug https://github.com/realm/realm-java/issues/4957
+                            .emitStatement("%sRealmList.clear()", fieldName)
                             .beginControlFlow("for (int i = 0; i < %sList.size(); i++)", fieldName)
                                 .emitStatement("%1$s %2$sItem = %2$sList.get(i)", genericType, fieldName)
                                 .emitStatement("%1$s cache%2$s = (%1$s) cache.get(%2$sItem)", genericType, fieldName)

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -820,6 +820,7 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         RealmList<some.test.AllTypes> columnRealmListList = realmObjectSource.realmGet$columnRealmList();
         if (columnRealmListList != null) {
             RealmList<some.test.AllTypes> columnRealmListRealmList = realmObjectCopy.realmGet$columnRealmList();
+            columnRealmListRealmList.clear();
             for (int i = 0; i < columnRealmListList.size(); i++) {
                 some.test.AllTypes columnRealmListItem = columnRealmListList.get(i);
                 some.test.AllTypes cachecolumnRealmList = (some.test.AllTypes) cache.get(columnRealmListItem);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -80,6 +80,7 @@ import io.realm.entities.DogPrimaryKey;
 import io.realm.entities.NoPrimaryKeyNullTypes;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.entities.NullTypes;
+import io.realm.entities.Object4957;
 import io.realm.entities.Owner;
 import io.realm.entities.OwnerPrimaryKey;
 import io.realm.entities.PrimaryKeyAsBoxedByte;
@@ -1923,6 +1924,41 @@ public class RealmTests {
         }).start();
 
         TestHelper.awaitOrFail(bgThreadDoneLatch);
+    }
+
+    // Test to reproduce issue https://github.com/realm/realm-java/issues/4957
+    @Test
+    public void copyToRealmOrUpdate_bug4957() {
+        Object4957 listElement = new Object4957();
+        listElement.setId(1);
+
+        Object4957 parent = new Object4957();
+        parent.setId(0);
+        parent.getChildList().add(listElement);
+
+        // parentCopy has same fields as the parent does. But they are not the same object.
+        Object4957 parentCopy = new Object4957();
+        parentCopy.setId(0);
+        parentCopy.getChildList().add(listElement);
+
+        parent.setChild(parentCopy);
+        parentCopy.setChild(parentCopy);
+
+        realm.beginTransaction();
+        Object4957 managedParent = realm.copyToRealmOrUpdate(parent);
+        realm.commitTransaction();
+        // The original bug fails here. It resulted the listElement has been added to the list twice.
+        // Because of the parent and parentCopy are not the same object, proxy will miss the cache to know the object
+        // has been created before. But it does know they share the same PK value.
+        assertEquals(1, managedParent.getChildList().size());
+
+        // insertOrUpdate doesn't have the problem!
+        realm.beginTransaction();
+        realm.deleteAll();
+        realm.insertOrUpdate(parent);
+        realm.commitTransaction();
+        managedParent = realm.where(Object4957.class).findFirst();
+        assertEquals(1, managedParent.getChildList().size());
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/Object4957.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/Object4957.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+// Object to reproduce issue https://github.com/realm/realm-java/issues/4957 .
+public class Object4957 extends RealmObject {
+    @PrimaryKey
+    private int id;
+    // Don't change the order of the field declaration! The order is the key to reproduce the original bug.
+    private Object4957 child;
+    private RealmList<Object4957> childList = new RealmList<Object4957>();
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setChild(Object4957 child) {
+        this.child = child;
+    }
+
+    public RealmList<Object4957> getChildList() {
+        return childList;
+    }
+
+    public Object4957 getChild() {
+        return child;
+    }
+}


### PR DESCRIPTION
Close #4957
We are using HashMap to maintain a cache of added managed RealmObject
when doing copyOrUpdate. But if the given object graph contains objects
which have same PK but are different java object, cache missing will
happen. That caused the object got set multiple times. For non-list
fields, it is not a problem since it will eventually has the expected
value if user's objects graph is consistent. For list, that results the
elements in the list are added multiple times since we don't clear the
RealmList in copy().