### PR TITLE
Update Object Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### Enhancements
 
 * [ObjectServer] Added `SyncSession.uploadAllLocalChanges()`.
+* [ObjectServer] APIs of `UserStore` have been changed to support same user identity but different authentication server scenario.
 * Added `Nullable` annotation to methods that may return `null` in order to improve Kotlin usability. This also introduced a dependency to `com.google.code.findbugs:jsr305`.
-* Added support for new data type `MutableRealmIntegers`. The new type behaves almost exactly as a reference to a Long (mutable nullable, etc) but supports `increment` and `decrement` methods, which implement a Conflict Free Replicated Data Type, whose value will converge even when changed across distributed devices with poor connections. (#4266)
+* Added support for new data type `MutableRealmIntegers`. The new type behaves almost exactly as a reference to a Long (mutable nullable, etc) but supports `increment` and `decrement` methods, which implement a Conflict Free Replicated Data Type, whose value will converge even when changed across distributed devices with poor connections. (#4266).
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncManagerTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncManagerTests.java
@@ -56,12 +56,13 @@ public class SyncManagerTests {
             }
 
             @Override
-            public SyncUser get(String identity) {
+            public SyncUser get(String identity, String authenticationUrl) {
                 return null;
             }
 
             @Override
-            public void remove(String identity) {}
+            public void remove(String identity, String authenticationUrl) {
+            }
 
             @Override
             public Collection<SyncUser> allUsers() {
@@ -69,7 +70,7 @@ public class SyncManagerTests {
             }
 
             @Override
-            public boolean isActive(String identity) {
+            public boolean isActive(String identity, String authenticationUrl) {
                 return true;
             }
         };

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
@@ -108,9 +108,8 @@ public class SyncedRealmMigrationTests {
         RealmObjectSchema stringOnlySchema = realm.getSchema().get(className);
         try {
             assertTrue(stringOnlySchema.hasField(StringOnly.FIELD_CHARS));
-            // TODO Field is currently hidden, but should the field be visible in the schema
-            assertFalse(stringOnlySchema.hasField("newField"));
-            assertEquals(1, stringOnlySchema.getFieldNames().size());
+            assertTrue(stringOnlySchema.hasField("newField"));
+            assertEquals(2, stringOnlySchema.getFieldNames().size());
         } finally {
             realm.close();
         }

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
@@ -35,23 +35,31 @@ static jstring to_user_string_or_null(JNIEnv* env, const std::shared_ptr<SyncUse
     }
 }
 
+static SyncUserIdentifier create_sync_user_identifier(JNIEnv* env, jstring j_user_id, jstring j_auth_url)
+{
+    JStringAccessor user_id(env, j_user_id);   // throws
+    JStringAccessor auth_url(env, j_auth_url); // throws
+    return {user_id, auth_url};
+}
+
 JNIEXPORT jstring JNICALL Java_io_realm_RealmFileUserStore_nativeGetCurrentUser(JNIEnv* env, jclass)
 {
     TR_ENTER()
     try {
-        const std::shared_ptr<SyncUser>& user = SyncManager::shared().get_current_user();
+        auto user = SyncManager::shared().get_current_user();
         return to_user_string_or_null(env, user);
     }
     CATCH_STD()
     return nullptr;
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_RealmFileUserStore_nativeGetUser(JNIEnv* env, jclass, jstring identity)
+JNIEXPORT jstring JNICALL Java_io_realm_RealmFileUserStore_nativeGetUser(JNIEnv* env, jclass, jstring j_user_id,
+                                                                         jstring j_auth_url)
 {
     TR_ENTER()
     try {
-        JStringAccessor id(env, identity); // throws
-        const std::shared_ptr<SyncUser>& user = SyncManager::shared().get_existing_logged_in_user(id);
+        auto user = SyncManager::shared().get_existing_logged_in_user(
+            create_sync_user_identifier(env, j_user_id, j_auth_url));
         return to_user_string_or_null(env, user);
     }
     CATCH_STD()
@@ -59,25 +67,24 @@ JNIEXPORT jstring JNICALL Java_io_realm_RealmFileUserStore_nativeGetUser(JNIEnv*
 }
 
 JNIEXPORT void JNICALL Java_io_realm_RealmFileUserStore_nativeUpdateOrCreateUser(JNIEnv* env, jclass,
-                                                                                 jstring identity, jstring json_token,
-                                                                                 jstring url)
+                                                                                 jstring j_user_id, jstring json_token,
+                                                                                 jstring j_auth_url)
 {
     TR_ENTER()
     try {
-        JStringAccessor user_identity(env, identity);     // throws
         JStringAccessor user_json_token(env, json_token); // throws
-        JStringAccessor auth_url(env, url);               // throws
-        SyncManager::shared().get_user(user_identity, user_json_token, std::string(auth_url));
+        SyncManager::shared().get_user(create_sync_user_identifier(env, j_user_id, j_auth_url), user_json_token);
     }
     CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_RealmFileUserStore_nativeLogoutUser(JNIEnv* env, jclass, jstring identity)
+JNIEXPORT void JNICALL Java_io_realm_RealmFileUserStore_nativeLogoutUser(JNIEnv* env, jclass, jstring j_user_id,
+                                                                         jstring j_auth_url)
 {
     TR_ENTER()
     try {
-        JStringAccessor id(env, identity); // throws
-        const std::shared_ptr<SyncUser>& user = SyncManager::shared().get_existing_logged_in_user(id);
+        auto user = SyncManager::shared().get_existing_logged_in_user(
+            create_sync_user_identifier(env, j_user_id, j_auth_url));
         if (user) {
             user->log_out();
         }
@@ -85,12 +92,13 @@ JNIEXPORT void JNICALL Java_io_realm_RealmFileUserStore_nativeLogoutUser(JNIEnv*
     CATCH_STD()
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_RealmFileUserStore_nativeIsActive(JNIEnv* env, jclass, jstring j_identity)
+JNIEXPORT jboolean JNICALL Java_io_realm_RealmFileUserStore_nativeIsActive(JNIEnv* env, jclass, jstring j_user_id,
+                                                                           jstring j_auth_url)
 {
     TR_ENTER()
     try {
-        JStringAccessor identity(env, j_identity); // throws
-        const std::shared_ptr<SyncUser>& user = SyncManager::shared().get_existing_logged_in_user(identity);
+        auto user = SyncManager::shared().get_existing_logged_in_user(
+            create_sync_user_identifier(env, j_user_id, j_auth_url));
         if (user) {
             return to_jbool(user->state() == SyncUser::State::Active);
         }
@@ -102,7 +110,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_RealmFileUserStore_nativeIsActive(JNIEn
 JNIEXPORT jobjectArray JNICALL Java_io_realm_RealmFileUserStore_nativeGetAllUsers(JNIEnv* env, jclass)
 {
     TR_ENTER()
-    std::vector<std::shared_ptr<SyncUser>> all_users = SyncManager::shared().all_logged_in_users();
+    auto all_users = SyncManager::shared().all_logged_in_users();
     if (!all_users.empty()) {
         size_t len = all_users.size();
         jobjectArray users_token = env->NewObjectArray(len, java_lang_string, 0);

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Property.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Property.cpp
@@ -1,8 +1,7 @@
 /*
  * Copyright 2016 Realm Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -25,22 +24,35 @@
 
 using namespace realm;
 
+static_assert(io_realm_internal_Property_TYPE_INT == static_cast<jint>(PropertyType::Int), "");
+static_assert(io_realm_internal_Property_TYPE_BOOL == static_cast<jint>(PropertyType::Bool), "");
+static_assert(io_realm_internal_Property_TYPE_STRING == static_cast<jint>(PropertyType::String), "");
+static_assert(io_realm_internal_Property_TYPE_DATA == static_cast<jint>(PropertyType::Data), "");
+static_assert(io_realm_internal_Property_TYPE_DATE == static_cast<jint>(PropertyType::Date), "");
+static_assert(io_realm_internal_Property_TYPE_FLOAT == static_cast<jint>(PropertyType::Float), "");
+static_assert(io_realm_internal_Property_TYPE_DOUBLE == static_cast<jint>(PropertyType::Double), "");
+static_assert(io_realm_internal_Property_TYPE_OBJECT == static_cast<jint>(PropertyType::Object), "");
+static_assert(io_realm_internal_Property_TYPE_LINKING_OBJECTS == static_cast<jint>(PropertyType::LinkingObjects), "");
+static_assert(io_realm_internal_Property_TYPE_REQUIRED == static_cast<jint>(PropertyType::Required), "");
+static_assert(io_realm_internal_Property_TYPE_NULLABLE == static_cast<jint>(PropertyType::Nullable), "");
+static_assert(io_realm_internal_Property_TYPE_ARRAY == static_cast<jint>(PropertyType::Array), "");
+
 static void finalize_property(jlong ptr)
 {
     TR_ENTER_PTR(ptr);
     delete reinterpret_cast<Property*>(ptr);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_Property_nativeCreateProperty__Ljava_lang_String_2IZZZ(
-    JNIEnv* env, jclass, jstring name_, jint type, jboolean is_primary, jboolean is_indexed, jboolean is_nullable)
+JNIEXPORT jlong JNICALL Java_io_realm_internal_Property_nativeCreateProperty__Ljava_lang_String_2IZZ(
+    JNIEnv* env, jclass, jstring name_, jint type, jboolean is_primary, jboolean is_indexed)
 {
     TR_ENTER()
     try {
         JStringAccessor str(env, name_);
         PropertyType p_type = static_cast<PropertyType>(static_cast<int>(type));
         std::unique_ptr<Property> property(
-            new Property(str, p_type, "", "", to_bool(is_primary), to_bool(is_indexed), to_bool(is_nullable)));
-        if (to_bool(is_indexed) && !property->is_indexable()) {
+            new Property(str, p_type, to_bool(is_primary), to_bool(is_indexed)));
+        if (to_bool(is_indexed) && !property->type_is_indexable()) {
             throw std::invalid_argument(
                 "This field cannot be indexed - Only String/byte/short/int/long/boolean/Date fields are supported.");
         }
@@ -62,8 +74,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Property_nativeCreateProperty__Lj
         JStringAccessor name(env, name_);
         JStringAccessor link_name(env, linkedToName_);
         PropertyType p_type = static_cast<PropertyType>(static_cast<int>(type));
-        bool is_nullable = (p_type == PropertyType::Object);
-        return reinterpret_cast<jlong>(new Property(name, p_type, link_name, "", false, false, is_nullable));
+        return reinterpret_cast<jlong>(new Property(name, p_type, link_name));
     }
     CATCH_STD()
     return 0;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Property.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Property.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright 2016 Realm Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -127,11 +127,10 @@ public:
 
         // Get logged in user
         JStringAccessor user_id(env, j_sync_user_id);
-        JStringAccessor realm_url(env, sync_realm_url);
-        SyncUserIdentifier sync_user_identifier = {user_id, realm_url};
+        JStringAccessor realm_auth_url(env, sync_realm_auth_url);
+        SyncUserIdentifier sync_user_identifier = {user_id, realm_auth_url};
         std::shared_ptr<SyncUser> user = SyncManager::shared().get_existing_logged_in_user(sync_user_identifier);
         if (!user) {
-            JStringAccessor realm_auth_url(env, sync_realm_auth_url);
             JStringAccessor refresh_token(env, sync_refresh_token);
             user = SyncManager::shared().get_user(sync_user_identifier, refresh_token);
         }
@@ -148,6 +147,7 @@ public:
             std::copy_n(m_config.encryption_key.begin(), 64, sync_encryption_key->begin());
         }
 
+        JStringAccessor realm_url(env, sync_realm_url);
         m_config.sync_config = std::make_shared<SyncConfig>(SyncConfig{
             user, realm_url, SyncSessionStopPolicy::Immediately, std::move(bind_handler), std::move(error_handler),
             nullptr, sync_encryption_key, to_bool(sync_client_validate_ssl), ssl_trust_certificate_path});

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -74,7 +74,7 @@ public:
     // Sync constructor
     JniConfigWrapper(REALM_UNUSED JNIEnv* env, REALM_UNUSED Realm::Config& config,
                      REALM_UNUSED jstring sync_realm_url, REALM_UNUSED jstring sync_realm_auth_url,
-                     REALM_UNUSED jstring sync_user_identity, REALM_UNUSED jstring sync_refresh_token,
+                     REALM_UNUSED jstring j_sync_user_id, REALM_UNUSED jstring sync_refresh_token,
                      REALM_UNUSED jboolean sync_client_validate_ssl,
                      REALM_UNUSED jstring sync_ssl_trust_certificate_path)
         : m_config(std::move(config))
@@ -126,14 +126,14 @@ public:
         };
 
         // Get logged in user
-        JStringAccessor user_identity(env, sync_user_identity);
+        JStringAccessor user_id(env, j_sync_user_id);
         JStringAccessor realm_url(env, sync_realm_url);
-        std::shared_ptr<SyncUser> user = SyncManager::shared().get_existing_logged_in_user(user_identity);
+        SyncUserIdentifier sync_user_identifier = {user_id, realm_url};
+        std::shared_ptr<SyncUser> user = SyncManager::shared().get_existing_logged_in_user(sync_user_identifier);
         if (!user) {
             JStringAccessor realm_auth_url(env, sync_realm_auth_url);
             JStringAccessor refresh_token(env, sync_refresh_token);
-            user = SyncManager::shared().get_user(user_identity, refresh_token,
-                                                  realm::util::Optional<std::string>(realm_auth_url));
+            user = SyncManager::shared().get_user(sync_user_identifier, refresh_token);
         }
 
         util::Optional<std::string> ssl_trust_certificate_path = util::none;
@@ -150,7 +150,7 @@ public:
 
         m_config.sync_config = std::make_shared<SyncConfig>(SyncConfig{
             user, realm_url, SyncSessionStopPolicy::Immediately, std::move(bind_handler), std::move(error_handler),
-            nullptr, sync_encryption_key, sync_client_validate_ssl, ssl_trust_certificate_path});
+            nullptr, sync_encryption_key, to_bool(sync_client_validate_ssl), ssl_trust_certificate_path});
 #else
         REALM_UNREACHABLE();
 #endif

--- a/realm/realm-library/src/main/java/io/realm/internal/Property.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Property.java
@@ -29,21 +29,90 @@ public class Property implements NativeObject {
     public static final boolean REQUIRED = true;
     public static final boolean INDEXED = true;
 
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_INT = 0;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_BOOL = 1;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_STRING = 2;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_DATA = 3;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_DATE = 4;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_FLOAT = 5;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_DOUBLE = 6;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_OBJECT = 7;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_LINKING_OBJECTS = 8;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_REQUIRED = 0;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_NULLABLE = 64;
+    @SuppressWarnings("WeakerAccess")
+    public static final int TYPE_ARRAY = 128;
+
     private long nativePtr;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
 
     Property(String name, RealmFieldType type, boolean isPrimary, boolean isIndexed, boolean isRequired) {
-        this.nativePtr = nativeCreateProperty(name, type.getNativeValue(), isPrimary, isIndexed, !isRequired);
+        this.nativePtr = nativeCreateProperty(name, convertFromRealmFieldType(type, isRequired), isPrimary, isIndexed);
         NativeContext.dummyContext.addReference(this);
     }
 
     Property(String name, RealmFieldType type, String linkedClassName) {
-        this.nativePtr = nativeCreateProperty(name, type.getNativeValue(), linkedClassName);
+        // Ignore the isRequired when creating the linking property.
+        int propertyType = convertFromRealmFieldType(type, false);
+        this.nativePtr = nativeCreateProperty(name, propertyType, linkedClassName);
         NativeContext.dummyContext.addReference(this);
     }
 
     protected Property(long nativePtr) {
         this.nativePtr = nativePtr;
+    }
+
+    private int convertFromRealmFieldType(RealmFieldType fieldType, boolean isRequired) {
+        int type;
+        switch (fieldType) {
+            case OBJECT:
+                type = TYPE_OBJECT | TYPE_NULLABLE;
+                return type;
+            case LIST:
+                type = TYPE_OBJECT | TYPE_ARRAY;
+                return type;
+            case LINKING_OBJECTS:
+                type = TYPE_LINKING_OBJECTS | TYPE_ARRAY;
+                return type;
+            case INTEGER:
+                type = TYPE_INT;
+                break;
+            case BOOLEAN:
+                type = TYPE_BOOL;
+                break;
+            case STRING:
+                type = TYPE_STRING;
+                break;
+            case BINARY:
+                type = TYPE_DATA;
+                break;
+            case DATE:
+                type = TYPE_DATE;
+                break;
+            case FLOAT:
+                type = TYPE_FLOAT;
+                break;
+            case DOUBLE:
+                type = TYPE_DOUBLE;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Unsupported filed type: '%s'.", fieldType.name()));
+
+        }
+        int requiredFlag = isRequired ? TYPE_REQUIRED : TYPE_NULLABLE;
+        return type | requiredFlag;
     }
 
     @Override
@@ -56,7 +125,7 @@ public class Property implements NativeObject {
         return nativeFinalizerPtr;
     }
 
-    private static native long nativeCreateProperty(String name, int type, boolean isPrimary, boolean isIndexed, boolean isNullable);
+    private static native long nativeCreateProperty(String name, int type, boolean isPrimary, boolean isIndexed);
 
     private static native long nativeCreateProperty(String name, int type, String linkedToName);
 

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmFileUserStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmFileUserStore.java
@@ -48,8 +48,8 @@ public class RealmFileUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
-    public SyncUser get(String identity) {
-        String userJson = nativeGetUser(identity);
+    public SyncUser get(String identity, String authUrl) {
+        String userJson = nativeGetUser(identity, authUrl);
         return toSyncUserOrNull(userJson);
     }
 
@@ -57,8 +57,8 @@ public class RealmFileUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
-    public void remove(String identity) {
-        nativeLogoutUser(identity);
+    public void remove(String identity, String authUrl) {
+        nativeLogoutUser(identity, authUrl);
     }
 
     /**
@@ -81,8 +81,8 @@ public class RealmFileUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
-    public boolean isActive(String identity) {
-        return nativeIsActive(identity);
+    public boolean isActive(String identity, String authenticationUrl) {
+        return nativeIsActive(identity, authenticationUrl);
     }
 
     private static SyncUser toSyncUserOrNull(String userJson) {
@@ -96,13 +96,13 @@ public class RealmFileUserStore implements UserStore {
     protected static native String nativeGetCurrentUser();
 
     // returns json data (token) of the specified user
-    protected static native String nativeGetUser(String identity);
+    protected static native String nativeGetUser(String identity, String authUrl);
 
     protected static native String[] nativeGetAllUsers();
 
     protected static native void nativeUpdateOrCreateUser(String identity, String jsonToken, String url);
 
-    protected static native void nativeLogoutUser(String identity);
+    protected static native void nativeLogoutUser(String identity, String authUrl);
 
-    protected static native boolean nativeIsActive(String identity);
+    protected static native boolean nativeIsActive(String identity, String authUrl);
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -269,7 +269,7 @@ public class SyncUser {
                 }
             }
 
-            SyncManager.getUserStore().remove(syncUser.getIdentity());
+            SyncManager.getUserStore().remove(syncUser.getIdentity(), getAuthenticationUrl().toString());
 
             // Delete all Realms if needed.
             for (ObjectServerUser.AccessDescription desc : syncUser.getRealms()) {
@@ -465,7 +465,7 @@ public class SyncUser {
                 throw response.getError();
             }
         } else {
-            SyncUser syncUser = SyncManager.getUserStore().get(response.getUserId());
+            SyncUser syncUser = SyncManager.getUserStore().get(response.getUserId(), getAuthenticationUrl().toString());
             if (syncUser != null) {
                 return syncUser;
             } else {
@@ -535,7 +535,8 @@ public class SyncUser {
      */
     public boolean isValid() {
         Token userToken = getSyncUser().getUserToken();
-        return userToken != null && userToken.expiresMs() > System.currentTimeMillis() && SyncManager.getUserStore().isActive(syncUser.getIdentity());
+        return userToken != null && userToken.expiresMs() > System.currentTimeMillis() &&
+                SyncManager.getUserStore().isActive(getIdentity(), getAuthenticationUrl().toString());
     }
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/UserStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/UserStore.java
@@ -49,9 +49,10 @@ public interface UserStore {
      * Retrieves specified {@link SyncUser}.
      *
      * @param identity identity of the user.
+     * @param authenticationUrl the URL of the authentication.
      * @return {@link SyncUser} object or {@code null} if not found.
      */
-    SyncUser get(String identity);
+    SyncUser get(String identity, String authenticationUrl);
 
     /**
      * Removes the user from the store.
@@ -59,8 +60,9 @@ public interface UserStore {
      * If the user is not found, this method does nothing.
      *
      * @param identity identity of the user.
+     * @param authenticationUrl the URL of the authentication.
      */
-    void remove(String identity);
+    void remove(String identity, String authenticationUrl);
 
     /**
      * Returns a collection of all users saved in the User store.
@@ -75,7 +77,8 @@ public interface UserStore {
      * this method will return {@code true}.
      *
      * @param identity identity of the user.
+     * @param authenticationUrl the URL of the authentication.
      * @return {@code true} if the user is not logged out, {@code false} otherwise.
      */
-    boolean isActive(String identity);
+    boolean isActive(String identity, String authenticationUrl);
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -91,7 +91,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
             // make sure the user is still valid
             SyncUser user = syncConfig.getUser();
             if (!user.isValid()) {
-                if (!SyncManager.getUserStore().isActive(user.getIdentity())) {
+                if (!SyncManager.getUserStore().isActive(user.getIdentity(), user.getAuthenticationUrl().toString())) {
                     throw new IllegalStateException("The SyncUser is already logged out and can not use the provided configuration to open a Realm.");
                 } else {
                     // user was not logged out but the `refresh_token` is not longer valid


### PR DESCRIPTION
Breaking changes from Object Store:

to 50cf5ee583
- To identify a user, Object Store needs both user ID and auth URL. Thus
  API has been changed in UserStore.
- Property::PropertyType has been changed which is not the same with
  field types in the core anymore.