### PR TITLE
Add support for ISO8601 2-digit time zone designator in Date parsing (#5309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.7.3 (xxxx-xx-xx)
+
+### Bug Fixes
+
+* Added support for ISO8601 2-digit time zone designators (#5309).
+
 ## 3.7.2 (2017-09-12)
 
 ### Bug Fixes

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/android/ISO8601UtilsTest.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/android/ISO8601UtilsTest.java
@@ -123,6 +123,17 @@ public class ISO8601UtilsTest extends AndroidTestCase {
         assertEquals(dateZeroSecondAndMillis, d);
     }
 
+    public void testTimeZoneDesignator() throws java.text.ParseException {
+        Date d = ISO8601Utils.parse("2007-08-13T21:51+02:00", new ParsePosition(0));
+        assertEquals(dateZeroSecondAndMillis, d);
+
+        d = ISO8601Utils.parse("2007-08-13T21:51+0200", new ParsePosition(0));
+        assertEquals(dateZeroSecondAndMillis, d);
+
+        d = ISO8601Utils.parse("2007-08-13T21:51+02", new ParsePosition(0));
+        assertEquals(dateZeroSecondAndMillis, d);
+    }
+
     public void testParseRfc3339Examples() throws java.text.ParseException {
         // Two digit milliseconds.
         Date d = ISO8601Utils.parse("1985-04-12T23:20:50.52Z", new ParsePosition(0));

--- a/realm/realm-library/src/main/java/io/realm/internal/android/ISO8601Utils.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/ISO8601Utils.java
@@ -158,6 +158,10 @@ public class ISO8601Utils {
             } else if (timezoneIndicator == '+' || timezoneIndicator == '-') {
                 String timezoneOffset = date.substring(offset);
                 offset += timezoneOffset.length();
+                // Convert 2-digit time zone designator to 4-digit designator
+                if (timezoneOffset.length() == 3) {
+                    timezoneOffset += "00";
+                }
                 // 18-Jun-2015, tatu: Minor simplification, skip offset of "+0000"/"+00:00"
                 if ("+0000".equals(timezoneOffset) || "+00:00".equals(timezoneOffset)) {
                     timezone = TIMEZONE_Z;


### PR DESCRIPTION
Fixes #5309 

Add support for ISO8601 2-digit time zone designator for Date parsing as reported in Issue #5309.