### PR TITLE
Ignore broken unit test

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
@@ -21,6 +21,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,6 +86,7 @@ public class PrimaryKeyTests {
 
     // Tests that primary key constraints are actually removed.
     @Test
+    @Ignore("Waiting for https://github.com/realm/realm-sync/issues/1628")
     public void removingPrimaryKeyRemovesConstraint_typeSetters() {
         RealmConfiguration config = configFactory.createConfigurationBuilder()
                 .name("removeConstraints").build();

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
@@ -93,7 +93,7 @@ public class PrimaryKeyTests {
     /**
      * This test surfaces a bunch of problems, most of them seem to be around caching of the schema
      * during a transaction
-     * 
+     *
      * 1) Removing the primary key do not invalidate the cache in RealmSchema and those cached
      *    are ImmutableRealmObjectSchema so do not change when the primary key is removed.
      *
@@ -101,7 +101,7 @@ public class PrimaryKeyTests {
      *    RealmPrimaryKeyConstraintException anyway. Unclear why.
      */
     @Test
-    @Ignore
+    @Ignore("See https://github.com/realm/realm-java/issues/5231")
     public void removingPrimaryKeyRemovesConstraint_typeSetters() {
         RealmConfiguration config = configFactory.createConfigurationBuilder()
                 .name("removeConstraints").build();


### PR DESCRIPTION
(for now)

We seem to have some issues with schema cache invalidation during a transaction. Not sure why this was not caught on the `master-4.0` branch. Anyway, disabling for now and tracking fixing it in https://github.com/realm/realm-java/issues/5231

Also, I moved the unit test to the public API as using the internal API missed some things like adding search indexes which broke other checks in the lower levels of the API.