### PR TITLE
apply kotlin-kapt plugin since original kapt feature has been deprecated

### DIFF
--- a/examples/kotlinExample/build.gradle
+++ b/examples/kotlinExample/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'android-command'
 apply plugin: 'realm-android'
 

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -2,6 +2,7 @@ import java.security.MessageDigest
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'


### PR DESCRIPTION
This PR is applying the same changes with #5126 to `releases` branch.

