### PR TITLE
Added APIs for Primitive List feature(Design 2)

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AllJavaTypes.java
@@ -25,6 +25,7 @@ import io.realm.annotations.Ignore;
 import io.realm.annotations.Index;
 import io.realm.annotations.LinkingObjects;
 import io.realm.annotations.PrimaryKey;
+import io.realm.valuelist.RealmValueList;
 
 
 public class AllJavaTypes extends RealmObject {
@@ -47,6 +48,16 @@ public class AllJavaTypes extends RealmObject {
     public static final String FIELD_LIST = "fieldList";
     public static final String FIELD_LO_OBJECT = "objectParents";
     public static final String FIELD_LO_LIST = "listParents";
+
+    public static final String FIELD_STRING_LIST = "stringList";
+    public static final String FIELD_LONG_LIST = "longList";
+    public static final String FIELD_INT_LIST = "intList";
+    public static final String FIELD_SHORT_LIST = "shortList";
+    public static final String FIELD_BYTE_LIST = "byteList";
+    public static final String FIELD_FLOAT_LIST = "floatList";
+    public static final String FIELD_DOUBLE_LIST = "doubleList";
+    public static final String FIELD_BOOLEAN_LIST = "booleanList";
+    public static final String FIELD_DATE_LIST = "dateList";
 
     public static final String[] INVALID_FIELDS_FOR_DISTINCT
             = new String[] {FIELD_OBJECT, FIELD_LIST, FIELD_DOUBLE, FIELD_FLOAT, FIELD_LO_OBJECT, FIELD_LO_LIST};
@@ -82,6 +93,16 @@ public class AllJavaTypes extends RealmObject {
 
     @LinkingObjects(FIELD_LIST)
     private final RealmResults<AllJavaTypes> listParents = null;
+
+    public RealmValueList<String> stringList;
+    public RealmValueList<Long> longList;
+    public RealmValueList<Integer> intList;
+    public RealmValueList<Short> shortList;
+    public RealmValueList<Byte> byteList;
+    public RealmValueList<Float> floatList;
+    public RealmValueList<Double> doubleList;
+    public RealmValueList<Boolean> booleanList;
+    public RealmValueList<Date> dateList;
 
     public AllJavaTypes() {
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/AllTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/AllTypes.java
@@ -22,6 +22,8 @@ import io.realm.MutableRealmInteger;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.Required;
+import io.realm.valuelist.RealmValueList;
+
 
 public class AllTypes extends RealmObject {
 
@@ -36,6 +38,13 @@ public class AllTypes extends RealmObject {
     public static final String FIELD_MUTABLEREALMINTEGER = "columnMutableRealmInteger";
     public static final String FIELD_REALMOBJECT = "columnRealmObject";
     public static final String FIELD_REALMLIST = "columnRealmList";
+
+    public static final String FIELD_STRING_LIST = "stringList";
+    public static final String FIELD_LONG_LIST = "longList";
+    public static final String FIELD_FLOAT_LIST = "floatList";
+    public static final String FIELD_DOUBLE_LIST = "doubleList";
+    public static final String FIELD_BOOLEAN_LIST = "booleanList";
+    public static final String FIELD_DATE_LIST = "dateList";
 
     public static final String[] INVALID_TYPES_FIELDS_FOR_DISTINCT
             = new String[] {FIELD_REALMOBJECT, FIELD_REALMLIST, FIELD_DOUBLE, FIELD_FLOAT};
@@ -54,6 +63,13 @@ public class AllTypes extends RealmObject {
     private final MutableRealmInteger columnMutableRealmInteger = MutableRealmInteger.ofNull();
     private Dog columnRealmObject;
     private RealmList<Dog> columnRealmList;
+
+    public RealmValueList<String> stringList;
+    public RealmValueList<Long> longList;
+    public RealmValueList<Float> floatList;
+    public RealmValueList<Double> doubleList;
+    public RealmValueList<Boolean> booleanList;
+    public RealmValueList<Date> dateList;
 
     public String getColumnString() {
         return columnString;

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/NullTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/NullTypes.java
@@ -24,6 +24,8 @@ import io.realm.RealmResults;
 import io.realm.annotations.LinkingObjects;
 import io.realm.annotations.PrimaryKey;
 import io.realm.annotations.Required;
+import io.realm.valuelist.RealmValueList;
+
 
 // Always follow below order and put comments like below to make NullTypes Related cases
 // 1 String
@@ -121,6 +123,34 @@ public class NullTypes extends RealmObject {
     // never nullable
     @LinkingObjects(FIELD_LIST_NULL)
     private final RealmResults<NullTypes> listParents = null;
+
+    @Required
+    public RealmValueList<Long> longListNotNull;
+    public RealmValueList<Long> longListNull;
+    @Required
+    public RealmValueList<Integer> intListNotNull;
+    public RealmValueList<Integer> intListNull;
+    @Required
+    public RealmValueList<Short> shortListNotNull;
+    public RealmValueList<Short> shortListNull;
+    @Required
+    public RealmValueList<Byte> byteListNotNull;
+    public RealmValueList<Byte> byteListNull;
+    @Required
+    public RealmValueList<Boolean> booleanListNotNull;
+    public RealmValueList<Boolean> booleanListNull;
+    @Required
+    public RealmValueList<Double> doubleListNotNull;
+    public RealmValueList<Double> doubleListNull;
+    @Required
+    public RealmValueList<Float> floatListNotNull;
+    public RealmValueList<Float> floatListNull;
+    @Required
+    public RealmValueList<String> stringListNotNull;
+    public RealmValueList<String> stringListNull;
+    @Required
+    public RealmValueList<Date> dateListNotNull;
+    public RealmValueList<Date> dateListNull;
 
     public int getId() {
         return id;

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -30,6 +30,7 @@ import io.realm.internal.Row;
 import io.realm.internal.Table;
 import io.realm.internal.UncheckedRow;
 import io.realm.internal.android.JsonUtils;
+import io.realm.valuelist.RealmValueList;
 
 
 /**
@@ -357,6 +358,11 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             checkFieldType(fieldName, columnIndex, RealmFieldType.LIST);
             throw e;
         }
+    }
+
+    public <E> RealmValueList<E> getValueList(String fieldName) {
+        // TODO implement this
+        return null;
     }
 
     /**
@@ -758,6 +764,10 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
         for (int i = 0; i < listLength; i++) {
             links.add(indices[i]);
         }
+    }
+
+    public void setValueList(String fieldName, RealmValueList<?> list) {
+        // TODO implement this
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -261,6 +261,9 @@ public abstract class RealmObjectSchema {
     /**
      * Sets a field to be required i.e., it is not allowed to hold {@code null} values. This is equivalent to switching
      * between boxed types and their primitive variant e.g., {@code Integer} to {@code int}.
+     * <p>
+     * If the type of designated field is a list of values (not {@link RealmObject}s , specified nullability
+     * only affects its elements, not the field itself. Value list itself is always non-nullable.
      *
      * @param fieldName name of field in the class.
      * @param required {@code true} if field should be required, {@code false} otherwise.
@@ -275,6 +278,9 @@ public abstract class RealmObjectSchema {
     /**
      * Sets a field to be nullable i.e., it should be able to hold {@code null} values. This is equivalent to switching
      * between primitive types and their boxed variant e.g., {@code int} to {@code Integer}.
+     * <p>
+     * If the type of designated field is a list of values (not {@link RealmObject}s , specified nullability
+     * only affects its elements, not the field itself. Value list itself is always non-nullable.
      *
      * @param fieldName name of field in the class.
      * @param nullable {@code true} if field should be nullable, {@code false} otherwise.

--- a/realm/realm-library/src/main/java/io/realm/valuelist/OrderedRealmValueCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/valuelist/OrderedRealmValueCollection.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.valuelist;
+
+import java.util.List;
+
+import io.realm.OrderedRealmCollection;
+import io.realm.OrderedRealmCollectionSnapshot;
+import io.realm.Sort;
+
+
+public interface OrderedRealmValueCollection<E> extends List<E>, RealmValueCollection<E> {
+
+
+    boolean isNull(int index);
+
+    /**
+     * Sorts a collection based on the provided field in ascending order.
+     *
+     * @return a new sorted {@link RealmValueListResults} will be created and returned. The original collection stays unchanged.
+     * @throws java.lang.IllegalArgumentException if field name does not exist or it has an invalid type.
+     * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
+     * an unmanaged collection.
+     */
+    RealmValueListResults<E> sort();
+
+
+    /**
+     * Sorts a collection based on the provided field and sort order.
+     *
+     * @param sortOrder the direction to sort by.
+     * @return a new sorted {@link RealmValueListResults} will be created and returned. The original collection stays unchanged.
+     * @throws java.lang.IllegalArgumentException if field name does not exist or has an invalid type.
+     * @throws java.lang.IllegalStateException if the Realm is closed, called on the wrong thread or the collection is
+     * an unmanaged collection.
+     */
+    RealmValueListResults<E> sort(Sort sortOrder);
+
+    /**
+     * Creates a snapshot from this {@link OrderedRealmCollection}.
+     *
+     * @return the snapshot of this collection.
+     * @throws java.lang.IllegalStateException if the Realm is closed or the method is called from the wrong thread.
+     * @throws UnsupportedOperationException if the collection is unmanaged.
+     * @see OrderedRealmCollectionSnapshot
+     */
+    RealmValueListSnapshot<E> createSnapshot();
+}

--- a/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueCollection.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.valuelist;
+
+import java.util.Collection;
+import java.util.Date;
+
+import javax.annotation.Nullable;
+
+import io.realm.internal.ManagableObject;
+
+
+public interface RealmValueCollection<E> extends Collection<E>, ManagableObject {
+
+    /**
+     * Returns a {@link RealmValueListQuery}, which can be used to query for specific objects from this collection.
+     *
+     * @return a RealmQuery object.
+     * @throws IllegalStateException if the Realm instance has been closed or queries are not otherwise available.
+     * @see io.realm.RealmQuery
+     */
+    RealmValueListQuery<E> where();
+
+    /**
+     * Finds the minimum value of a field.
+     *
+     * @return if no objects exist or they all have {@code null} as the value for the given field, {@code null} will be
+     * returned. Otherwise the minimum value is returned. When determining the minimum value, objects with {@code null}
+     * values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    @Nullable
+    Number min();
+
+    /**
+     * Finds the maximum value of a field.
+     *
+     * @return if no objects exist or they all have {@code null} as the value for the given field, {@code null} will be
+     * returned. Otherwise the maximum value is returned. When determining the maximum value, objects with {@code null}
+     * values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    @Nullable
+    Number max();
+
+    /**
+     * Calculates the sum of a given field.
+     *
+     * @return the sum. If no objects exist or they all have {@code null} as the value for the given field, {@code 0}
+     * will be returned. When computing the sum, objects with {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    Number sum();
+
+    /**
+     * Returns the average of a given field.
+     *
+     * @return the average for the given field amongst objects in query results. This will be of type double for all
+     * types of number fields. If no objects exist or they all have {@code null} as the value for the given field,
+     * {@code 0} will be returned. When computing the average, objects with {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if the field is not a number type.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    double average();
+
+    /**
+     * Finds the maximum date.
+     *
+     * @return if no objects exist or they all have {@code null} as the value for the given date field, {@code null}
+     * will be returned. Otherwise the maximum date is returned. When determining the maximum date, objects with
+     * {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if fieldName is not a Date field.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    @Nullable
+    Date maxDate();
+
+    /**
+     * Finds the minimum date.
+     *
+     * @return if no objects exist or they all have {@code null} as the value for the given date field, {@code null}
+     * will be returned. Otherwise the minimum date is returned. When determining the minimum date, objects with
+     * {@code null} values are ignored.
+     * @throws java.lang.IllegalArgumentException if fieldName is not a Date field.
+     * @throws java.lang.IllegalStateException if the Realm has been closed or called from an incorrect thread.
+     */
+    @Nullable
+    Date minDate();
+
+    /**
+     * Checks if the collection is still valid to use, i.e., the {@link io.realm.Realm} instance hasn't been closed. It
+     * will always return {@code true} for an unmanaged collection.
+     *
+     * @return {@code true} if it is still valid to use or an unmanaged collection, {@code false} otherwise.
+     */
+    @Override
+    boolean isValid();
+
+    /**
+     * Checks if the collection is managed by Realm. A managed collection is just a wrapper around the data in the
+     * underlying Realm file. On Looper threads, a managed collection will be live-updated so it always points to the
+     * latest data. Managed collections are thread confined so that they cannot be accessed from other threads than the
+     * one that created them.
+     * <p>
+     * <p>
+     * If this method returns {@code false}, the collection is unmanaged. An unmanaged collection is just a normal java
+     * collection, so it will not be live updated.
+     * <p>
+     *
+     * @return {@code true} if this is a managed {@link RealmValueCollection}, {@code false} otherwise.
+     */
+    @Override
+    boolean isManaged();
+
+    /**
+     * Tests whether this {@code Collection} contains the specified object. Returns
+     * {@code true} if and only if at least one element {@code elem} in this
+     * {@code Collection} meets following requirement:
+     * {@code (object==null ? elem==null : object.equals(elem))}.
+     *
+     * @param object the object to search for.
+     * @return {@code true} if object is an element of this {@code Collection}, {@code false} otherwise.
+     * @throws NullPointerException if the object to look for is {@code null} and this {@code Collection} doesn't
+     * support {@code null} elements.
+     */
+    @Override
+    boolean contains(@Nullable Object object);
+}

--- a/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueList.java
+++ b/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueList.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.valuelist;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.annotation.Nonnull;
+
+
+/**
+ * {@link RealmValueList} is used to model a list of values those have exactly the same type
+ * in a {@link io.realm.RealmObject}.
+ * RealmValueList has two modes: A managed and unmanaged mode. In managed mode values all v are persisted inside a Realm,
+ * in unmanaged mode it works as a normal ArrayList.
+ * <p>
+ * Only Realm can create managed RealmValueLists. Managed RealmValueLists will automatically update the content whenever
+ * the underlying Realm is updated, and can only be accessed using the getter of a {@link io.realm.RealmObject}.
+ * <p>
+ * Unmanaged RealmValueLists can be created by the user. This is useful when dealing with JSON deserializers like GSON
+ * or other frameworks that inject values into a class.
+ * <p>
+ * {@link RealmValueList} can contain more elements than {@code Integer.MAX_VALUE}.
+ * In that case, you can access only first {@code Integer.MAX_VALUE} elements in it.
+ *
+ * @param <E> the class of values in list. It must be one of {@link String}, {@link Long}, {@link Integer},
+ * {@link Short}, {@link Byte}, {@link Double}, {@link Float}, {@link Boolean} and {@link java.util.Date}.
+ */
+public abstract class RealmValueList<E> implements OrderedRealmValueCollection<E> {
+
+    /**
+     * Creates unmanaged empty {@link RealmValueList}.
+     *
+     * @param valueType the type of values. It must be one of the supported class described
+     * in the class comment of {@link RealmValueList}.
+     * @param <E> type of values in the list.
+     * @return newly created unmanaged {@link RealmValueList} instance.
+     */
+    public static <E> RealmValueList<E> of(Class<E> valueType) {
+        // TODO implement this
+        return null;
+    }
+
+    /**
+     * Creates unmanaged empty {@link RealmValueList}.
+     *
+     * @param valueType the type of values. It must be one of the supported class described
+     * in the class comment of {@link RealmValueList}.
+     * @param values initial values.
+     * @param <E> type of values in the list.
+     * @return newly created unmanaged {@link RealmValueList} instance.
+     */
+    @SafeVarargs
+    public static <E> RealmValueList<E> copyOf(Class<E> valueType, E... values) {
+        // TODO implement this
+        return null;
+    }
+
+    protected RealmValueList() {
+    }
+
+    @Nonnull
+    @Override
+    public Object[] toArray() {
+        // TODO implement this
+        return null;
+    }
+
+    /*
+     * MEMO: This method supports {@code long}, {@code  int}, {@code short}, {@code byte},
+     * {@code double}, {@code float} and {@code boolean} as {@code T} in addition to classes
+     * mentioned in the class comment of {@link RealmValueList}.
+     */
+    @Nonnull
+    @Override
+    public <T> T[] toArray(T[] array) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean add(E e) {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public void add(int index, E element) {
+        // TODO implement this
+    }
+
+    @Override
+    public E set(int index, E element) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        // TODO implement this
+    }
+
+    @Override
+    public E remove(int index) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        // TODO implement this
+        return false;
+    }
+
+    public void move(int oldIndex, int newIndex) {
+        // TODO implement this
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        // TODO implement this
+        return super.toString();
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueListQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueListQuery.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.valuelist;
+
+import java.util.Date;
+
+import javax.annotation.Nullable;
+
+import io.realm.Case;
+import io.realm.Sort;
+
+
+public class RealmValueListQuery<E> {
+
+    public boolean isValid() {
+        // TODO implement this
+        return false;
+    }
+
+    public RealmValueListQuery<E> isNull() {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> isNotNull() {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable String value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable String value, Case casing) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Long value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Integer value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Short value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Byte value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Double value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Float value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Boolean value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> equalTo(@Nullable Date value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(String[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(String[] values, Case casing) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Long[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Integer[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Short[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Byte[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Double[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Float[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Boolean[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> in(Date[] values) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable String value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable String value, Case casing) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Long value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Integer value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Short value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Byte value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Double value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Float value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Boolean value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> notEqualTo(@Nullable Date value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThan(long value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThan(int value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThan(double value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThan(float value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThan(Date value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThanOrEqualTo(long value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThanOrEqualTo(int value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThanOrEqualTo(double value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThanOrEqualTo(float value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> greaterThanOrEqualTo(Date value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThan(long value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThan(int value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThan(double value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThan(float value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThan(Date value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThanOrEqualTo(long value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThanOrEqualTo(int value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThanOrEqualTo(double value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThanOrEqualTo(float value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> lessThanOrEqualTo(Date value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> between(long from, long to) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> between(int from, int to) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> between(double from, double to) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> between(float from, float to) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> between(Date from, Date to) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> contains(String value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> contains(String value, Case casing) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> beginsWith(String value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> beginsWith(String value, Case casing) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> endsWith(String value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> endsWith(String value, Case casing) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> like(String value) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> like(String value, Case casing) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> beginGroup() {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> endGroup() {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> or() {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListQuery<E> not() {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListResults<E> distinct() {
+        // TODO implement this
+        return null;
+    }
+
+    public Number sum() {
+        // TODO implement this
+        return 0;
+    }
+
+    public double average() {
+        // TODO implement this
+        return 0D;
+    }
+
+    @Nullable
+    public Number min() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    public Date minimumDate() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    public Number max() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    public Date maximumDate() {
+        // TODO implement this
+        return null;
+    }
+
+    public long count() {
+
+        // TODO implement this
+        return 0L;
+    }
+
+    public RealmValueListResults<E> findAll() {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListResults<E> findAllSorted(Sort sortOrder) {
+        // TODO implement this
+        return null;
+    }
+
+    public RealmValueListResults<E> findAllSorted() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        // TODO implement this
+        return super.toString();
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueListResults.java
+++ b/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueListResults.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.valuelist;
+
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.realm.Sort;
+
+
+public class RealmValueListResults<E> extends AbstractList<E>
+        implements OrderedRealmValueCollection<E> {
+    private RealmValueListResults() {
+    }
+
+    @Override
+    public int size() {
+        // TODO implement this
+        return 0;
+    }
+
+    @Override
+    public E get(int i) {
+        return null;
+    }
+
+    @Override
+    public boolean isNull(int index) {
+        // TODO implement this
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListResults<E> sort() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListResults<E> sort(Sort sortOrder) {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListSnapshot<E> createSnapshot() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListQuery<E> where() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Number min() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Number max() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public Number sum() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public double average() {
+        // TODO implement this
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public Date maxDate() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Date minDate() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean isValid() {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public boolean isManaged() {
+        // TODO implement this
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public Object[] toArray() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public <T> T[] toArray(@Nonnull T[] a) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean add(E e) {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public void add(int index, E element) {
+        // TODO implement this
+    }
+
+    @Override
+    public E set(int index, E element) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        // TODO implement this
+    }
+
+    @Override
+    public E remove(int index) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        // TODO implement this
+        return false;
+    }
+
+    public void move(int oldIndex, int newIndex) {
+        // TODO implement this
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        // TODO implement this
+        return super.toString();
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueListSnapshot.java
+++ b/realm/realm-library/src/main/java/io/realm/valuelist/RealmValueListSnapshot.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.valuelist;
+
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.realm.Sort;
+
+
+public class RealmValueListSnapshot<E> extends AbstractList<E>
+        implements OrderedRealmValueCollection<E> {
+    private RealmValueListSnapshot() {
+    }
+
+    @Override
+    public int size() {
+        // TODO implement this
+        return 0;
+    }
+
+    @Override
+    public E get(int i) {
+        return null;
+    }
+
+    @Override
+    public boolean isNull(int index) {
+        // TODO implement this
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListResults<E> sort() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListResults<E> sort(Sort sortOrder) {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListSnapshot<E> createSnapshot() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RealmValueListQuery<E> where() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Number min() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Number max() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public Number sum() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public double average() {
+        // TODO implement this
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public Date maxDate() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Date minDate() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean isValid() {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public boolean isManaged() {
+        // TODO implement this
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public Object[] toArray() {
+        // TODO implement this
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public <T> T[] toArray(@Nonnull T[] a) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean add(E e) {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public void add(int index, E element) {
+        // TODO implement this
+    }
+
+    @Override
+    public E set(int index, E element) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        // TODO implement this
+    }
+
+    @Override
+    public E remove(int index) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        // TODO implement this
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        // TODO implement this
+        return false;
+    }
+
+    public void move(int oldIndex, int newIndex) {
+        // TODO implement this
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        // TODO implement this
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        // TODO implement this
+        return super.toString();
+    }
+}

--- a/realm/realm-library/src/main/java/io/realm/valuelist/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/valuelist/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.valuelist;


### PR DESCRIPTION
This PR is basically following `Design 2` in RFC https://github.com/realm/realm-java/pull/4165/files

Many classes and methods don't have Javadoc comment for now. I'll add them later.

Differences are:

* This PR is using `ValueList` instead of `Primitive` or `Primitive List` since values in lists are not limited to `primitive`s.
* This PR omits async APIs. I don't think it's necessary, but need to be discussed.
* This PR does not contain APIs for querying `RealmObject`s with values in the list.

Could you review APIs to make sure that I am on the same track? @realm/java 

----
List of tasks (Added by CM, Am I missing something?):

- [ ] New `RealmValueQuery` class + tests
- [ ] New `RealmValueCollection` interface + tests
- [ ] New `OrderedRealmValueCollection` interface + tests
- [ ] New `RealmValueList` class + tests
- [ ] New `RealmValueResults` class + tests
- [ ] New `RealmValueResultsSnapshot` class + tests
- [ ] Add support to `DynamicRealmObject` + tests
- [ ] Add support to `RealmObjectSchema` + tests
- [ ] Extend `RxObservableFactory` interface to support the above
- [ ] Extend `RealmQuery` to allow queries on value lists
- [ ] Extend AP to emit schema validation for `RealmValueList`

