### PR TITLE
Fix a bug that BaseRealm.migrateRealm cancels a transaction even if it is not in a transaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `RealmSchema.create(String)` and `RealmObjectSchema.setClassName(String)` did not accept class name whose length was 51 to 57.
 * Workaround for an Android JVM crash when using `compactOnLaunch()` (#4964).
 * Class name in exception message from link query is wrong (#5096).
+* `BaseRealm.migrateRealm` cancels a transaction even if it is not in a transaction (#5163).
 
 ### Internal
 

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -649,7 +649,7 @@ abstract class BaseRealm implements Closeable {
                     realm.setVersion(configuration.getSchemaVersion());
                     realm.commitTransaction();
                 } catch (RuntimeException e) {
-                    if (realm != null) {
+                    if (realm != null && realm.isInTransaction()) {
                         realm.cancelTransaction();
                     }
                     throw e;


### PR DESCRIPTION
Address #5163 