### PR TITLE
Minimize overhead on CI for PR builds.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,103 +9,103 @@ try {
     timeout(time: 1, unit: 'HOURS') {
       // Allocate a custom workspace to avoid having % in the path (it breaks ld)
       ws('/tmp/realm-java') {
-	stage('SCM') {
-	  checkout([
-		     $class: 'GitSCM',
-		    branches: scm.branches,
-		    gitTool: 'native git',
-		    extensions: scm.extensions + [
-		      [$class: 'CleanCheckout'],
-		      [$class: 'SubmoduleOption', recursiveSubmodules: true]
-		    ],
-		    userRemoteConfigs: scm.userRemoteConfigs
-		   ])
-	}
+        stage('SCM') {
+          checkout([
+                 $class: 'GitSCM',
+                branches: scm.branches,
+                gitTool: 'native git',
+                extensions: scm.extensions + [
+                  [$class: 'CleanCheckout'],
+                  [$class: 'SubmoduleOption', recursiveSubmodules: true]
+                ],
+                userRemoteConfigs: scm.userRemoteConfigs
+               ])
+        }
 
-	def buildEnv
-	def rosEnv
-	stage('Docker build') {
-	  // Docker image for build
-	  buildEnv = docker.build 'realm-java:snapshot'
-	  // Docker image for testing Realm Object Server
-	  def dependProperties = readProperties file: 'dependencies.list'
-	  def rosDeVersion = dependProperties["REALM_OBJECT_SERVER_DE_VERSION"]
-	  rosEnv = docker.build 'ros:snapshot', "--build-arg ROS_DE_VERSION=${rosDeVersion} tools/sync_test_server"
-	}
+        def buildEnv
+        def rosEnv
+        stage('Docker build') {
+          // Docker image for build
+          buildEnv = docker.build 'realm-java:snapshot'
+          // Docker image for testing Realm Object Server
+          def dependProperties = readProperties file: 'dependencies.list'
+          def rosDeVersion = dependProperties["REALM_OBJECT_SERVER_DE_VERSION"]
+          rosEnv = docker.build 'ros:snapshot', "--build-arg ROS_DE_VERSION=${rosDeVersion} tools/sync_test_server"
+        }
 
-	rosContainer = rosEnv.run('-v /tmp=/tmp/.ros')
+	    rosContainer = rosEnv.run('-v /tmp=/tmp/.ros')
 
-	try {
-          buildEnv.inside("-e HOME=/tmp " +
-			  "-e _JAVA_OPTIONS=-Duser.home=/tmp " +
-			  "--privileged " +
-			  "-v /dev/bus/usb:/dev/bus/usb " +
-			  "-v ${env.HOME}/gradle-cache:/tmp/.gradle " +
-			  "-v ${env.HOME}/.android:/tmp/.android " +
-			  "-v ${env.HOME}/ccache:/tmp/.ccache " +
-			  "--network container:${rosContainer.id}") {
-            stage('JVM tests') {
-              try {
-                withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                  sh "chmod +x gradlew && ./gradlew assemble check javadoc -Ps3cfg=${env.S3CFG}"
+        try {
+              buildEnv.inside("-e HOME=/tmp " +
+                  "-e _JAVA_OPTIONS=-Duser.home=/tmp " +
+                  "--privileged " +
+                  "-v /dev/bus/usb:/dev/bus/usb " +
+                  "-v ${env.HOME}/gradle-cache:/tmp/.gradle " +
+                  "-v ${env.HOME}/.android:/tmp/.android " +
+                  "-v ${env.HOME}/ccache:/tmp/.ccache " +
+                  "--network container:${rosContainer.id}") {
+                stage('JVM tests') {
+                  try {
+                    withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
+                      sh "chmod +x gradlew && ./gradlew assemble check javadoc -Ps3cfg=${env.S3CFG}"
+                    }
+                  } finally {
+                    storeJunitResults 'realm/realm-annotations-processor/build/test-results/test/TEST-*.xml'
+                    storeJunitResults 'examples/unitTestExample/build/test-results/**/TEST-*.xml'
+                    step([$class: 'LintPublisher'])
+                  }
                 }
-              } finally {
-                storeJunitResults 'realm/realm-annotations-processor/build/test-results/test/TEST-*.xml'
-                storeJunitResults 'examples/unitTestExample/build/test-results/**/TEST-*.xml'
-                step([$class: 'LintPublisher'])
-              }
-            }
 
-            stage('Static code analysis') {
-              try {
-                gradle('realm', 'findbugs pmd checkstyle')
-              } finally {
-                publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/findbugs', reportFiles: 'findbugs-output.html', reportName: 'Findbugs issues'])
-                publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/reports/pmd', reportFiles: 'pmd.html', reportName: 'PMD Issues'])
-                step([$class: 'CheckStylePublisher',
-		      canComputeNew: false,
-		      defaultEncoding: '',
-		      healthy: '',
-		      pattern: 'realm/realm-library/build/reports/checkstyle/checkstyle.xml',
-		      unHealthy: ''
-		     ])
-              }
-            }
+                stage('Static code analysis') {
+                  try {
+                    gradle('realm', 'findbugs pmd checkstyle')
+                  } finally {
+                    publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/findbugs', reportFiles: 'findbugs-output.html', reportName: 'Findbugs issues'])
+                    publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/reports/pmd', reportFiles: 'pmd.html', reportName: 'PMD Issues'])
+                    step([$class: 'CheckStylePublisher',
+                  canComputeNew: false,
+                  defaultEncoding: '',
+                  healthy: '',
+                  pattern: 'realm/realm-library/build/reports/checkstyle/checkstyle.xml',
+                  unHealthy: ''
+                 ])
+                  }
+                }
 
-            stage('Run instrumented tests') {
-              lock("${env.NODE_NAME}-android") {
-                boolean archiveLog = true
-                String backgroundPid
-                try {
-                  backgroundPid = startLogCatCollector()
-                  forwardAdbPorts()
-                  gradle('realm', 'connectedAndroidTest')
-                  archiveLog = false;
-                } finally {
-                  stopLogCatCollector(backgroundPid, archiveLog)
-                  storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'
+                stage('Run instrumented tests') {
+                  lock("${env.NODE_NAME}-android") {
+                    boolean archiveLog = true
+                    String backgroundPid
+                    try {
+                      backgroundPid = startLogCatCollector()
+                      forwardAdbPorts()
+                      gradle('realm', 'connectedAndroidTest')
+                      archiveLog = false;
+                    } finally {
+                      stopLogCatCollector(backgroundPid, archiveLog)
+                      storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'
+                    }
+                  }
+                }
+
+                // TODO: add support for running monkey on the example apps
+
+                if (env.BRANCH_NAME == 'master') {
+                  stage('Collect metrics') {
+                    collectAarMetrics()
+                  }
+
+                  stage('Publish to OJO') {
+                    withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'bintray', passwordVariable: 'BINTRAY_KEY', usernameVariable: 'BINTRAY_USER']]) {
+                      sh "chmod +x gradlew && ./gradlew -PbintrayUser=${env.BINTRAY_USER} -PbintrayKey=${env.BINTRAY_KEY} assemble ojoUpload --stacktrace"
+                    }
+                  }
                 }
               }
-            }
-
-            // TODO: add support for running monkey on the example apps
-
-            if (env.BRANCH_NAME == 'master') {
-              stage('Collect metrics') {
-                collectAarMetrics()
-              }
-
-              stage('Publish to OJO') {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'bintray', passwordVariable: 'BINTRAY_KEY', usernameVariable: 'BINTRAY_USER']]) {
-                  sh "chmod +x gradlew && ./gradlew -PbintrayUser=${env.BINTRAY_USER} -PbintrayKey=${env.BINTRAY_KEY} assemble ojoUpload --stacktrace"
-                }
-              }
-            }
-          }
-	} finally {
-          sh "docker logs ${rosContainer.id}"
-          rosContainer.stop()
-	}
+        } finally {
+              sh "docker logs ${rosContainer.id}"
+              rosContainer.stop()
+        }
       }
     }
     currentBuild.rawBuild.setResult(Result.SUCCESS)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ try {
         // A full build is done on `master`.
         // TODO Once Android emulators are available on all nodes, we can switch to x86 builds
         // on PR's for even more throughput.
-        def ABIs = null
+        def ABIs = ""
         def instrumentationTestTarget = "connectedAndroidTest"
         if (!['master'].contains(env.BRANCH_NAME)) {
             ABIs = "armeabi-v7a"


### PR DESCRIPTION
This PR changes PR's so they only build for `armeabi-v7a` and run integration tests against the `ObjectServer` variant. `master` still runs the full test suite.

Nesting was wrong as well so fixed.
Relevant changes are in https://github.com/realm/realm-java/commit/78a2af9af4f3e73a8edec4f57143f88c53cf3479

Build time for PR's have been reduced to ~22 minutes, so at least a 50% reduction. We can probably get that lower.

@emanuelez What would it take to run integration tests on an x86 emulator instead of on a device?


TODO
- [x] Make build work
- [x] Measure savings