### PR TITLE
Fix possible leaks with java callback in config

### DIFF
--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -26,7 +26,7 @@
 #include "util.hpp"
 #include "jni_util/java_method.hpp"
 #include "jni_util/java_class.hpp"
-#include "jni_util/java_global_ref.hpp"
+#include "jni_util/java_global_weak_ref.hpp"
 #include "jni_util/jni_utils.hpp"
 #include "jni_util/java_exception_thrower.hpp"
 
@@ -132,16 +132,26 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeSetSchemaConfi
             static JavaMethod run_migration_callback_method(
                 env, get_shared_realm_class(env), "runMigrationCallback",
                 "(JLio/realm/internal/OsRealmConfig;Lio/realm/internal/SharedRealm$MigrationCallback;J)V", true);
-            JavaGlobalRef j_config_ref(env, j_config, true);
-            JavaGlobalRef j_migration_callback_ref(env, j_migration_callback, true);
-            config.migration_function = [j_config_ref, j_migration_callback_ref](SharedRealm old_realm,
+            // weak ref to avoid leaks caused by circular refs.
+            JavaGlobalWeakRef j_config_weak(env, j_config);
+            JavaGlobalWeakRef j_migration_cb_weak(env, j_migration_callback);
+            // TODO: It would be great if we can use move constructor in the lambda capture which was introduced in
+            // c++14. But sadly it seems to be a bug with gcc 4.9 to support it.
+            config.migration_function = [j_migration_cb_weak, j_config_weak](SharedRealm old_realm,
                                                                                  SharedRealm realm, Schema&) {
                 JNIEnv* env = JniUtils::get_env(false);
                 // Java needs a new pointer for the SharedRealm life control.
                 SharedRealm* new_shared_realm_ptr = new SharedRealm(realm);
-                env->CallStaticVoidMethod(get_shared_realm_class(env), run_migration_callback_method,
-                                          reinterpret_cast<jlong>(new_shared_realm_ptr), j_config_ref.get(),
-                                          j_migration_callback_ref.get(), old_realm->schema_version());
+                JavaGlobalRef config_global = j_config_weak.global_ref(env);
+                if (!config_global) {
+                    return;
+                }
+
+                j_migration_cb_weak.call_with_local_ref(env, [&](JNIEnv* env, jobject obj) {
+                    env->CallStaticVoidMethod(get_shared_realm_class(env), run_migration_callback_method,
+                                              reinterpret_cast<jlong>(new_shared_realm_ptr), config_global.get(), obj,
+                                              old_realm->schema_version());
+                });
                 TERMINATE_JNI_IF_JAVA_EXCEPTION_OCCURRED(env);
             };
         }
