### PR TITLE
java_class_global_def for global class loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 * Fixed potential memory leaks of `LinkView` when calling bulk insertions APIs.
+* Fixed possible assertion when using `PermissionManager` at the beginning (#5195).
 
 ### Internal
 

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFileUserStore.cpp
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-#include <jni.h>
-#include <jni_util/log.hpp>
 #include "io_realm_RealmFileUserStore.h"
-#include "sync/sync_manager.hpp"
-#include "sync/sync_user.hpp"
+
+#include <sync/sync_manager.hpp>
+#include <sync/sync_user.hpp>
+
+#include "java_class_global_def.hpp"
 #include "util.hpp"
+#include "jni_util/log.hpp"
 
 using namespace realm;
+using namespace realm::_impl;
 
 static const char* ERR_COULD_NOT_ALLOCATE_MEMORY = "Could not allocate memory to return all users.";
 
@@ -113,7 +116,7 @@ JNIEXPORT jobjectArray JNICALL Java_io_realm_RealmFileUserStore_nativeGetAllUser
     auto all_users = SyncManager::shared().all_logged_in_users();
     if (!all_users.empty()) {
         size_t len = all_users.size();
-        jobjectArray users_token = env->NewObjectArray(len, java_lang_string, 0);
+        jobjectArray users_token = env->NewObjectArray(len, JavaClassGlobalDef::java_lang_string(), 0);
         if (users_token == nullptr) {
             ThrowException(env, OutOfMemory, ERR_COULD_NOT_ALLOCATE_MEMORY);
             return nullptr;

--- a/realm/realm-library/src/main/cpp/io_realm_SyncSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_SyncSession.cpp
@@ -23,6 +23,7 @@
 #include "object-store/src/sync/sync_session.hpp"
 
 #include "util.hpp"
+#include "java_class_global_def.hpp"
 #include "jni_util/java_global_ref.hpp"
 #include "jni_util/java_local_ref.hpp"
 #include "jni_util/java_method.hpp"
@@ -30,8 +31,9 @@
 #include "jni_util/jni_utils.hpp"
 
 using namespace realm;
-using namespace jni_util;
-using namespace sync;
+using namespace realm::jni_util;
+using namespace realm::sync;
+using namespace realm::_impl;
 
 static_assert(SyncSession::PublicState::WaitingForAccessToken ==
                   static_cast<SyncSession::PublicState>(io_realm_SyncSession_STATE_VALUE_WAITING_FOR_ACCESS_TOKEN),
@@ -156,7 +158,8 @@ JNIEXPORT jboolean JNICALL Java_io_realm_SyncSession_nativeWaitForDownloadComple
                     JavaLocalRef<jobject> java_error_code;
                     JavaLocalRef<jstring> java_error_message;
                     if (error != std::error_code{}) {
-                        java_error_code = JavaLocalRef<jobject>(env, NewLong(env, error.value()));
+                        java_error_code =
+                            JavaLocalRef<jobject>(env, JavaClassGlobalDef::new_long(env, error.value()));
                         java_error_message = JavaLocalRef<jstring>(env, env->NewStringUTF(error.message().c_str()));
                     }
                     env->CallVoidMethod(java_session_object_ref.get(), java_notify_result_method, java_error_code.get(),
@@ -191,7 +194,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_SyncSession_nativeWaitForUploadCompleti
                     JavaLocalRef<jobject> java_error_code;
                     JavaLocalRef<jstring> java_error_message;
                     if (error != std::error_code{}) {
-                        java_error_code = JavaLocalRef<jobject>(env, NewLong(env, error.value()));
+                        java_error_code = JavaLocalRef<jobject>(env, JavaClassGlobalDef::new_long(env, error.value()));
                         java_error_message = JavaLocalRef<jstring>(env, env->NewStringUTF(error.message().c_str()));
                     }
                     env->CallVoidMethod(java_session_object_ref.get(), java_notify_result_method,

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Collection.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Collection.cpp
@@ -23,6 +23,7 @@
 
 #include "java_sort_descriptor.hpp"
 #include "util.hpp"
+#include "java_class_global_def.hpp"
 
 #include "jni_util/java_class.hpp"
 #include "jni_util/java_global_weak_ref.hpp"
@@ -245,13 +246,13 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_Collection_nativeAggregate(JNIE
         Mixed m = *value;
         switch (m.get_type()) {
             case type_Int:
-                return NewLong(env, m.get_int());
+                return JavaClassGlobalDef::new_long(env, m.get_int());
             case type_Float:
-                return NewFloat(env, m.get_float());
+                return JavaClassGlobalDef::new_float(env, m.get_float());
             case type_Double:
-                return NewDouble(env, m.get_double());
+                return JavaClassGlobalDef::new_double(env, m.get_double());
             case type_Timestamp:
-                return NewDate(env, m.get_timestamp());
+                return JavaClassGlobalDef::new_date(env, m.get_timestamp());
             default:
                 throw std::invalid_argument("Excepted numeric type");
         }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -23,6 +23,7 @@
 #include <util/format.hpp>
 
 #include "util.hpp"
+#include "java_class_global_def.hpp"
 
 #include "jni_util/java_global_weak_ref.hpp"
 #include "jni_util/java_method.hpp"
@@ -90,7 +91,7 @@ struct ChangeCallback {
             // wrapper->m_object.get_object_schema() will be faster.
             field_names.push_back(JavaGlobalRef(env, to_jstring(env, table->get_column_name(i)), true));
         }
-        m_field_names_array = env->NewObjectArray(field_names.size(), java_lang_string, 0);
+        m_field_names_array = env->NewObjectArray(field_names.size(), JavaClassGlobalDef::java_lang_string(), 0);
         for (size_t i = 0; i < field_names.size(); ++i) {
             env->SetObjectArrayElement(m_field_names_array, i, field_names[i].get());
         }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -25,9 +25,11 @@
 #include <results.hpp>
 
 #include "util.hpp"
+#include "java_class_global_def.hpp"
 
 using namespace realm;
 using namespace realm::jni_util;
+using namespace realm::_impl;
 
 #if 1
 #define QUERY_COL_TYPE_VALID(env, jPtr, col, type) query_col_type_valid(env, jPtr, col, type)
@@ -1196,7 +1198,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumInt(JNI
         size_t return_ndx;
         int64_t result = pQuery->maximum_int(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
         if (return_ndx != npos) {
-            return NewLong(env, result);
+            return JavaClassGlobalDef::new_long(env, result);
         }
     }
     CATCH_STD()
@@ -1217,7 +1219,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumInt(JNI
         size_t return_ndx;
         int64_t result = pQuery->minimum_int(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
         if (return_ndx != npos) {
-            return NewLong(env, result);
+            return JavaClassGlobalDef::new_long(env, result);
         }
     }
     CATCH_STD()
@@ -1280,7 +1282,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumFloat(J
         size_t return_ndx;
         float result = pQuery->maximum_float(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
         if (return_ndx != npos) {
-            return NewFloat(env, result);
+            return JavaClassGlobalDef::new_float(env, result);
         }
     }
     CATCH_STD()
@@ -1302,7 +1304,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumFloat(J
         size_t return_ndx;
         float result = pQuery->minimum_float(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
         if (return_ndx != npos) {
-            return NewFloat(env, result);
+            return JavaClassGlobalDef::new_float(env, result);
         }
     }
     CATCH_STD()
@@ -1363,7 +1365,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumDouble(
         size_t return_ndx;
         double result = pQuery->maximum_double(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
         if (return_ndx != npos) {
-            return NewDouble(env, result);
+            return JavaClassGlobalDef::new_double(env, result);
         }
     }
     CATCH_STD()
@@ -1385,7 +1387,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumDouble(
         size_t return_ndx;
         double result = pQuery->minimum_double(S(columnIndex), NULL, S(start), S(end), S(limit), &return_ndx);
         if (return_ndx != npos) {
-            return NewDouble(env, result);
+            return JavaClassGlobalDef::new_double(env, result);
         }
     }
     CATCH_STD()
@@ -1431,7 +1433,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMaximumTimesta
         size_t return_ndx;
         Timestamp result = pQuery->find_all().maximum_timestamp(S(columnIndex), &return_ndx);
         if (return_ndx != npos && !result.is_null()) {
-            return NewLong(env, to_milliseconds(result));
+            return JavaClassGlobalDef::new_long(env, to_milliseconds(result));
         }
     }
     CATCH_STD()
@@ -1453,7 +1455,7 @@ JNIEXPORT jobject JNICALL Java_io_realm_internal_TableQuery_nativeMinimumTimesta
         size_t return_ndx;
         Timestamp result = pQuery->find_all().minimum_timestamp(S(columnIndex), &return_ndx);
         if (return_ndx != npos && !result.is_null()) {
-            return NewLong(env, to_milliseconds(result));
+            return JavaClassGlobalDef::new_long(env, to_milliseconds(result));
         }
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Util.cpp
@@ -18,6 +18,7 @@
 
 #include "jni_util/jni_utils.hpp"
 #include "jni_util/hack.hpp"
+#include "java_class_global_def.hpp"
 
 #include <realm/string_data.hpp>
 #include <realm/unicode.hpp>
@@ -26,6 +27,7 @@
 
 using std::string;
 using namespace realm::jni_util;
+using namespace realm::_impl;
 
 //#define USE_VLD
 #if defined(_MSC_VER) && defined(_DEBUG) && defined(USE_VLD)
@@ -46,16 +48,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
     }
     else {
         JniUtils::initialize(vm, JNI_VERSION_1_6);
-        // Loading classes and constructors for later use - used by box typed fields and a few methods' return value
-        java_lang_long = GetClass(env, "java/lang/Long");
-        java_lang_long_init = env->GetMethodID(java_lang_long, "<init>", "(J)V");
-        java_lang_float = GetClass(env, "java/lang/Float");
-        java_lang_float_init = env->GetMethodID(java_lang_float, "<init>", "(F)V");
-        java_lang_double = GetClass(env, "java/lang/Double");
-        java_lang_string = GetClass(env, "java/lang/String");
-        java_lang_double_init = env->GetMethodID(java_lang_double, "<init>", "(D)V");
-        java_util_date = GetClass(env, "java/util/Date");
-        java_util_date_init = env->GetMethodID(java_util_date, "<init>", "(J)V");
+        JavaClassGlobalDef::initialize(env);
     }
 
     return JNI_VERSION_1_6;
@@ -68,11 +61,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void*)
         return;
     }
     else {
-        env->DeleteGlobalRef(java_lang_long);
-        env->DeleteGlobalRef(java_lang_float);
-        env->DeleteGlobalRef(java_lang_double);
-        env->DeleteGlobalRef(java_util_date);
-        env->DeleteGlobalRef(java_lang_string);
+        JavaClassGlobalDef::release();
         JniUtils::release();
     }
 }

--- a/realm/realm-library/src/main/cpp/java_binding_context.hpp
+++ b/realm/realm-library/src/main/cpp/java_binding_context.hpp
@@ -26,10 +26,6 @@
 
 namespace realm {
 
-namespace jni_util {
-class JavaClass;
-}
-
 namespace _impl {
 // Binding context which will be called from OS.
 class JavaBindingContext final : public BindingContext {
@@ -43,10 +39,6 @@ private:
     // Java should hold a strong ref to them as long as the SharedRealm lives
     jni_util::JavaGlobalWeakRef m_java_notifier;
     jni_util::JavaGlobalWeakRef m_schema_changed_callback;
-    // Problem has been seen if the class is retrieved directly from loop callback. So make sure get_notifier_class()
-    // is called once when creating BindingContext.
-    jni_util::JavaClass const& m_notifier_class;
-    static jni_util::JavaClass const& get_notifier_class(JNIEnv*);
 
 public:
     virtual ~JavaBindingContext(){};
@@ -58,7 +50,6 @@ public:
     explicit JavaBindingContext(const ConcreteJavaBindContext& concrete_context)
         : m_java_notifier(concrete_context.jni_env, concrete_context.java_notifier)
         , m_schema_changed_callback()
-        , m_notifier_class(get_notifier_class(concrete_context.jni_env))
     {
     }
     JavaBindingContext(const JavaBindingContext&) = delete;

--- a/realm/realm-library/src/main/cpp/java_class_global_def.hpp
+++ b/realm/realm-library/src/main/cpp/java_class_global_def.hpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_JNI_IMPL_CLASS_GLOBAL_DEF_HPP
+#define REALM_JNI_IMPL_CLASS_GLOBAL_DEF_HPP
+
+#include "util.hpp"
+#include "jni_util/java_class.hpp"
+#include "jni_util/java_method.hpp"
+
+#include <memory>
+
+#include <realm/util/assert.hpp>
+
+namespace realm {
+namespace _impl {
+
+// Manage a global static jclass pool which will be initialized when JNI_OnLoad() called.
+// FindClass is a relatively slow operation, loading all the needed classes when start is not good since usually user
+// will call Realm.init() when the app starts.
+// Instead, we only load necessary classes including:
+// 1. Common types which might be used everywhere. (Boxed types, String, etc.)
+// 2. Classes which might be initialized in the native thread.
+//
+// FindClass will fail if it is called from a native thread (e.g.: the sync client thread.). But usually it is not a
+// problem if the FindClass is called from an JNI method. So keeping a static JavaClass var locally is still preferred
+// if it is possible.
+class JavaClassGlobalDef {
+private:
+    JavaClassGlobalDef(JNIEnv* env)
+        : m_java_lang_long(env, "java/lang/Long", false)
+        , m_java_lang_float(env, "java/lang/Float", false)
+        , m_java_lang_double(env, "java/lang/Double", false)
+        , m_java_util_date(env, "java/util/Date", false)
+        , m_java_lang_string(env, "java/lang/String", false)
+        , m_shared_realm_schema_change_callback(env, "io/realm/internal/SharedRealm$SchemaChangedCallback", false)
+        , m_realm_notifier(env, "io/realm/internal/RealmNotifier", false)
+    {
+    }
+
+    jni_util::JavaClass m_java_lang_long;
+    jni_util::JavaClass m_java_lang_float;
+    jni_util::JavaClass m_java_lang_double;
+    jni_util::JavaClass m_java_util_date;
+    jni_util::JavaClass m_java_lang_string;
+
+    jni_util::JavaClass m_shared_realm_schema_change_callback;
+    jni_util::JavaClass m_realm_notifier;
+
+    inline static std::unique_ptr<JavaClassGlobalDef>& instance()
+    {
+        static std::unique_ptr<JavaClassGlobalDef> instance;
+        return instance;
+    };
+
+public:
+    // Called in JNI_OnLoad
+    static void initialize(JNIEnv* env)
+    {
+        REALM_ASSERT(!instance());
+        instance().reset(new JavaClassGlobalDef(env));
+    }
+    // Called in JNI_OnUnload
+    static void release()
+    {
+        REALM_ASSERT(instance());
+        instance().release();
+    }
+
+    // java.lang.Long
+    inline static jobject new_long(JNIEnv* env, int64_t value)
+    {
+        static jni_util::JavaMethod init(env, instance()->m_java_lang_long, "<init>", "(J)V");
+        return env->NewObject(instance()->m_java_lang_long, init, value);
+    }
+    inline static const jni_util::JavaClass& java_lang_long()
+    {
+        return instance()->m_java_lang_long;
+    }
+
+    // java.lang.Float
+    inline static jobject new_float(JNIEnv* env, float value)
+    {
+        static jni_util::JavaMethod init(env, instance()->m_java_lang_float, "<init>", "(F)V");
+        return env->NewObject(instance()->m_java_lang_float, init, value);
+    }
+    inline static const jni_util::JavaClass& java_lang_float()
+    {
+        return instance()->m_java_lang_float;
+    }
+
+    // java.lang.Double
+    inline static jobject new_double(JNIEnv* env, double value)
+    {
+        static jni_util::JavaMethod init(env, instance()->m_java_lang_double, "<init>", "(D)V");
+        return env->NewObject(instance()->m_java_lang_double, init, value);
+    }
+    inline static const jni_util::JavaClass& java_lang_double()
+    {
+        return instance()->m_java_lang_double;
+    }
+
+    // java.util.Date
+    inline static jobject new_date(JNIEnv* env, const realm::Timestamp& ts)
+    {
+        static jni_util::JavaMethod init(env, instance()->m_java_util_date, "<init>", "(J)V");
+        return env->NewObject(instance()->m_java_util_date, init, to_milliseconds(ts));
+    }
+    inline static const jni_util::JavaClass& java_util_date()
+    {
+        return instance()->m_java_util_date;
+    }
+
+    // java.util.String
+    inline static const jni_util::JavaClass& java_lang_string()
+    {
+        return instance()->m_java_lang_string;
+    }
+
+    // io.realm.internal.SharedRealm.SchemaChangedCallback
+    inline static const jni_util::JavaClass& shared_realm_schema_change_callback()
+    {
+        return instance()->m_shared_realm_schema_change_callback;
+    }
+
+    // io.realm.internal.RealmNotifier
+    inline static const jni_util::JavaClass& realm_notifier()
+    {
+        return instance()->m_realm_notifier;
+    }
+};
+
+} // namespace realm
+} // namespace jni_impl
+
+
+#endif // REALM_JNI_IMPL_CLASS_GLOBAL_DEF_HPP

--- a/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/java_method.cpp
@@ -30,5 +30,5 @@ JavaMethod::JavaMethod(JNIEnv* env, JavaClass const& cls, const char* method_nam
         m_method_id = env->GetMethodID(cls, method_name, signature);
     }
 
-    REALM_ASSERT_RELEASE(m_method_id != nullptr);
+    REALM_ASSERT_RELEASE_EX(m_method_id != nullptr, method_name, signature);
 }

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -38,17 +38,6 @@ using namespace realm::util;
 using namespace realm::jni_util;
 using namespace realm::_impl;
 
-// Caching classes and constructors for boxed types.
-jclass java_lang_long;
-jmethodID java_lang_long_init;
-jclass java_lang_float;
-jmethodID java_lang_float_init;
-jclass java_lang_double;
-jclass java_lang_string;
-jmethodID java_lang_double_init;
-jclass java_util_date;
-jmethodID java_util_date_init;
-
 void ThrowRealmFileException(JNIEnv* env, const std::string& message, realm::RealmFileException::Kind kind);
 
 void ConvertException(JNIEnv* env, const char* file, int line)
@@ -241,19 +230,6 @@ void ThrowRealmFileException(JNIEnv* env, const std::string& message, realm::Rea
     env->Throw(reinterpret_cast<jthrowable>(exception));
     env->DeleteLocalRef(cls);
     env->DeleteLocalRef(exception);
-}
-
-jclass GetClass(JNIEnv* env, const char* classStr)
-{
-    jclass localRefClass = env->FindClass(classStr);
-    if (localRefClass == NULL) {
-        ThrowException(env, ClassNotFound, classStr);
-        return NULL;
-    }
-
-    jclass myClass = reinterpret_cast<jclass>(env->NewGlobalRef(localRefClass));
-    env->DeleteLocalRef(localRefClass);
-    return myClass;
 }
 
 void ThrowNullValueException(JNIEnv* env, Table* table, size_t col_ndx)

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -106,9 +106,6 @@ void ThrowException(JNIEnv* env, ExceptionKind exception, const std::string& cla
 void ThrowException(JNIEnv* env, ExceptionKind exception, const char* classStr);
 void ThrowNullValueException(JNIEnv* env, realm::Table* table, size_t col_ndx);
 
-jclass GetClass(JNIEnv* env, const char* classStr);
-
-
 // Check parameters
 
 #define TABLE_VALID(env, ptr) TableIsValid(env, ptr)
@@ -691,35 +688,6 @@ private:
     jint m_releaseMode;
 };
 
-extern jclass java_lang_long;
-extern jmethodID java_lang_long_init;
-extern jclass java_lang_float;
-extern jmethodID java_lang_float_init;
-extern jclass java_lang_double;
-extern jclass java_lang_string;
-extern jmethodID java_lang_double_init;
-extern jclass java_util_date;
-extern jmethodID java_util_date_init;
-#if REALM_ENABLE_SYNC
-extern jclass java_syncmanager_class;
-extern jmethodID java_notify_progress_listener;
-#endif
-
-inline jobject NewLong(JNIEnv* env, int64_t value)
-{
-    return env->NewObject(java_lang_long, java_lang_long_init, value);
-}
-
-inline jobject NewDouble(JNIEnv* env, double value)
-{
-    return env->NewObject(java_lang_double, java_lang_double_init, value);
-}
-
-inline jobject NewFloat(JNIEnv* env, float value)
-{
-    return env->NewObject(java_lang_float, java_lang_float_init, value);
-}
-
 inline jlong to_milliseconds(const realm::Timestamp& ts)
 {
     // From core's reference implementation aka unit test
@@ -736,11 +704,6 @@ inline realm::Timestamp from_milliseconds(jlong milliseconds)
     int64_t seconds = milliseconds / 1000;
     int32_t nanoseconds = (milliseconds % 1000) * 1000000;
     return realm::Timestamp(seconds, nanoseconds);
-}
-
-inline jobject NewDate(JNIEnv* env, const realm::Timestamp& ts)
-{
-    return env->NewObject(java_util_date, java_util_date_init, to_milliseconds(ts));
 }
 
 extern const std::string TABLE_PREFIX;


### PR DESCRIPTION
- Add JavaClassGlobalDef to handle global jclass loading.
- Move common types classes loading to JavaClassGlobalDef.
- Load SharedRealm$$SchemaChangeCallback & RealmNotifier in JNI_OnLoad
  to fix #5195 .
- Code clean up.

NOTE:
Currently the JavaClassGlobalDef::initialize() takes about 0.3 ms on a
lowend armv7 device. So keeping less classes loaded at the beginning
will still be a good idea since the Realm.init() will be usually called
on the UI thread when start.