### PR TITLE
Apply kotlin-kapt plugin

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'android-command'
 apply plugin: 'realm-android'
 

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -2,6 +2,7 @@ import java.security.MessageDigest
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'


### PR DESCRIPTION
Original kapt feature has been deprecated. This PR enables `kotlin-kapt` plugin instead.
