### PR TITLE
Refactor compileFieldDescription() in CachedFieldDescriptor and DynamicFieldDescriptor

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
@@ -54,43 +54,41 @@ class CachedFieldDescriptor extends FieldDescriptor {
         final int nFields = fields.size();
         long[] columnIndices = new long[nFields];
         long[] tableNativePointers = new long[nFields];
-        String currentTable = className;
 
-        ColumnInfo tableInfo;
-        String columnName = null;
-        RealmFieldType columnType = null;
-        long columnIndex;
+        String currentClassName = className;
+        String currentColumnName = null;
+        RealmFieldType currentColumnType = null;
         for (int i = 0; i < nFields; i++) {
-            columnName = fields.get(i);
-            if ((columnName == null) || (columnName.length() <= 0)) {
+            currentColumnName = fields.get(i);
+            if ((currentColumnName == null) || (currentColumnName.length() <= 0)) {
                 throw new IllegalArgumentException(
                         "Invalid query: Field descriptor contains an empty field.  A field description may not begin with or contain adjacent periods ('.').");
             }
 
-            tableInfo = schema.getColumnInfo(currentTable);
-            if (tableInfo == null) {
+            final ColumnInfo columnInfo = schema.getColumnInfo(currentClassName);
+            if (columnInfo == null) {
                 throw new IllegalArgumentException(
-                        String.format(Locale.US, "Invalid query: table '%s' not found in this schema.", currentTable));
+                        String.format(Locale.US, "Invalid query: class '%s' not found in this schema.", currentClassName));
             }
 
-            columnIndex = tableInfo.getColumnIndex(columnName);
+            final long columnIndex = columnInfo.getColumnIndex(currentColumnName);
             if (columnIndex < 0) {
                 throw new IllegalArgumentException(
-                        String.format(Locale.US, "Invalid query: field '%s' not found in table '%s'.", columnName, currentTable));
+                        String.format(Locale.US, "Invalid query: field '%s' not found in table '%s'.", currentColumnName, currentClassName));
             }
 
-            columnType = tableInfo.getColumnType(columnName);
+            currentColumnType = columnInfo.getColumnType(currentColumnName);
             // we don't check the type of the last field in the chain since it is done in the C++ code
             if (i < nFields - 1) {
-                verifyInternalColumnType(currentTable, columnName, columnType);
+                verifyInternalColumnType(currentClassName, currentColumnName, currentColumnType);
             }
-            currentTable = tableInfo.getLinkedTable(columnName);
+            currentClassName = columnInfo.getLinkedTable(currentColumnName);
             columnIndices[i] = columnIndex;
-            tableNativePointers[i] = (columnType != RealmFieldType.LINKING_OBJECTS)
+            tableNativePointers[i] = (currentColumnType != RealmFieldType.LINKING_OBJECTS)
                     ? NativeObject.NULLPTR
-                    : schema.getNativeTablePtr(currentTable);
+                    : schema.getNativeTablePtr(currentClassName);
         }
 
-        setCompilationResults(className, columnName, columnType, columnIndices, tableNativePointers);
+        setCompilationResults(className, currentColumnName, currentColumnType, columnIndices, tableNativePointers);
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/DynamicFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/DynamicFieldDescriptor.java
@@ -47,36 +47,35 @@ class DynamicFieldDescriptor extends FieldDescriptor {
     protected void compileFieldDescription(List<String> fields) {
         final int nFields = fields.size();
         long[] columnIndices = new long[nFields];
-        Table currentTable = table;
 
-        long columnIndex;
-        String tableName = null;
-        String columnName = null;
-        RealmFieldType columnType = null;
+        Table currentTable = table;
+        String currentClassName = null;
+        String currentColumnName = null;
+        RealmFieldType currentColumnType = null;
         for (int i = 0; i < nFields; i++) {
-            columnName = fields.get(i);
-            if ((columnName == null) || (columnName.length() <= 0)) {
+            currentColumnName = fields.get(i);
+            if ((currentColumnName == null) || (currentColumnName.length() <= 0)) {
                 throw new IllegalArgumentException(
                         "Invalid query: Field descriptor contains an empty field.  A field description may not begin with or contain adjacent periods ('.').");
             }
 
-            tableName = currentTable.getClassName();
+            currentClassName = currentTable.getClassName();
 
-            columnIndex = currentTable.getColumnIndex(columnName);
+            final long columnIndex = currentTable.getColumnIndex(currentColumnName);
             if (columnIndex < 0) {
                 throw new IllegalArgumentException(
-                        String.format(Locale.US, "Invalid query: field '%s' not found in table '%s'.", columnName, tableName));
+                        String.format(Locale.US, "Invalid query: field '%s' not found in table '%s'.", currentColumnName, currentClassName));
             }
 
-            columnType = currentTable.getColumnType(columnIndex);
+            currentColumnType = currentTable.getColumnType(columnIndex);
             if (i < nFields - 1) {
-                verifyInternalColumnType(tableName, columnName, columnType);
+                verifyInternalColumnType(currentClassName, currentColumnName, currentColumnType);
                 currentTable = currentTable.getLinkTarget(columnIndex);
             }
 
             columnIndices[i] = columnIndex;
         }
 
-        setCompilationResults(tableName, columnName, columnType, columnIndices, new long[nFields]);
+        setCompilationResults(currentClassName, currentColumnName, currentColumnType, columnIndices, new long[nFields]);
     }
 }


### PR DESCRIPTION
This PR did not change the logic at all, but gave a common prefix `current` to variables those are updated in the loop.

The most important improvement in this PR is correct usage of `table` and `class`.