### PR TITLE
Unclosed realm & SyncManager::reset_for_testing

### DIFF
--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/SyncSessionTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/SyncSessionTests.java
@@ -246,6 +246,7 @@ public class SyncSessionTests extends BaseIntegrationTest {
         });
 
         TestHelper.awaitOrFail(testCompleted, 60);
+        realm.close();
     }
 
     // A Realm that was opened before a user logged out should be able to resume uploading if the user logs back in.
@@ -375,6 +376,7 @@ public class SyncSessionTests extends BaseIntegrationTest {
                     e.printStackTrace();
                     fail(e.getMessage());
                 }
+                adminRealm.close();
 
                 backgroundUpload.countDown();
                 handlerThread.quit();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/suite/IntegrationTestSuite.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/suite/IntegrationTestSuite.java
@@ -26,6 +26,8 @@ import io.realm.objectserver.AuthTests;
 import io.realm.objectserver.EncryptedSynchronizedRealmTests;
 import io.realm.objectserver.ManagementRealmTests;
 import io.realm.objectserver.ProcessCommitTests;
+import io.realm.objectserver.ProgressListenerTests;
+import io.realm.objectserver.SyncSessionTests;
 
 // Test suite includes all integration tests. Makes it easy to run all integration tests in the Android Studio.
 @RunWith(Suite.class)
@@ -35,6 +37,8 @@ import io.realm.objectserver.ProcessCommitTests;
         AuthTests.class,
         EncryptedSynchronizedRealmTests.class,
         ManagementRealmTests.class,
-        ProcessCommitTests.class})
+        ProcessCommitTests.class,
+        ProgressListenerTests.class,
+        SyncSessionTests.class})
 public class IntegrationTestSuite {
 }


### PR DESCRIPTION
See https://github.com/realm/realm-object-store/pull/532
When assertion enabled, those will fail earlier. Without the assertion,
all different kind of native crash will happen.