### PR TITLE
Upgrade to latest Sync RC + ROS 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def buildSuccess = false
 def rosContainer
 try {
   node('android') {
-    timeout(time: 1, unit: 'HOURS') {
+    timeout(time: 90, unit: 'MINUTES') {
       // Allocate a custom workspace to avoid having % in the path (it breaks ld)
       ws('/tmp/realm-java') {
 	stage('SCM') {

--- a/dependencies.list
+++ b/dependencies.list
@@ -5,4 +5,4 @@ REALM_SYNC_SHA256=5e09e54e68e78683e006898f5a703f80e0ee49492fb0f9dc2384fcbbb9f02f
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.
-REALM_OBJECT_SERVER_DE_VERSION=2.0.0-alpha.32
+REALM_OBJECT_SERVER_DE_VERSION=2.0.0-alpha.34

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,8 +1,8 @@
 # Realm Sync Core release used by Realm Java
 # https://github.com/realm/realm-sync/releases
-REALM_SYNC_VERSION=2.0.0-rc18
-REALM_SYNC_SHA256=73cb89c1a04cafa871444aa91d93eb9df16af088bcb7d3ede73bb815d53a06e5
+REALM_SYNC_VERSION=2.0.0-rc21
+REALM_SYNC_SHA256=5e09e54e68e78683e006898f5a703f80e0ee49492fb0f9dc2384fcbbb9f02f70
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.
-REALM_OBJECT_SERVER_DE_VERSION=2.0.0-alpha.30
+REALM_OBJECT_SERVER_DE_VERSION=2.0.0-alpha.32

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -224,6 +224,9 @@ void ThrowRealmFileException(JNIEnv* env, const std::string& message, realm::Rea
         case realm::RealmFileException::Kind::FormatUpgradeRequired:
             kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_KIND_FORMAT_UPGRADE_REQUIRED;
             break;
+        case realm::RealmFileException::Kind::IncompatibleSyncedRealm:
+            kind_code = io_realm_internal_SharedRealm_FILE_EXCEPTION_INCOMPATIBLE_SYNC_FILE;
+            break;
     }
     jstring jstr = env->NewStringUTF(message.c_str());
     jobject exception = env->NewObject(cls, constructor, kind_code, jstr);

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmFileException.java
@@ -60,7 +60,12 @@ public class RealmFileException extends RuntimeException {
         /**
          * Thrown if the file needs to be upgraded to a new format, but upgrades have been explicitly disabled.
          */
-        FORMAT_UPGRADE_REQUIRED;
+        FORMAT_UPGRADE_REQUIRED,
+        /**
+         * Thrown if an attempt was made to open an Realm file created with Realm Object Server 1.*, which is
+         * not compatible with Realm Object Server 2.*. This exception should automatically be handled by Realm.
+         */
+        INCOMPATIBLE_SYNC_FILE;
 
         // Created from byte values by JNI.
         static Kind getKind(byte value) {
@@ -79,6 +84,8 @@ public class RealmFileException extends RuntimeException {
                     return FORMAT_UPGRADE_REQUIRED;
                 case SharedRealm.FILE_EXCEPTION_KIND_BAD_HISTORY:
                     return BAD_HISTORY;
+                case SharedRealm.FILE_EXCEPTION_INCOMPATIBLE_SYNC_FILE:
+                    return INCOMPATIBLE_SYNC_FILE;
                 default:
                     throw new RuntimeException("Unknown value for RealmFileException kind.");
             }

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -41,6 +41,7 @@ public final class SharedRealm implements Closeable, NativeObject {
     public static final byte FILE_EXCEPTION_KIND_NOT_FOUND = 4;
     public static final byte FILE_EXCEPTION_KIND_INCOMPATIBLE_LOCK_FILE = 5;
     public static final byte FILE_EXCEPTION_KIND_FORMAT_UPGRADE_REQUIRED = 6;
+    public static final byte FILE_EXCEPTION_INCOMPATIBLE_SYNC_FILE = 7;
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
 
     public static void initialize(File tempDirectory) {

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -131,6 +131,7 @@ public class SyncUser {
         Collection<SyncUser> storedUsers = userStore.allUsers();
         Map<String, SyncUser> map = new HashMap<>();
         for (SyncUser user : storedUsers) {
+            // FIXME: Users might be marked for deletion here
             if (user.isValid()) {
                 map.put(user.getIdentity(), user);
             }
@@ -280,20 +281,17 @@ public class SyncUser {
             // don't reference directly the refreshToken inside the revoke request
             // as it may revoke the newly acquired and refresh_token
             final Token refreshTokenToBeRevoked = refreshToken;
-            RealmLog.error("revoke " + refreshTokenToBeRevoked.value());
 
             ThreadPoolExecutor networkPoolExecutor = SyncManager.NETWORK_POOL_EXECUTOR;
             networkPoolExecutor.submit(new ExponentialBackoffTask<LogoutResponse>() {
 
                 @Override
                 protected LogoutResponse execute() {
-                    RealmLog.error("Executing revoke: " + refreshTokenToBeRevoked.value());
                     return server.logout(refreshTokenToBeRevoked, getAuthenticationUrl());
                 }
 
                 @Override
                 protected void onSuccess(LogoutResponse response) {
-                    RealmLog.error("User logged out success" + SyncUser.this.getAccessToken().value());
                     SyncManager.notifyUserLoggedOut(SyncUser.this);
                 }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -528,16 +528,10 @@ public class SyncUser {
         AuthenticationServer authServer = SyncManager.getAuthServer();
         LookupUserIdResponse response = authServer.retrieveUser(refreshToken, provider, providerUserIdentity, getAuthenticationUrl());
         if (!response.isValid()) {
-            // the endpoint returns a 404 if it can't honor the query, either because
-            // - provider is not valid
-            // - provider_id is not valid
-            // - token used is not an admin one
-            // in this case we should return null instead of throwing
-            if (response.getError().getErrorCode() == ErrorCode.UNKNOWN_ACCOUNT) {
-                return null;
-            } else {
-                throw response.getError();
-            }
+            // Right now errors are very inconsistent. See https://github.com/realm/ros/issues/310
+            // Treat them all as "User not existing". This is too broad, and should be revisited
+            // once #310 is fixed.
+            return null;
         } else {
             return SyncUserInfo.fromLookupUserIdResponse(response);
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -131,7 +131,6 @@ public class SyncUser {
         Collection<SyncUser> storedUsers = userStore.allUsers();
         Map<String, SyncUser> map = new HashMap<>();
         for (SyncUser user : storedUsers) {
-            // FIXME: Users might be marked for deletion here
             if (user.isValid()) {
                 map.put(user.getIdentity(), user);
             }
@@ -279,7 +278,7 @@ public class SyncUser {
             // Finally revoke server token. The local user is logged out in any case.
             final AuthenticationServer server = SyncManager.getAuthServer();
             // don't reference directly the refreshToken inside the revoke request
-            // as it may revoke the newly acquired and refresh_token
+            // as it may revoke the newly acquired refresh_token
             final Token refreshTokenToBeRevoked = refreshToken;
 
             ThreadPoolExecutor networkPoolExecutor = SyncManager.NETWORK_POOL_EXECUTOR;

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthServerResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthServerResponse.java
@@ -63,7 +63,14 @@ public abstract class AuthServerResponse {
             JSONObject obj = new JSONObject(response);
             String title = obj.optString("title", null);
             String hint = obj.optString("hint", null);
-            ErrorCode errorCode = ErrorCode.fromInt(obj.optInt("code", -1));
+            ErrorCode errorCode;
+            if (obj.has("code")) {
+                errorCode = ErrorCode.fromInt(obj.getInt("code"));
+            } else if (obj.has("status")) {
+                errorCode = ErrorCode.fromInt(obj.getInt("status"));
+            } else {
+                errorCode = ErrorCode.UNKNOWN;
+            }
             return new ObjectServerError(errorCode, title, hint);
         } catch (JSONException e) {
             return new ObjectServerError(ErrorCode.JSON_EXCEPTION, "Server failed with " +

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/ChangePasswordRequest.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/ChangePasswordRequest.java
@@ -56,10 +56,9 @@ public class ChangePasswordRequest {
     public String toJson() {
         try {
             JSONObject request = new JSONObject();
-            request.put("token", token);
-            request.put("password", newPassword);
+            request.put("newPassword", newPassword);
             if (userID != null) {
-                request.put("user_id", userID);
+                request.put("userId", userID);
             }
             return request.toString();
         } catch (JSONException e) {

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -38,7 +38,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     private static final String ACTION_LOGOUT = "revoke"; // Auth end point for logging out users
     private static final String ACTION_CHANGE_PASSWORD = "password"; // Auth end point for changing passwords
-    private static final String ACTION_LOOKUP_USER_ID = "users"; // Auth end point for looking up user id
+    private static final String ACTION_LOOKUP_USER_ID = "/users/:provider:/:providerId:"; // Auth end point for looking up user id
 
     private final OkHttpClient client = new OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
@@ -116,7 +116,10 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     @Override
     public LookupUserIdResponse retrieveUser(Token adminToken, String provider, String providerId, URL authenticationUrl) {
         try {
-            return lookupUserId(buildLookupUserIdUrl(authenticationUrl, ACTION_LOOKUP_USER_ID, provider, providerId), adminToken.value());
+            String action = ACTION_LOOKUP_USER_ID
+                .replace(":provider:", provider)
+                .replace(":providerId:", providerId);
+            return lookupUserId(buildActionUrl(authenticationUrl, action), adminToken.value());
         } catch (Exception e) {
             return LookupUserIdResponse.from(e);
         }
@@ -128,16 +131,6 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
         try {
             String separator = baseUrlString.endsWith("/") ? "" : "/";
             return new URL(baseUrlString + separator + action);
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static URL buildLookupUserIdUrl(URL authenticationUrl, String action, String provider, String providerId) {
-        String authURL = authenticationUrl.toExternalForm();
-        String separator = authURL.endsWith("/") ? "" : "/";
-        try {
-            return new URL(authURL + separator + action + "/" + providerId);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 import io.realm.SyncCredentials;
+import io.realm.internal.Util;
 import io.realm.internal.objectserver.Token;
 import io.realm.log.RealmLog;
 import okhttp3.Call;
@@ -86,7 +87,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     public LogoutResponse logout(Token userToken, URL authenticationUrl) {
         try {
             String requestBody = LogoutRequest.create(userToken).toJson();
-            return logout(buildActionUrl(authenticationUrl, ACTION_LOGOUT), requestBody);
+            return logout(buildActionUrl(authenticationUrl, ACTION_LOGOUT), userToken.value(), requestBody);
         } catch (Exception e) {
             return LogoutResponse.from(e);
         }
@@ -96,7 +97,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     public ChangePasswordResponse changePassword(Token userToken, String newPassword, URL authenticationUrl) {
         try {
             String requestBody = ChangePasswordRequest.create(userToken, newPassword).toJson();
-            return changePassword(buildActionUrl(authenticationUrl, ACTION_CHANGE_PASSWORD), requestBody);
+            return changePassword(buildActionUrl(authenticationUrl, ACTION_CHANGE_PASSWORD), userToken.value(), requestBody);
         } catch (Exception e) {
             return ChangePasswordResponse.from(e);
         }
@@ -106,7 +107,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     public ChangePasswordResponse changePassword(Token adminToken, String userId, String newPassword, URL authenticationUrl) {
         try {
             String requestBody = ChangePasswordRequest.create(adminToken, userId, newPassword).toJson();
-            return changePassword(buildActionUrl(authenticationUrl, ACTION_CHANGE_PASSWORD.replace(":userId:", userId)), requestBody);
+            return changePassword(buildActionUrl(authenticationUrl, ACTION_CHANGE_PASSWORD.replace(":userId:", userId)), adminToken.value(), requestBody);
         } catch (Exception e) {
             return ChangePasswordResponse.from(e);
         }
@@ -144,41 +145,60 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
 
     private AuthenticateResponse authenticate(URL authenticationUrl, String requestBody) throws Exception {
         RealmLog.debug("Network request (authenticate): " + authenticationUrl);
-        Request request = newAuthRequest(authenticationUrl).post(RequestBody.create(JSON, requestBody)).build();
+        Request request = newAuthRequest(authenticationUrl)
+                .post(RequestBody.create(JSON, requestBody))
+                .build();
         Call call = client.newCall(request);
         Response response = call.execute();
         return AuthenticateResponse.from(response);
     }
 
-    private LogoutResponse logout(URL logoutUrl, String requestBody) throws Exception {
+    private LogoutResponse logout(URL logoutUrl, String authToken, String requestBody) throws Exception {
         RealmLog.debug("Network request (logout): " + logoutUrl);
-        Request request = newAuthRequest(logoutUrl).post(RequestBody.create(JSON, requestBody)).build();
+        Request request = newAuthRequest(logoutUrl, authToken)
+                .post(RequestBody.create(JSON, requestBody))
+                .build();
         Call call = client.newCall(request);
         Response response = call.execute();
         return LogoutResponse.from(response);
     }
 
-    private ChangePasswordResponse changePassword(URL changePasswordUrl, String requestBody) throws Exception {
+    private ChangePasswordResponse changePassword(URL changePasswordUrl, String authToken, String requestBody) throws Exception {
         RealmLog.debug("Network request (changePassword): " + changePasswordUrl);
-        Request request = newAuthRequest(changePasswordUrl).put(RequestBody.create(JSON, requestBody)).build();
+        Request request = newAuthRequest(changePasswordUrl, authToken)
+                .put(RequestBody.create(JSON, requestBody))
+                .build();
         Call call = client.newCall(request);
         Response response = call.execute();
         return ChangePasswordResponse.from(response);
     }
 
-    private LookupUserIdResponse lookupUserId(URL lookupUserIdUrl, String token) throws Exception {
+    private LookupUserIdResponse lookupUserId(URL lookupUserIdUrl, String authToken) throws Exception {
         RealmLog.debug("Network request (lookupUserId): " + lookupUserIdUrl);
-        Request request = newAuthRequest(lookupUserIdUrl).get().header("Authorization", token).build();
+        Request request = newAuthRequest(lookupUserIdUrl, authToken)
+                .get()
+                .build();
         Call call = client.newCall(request);
         Response response = call.execute();
         return LookupUserIdResponse.from(response);
     }
 
     private Request.Builder newAuthRequest(URL url) {
-        return new Request.Builder()
+        return newAuthRequest(url, null);
+    }
+
+    private Request.Builder newAuthRequest(URL url, String authToken) {
+        Request.Builder builder = new Request.Builder()
                 .url(url)
                 .addHeader("Content-Type", "application/json")
                 .addHeader("Accept", "application/json");
+
+        // Only add Authorization header for those API's that require it.
+        if (!Util.isEmptyString(authToken)) {
+            builder.addHeader("Authorization", authToken);
+        }
+
+        return builder;
     }
 
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -37,7 +37,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
 
     public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     private static final String ACTION_LOGOUT = "revoke"; // Auth end point for logging out users
-    private static final String ACTION_CHANGE_PASSWORD = "users/:userId:/password"; // Auth end point for changing passwords
+    private static final String ACTION_CHANGE_PASSWORD = "password"; // Auth end point for changing passwords
     private static final String ACTION_LOOKUP_USER_ID = "users"; // Auth end point for looking up user id
 
     private final OkHttpClient client = new OkHttpClient.Builder()
@@ -107,7 +107,7 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     public ChangePasswordResponse changePassword(Token adminToken, String userId, String newPassword, URL authenticationUrl) {
         try {
             String requestBody = ChangePasswordRequest.create(adminToken, userId, newPassword).toJson();
-            return changePassword(buildActionUrl(authenticationUrl, ACTION_CHANGE_PASSWORD.replace(":userId:", userId)), adminToken.value(), requestBody);
+            return changePassword(buildActionUrl(authenticationUrl, ACTION_CHANGE_PASSWORD), adminToken.value(), requestBody);
         } catch (Exception e) {
             return ChangePasswordResponse.from(e);
         }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -32,9 +32,11 @@ import io.realm.SyncManager;
 import io.realm.SyncSession;
 import io.realm.SyncUser;
 import io.realm.SyncUserInfo;
+import io.realm.TestHelper;
 import io.realm.entities.StringOnly;
 import io.realm.internal.async.RealmAsyncTaskImpl;
 import io.realm.internal.objectserver.Token;
+import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.StringOnlyModule;
 import io.realm.objectserver.utils.UserFactory;
@@ -90,7 +92,8 @@ public class AuthTests extends StandardIntegrationTest {
     @Test
     @RunTestInLooperThread
     public void login_newUser() {
-        SyncCredentials credentials = SyncCredentials.usernamePassword("myUser", "password", true);
+        String userId = UUID.randomUUID().toString();
+        SyncCredentials credentials = SyncCredentials.usernamePassword(userId, "password", true);
         SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback() {
             @Override
             public void onSuccess(SyncUser user) {
@@ -500,23 +503,38 @@ public class AuthTests extends StandardIntegrationTest {
     }
 
     @Test
-    @Ignore("Resolve https://github.com/realm/ros/issues/261")
     public void revokedRefreshTokenIsNotSameAfterLogin() throws InterruptedException {
+        final CountDownLatch userLoggedInAgain = new CountDownLatch(1);
         final String uniqueName = UUID.randomUUID().toString();
 
-        SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
+        final SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
         SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
-        Token revokedRefreshToken = user.getAccessToken();
+        final Token revokedRefreshToken = user.getAccessToken();
+
+        SyncManager.addAuthenticationListener(new AuthenticationListener() {
+            @Override
+            public void loggedIn(SyncUser user) {
+
+            }
+
+            @Override
+            public void loggedOut(SyncUser user) {
+                SystemClock.sleep(1000); // Remove once https://github.com/realm/ros/issues/304 is fixed
+                SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", false);
+                SyncUser loggedInUser = SyncUser.login(credentials, Constants.AUTH_URL);
+
+                // still comparing the same user
+                assertEquals(revokedRefreshToken.identity(), loggedInUser.getAccessToken().identity());
+
+                // different tokens
+                assertNotEquals(revokedRefreshToken.value(), loggedInUser.getAccessToken().value());
+                SyncManager.removeAuthenticationListener(this);
+                userLoggedInAgain.countDown();
+            }
+        });
 
         user.logout();
-
-        credentials = SyncCredentials.usernamePassword(uniqueName, "password", false);
-        SyncUser loggedInUser = SyncUser.login(credentials, Constants.AUTH_URL);
-
-        // still comparing the same user
-        Assert.assertEquals(revokedRefreshToken.identity(), loggedInUser.getAccessToken().identity());
-        // different tokens
-        assertNotEquals(revokedRefreshToken.value(), loggedInUser.getAccessToken().value());
+        TestHelper.awaitOrFail(userLoggedInAgain);
     }
 
     // The pre-emptive token refresh subsystem should function, and properly refresh the access token.

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -36,7 +36,6 @@ import io.realm.TestHelper;
 import io.realm.entities.StringOnly;
 import io.realm.internal.async.RealmAsyncTaskImpl;
 import io.realm.internal.objectserver.Token;
-import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.StringOnlyModule;
 import io.realm.objectserver.utils.UserFactory;
@@ -197,7 +196,6 @@ public class AuthTests extends StandardIntegrationTest {
     }
 
     @Test
-    @Ignore("Resolve https://github.com/realm/ros/issues/273")
     public void changePassword() {
         String username = UUID.randomUUID().toString();
         String originalPassword = "password";
@@ -217,7 +215,6 @@ public class AuthTests extends StandardIntegrationTest {
     }
 
     @Test
-    @Ignore("Resolve https://github.com/realm/ros/issues/273")
     public void changePassword_using_admin() {
         String username = UUID.randomUUID().toString();
         String originalPassword = "password";
@@ -245,7 +242,6 @@ public class AuthTests extends StandardIntegrationTest {
 
     @Test
     @RunTestInLooperThread
-    @Ignore("Resolve https://github.com/realm/ros/issues/273")
     public void changePassword_using_admin_async() {
         final String username = UUID.randomUUID().toString();
         final String originalPassword = "password";
@@ -285,6 +281,7 @@ public class AuthTests extends StandardIntegrationTest {
 
     @Test
     @RunTestInLooperThread
+    @Ignore("Wait until https://github.com/realm/ros/issues/309 is resolved")
     public void changePassword_throwWhenUserIsLoggedOut() {
         String username = UUID.randomUUID().toString();
         String password = "password";
@@ -401,7 +398,6 @@ public class AuthTests extends StandardIntegrationTest {
         RealmConfiguration configuration = new SyncConfiguration.Builder(user, Constants.USER_REALM).build();
         user.logout();
         assertFalse(user.isValid());
-
         Realm instance = Realm.getInstance(configuration);
         instance.close();
     }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
@@ -3,6 +3,7 @@ package io.realm.objectserver;
 import android.os.SystemClock;
 import android.text.style.TabStopSpan;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -100,6 +101,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
 
     // If an encrypted synced Realm is re-opened with the wrong key, throw an exception.
     @Test
+    @Ignore("See https://github.com/realm/realm-java/issues/5281")
     public void setEncryptionKey_shouldCrashIfKeyNotProvided() throws InterruptedException {
         // STEP 1: open a synced Realm using a local encryption key
         String username = UUID.randomUUID().toString();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
@@ -51,7 +51,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-@Ignore("See https://github.com/realm/realm-java/issues/5282")
 public class ProgressListenerTests extends StandardIntegrationTest {
 
     private static final long TEST_SIZE = 10;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
+@Ignore("See https://github.com/realm/realm-java/issues/5282")
 public class ProgressListenerTests extends StandardIntegrationTest {
 
     private static final long TEST_SIZE = 10;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -161,40 +161,11 @@ public class UserFactory {
         handler.post(new Runnable() {
             @Override
             public void run() {
-                final AtomicInteger usersLoggedOut = new AtomicInteger(0);
-                final int activeUsers = SyncUser.all().size();
-                final AuthenticationListener listener = new AuthenticationListener() {
-                    @Override
-                    public void loggedIn(SyncUser user) {
-                        SyncManager.removeAuthenticationListener(this);
-                        fail("User logged in while exiting test: " + user);
-                    }
-
-                    @Override
-                    public void loggedOut(SyncUser user) {
-                        if (usersLoggedOut.incrementAndGet() == activeUsers) {
-                            SyncManager.removeAuthenticationListener(this);
-                            allUsersLoggedOut.countDown();
-                        }
-                    }
-                };
-                SyncManager.addAuthenticationListener(listener);
-
                 Map<String, SyncUser> users = SyncUser.all();
-                if (users.isEmpty()) {
-                    SyncManager.removeAuthenticationListener(listener);
-                    allUsersLoggedOut.countDown();
-                } else {
-                    for (SyncUser user : users.values()) {
-                        user.logout();
-                        if (!user.getAuthenticationUrl().toString().contains("127.0.0.1")) {
-                            // For dummy users, calling `logout()` will never result in the
-                            // authentication listener to trigger since the URL doesn't exist.
-                            // For these cases, we manually trigger the listener.
-                            listener.loggedOut(user);
-                        }
-                    }
+                for (SyncUser user : users.values()) {
+                    user.logout();
                 }
+                allUsersLoggedOut.countDown();
             }
         });
         TestHelper.awaitOrFail(allUsersLoggedOut);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -165,6 +165,7 @@ public class UserFactory {
                 for (SyncUser user : users.values()) {
                     user.logout();
                 }
+                SystemClock.sleep(2000); // Remove when https://github.com/realm/ros/issues/304 is fixed
                 allUsersLoggedOut.countDown();
             }
         });

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -96,9 +96,7 @@ function stopRealmObjectServer(onSuccess, onError) {
         onSuccess();
     });
 
-    // Move back to `SIGTERM` once https://github.com/realm/ros/issues/234
-    // is resolved
-    syncServerChildProcess.kill('SIGKILL');
+    syncServerChildProcess.kill();
 }
 
 // start sync server

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -42,7 +42,7 @@ function waitForRosToInitialize(attempts, onSuccess, onError) {
     http.get("http://0.0.0.0:9080/health", function(res) {
         if (res.statusCode != 200) {
             winston.info("ROS /health/ returned: " + res.statusCode)
-            waitForRosToInitialize(attempts - 1,onSuccess)
+            waitForRosToInitialize(attempts - 1, onSuccess, onError)
         } else {
             onSuccess();
         }
@@ -51,7 +51,7 @@ function waitForRosToInitialize(attempts, onSuccess, onError) {
         // Errors like ECONNREFUSED 0.0.0.0:9080 will be reported here.
         // Wait a little before trying again (common startup is ~1 second).
         setTimeout(function() {
-            waitForRosToInitialize(attempts - 1, onSuccess);
+            waitForRosToInitialize(attempts - 1, onSuccess, onError);
         }, 200);
     });
 }
@@ -104,10 +104,10 @@ dispatcher.onGet("/start", function(req, res) {
     winston.info("Attempting to start ROS");
     startRealmObjectServer(() => {
         res.writeHead(200, {'Content-Type': 'text/plain'});
-        res.end('ROS server started');
+        res.end('ROS started');
     }, function (err) {
         res.writeHead(500, {'Content-Type': 'text/plain'});
-        res.end('Starting a ROS server failed: ' + err);
+        res.end('Starting ROS failed: ' + err);
     });
 });
 
@@ -115,8 +115,11 @@ dispatcher.onGet("/start", function(req, res) {
 dispatcher.onGet("/stop", function(req, res) {
   winston.info("Attempting to stop ROS")
   stopRealmObjectServer(function() {
-      res.writeHead(200, {'Content-Type': 'text/plain'});
-      res.end('ROS server stopped');
+        res.writeHead(200, {'Content-Type': 'text/plain'});
+        res.end('ROS stopped');
+  }, function(err) {
+        res.writeHead(500, {'Content-Type': 'text/plain'});
+        res.end('Stopping ROS failed: ' + err);
   });
 });
 

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -96,7 +96,7 @@ function stopRealmObjectServer(onSuccess, onError) {
         onSuccess();
     });
 
-    syncServerChildProcess.kill();
+    syncServerChildProcess.kill('SIGKILL');
 }
 
 // start sync server

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -64,7 +64,10 @@ function startRealmObjectServer(onSuccess, onError) {
             winston.info(env.NODE_ENV);
             env.NODE_ENV = 'development';
             syncServerChildProcess = spawn('ros',
-                    ['start', '--data', path],
+                    ['start',
+                        '--data', path,
+                        '--access-token-ttl', '20' //WARNING : Changing this value may impact the timeout of the refresh token test (AuthTests#preemptiveTokenRefresh)
+                    ],
                     { env: env, cwd: path});
 
             // local config:


### PR DESCRIPTION
* Sync-RC21
* ROS 2.0.0-alpha.34
* Added support for Authorization headers
* Added support for new Sync exception
* Enabled remote revokation again

TODO
- [x] Figure out why some `retrieve` tests are now failing