### PR TITLE
Fix misleading documentation about FieldAttribute.PRIMARY_KEY

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/FieldAttribute.java
+++ b/realm/realm-library/src/main/java/io/realm/FieldAttribute.java
@@ -30,7 +30,7 @@ public enum FieldAttribute {
     INDEXED,
 
     /**
-     * Marks a field as a primary key. This also implicitly mark it as {@link #INDEXED} and {@link #REQUIRED}.
+     * Marks a field as a primary key. This also implicitly mark it as {@link #INDEXED}.
      *
      * @see io.realm.annotations.PrimaryKey
      */


### PR DESCRIPTION
`FieldAttribute.PRIMARY_KEY` does not mark `REQUIRED` the field after this change https://github.com/realm/realm-java/commit/e36e69bb6887d3427b40f661a80c71b6dfb2548f#diff-8b882bdae59573a63bd9922af9ec0f81R144

