### PR TITLE
Upgrade Integration Test setup

### DIFF
--- a/dependencies.list
+++ b/dependencies.list
@@ -10,4 +10,4 @@ REALM_SYNC_SHA256=c93caa9b0ff1391550ce6b68ab3822fea7e6ae921498a3ebf3a5e6b17c56fa
 # /tools/sync_test_server/Dockerfile specify which repo (apt) we should
 # install/use between 'realm' and 'realm-testing', the version below should
 # correspond to an existing version on the *specified* repo.
-REALM_OBJECT_SERVER_DE_VERSION=1.8.1-149
+REALM_OBJECT_SERVER_DE_VERSION=1.8.3-83

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -7,6 +7,26 @@ const exec = require('child_process').exec;
 var http = require('http');
 var dispatcher = require('httpdispatcher');
 
+// this query is used to check if ROS has started
+// while waiting for a permanante fix in https://github.com/realm/realm-object-server/issues/1297.
+// query should return 200 with the JSON payload Ex: {"version":"1.8.1","flavor":"developer","setupRequired":true}
+var options = {
+  hostname: '127.0.0.1',
+  port: 9080,
+  path: '/api/info',
+  method: 'GET'
+};
+
+function tryUntilROSStart(options, callback) {
+    var req = http.request(options, function(res) {
+        callback(null, res);
+    });
+    req.on('error', function(e) {
+        tryUntilROSStart(options, callback);
+    });
+    req.end();
+}
+
 // Automatically track and cleanup files at exit
 temp.track();
 
@@ -34,12 +54,6 @@ function handleRequest(request, response) {
 var syncServerChildProcess = null;
 
 function startRealmObjectServer(done) {
-    // Hack for checking the ROS is fully initialized.
-    // Consider the ROS is initialized fully only if log below shows twice
-    // "client: Closing Realm file: /tmp/ros117521-7-1eiqt7a/internal_data/permission/__auth.realm"
-    // https://github.com/realm/realm-object-server/issues/1297
-    var logFindingCounter = 2
-
     stopRealmObjectServer(function(err) {
         if(err) {
           return;
@@ -56,12 +70,6 @@ function startRealmObjectServer(done) {
                         { env: env, cwd: path});
                 // local config:
                 syncServerChildProcess.stdout.on('data', (data) => {
-                    if (logFindingCounter != 0 && /client: Closing Realm file: .*__auth.realm/.test(data)) {
-                        if (logFindingCounter == 1) {
-                            done()
-                        }
-                        logFindingCounter--
-                    }
                     winston.info(`stdout: ${data}`);
                 });
 
@@ -71,6 +79,11 @@ function startRealmObjectServer(done) {
 
                 syncServerChildProcess.on('close', (code) => {
                     winston.info(`child process exited with code ${code}`);
+                });
+
+                tryUntilROSStart(options, function(err, resp) {
+                    winston.info('>>>>>>>>>>>>>>>>>>> [ROS] server started <<<<<<<<<<<<<<<<<<<');
+                    done()
                 });
             }
         });
@@ -94,7 +107,7 @@ function stopRealmObjectServer(callback) {
 dispatcher.onGet("/start", function(req, res) {
     startRealmObjectServer(() => {
         res.writeHead(200, {'Content-Type': 'text/plain'});
-        res.end('Starting a server');
+        res.end('Server started');
     })
 });
 


### PR DESCRIPTION
Better detection of when ROS is running. Previously you could run into a lot of `SocketTimeout` exceptions. Also upgraded ROS used in tests to latest stable Debian version.

@realm/java 