### PR TITLE
Update kotlin to 1.1.4-2

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.3-2'
+    ext.kotlin_version = '1.1.4'
     repositories {
         jcenter()
         mavenCentral()

--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.4'
+    ext.kotlin_version = '1.1.4-2'
     repositories {
         jcenter()
         mavenCentral()

--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.4-2'
+    ext.kotlin_version = '1.1.4'
     repositories {
         jcenter()
         mavenCentral()

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.3-2'
+    ext.kotlin_version = '1.1.4'
     repositories {
         mavenLocal()
         google()

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.4-2'
+    ext.kotlin_version = '1.1.4'
     repositories {
         mavenLocal()
         google()

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.4'
+    ext.kotlin_version = '1.1.4-2'
     repositories {
         mavenLocal()
         google()


### PR DESCRIPTION
https://blog.jetbrains.com/kotlin/2017/08/kotlin-1-1-4-is-out/

Kotlin 1.1.4 now supports default nullability that we recently introduced to Realm Java.