### PR TITLE
Update a reference URL of Client Error

### DIFF
--- a/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ErrorCode.java
@@ -23,7 +23,7 @@ import java.net.ConnectException;
  */
 public enum ErrorCode {
 
-    // See https://github.com/realm/realm-sync/blob/master/doc/protocol_17.md
+    // See Client::Error in https://github.com/realm/realm-sync/blob/master/src/realm/sync/client.hpp
     // See https://github.com/realm/realm-object-server/blob/master/object-server/doc/problems.md
 
     // Realm Java errors (0-49)


### PR DESCRIPTION
@morten-krogh told me that `doc/protocol.md` was not the one we should refer from `ErrorCode.java`.

https://github.com/realm/realm-sync/pull/1561#issuecomment-323847407

I've update the comment in `ErrorCode.java`.
