### PR TITLE
Add support for `RunInHandlerThread` to emulate the Main thread

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/internal/AndroidCapabilitiesTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/AndroidCapabilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Realm Inc.
+ * Copyright 2017 Realm Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/AndroidCapabilitiesTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/AndroidCapabilitiesTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm.internal;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.realm.internal.android.AndroidCapabilities;
+import io.realm.rule.RunInLooperThread;
+import io.realm.rule.RunTestInLooperThread;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class AndroidCapabilitiesTest {
+
+    @Rule
+    public final RunInLooperThread looperThread = new RunInLooperThread();
+
+    @Test
+    @RunTestInLooperThread()
+    public void emulateMainThread_false() {
+        assertFalse(new AndroidCapabilities().isMainThread());
+        looperThread.testComplete();
+    }
+
+    @Test
+    @RunTestInLooperThread(emulateMainThread = true)
+    public void emulateMainThread_true() {
+        assertTrue(new AndroidCapabilities().isMainThread());
+        looperThread.testComplete();
+    }
+
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunInLooperThread.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ThreadFactory;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import io.realm.TestHelper;
+import io.realm.internal.android.AndroidCapabilities;
 
 
 /**
@@ -281,7 +282,7 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
         // Wait for all async tasks to have completed to ensure a successful deleteRealm call.
         // If it times out, it will throw.
         TestHelper.waitRealmThreadExecutorFinish();
-
+        AndroidCapabilities.EMULATE_MAIN_THREAD = false;
         super.after();
 
         // probably belt *and* suspenders...
@@ -376,6 +377,7 @@ public class RunInLooperThread extends TestRealmConfigurationFactory {
                 runnableBefore.newInstance().run(getConfiguration());
             }
 
+            AndroidCapabilities.EMULATE_MAIN_THREAD = annotation.emulateMainThread();
             runTest(annotation.threadName());
         }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/rule/RunTestInLooperThread.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/rule/RunTestInLooperThread.java
@@ -33,4 +33,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface RunTestInLooperThread {
         String threadName() default "RunTestInLooperThread";
         Class<?extends RunInLooperThread.RunnableBefore> before() default RunInLooperThread.RunnableBefore.class;
+        boolean emulateMainThread() default false;
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
@@ -17,6 +17,7 @@ package io.realm.internal.android;
 
 import android.os.Looper;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.internal.Capabilities;
 
 
@@ -29,6 +30,7 @@ public class AndroidCapabilities implements Capabilities {
     // If set, it will treat the current looper thread as the main thread.
     // It is up to the caller to handle any race conditions around this. Right now only
     // RunInLooperThread.java does this as part of setting up the test.
+    @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static boolean EMULATE_MAIN_THREAD = false;
 
     private final Looper looper;

--- a/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
@@ -17,6 +17,8 @@ package io.realm.internal.android;
 
 import android.os.Looper;
 
+import java.util.ArrayList;
+
 import io.realm.internal.Capabilities;
 
 
@@ -24,6 +26,12 @@ import io.realm.internal.Capabilities;
  * Realm capabilities for Android.
  */
 public class AndroidCapabilities implements Capabilities {
+
+    // Public so it can be set from tests.
+    // If set, it will treat the current looper thread as the main thread.
+    // It is up to the caller to handle any race conditions around this. Right now only
+    // RunInLooperThread.java does this as part of setting up the test.
+    public static boolean EMULATE_MAIN_THREAD = false;
 
     private final Looper looper;
     private final boolean isIntentServiceThread;
@@ -52,7 +60,7 @@ public class AndroidCapabilities implements Capabilities {
 
     @Override
     public boolean isMainThread() {
-        return looper != null && looper == Looper.getMainLooper();
+        return looper != null && (EMULATE_MAIN_THREAD || looper == Looper.getMainLooper());
     }
 
     private boolean hasLooper() {

--- a/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
@@ -17,8 +17,6 @@ package io.realm.internal.android;
 
 import android.os.Looper;
 
-import java.util.ArrayList;
-
 import io.realm.internal.Capabilities;
 
 


### PR DESCRIPTION
Required to test functionality that requires the Main thread _and_ also loops. The `@UITest` annotation does not have this capability.