### PR TITLE
Move PK table migration to JNI totally

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
@@ -179,9 +179,7 @@ public class PrimaryKeyTests {
     public void migratePrimaryKeyTableIfNeeded_first() throws IOException {
         configFactory.copyRealmFromAssets(context, "080_annotationtypes.realm", "default.realm");
         sharedRealm = SharedRealm.getInstance(config);
-        sharedRealm.beginTransaction();
-        assertTrue(Table.migratePrimaryKeyTableIfNeeded(sharedRealm));
-        sharedRealm.commitTransaction();
+        Table.migratePrimaryKeyTableIfNeeded(sharedRealm);
         Table t = sharedRealm.getTable("class_AnnotationTypes");
         assertEquals("id", OsObjectStore.getPrimaryKeyForObject(sharedRealm, "AnnotationTypes"));
         assertEquals(RealmFieldType.STRING, sharedRealm.getTable("pk").getColumnType(0));
@@ -191,9 +189,7 @@ public class PrimaryKeyTests {
     public void migratePrimaryKeyTableIfNeeded_second() throws IOException {
         configFactory.copyRealmFromAssets(context, "0841_annotationtypes.realm", "default.realm");
         sharedRealm = SharedRealm.getInstance(config);
-        sharedRealm.beginTransaction();
-        assertTrue(Table.migratePrimaryKeyTableIfNeeded(sharedRealm));
-        sharedRealm.commitTransaction();
+        Table.migratePrimaryKeyTableIfNeeded(sharedRealm);
         Table t = sharedRealm.getTable("class_AnnotationTypes");
         assertEquals("id", OsObjectStore.getPrimaryKeyForObject(sharedRealm, "AnnotationTypes"));
         assertEquals("AnnotationTypes", sharedRealm.getTable("pk").getString(0, 0));
@@ -213,9 +209,7 @@ public class PrimaryKeyTests {
 
         configFactory.copyRealmFromAssets(context, "0841_pk_migration.realm", "default.realm");
         sharedRealm = SharedRealm.getInstance(config);
-        sharedRealm.beginTransaction();
-        assertTrue(Table.migratePrimaryKeyTableIfNeeded(sharedRealm));
-        sharedRealm.commitTransaction();
+        Table.migratePrimaryKeyTableIfNeeded(sharedRealm);
 
         Table table = sharedRealm.getTable("pk");
         for (int i = 0; i < table.size(); i++) {
@@ -255,13 +249,17 @@ public class PrimaryKeyTests {
         } catch (IllegalStateException ignored) {
             // Column has no search index.
         }
+        sharedRealm.commitTransaction();
 
         assertFalse(pkTable.hasSearchIndex(classColumn));
 
         Table.migratePrimaryKeyTableIfNeeded(sharedRealm);
         assertTrue(pkTable.hasSearchIndex(classColumn));
+
+        sharedRealm.beginTransaction();
         // Now it works.
         table2.addSearchIndex(column2);
-        sharedRealm.cancelTransaction();
+        OsObjectStore.setPrimaryKeyForObject(sharedRealm, "TestTable2", "PKColumn");
+        sharedRealm.commitTransaction();
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_SharedRealm.cpp
@@ -158,20 +158,6 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeIsInTransact
     return static_cast<jboolean>(shared_realm->is_in_transaction());
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_SharedRealm_nativeReadGroup(JNIEnv* env, jclass,
-                                                                           jlong shared_realm_ptr)
-{
-    TR_ENTER_PTR(shared_realm_ptr)
-
-    auto& shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-    try {
-        return reinterpret_cast<jlong>(&shared_realm->read_group());
-    }
-    CATCH_STD()
-
-    return static_cast<jlong>(NULL);
-}
-
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_SharedRealm_nativeIsEmpty(JNIEnv* env, jclass,
                                                                             jlong shared_realm_ptr)
 {

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -315,15 +315,7 @@ final class RealmCache {
                     if (fileExists) {
                         // Primary key problem only exists before we release sync.
                         sharedRealm = SharedRealm.getInstance(configuration);
-
-                        if (Table.primaryKeyTableNeedsMigration(sharedRealm)) {
-                            sharedRealm.beginTransaction();
-                            if (Table.migratePrimaryKeyTableIfNeeded(sharedRealm)) {
-                                sharedRealm.commitTransaction();
-                            } else {
-                                sharedRealm.cancelTransaction();
-                            }
-                        }
+                        Table.migratePrimaryKeyTableIfNeeded(sharedRealm);
                     }
                 }
             } finally {

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -243,11 +243,6 @@ public final class SharedRealm implements Closeable, NativeObject {
         return nativeIsInTransaction(nativePtr);
     }
 
-    // FIXME: This should be removed, migratePrimaryKeyTableIfNeeded is using it which should be in Object Store instead?
-    long getGroupNative() {
-        return nativeReadGroup(nativePtr);
-    }
-
     public boolean hasTable(String name) {
         return nativeHasTable(nativePtr, name);
     }
@@ -496,8 +491,6 @@ public final class SharedRealm implements Closeable, NativeObject {
     private static native void nativeCancelTransaction(long nativeSharedRealmPtr);
 
     private static native boolean nativeIsInTransaction(long nativeSharedRealmPtr);
-
-    private static native long nativeReadGroup(long nativeSharedRealmPtr);
 
     private static native boolean nativeIsEmpty(long nativeSharedRealmPtr);
 


### PR DESCRIPTION
- Hide all the information about PK table from Java.
- Remove SharedRealm.readGroup().