### PR TITLE
Object notifications cannot find class

### DIFF
--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -62,8 +62,9 @@ struct ObjectWrapper {
 };
 
 struct ChangeCallback {
-    ChangeCallback(ObjectWrapper* wrapper)
-        : m_wrapper(wrapper)
+    ChangeCallback(ObjectWrapper* wrapper, JavaMethod notify_change_listeners)
+        : m_wrapper(wrapper),
+        m_notify_change_listeners_method(notify_change_listeners)
     {
     }
 
@@ -126,12 +127,8 @@ struct ChangeCallback {
         }
 
         parse_fields(env, change_set);
-
         m_wrapper->m_row_object_weak_ref.call_with_local_ref(env, [&](JNIEnv*, jobject row_obj) {
-            static JavaClass os_object_class(env, "io/realm/internal/OsObject");
-            static JavaMethod notify_change_listeners(env, os_object_class, "notifyChangeListeners",
-                                                      "([Ljava/lang/String;)V");
-            env->CallVoidMethod(row_obj, notify_change_listeners, m_deleted ? nullptr : m_field_names_array);
+            env->CallVoidMethod(row_obj, m_notify_change_listeners_method, m_deleted ? nullptr : m_field_names_array);
         });
         m_field_names_array = nullptr;
         m_deleted = false;
@@ -153,6 +150,7 @@ private:
     ObjectWrapper* m_wrapper;
     bool m_deleted = false;
     jobjectArray m_field_names_array = nullptr;
+    JavaMethod m_notify_change_listeners_method;
 };
 
 static void finalize_object(jlong ptr)
@@ -270,10 +268,13 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsObject_nativeStartListening(JNIE
             wrapper->m_row_object_weak_ref = JavaGlobalWeakRef(env, instance);
         }
 
+        static JavaClass os_object_class(env, "io/realm/internal/OsObject");
+        static JavaMethod notify_change_listeners(env, os_object_class, "notifyChangeListeners",
+                                                  "([Ljava/lang/String;)V");
         // The wrapper pointer will be used in the callback. But it should never become an invalid pointer when the
         // notification block gets called. This should be guaranteed by the Object Store that after the notification
         // token is destroyed, the block shouldn't be called.
-        wrapper->m_notification_token = wrapper->m_object.add_notification_callback(ChangeCallback(wrapper));
+        wrapper->m_notification_token = wrapper->m_object.add_notification_callback(ChangeCallback(wrapper, notify_change_listeners));
     }
     CATCH_STD()
 }


### PR DESCRIPTION
I ran into this while debugging a unit test failure my unit tests in #4558  kept running into. 
I cannot reproduce it in standalone unit tests. It is 100% triggerable in some of my other tests but only in Android Studio, not from the commandline 🤔 Really puzzling

Anyway, getting the method reference when calling JNI works. If anyone has a better idea on how to do this, I'm all ears.

Sidenote: After this fix, all the flakiness from my PermissionManager tests seems have disappeared. So I suspect it previously was caused by flakiness in the notification subsystem and recent changes just caused the error to finally bubble up.

EDIT: And no, still got failing tests 😢 