@@ -162,13 +172,17 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeSetCompactOnLa
         if (j_compact_on_launch) {
             static JavaClass compact_on_launch_class(env, "io/realm/CompactOnLaunchCallback");
             static JavaMethod should_compact(env, compact_on_launch_class, "shouldCompact", "(JJ)Z");
-            JavaGlobalRef java_compact_on_launch_ref(env, j_compact_on_launch);
+            // weak ref to avoid leaks caused by circular refs.
+            JavaGlobalWeakRef java_compact_on_launch_weak(env, j_compact_on_launch);
 
-            config.should_compact_on_launch_function = [java_compact_on_launch_ref](uint64_t totalBytes,
+            config.should_compact_on_launch_function = [java_compact_on_launch_weak](uint64_t totalBytes,
                                                                                     uint64_t usedBytes) {
                 JNIEnv* env = JniUtils::get_env(false);
-                bool result = env->CallBooleanMethod(java_compact_on_launch_ref.get(), should_compact,
-                                                     static_cast<jlong>(totalBytes), static_cast<jlong>(usedBytes));
+                bool result = false;
+                java_compact_on_launch_weak.call_with_local_ref(env, [&](JNIEnv* env, jobject obj) {
+                    result = env->CallBooleanMethod(obj, should_compact, static_cast<jlong>(totalBytes),
+                                                    static_cast<jlong>(usedBytes));
+                });
                 TERMINATE_JNI_IF_JAVA_EXCEPTION_OCCURRED(env);
                 return result;
             };
@@ -194,15 +208,22 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeSetInitializat
             static JavaMethod run_initialization_callback_method(
                 env, get_shared_realm_class(env), "runInitializationCallback",
                 "(JLio/realm/internal/OsRealmConfig;Lio/realm/internal/SharedRealm$InitializationCallback;)V", true);
-            JavaGlobalRef j_init_callback_ref(env, j_init_callback, true);
-            JavaGlobalRef j_config_ref(env, j_config, true);
-            config.initialization_function = [j_init_callback_ref, j_config_ref](SharedRealm realm) {
+            // weak ref to avoid leaks caused by circular refs.
+            JavaGlobalWeakRef j_init_cb_weak(env, j_init_callback);
+            JavaGlobalWeakRef j_config_weak(env, j_config);
+            config.initialization_function = [j_init_cb_weak, j_config_weak](SharedRealm realm) {
                 JNIEnv* env = JniUtils::get_env(false);
                 // Java needs a new pointer for the SharedRealm life control.
                 SharedRealm* new_shared_realm_ptr = new SharedRealm(realm);
-                env->CallStaticVoidMethod(get_shared_realm_class(env), run_initialization_callback_method,
-                                          reinterpret_cast<jlong>(new_shared_realm_ptr), j_config_ref.get(),
-                                          j_init_callback_ref.get());
+                JavaGlobalRef config_global_ref = j_config_weak.global_ref(env);
+                if (!config_global_ref) {
+                    return;
+                }
+                j_init_cb_weak.call_with_local_ref(env, [&](JNIEnv* env, jobject obj) {
+                    env->CallStaticVoidMethod(get_shared_realm_class(env), run_initialization_callback_method,
+                                              reinterpret_cast<jlong>(new_shared_realm_ptr), config_global_ref.get(),
+                                              obj);
+                });
                 TERMINATE_JNI_IF_JAVA_EXCEPTION_OCCURRED(env);
             };
         }

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_ref.hpp
@@ -45,6 +45,7 @@ public:
     ~JavaGlobalRef();
 
     JavaGlobalRef& operator=(JavaGlobalRef&& rhs);
+    JavaGlobalRef& operator=(JavaGlobalRef& rhs) = delete;
     JavaGlobalRef(JavaGlobalRef&);
 
     inline operator bool() const noexcept

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.cpp
@@ -19,7 +19,56 @@
 
 using namespace realm::jni_util;
 
-bool JavaGlobalWeakRef::call_with_local_ref(JNIEnv* env, std::function<Callback> callback)
+JavaGlobalWeakRef::JavaGlobalWeakRef()
+    : m_weak(nullptr)
+{
+}
+
+JavaGlobalWeakRef::JavaGlobalWeakRef(JNIEnv* env, jobject obj)
+    : m_weak(obj ? env->NewWeakGlobalRef(obj) : nullptr)
+{
+}
+
+JavaGlobalWeakRef::~JavaGlobalWeakRef()
+{
+    if (m_weak) {
+        JniUtils::get_env()->DeleteWeakGlobalRef(m_weak);
+    }
+}
+
+JavaGlobalWeakRef::JavaGlobalWeakRef(JavaGlobalWeakRef&& rhs)
+    : m_weak(rhs.m_weak)
+{
+    rhs.m_weak = nullptr;
+}
+
+JavaGlobalWeakRef& JavaGlobalWeakRef::operator=(JavaGlobalWeakRef&& rhs)
+{
+    this->~JavaGlobalWeakRef();
+    new (this) JavaGlobalWeakRef(std::move(rhs));
+    return *this;
+}
+
+JavaGlobalWeakRef::JavaGlobalWeakRef(const JavaGlobalWeakRef& rhs)
+    : m_weak(JniUtils::get_env(true)->NewWeakGlobalRef(rhs.m_weak))
+{
+}
+
+JavaGlobalWeakRef& JavaGlobalWeakRef::operator=(const JavaGlobalWeakRef& rhs)
+{
+    new (this) JavaGlobalWeakRef(rhs);
+    return *this;
+}
+
+JavaGlobalRef JavaGlobalWeakRef::global_ref(JNIEnv* env) const
+{
+    if (!env) {
+        env = JniUtils::get_env(true);
+    }
+    return JavaGlobalRef(env, m_weak);
+}
+
+bool JavaGlobalWeakRef::call_with_local_ref(JNIEnv* env, std::function<Callback> callback) const
 {
     if (!m_weak) {
         return false;
@@ -34,7 +83,7 @@ bool JavaGlobalWeakRef::call_with_local_ref(JNIEnv* env, std::function<Callback>
     return true;
 }
 
-bool JavaGlobalWeakRef::call_with_local_ref(std::function<Callback> callback)
+bool JavaGlobalWeakRef::call_with_local_ref(std::function<Callback> callback) const
 {
     return call_with_local_ref(JniUtils::get_env(), callback);
 }

--- a/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_global_weak_ref.hpp
@@ -28,48 +28,30 @@ namespace jni_util {
 // RAII wrapper for weak global ref.
 class JavaGlobalWeakRef {
 public:
-    JavaGlobalWeakRef()
-        : m_weak(nullptr)
-    {
-    }
-    JavaGlobalWeakRef(JNIEnv* env, jobject obj)
-        : m_weak(obj ? env->NewWeakGlobalRef(obj) : nullptr)
-    {
-    }
-    ~JavaGlobalWeakRef()
-    {
-        if (m_weak) {
-            JniUtils::get_env()->DeleteWeakGlobalRef(m_weak);
-        }
-    }
+    JavaGlobalWeakRef();
+    JavaGlobalWeakRef(JNIEnv*, jobject);
+    ~JavaGlobalWeakRef();
 
-    JavaGlobalWeakRef(JavaGlobalWeakRef&& rhs)
-        : m_weak(rhs.m_weak)
-    {
-        rhs.m_weak = nullptr;
-    }
-    JavaGlobalWeakRef& operator=(JavaGlobalWeakRef&& rhs)
-    {
-        this->~JavaGlobalWeakRef();
-        new (this) JavaGlobalWeakRef(std::move(rhs));
-        return *this;
-    }
+    JavaGlobalWeakRef(JavaGlobalWeakRef&&);
+    JavaGlobalWeakRef& operator=(JavaGlobalWeakRef&&);
 
-    JavaGlobalWeakRef(const JavaGlobalWeakRef&) = delete;
-    JavaGlobalWeakRef& operator=(const JavaGlobalWeakRef&) = delete;
+    JavaGlobalWeakRef(const JavaGlobalWeakRef&);
+    JavaGlobalWeakRef& operator=(const JavaGlobalWeakRef&);
 
     inline operator bool() const noexcept
     {
         return m_weak != nullptr;
     }
 
+    JavaGlobalRef global_ref(JNIEnv* env = nullptr) const;
+
     using Callback = void(JNIEnv* env, jobject obj);
 
     // Acquire a local ref and run the callback with it if the weak ref is valid. The local ref will be deleted after
     // callback finished. Return false if the weak ref is not valid anymore.
-    bool call_with_local_ref(JNIEnv* env, std::function<Callback> callback);
+    bool call_with_local_ref(JNIEnv* env, std::function<Callback> callback) const ;
     // Try to get an JNIEnv for current thread then run the callback.
-    bool call_with_local_ref(std::function<Callback> callback);
+    bool call_with_local_ref(std::function<Callback> callback) const;
 
 private:
     jweak m_weak;


### PR DESCRIPTION
Holding strong java refs in the lambda function in the Object Store
config will cause circular refs with SharedRealm/Callbacks/Config. That
will leak some objects.