### PR TITLE
Work around jmethod bug with Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Potential crash after using `Realm.getSchema()` to change the schema of a typed Realm. `Realm.getSchema()` now returns an immutable `RealmSchema` instance.
 * `RealmSchema.create(String)` and `RealmObjectSchema.setClassName(String)` did not accept class name whose length was 51 to 57.
+* Workaround for a Android JVM crash when using 'compactOnLaunch()' (#4964).
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/AndroidManifest.xml
+++ b/realm/realm-library/src/androidTest/AndroidManifest.xml
@@ -7,12 +7,14 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.SET_DEBUG_APP"/>
 
     <uses-sdk
         android:minSdkVersion="9"
         android:targetSdkVersion="22"/>
 
-    <application>
+    <application
+        android:debuggable="true">
         <uses-library android:name="android.test.runner"/>
         <service
             android:name=".services.RemoteProcessService"

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Collection.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Collection.cpp
@@ -23,6 +23,7 @@
 #include "java_sort_descriptor.hpp"
 #include "util.hpp"
 
+#include "jni_util/java_class.hpp"
 #include "jni_util/java_global_weak_ref.hpp"
 #include "jni_util/java_method.hpp"
 
@@ -285,7 +286,8 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Collection_nativeStartListening(JN
 {
     TR_ENTER_PTR(native_ptr)
 
-    static JavaMethod notify_change_listeners(env, instance, "notifyChangeListeners", "(J)V");
+    static JavaClass os_results_class(env, "io/realm/internal/Collection");
+    static JavaMethod notify_change_listeners(env, os_results_class, "notifyChangeListeners", "(J)V");
 
     try {
         auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -128,7 +128,8 @@ struct ChangeCallback {
         parse_fields(env, change_set);
 
         m_wrapper->m_row_object_weak_ref.call_with_local_ref(env, [&](JNIEnv*, jobject row_obj) {
-            static JavaMethod notify_change_listeners(env, row_obj, "notifyChangeListeners",
+            static JavaClass os_object_class(env, "io/realm/internal/OsObject");
+            static JavaMethod notify_change_listeners(env, os_object_class, "notifyChangeListeners",
                                                       "([Ljava/lang/String;)V");
             env->CallVoidMethod(row_obj, notify_change_listeners, m_deleted ? nullptr : m_field_names_array);
         });

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -205,7 +205,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeCreateConfig(
         config.automatic_change_notifications = auto_change_notification;
 
         if (compact_on_launch) {
-            static JavaMethod should_compact(env, compact_on_launch, "shouldCompact", "(JJ)Z");
+            static JavaClass callback_class(env, "io/realm/CompactOnLaunchCallback");
+            static JavaMethod should_compact(env, callback_class, "shouldCompact", "(JJ)Z");
             JavaGlobalRef java_compact_on_launch_ref(env, compact_on_launch);
 
             auto should_compact_on_launch_function = [java_compact_on_launch_ref](uint64_t totalBytes, uint64_t usedBytes) {

--- a/realm/realm-library/src/main/cpp/java_binding_context.cpp
+++ b/realm/realm-library/src/main/cpp/java_binding_context.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "java_binding_context.hpp"
+#include "jni_util/java_class.hpp"
 #include "jni_util/java_method.hpp"
 
 #include "util.hpp"
@@ -31,7 +32,7 @@ void JavaBindingContext::before_notify()
     if (m_java_notifier) {
         m_java_notifier.call_with_local_ref([&](JNIEnv* env, jobject notifier_obj) {
             // Method IDs from RealmNotifier implementation. Cache them as member vars.
-            static JavaMethod notify_by_other_method(env, notifier_obj, "beforeNotify", "()V");
+            static JavaMethod notify_by_other_method(env, get_notifier_class(env), "beforeNotify", "()V");
             env->CallVoidMethod(notifier_obj, notify_by_other_method);
         });
     }
@@ -47,8 +48,14 @@ void JavaBindingContext::did_change(std::vector<BindingContext::ObserverState> c
     }
     if (version_changed) {
         m_java_notifier.call_with_local_ref(env, [&](JNIEnv*, jobject notifier_obj) {
-            static JavaMethod realm_notifier_did_change_method(env, notifier_obj, "didChange", "()V");
+            static JavaMethod realm_notifier_did_change_method(env, get_notifier_class(env), "didChange", "()V");
             env->CallVoidMethod(notifier_obj, realm_notifier_did_change_method);
         });
     }
+}
+
+JavaClass const& JavaBindingContext::get_notifier_class(JNIEnv* env)
+{
+    static JavaClass notifier_class(env, "io/realm/internal/RealmNotifier");
+    return notifier_class;
 }

--- a/realm/realm-library/src/main/cpp/java_binding_context.hpp
+++ b/realm/realm-library/src/main/cpp/java_binding_context.hpp
@@ -26,8 +26,11 @@
 
 namespace realm {
 
-namespace _impl {
+namespace jni_util {
+class JavaClass;
+}
 
+namespace _impl {
 // Binding context which will be called from OS.
 class JavaBindingContext final : public BindingContext {
 private:
@@ -39,6 +42,7 @@ private:
     // A weak global ref to the implementation of RealmNotifier
     // Java should hold a strong ref to it as long as the SharedRealm lives
     jni_util::JavaGlobalWeakRef m_java_notifier;
+    jni_util::JavaClass const& get_notifier_class(JNIEnv*);
 
 public:
     virtual ~JavaBindingContext(){};

--- a/realm/realm-library/src/main/cpp/java_sort_descriptor.cpp
+++ b/realm/realm-library/src/main/cpp/java_sort_descriptor.cpp
@@ -17,6 +17,7 @@
 
 #include "java_sort_descriptor.hpp"
 #include "util.hpp"
+#include "jni_util/java_class.hpp"
 #include "jni_util/java_method.hpp"
 
 using namespace realm;
@@ -42,14 +43,14 @@ DistinctDescriptor JavaSortDescriptor::distinct_descriptor() const noexcept
 
 Table* JavaSortDescriptor::get_table_ptr() const noexcept
 {
-    static JavaMethod get_table_ptr_method(m_env, m_sort_desc_obj, "getTablePtr", "()J");
+    static JavaMethod get_table_ptr_method(m_env, get_sort_desc_class(), "getTablePtr", "()J");
     jlong table_ptr = m_env->CallLongMethod(m_sort_desc_obj, get_table_ptr_method);
     return reinterpret_cast<Table*>(table_ptr);
 }
 
 std::vector<std::vector<size_t>> JavaSortDescriptor::get_column_indices() const noexcept
 {
-    static JavaMethod get_column_indices_method(m_env, m_sort_desc_obj, "getColumnIndices", "()[[J");
+    static JavaMethod get_column_indices_method(m_env, get_sort_desc_class(), "getColumnIndices", "()[[J");
     jobjectArray column_indices =
         static_cast<jobjectArray>(m_env->CallObjectMethod(m_sort_desc_obj, get_column_indices_method));
     JniArrayOfArrays<JniLongArray, jlongArray> arrays(m_env, column_indices);
@@ -69,7 +70,7 @@ std::vector<std::vector<size_t>> JavaSortDescriptor::get_column_indices() const 
 
 std::vector<bool> JavaSortDescriptor::get_ascendings() const noexcept
 {
-    static JavaMethod get_ascendings_method(m_env, m_sort_desc_obj, "getAscendings", "()[Z");
+    static JavaMethod get_ascendings_method(m_env, get_sort_desc_class(), "getAscendings", "()[Z");
 
     jbooleanArray ascendings =
         static_cast<jbooleanArray>(m_env->CallObjectMethod(m_sort_desc_obj, get_ascendings_method));
@@ -87,3 +88,10 @@ std::vector<bool> JavaSortDescriptor::get_ascendings() const noexcept
     }
     return ascending_list;
 }
+
+JavaClass const& JavaSortDescriptor::get_sort_desc_class() const noexcept
+{
+    static JavaClass sort_desc_class(m_env, "io/realm/internal/SortDescriptor");
+    return sort_desc_class;
+}
+

--- a/realm/realm-library/src/main/cpp/java_sort_descriptor.hpp
+++ b/realm/realm-library/src/main/cpp/java_sort_descriptor.hpp
@@ -22,6 +22,11 @@
 #include "descriptor_ordering.hpp"
 
 namespace realm {
+
+namespace jni_util {
+class JavaClass;
+}
+
 namespace _impl {
 
 // For converting a Java SortDescriptor object to realm::SortDescriptor.
@@ -58,6 +63,8 @@ private:
     realm::Table* get_table_ptr() const noexcept;
     std::vector<std::vector<size_t>> get_column_indices() const noexcept;
     std::vector<bool> get_ascendings() const noexcept;
+
+    jni_util::JavaClass const& get_sort_desc_class() const noexcept;
 };
 
 } // namespace _impl

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
@@ -15,12 +15,13 @@
  */
 
 #include "java_method.hpp"
+#include "java_class.hpp"
 
 #include <realm/util/assert.hpp>
 
 using namespace realm::jni_util;
 
-JavaMethod::JavaMethod(JNIEnv* env, jclass cls, const char* method_name, const char* signature, bool static_method)
+JavaMethod::JavaMethod(JNIEnv* env, JavaClass const& cls, const char* method_name, const char* signature, bool static_method)
 {
     if (static_method) {
         m_method_id = env->GetStaticMethodID(cls, method_name, signature);
@@ -30,25 +31,4 @@ JavaMethod::JavaMethod(JNIEnv* env, jclass cls, const char* method_name, const c
     }
 
     REALM_ASSERT_RELEASE(m_method_id != nullptr);
-}
-
-JavaMethod::JavaMethod(JNIEnv* env, jobject obj, const char* method_name, const char* signature)
-{
-    jclass cls = env->GetObjectClass(obj);
-    m_method_id = env->GetMethodID(cls, method_name, signature);
-    REALM_ASSERT_RELEASE(m_method_id != nullptr);
-    env->DeleteLocalRef(cls);
-}
-
-JavaMethod::JavaMethod(JNIEnv* env, const char* class_name, const char* method_name, const char* signature,
-                       bool static_method)
-{
-    jclass cls = env->FindClass(class_name);
-    REALM_ASSERT_RELEASE(cls != nullptr);
-    if (static_method) {
-        m_method_id = env->GetStaticMethodID(cls, method_name, signature);
-    }
-    else {
-        m_method_id = env->GetMethodID(cls, method_name, signature);
-    }
 }

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.hpp
@@ -22,6 +22,7 @@
 namespace realm {
 namespace jni_util {
 
+class JavaClass;
 // RAII wrapper for java method ID. Since normally method ID stays unchanged for the whole JVM life cycle, it would be
 // safe to have a static JavaMethod object to avoid calling GetMethodID multiple times.
 class JavaMethod {
@@ -30,10 +31,27 @@ public:
         : m_method_id(nullptr)
     {
     }
-    JavaMethod(JNIEnv* env, jclass cls, const char* method_name, const char* signature, bool static_method = false);
-    JavaMethod(JNIEnv* env, jobject obj, const char* method_name, const char* signature);
-    JavaMethod(JNIEnv* env, const char* class_name, const char* method_name, const char* signature,
+    JavaMethod(JNIEnv* env, JavaClass const& cls, const char* method_name, const char* signature,
                bool static_method = false);
+
+    // From https://developer.android.com/training/articles/perf-jni.html
+    // The class references, field IDs, and method IDs are guaranteed valid until the class is unloaded. Classes are
+    // only unloaded if all classes associated with a ClassLoader can be garbage collected, which is rare but will not
+    // be impossible in Android. Note however that the jclass is a class reference and must be protected with a call
+    // to NewGlobalRef (see the next section).
+    //
+    // BUT THERE ARE BUGS. See below:
+    //
+    // WARNING!! For anyone wants to implement this method, please DON'T. There might be a bug in JVM implementation
+    // that the jmethodID retrieved from jobject's jclass would be invalid under some certain conditions.
+    // See https://github.com/realm/realm-java/issues/4964 for how to reproduce it.
+    // JavaMethod(JNIEnv* env, jobject obj, const char* method_name, const char* signature);
+
+    // For this constructor, there is no evidence that jmethodID will be invalidated when there is no ref to the jclass.
+    // Just in case, though we force the caller to keep a global ref by JavaClass to make sure we won't encounter another
+    // JVM bug.
+    // JavaMethod(JNIEnv* env, const char* class_name, const char* method_name, const char* signature,
+    //           bool static_method = false);
 
     JavaMethod(const JavaMethod&) = default;
     JavaMethod& operator=(const JavaMethod&) = default;

--- a/realm/realm-library/src/main/java/io/realm/CompactOnLaunchCallback.java
+++ b/realm/realm-library/src/main/java/io/realm/CompactOnLaunchCallback.java
@@ -17,14 +17,13 @@
 package io.realm;
 
 import io.realm.internal.Keep;
-import io.realm.internal.KeepMember;
 
 /**
  * This interface is used to determine if a Realm file should be compacted the first time the file is opened and before
  * the instance is returned.
  * <p>
  * Note that compacting a file can take a while, so compacting should generally only be done on a background thread or
- * when used in combination with {@link Realm#getInstanceAsync(RealmConfiguration, Callback)}.
+ * when used in combination with {@link Realm#getInstanceAsync(RealmConfiguration, Realm.Callback)}.
  */
 @Keep
 public interface CompactOnLaunchCallback {

--- a/realm/realm-library/src/main/java/io/realm/internal/OsObject.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsObject.java
@@ -26,7 +26,7 @@ import io.realm.exceptions.RealmException;
 /**
  * Java wrapper for Object Store's {@code Object} class.
  */
-@KeepMember
+@Keep
 public class OsObject implements NativeObject {
 
     private static class OsObjectChangeSet implements ObjectChangeSet {
@@ -239,7 +239,6 @@ public class OsObject implements NativeObject {
 
     // Called by JNI
     @SuppressWarnings("unused")
-    @KeepMember
     private void notifyChangeListeners(String[] changedFields) {
         observerPairs.foreach(new Callback(changedFields));
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
@@ -37,7 +37,7 @@ import io.realm.internal.fields.FieldDescriptor;
  * <p>
  * Sort descriptors do not support Linking Objects, either internally or as terminal types.
  */
-@KeepMember
+@Keep
 public class SortDescriptor {
     //@VisibleForTesting
     final static Set<RealmFieldType> SORT_VALID_FIELD_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
@@ -128,21 +128,18 @@ public class SortDescriptor {
     }
 
     // Called by JNI.
-    @KeepMember
     @SuppressWarnings("unused")
     long[][] getColumnIndices() {
         return columnIndices;
     }
 
     // Called by JNI.
-    @KeepMember
     @SuppressWarnings("unused")
     boolean[] getAscendings() {
         return ascendings;
     }
 
     // Called by JNI.
-    @KeepMember
     @SuppressWarnings("unused")
     private long getTablePtr() {
         return table.getNativePtr();

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.internal.Keep;
-import io.realm.internal.KeepMember;
 import io.realm.internal.network.AuthenticationServer;
 import io.realm.internal.network.NetworkStateReceiver;
 import io.realm.internal.network.OkHttpAuthenticationServer;
@@ -292,7 +291,6 @@ public class SyncManager {
      * can leak since we don't have control over the session lifecycle.
      */
     @SuppressWarnings("unused")
-    @KeepMember
     private static synchronized void notifyProgressListener(String localRealmPath, long listenerId, long transferedBytes, long transferableBytes) {
         SyncSession session = sessions.get(localRealmPath);
         if (session != null) {

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.realm.internal.Keep;
-import io.realm.internal.KeepMember;
 import io.realm.internal.SyncObjectServerFacade;
 import io.realm.internal.android.AndroidCapabilities;
 import io.realm.internal.async.RealmAsyncTaskImpl;
@@ -153,7 +152,6 @@ public class SyncSession {
     }
 
     // This callback will happen on the thread running the Sync Client.
-    @KeepMember
     void notifySessionError(int errorCode, String errorMessage) {
         if (errorHandler == null) {
             return;
@@ -179,7 +177,6 @@ public class SyncSession {
      * @return the state of the session.
      * @see SyncSession.State
      */
-    @KeepMember
     @SuppressWarnings("unused")
     public State getState() {
         byte state = nativeGetState(configuration.getPath());


### PR DESCRIPTION
- cherry-pick #4939 to enabled debug in menifest which caused a crash described in #4964.
- Removed API to create JavaMethod from jobject/class name string.  There seems to be a bug in Android JVM when getting the method by: jclass cls = env->GetObjectClass(obj); jmethodID method = env->GetMethodID(cls, "xxx", "xxx") The methodID retrieved by the above way triggers a strange bug in JVM, it reports the method cannot be found on a non-relevant object. Like:
  > can't call boolean io.realm.DefaultCompactOnLaunchCallback.shouldCompact(long, long) on instance of io.realm.RealmTests$6'

  Where RealmTest$6 has nothing to do with that JNI call.  It is not because of the local ref of cls has been deleted -- Even if it is deleted, the methodID should still be valid according to the doc:

  > The class references, field IDs, and method IDs are guaranteed valid until the class is unloaded. Classes are only unloaded if all classes associated with a ClassLoader can be garbage collected, which is rare but will not be impossible in Android.

  The class should never be unload in this case!
- For safety reasons, the JavaMethod should only be created from a JavaClass right now to avoid future surprise.

Close #4964