### PR TITLE
Optimize opening Realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and `SyncUser#retrieveInfoForUserAsync` which returns a `SyncUserInfo` with mode
 
 ### Bug Fixes
 
+* The `compactOnLaunch` callback is no longer invoked if the Realm at that path is already open on other threads.
+
 ### Internal
 
 * [ObjectServer] removed `ObjectServerUser` and its inner classes, in a step to reduce `SyncUser` complexity (#3741).

--- a/realm/realm-library/src/main/java/io/realm/DefaultCompactOnLaunchCallback.java
+++ b/realm/realm-library/src/main/java/io/realm/DefaultCompactOnLaunchCallback.java
@@ -16,8 +16,6 @@
 
 package io.realm;
 
-import io.realm.log.RealmLog;
-
 /**
  * The default implementation for determining if a file should be compacted or not. This implementation will only
  * trigger if the file is above 50 MB and more than 50% can be reclaimed.


### PR DESCRIPTION
- Open realm for checking legacy PK table issue only if 1) the realm
  file doesn't exist, 2) it is not a sync realm config.
- Open realm for downloading initial data only if 1) it is sync realm
  config, 2) the realm file doesn't exist.
- Modify the compactOnLaunch_multipleThread to reflect the fix in
  https://github.com/realm/realm-object-store/pull/496
  Close #5036
- Optimize the compactOnLaunch test case. Populate 300000 objects with
  debug version core will take 3+ minutes.