### PR TITLE
Fix class name in exception message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `Realm.copyToRealmOrUpdate()` might cause a `RealmList` field to contain duplicated elements (#4957).
 * `RealmSchema.create(String)` and `RealmObjectSchema.setClassName(String)` did not accept class name whose length was 51 to 57.
 * Workaround for an Android JVM crash when using `compactOnLaunch()` (#4964).
+* Class name in exception message from link query is wrong (#5096).
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
 import java.util.Date;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -2770,6 +2771,26 @@ public class RealmQueryTests extends QueryTests {
                 realm.where(AllJavaTypes.class).isEmpty(fieldName).findAll();
                 fail();
             } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void isEmpty_acrossLink_wrongTypeThrows() {
+        for (RealmFieldType type : RealmFieldType.values()) {
+            if (SUPPORTED_IS_EMPTY_TYPES.contains(type)) {
+                continue;
+            }
+
+            RealmQuery<Owner> query = realm.where(Owner.class);
+            try {
+                query.isEmpty(Owner.FIELD_CAT + "." + Cat.FIELD_AGE);
+                fail();
+            } catch (IllegalArgumentException expected) {
+                assertEquals(String.format(Locale.US,
+                        "Invalid query: field '%s' in class '%s' is of invalid type '%s'.",
+                        Cat.FIELD_AGE, Cat.CLASS_NAME, RealmFieldType.INTEGER.name()),
+                        expected.getMessage());
             }
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/SortDescriptorTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/SortDescriptorTests.java
@@ -231,7 +231,7 @@ public class SortDescriptorTests {
         table.addColumnLink(listType, listType.name(), table);
 
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid query: field 'LIST' in table 'test_table' is of invalid type 'LIST'.");
+        thrown.expectMessage("Invalid query: field 'LIST' in class 'test_table' is of invalid type 'LIST'.");
         SortDescriptor.getInstanceForSort(null, table, String.format("%s.%s", listType.name(), type.name()), Sort.ASCENDING);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -485,13 +485,8 @@ public abstract class RealmObjectSchema {
         }
 
         @Override
-        public RealmFieldType getColumnType(String columnName) {
-            throw new UnsupportedOperationException("DynamicColumnIndices do not support 'getColumnType'");
-        }
-
-        @Override
-        public String getLinkedTable(String columnName) {
-            throw new UnsupportedOperationException("DynamicColumnIndices do not support 'getLinkedTable'");
+        public ColumnDetails getColumnDetails(String columnName) {
+            throw new UnsupportedOperationException("DynamicColumnIndices do not support 'getColumnDetails'");
         }
 
         @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
@@ -124,24 +124,6 @@ public final class ColumnIndices {
     }
 
     /**
-     * Convenience method to return the column index for a given field on a class
-     * or {@code -1} if no such field exists.
-     *
-     * @param clazz the class to search.
-     * @param fieldName the name of the field whose index is needed.
-     * @return the index in clazz of the field fieldName.
-     * @deprecated Use {@code getColumnInfo().getColumnIndex()} instead.
-     */
-    @Deprecated
-    public long getColumnIndex(Class<? extends RealmModel> clazz, String fieldName) {
-        final ColumnInfo columnInfo = getColumnInfo(clazz);
-        if (columnInfo == null) {
-            return -1;
-        }
-        return columnInfo.getColumnIndex(fieldName);
-    }
-
-    /**
      * Make this instance contain a (non-strict) subset of the data in the passed ColumnIndices.
      * The schemaVersion and every ColumnInfo object held by this instance will be updated to be
      * the same the corresponding data in the passed instance or IllegalStateException will be thrown.

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnInfo.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnInfo.java
@@ -33,7 +33,7 @@ import io.realm.RealmFieldType;
  * <p>
  * While the use of the fields in {@code ColumnDetails} is consistent, there are three subtly different cases:
  * <ul>
- * <li>If the column type is a simple type, the {@code peerClassName} field is empty (0L / NULLPTR)</li>
+ * <li>If the column type is a simple type, the {@code peerClassName} field is {@code null}</li>
  * <li>If the column type is OBJECT or LINK, the {@code peerClassName} field is the class name of the OBJECT/LINK type</li>
  * <li>If the column type is LINKING_OBJECT, the {@code peerClassName} field is the class name of the backlink source table
  * and the column index field is the index of the backlink source field, in the source table</li>
@@ -134,7 +134,7 @@ public abstract class ColumnInfo {
     }
 
     /**
-     * Returns the {@link ColumnDetails}, in the described table, for the named column.
+     * Returns the {@link ColumnDetails}, in the described table, of the named column.
      *
      * @return {@link ColumnDetails} or {@code null} if not found.
      */

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnInfo.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnInfo.java
@@ -33,9 +33,9 @@ import io.realm.RealmFieldType;
  * <p>
  * While the use of the fields in {@code ColumnDetails} is consistent, there are three subtly different cases:
  * <ul>
- * <li>If the column type is a simple type, the {@code peerClassName} field is {@code null}</li>
- * <li>If the column type is OBJECT or LINK, the {@code peerClassName} field is the class name of the OBJECT/LINK type</li>
- * <li>If the column type is LINKING_OBJECT, the {@code peerClassName} field is the class name of the backlink source table
+ * <li>If the column type is a simple type, the {@code linkedClassName} field is {@code null}</li>
+ * <li>If the column type is OBJECT or LINK, the {@code linkedClassName} field is the class name of the OBJECT/LINK type</li>
+ * <li>If the column type is LINKING_OBJECT, the {@code linkedClassName} field is the class name of the backlink source table
  * and the column index field is the index of the backlink source field, in the source table</li>
  * </ul>
  *
@@ -63,13 +63,13 @@ public abstract class ColumnInfo {
     public static final class ColumnDetails {
         public final long columnIndex;
         public final RealmFieldType columnType;
-        public final String peerClassName;
+        public final String linkedClassName;
 
-        ColumnDetails(long columnIndex, RealmFieldType columnType, String peerClassName) {
-            // invariant: (columnType == OBJECT || columnType == LIST || columnType == LINKING_OBJECTS) == (peerClassName != null)
+        ColumnDetails(long columnIndex, RealmFieldType columnType, String linkedClassName) {
+            // invariant: (columnType == OBJECT || columnType == LIST || columnType == LINKING_OBJECTS) == (linkedClassName != null)
             this.columnIndex = columnIndex;
             this.columnType = columnType;
-            this.peerClassName = peerClassName;
+            this.linkedClassName = linkedClassName;
         }
 
         @Override
@@ -77,7 +77,7 @@ public abstract class ColumnInfo {
             StringBuilder buf = new StringBuilder("ColumnDetails[");
             buf.append(columnIndex);
             buf.append(", ").append(columnType);
-            buf.append(", ").append(peerClassName);
+            buf.append(", ").append(linkedClassName);
             return buf.append("]").toString();
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
@@ -81,12 +81,12 @@ class CachedFieldDescriptor extends FieldDescriptor {
             // we don't check the type of the last field in the chain since it is done in the C++ code
             if (i < nFields - 1) {
                 verifyInternalColumnType(currentClassName, currentColumnName, currentColumnType);
-                currentClassName = details.peerClassName;
+                currentClassName = details.linkedClassName;
             }
             columnIndices[i] = details.columnIndex;
             tableNativePointers[i] = (currentColumnType != RealmFieldType.LINKING_OBJECTS)
                     ? NativeObject.NULLPTR
-                    : schema.getNativeTablePtr(details.peerClassName);
+                    : schema.getNativeTablePtr(details.linkedClassName);
         }
 
         setCompilationResults(currentClassName, currentColumnName, currentColumnType, columnIndices, tableNativePointers);

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/CachedFieldDescriptor.java
@@ -71,24 +71,24 @@ class CachedFieldDescriptor extends FieldDescriptor {
                         String.format(Locale.US, "Invalid query: class '%s' not found in this schema.", currentClassName));
             }
 
-            final long columnIndex = columnInfo.getColumnIndex(currentColumnName);
-            if (columnIndex < 0) {
+            final ColumnInfo.ColumnDetails details = columnInfo.getColumnDetails(currentColumnName);
+            if (details == null) {
                 throw new IllegalArgumentException(
-                        String.format(Locale.US, "Invalid query: field '%s' not found in table '%s'.", currentColumnName, currentClassName));
+                        String.format(Locale.US, "Invalid query: field '%s' not found in class '%s'.", currentColumnName, currentClassName));
             }
 
-            currentColumnType = columnInfo.getColumnType(currentColumnName);
+            currentColumnType = details.columnType;
             // we don't check the type of the last field in the chain since it is done in the C++ code
             if (i < nFields - 1) {
                 verifyInternalColumnType(currentClassName, currentColumnName, currentColumnType);
+                currentClassName = details.peerClassName;
             }
-            currentClassName = columnInfo.getLinkedTable(currentColumnName);
-            columnIndices[i] = columnIndex;
+            columnIndices[i] = details.columnIndex;
             tableNativePointers[i] = (currentColumnType != RealmFieldType.LINKING_OBJECTS)
                     ? NativeObject.NULLPTR
-                    : schema.getNativeTablePtr(currentClassName);
+                    : schema.getNativeTablePtr(details.peerClassName);
         }
 
-        setCompilationResults(className, currentColumnName, currentColumnType, columnIndices, tableNativePointers);
+        setCompilationResults(currentClassName, currentColumnName, currentColumnType, columnIndices, tableNativePointers);
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/fields/FieldDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/fields/FieldDescriptor.java
@@ -272,11 +272,11 @@ public abstract class FieldDescriptor {
         return Arrays.asList(fieldDescription.split("\\."));
     }
 
-    private void verifyColumnType(String tableName, String columnName, RealmFieldType columnType, Set<RealmFieldType> validTypes) {
+    private void verifyColumnType(String className, String columnName, RealmFieldType columnType, Set<RealmFieldType> validTypes) {
         if (!validTypes.contains(columnType)) {
             throw new IllegalArgumentException(String.format(Locale.US,
-                    "Invalid query: field '%s' in table '%s' is of invalid type '%s'.",
-                    columnName, tableName, columnType.toString()));
+                    "Invalid query: field '%s' in class '%s' is of invalid type '%s'.",
+                    columnName, className, columnType.toString()));
         }
     }
 


### PR DESCRIPTION
This PR fixes #5096

The important change is in `CachedFieldDescriptor#compileFieldDescription()`.
At the end of the method, they passed `className` as an first argument of `setCompilationResults()`. However, that argument should be the name of the container class of final field and actually the `className` is not the one. 

This PR also improve performance of `CachedFieldDescriptor#compileFieldDescription()`.
In the method, map lookup happened three times with the same key for each field. This PR replaced it with just one lookup for each field.