### PR TITLE
Deprecate Management Realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 3.6.0 (YYYY-MM-DD)
 
+### Deprecated
+
+* `SyncUser.getManagementRealm()`. Use `SyncUser.getPermissionManager()` instead.
+
 ### Enhancements
 
 * [ObjectServer] Added `SyncSession.uploadAllLocalChanges()`.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -571,13 +571,9 @@ public class SyncUser {
     }
 
     /**
-     * Returns an instance of the Management Realm owned by the user.
-     * <p>
-     * This Realm can be used to control access and permissions for Realms owned by the user. This includes
-     * giving other users access to Realms.
-     *
-     * @see <a href="https://realm.io/docs/realm-object-server/#permissions">How to control permissions</a>
+     * Use {@link #getPermissionManager()} instead.
      */
+    @Deprecated
     public Realm getManagementRealm() {
         return Realm.getInstance(managementConfig.initAndGetManagementRealmConfig(this));
     }


### PR DESCRIPTION
Part of #4558 

Deprecates `getManagementRealm()` in favour of `getPermissionManager()`. The implementation should be deleted in 4.0