### PR TITLE
Build core from source

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -61,6 +61,7 @@ android {
                         "-DENABLE_DEBUG_CORE=$project.enableDebugCore"
                 if (project.ccachePath) arguments "-DNDK_CCACHE=$project.ccachePath"
                 if (project.lcachePath) arguments "-DNDK_LCACHE=$project.lcachePath"
+                if (project.coreSourcePath) arguments "-DCORE_SOURCE_PATH=$project.coreSourcePath"
                 if (project.hasProperty('buildTargetABIs') && !project.getProperty('buildTargetABIs').trim().isEmpty()) {
                     abiFilters(*project.getProperty('buildTargetABIs').trim().split('\\s*,\\s*'))
                 } else {
@@ -120,7 +121,7 @@ android {
         abortOnError false
     }
 
-   flavorDimensions 'api'
+    flavorDimensions 'api'
 
     productFlavors {
         base {
@@ -496,35 +497,9 @@ task downloadCore() {
     }
 }
 
-task compileCore(group: 'build setup', description: 'Compile the core library from source code') {
-    // Build the library from core source code
-    doFirst {
-        if (!coreSourcePath) {
-            throw new GradleException('The coreSourcePath is not set.')
-        }
-        exec {
-            workingDir = coreSourcePath
-            commandLine = [
-                    "bash",
-                    "build.sh",
-                    "build-android"
-            ]
-        }
-    }
-
-    // Copy the core tar ball
-    doLast {
-        copy {
-            from "${coreSourcePath}/realm-core-android-${coreVersion}.tar.gz"
-            into project.coreArchiveFile.parent
-            rename "realm-core-android-${coreVersion}.tar.gz", "realm-sync-android-${coreVersion}.tar.gz"
-        }
-    }
-}
-
 task deployCore(group: 'build setup', description: 'Deploy the latest version of Realm Core') {
     dependsOn {
-        coreSourcePath ? compileCore : downloadCore
+        downloadCore
     }
 
     // Build with the output from core source dir. No need to deploy anything.

--- a/realm/realm-library/src/main/cpp/CMake/RealmCore.cmake
+++ b/realm/realm-library/src/main/cpp/CMake/RealmCore.cmake
@@ -1,0 +1,125 @@
+###########################################################################
+#
+# Copyright 2017 Realm Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###########################################################################
+include(ExternalProject)
+
+function(build_existing_realm_core core_source_path)
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(debug_lib_suffix "-dbg")
+        add_compile_options(-DREALM_DEBUG)
+    else()
+        add_compile_options(-DNDEBUG)
+    endif()
+
+    ExternalProject_Add(realm-core
+        SOURCE_DIR ${core_source_path}
+        PREFIX ${core_source_path}/build-android-${ANDROID_ABI}-${CMAKE_BUILD_TYPE}
+        CMAKE_ARGS  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                    -DANDROID_ABI=${ANDROID_ABI}
+                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                    -DREALM_BUILD_LIB_ONLY=YES
+                    -DREALM_ENABLE_ENCRYPTION=1
+        INSTALL_COMMAND ""
+        LOG_CONFIGURE 1
+        LOG_BUILD 1
+        )
+
+    ExternalProject_Get_Property(realm-core SOURCE_DIR)
+    ExternalProject_Get_Property(realm-core BINARY_DIR)
+
+    # Create directories that are included in INTERFACE_INCLUDE_DIRECTORIES, as CMake requires they exist at
+    # configure time, when they'd otherwise not be created until we download and extract core.
+    file(MAKE_DIRECTORY "${BINARY_DIR}/src")
+
+    set(core_lib_file "${BINARY_DIR}/src/realm/librealm${debug_lib_suffix}.a")
+    add_library(lib_realm_core STATIC IMPORTED)
+    set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_file}
+        IMPORTED_LINK_INTERFACE_LIBRARIES atomic
+        INTERFACE_INCLUDE_DIRECTORIES "${SOURCE_DIR}/src;${BINARY_DIR}/src")
+
+    ExternalProject_Add_Step(realm-core ensure-libraries
+        DEPENDEES build
+        BYPRODUCTS ${core_lib_file}
+        )
+
+    add_dependencies(lib_realm_core realm-core)
+endfunction()
+
+# Add the sync released as the library.
+function(use_sync_release enable_sync sync_dist_path)
+    # Link to core/sync debug lib for debug build if it is debug build and linking with debug core is enabled.
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND ${ENABLE_DEBUG_CORE})
+        set(debug_lib_suffix "-dbg")
+        add_compile_options(-DREALM_DEBUG)
+    else()
+        add_compile_options(-DNDEBUG)
+    endif()
+
+    # Configure import realm core lib
+    set(core_lib_path ${sync_dist_path}/librealm-android-${ANDROID_ABI}${debug_lib_suffix}.a)
+    if (NOT EXISTS ${core_lib_path})
+        if (ARMEABI)
+            set(core_lib_path ${sync_dist_path}/librealm-android-arm${debug_lib_suffix}.a)
+        elseif (ARMEABI_V7A)
+            set(core_lib_path ${sync_dist_path}/librealm-android-arm-v7a${debug_lib_suffix}.a)
+        elseif (ARM64_V8A)
+            set(core_lib_path ${sync_dist_path}/librealm-android-arm64${debug_lib_suffix}.a)
+        else()
+            message(FATAL_ERROR "Cannot find core lib file: ${core_lib_path}")
+        endif()
+    endif()
+
+    add_library(lib_realm_core STATIC IMPORTED)
+
+    # -latomic is not set by default for mips and armv5.
+    # See https://code.google.com/p/android/issues/detail?id=182094
+    set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_path}
+        IMPORTED_LINK_INTERFACE_LIBRARIES atomic
+        INTERFACE_INCLUDE_DIRECTORIES "${sync_dist_path}/include")
+
+    if (enable_sync)
+        # Sync static library
+        set(sync_lib_path ${sync_dist_path}/librealm-sync-android-${ANDROID_ABI}${debug_lib_suffix}.a)
+        # Workaround for old core's funny ABI nicknames
+        if (NOT EXISTS ${sync_lib_path})
+            if (ARMEABI)
+                set(sync_lib_path ${sync_dist_path}/librealm-sync-android-arm${debug_lib_suffix}.a)
+            elseif (ARMEABI_V7A)
+                set(sync_lib_path ${sync_dist_path}/librealm-sync-android-arm-v7a${debug_lib_suffix}.a)
+            elseif (ARM64_V8A)
+                set(sync_lib_path ${sync_dist_path}/librealm-sync-android-arm64${debug_lib_suffix}.a)
+            else()
+                message(FATAL_ERROR "Cannot find sync lib file: ${sync_lib_path}")
+            endif()
+        endif()
+        add_library(lib_realm_sync STATIC IMPORTED)
+        set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_path}
+            IMPORTED_LINK_INTERFACE_LIBRARIES lib_realm_core)
+    endif()
+
+    set(REALM_CORE_INCLUDE_DIR "${sync_dist_path}/include")
+endfunction()
+
+# Add core/sync libraries. Set the core_source_path to build core from source.
+# FIXME: Build from sync source is not supported yet.
+function(use_realm_core enable_sync sync_dist_path core_source_path)
+    if (core_source_path)
+        build_existing_realm_core(${core_source_path})
+    else()
+        use_sync_release(${enable_sync} ${sync_dist_path})
+    endif()
+endfunction()

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,23 @@
+###########################################################################
+#
+# Copyright 2017 Realm Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###########################################################################
 cmake_minimum_required(VERSION 3.6.0)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
 # find javah
 find_package(Java COMPONENTS Development)
@@ -63,56 +82,9 @@ create_javah(TARGET jni_headers
     DEPENDS ${classes_PATH}
 )
 
-# Link to core/sync debug lib for debug build if it is debug build and linking with debug core is enabled.
-# FIXME: Ideally we should linking to debug core on CI for testing, but the assertions slow down the CI a lot.
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND ${ENABLE_DEBUG_CORE})
-    set(debug_lib_SUFFIX "-dbg")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DREALM_DEBUG")
-else()
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DNDEBUG")
-endif()
+include(RealmCore)
 
-# Configure import realm core lib
-set(core_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-android-${ANDROID_ABI}${debug_lib_SUFFIX}.a)
-# Workaround for old core's funny ABI nicknames
-if (NOT EXISTS ${core_lib_PATH})
-    if (ARMEABI)
-        set(core_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-android-arm${debug_lib_SUFFIX}.a)
-    elseif (ARMEABI_V7A)
-        set(core_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-android-arm-v7a${debug_lib_SUFFIX}.a)
-    elseif (ARM64_V8A)
-        set(core_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-android-arm64${debug_lib_SUFFIX}.a)
-    else()
-        message(FATAL_ERROR "Cannot find core lib file: ${core_lib_PATH}")
-    endif()
-endif()
-
-add_library(lib_realm_core STATIC IMPORTED)
-
-# -latomic is not set by default for mips and armv5.
-# See https://code.google.com/p/android/issues/detail?id=182094
-set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_PATH}
-                                                IMPORTED_LINK_INTERFACE_LIBRARIES atomic)
-
-if (build_SYNC)
-    # Sync static library
-    set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-${ANDROID_ABI}${debug_lib_SUFFIX}.a)
-    # Workaround for old core's funny ABI nicknames
-    if (NOT EXISTS ${sync_lib_PATH})
-        if (ARMEABI)
-            set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm${debug_lib_SUFFIX}.a)
-        elseif (ARMEABI_V7A)
-            set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm-v7a${debug_lib_SUFFIX}.a)
-        elseif (ARM64_V8A)
-            set(sync_lib_PATH ${REALM_CORE_DIST_DIR}/librealm-sync-android-arm64${debug_lib_SUFFIX}.a)
-        else()
-            message(FATAL_ERROR "Cannot find sync lib file: ${sync_lib_PATH}")
-        endif()
-    endif()
-    add_library(lib_realm_sync STATIC IMPORTED)
-    set_target_properties(lib_realm_sync PROPERTIES IMPORTED_LOCATION ${sync_lib_PATH}
-                                                    IMPORTED_LINK_INTERFACE_LIBRARIES lib_realm_core)
-endif()
+use_realm_core(${build_SYNC} "${REALM_CORE_DIST_DIR}" "${CORE_SOURCE_PATH}")
 
 # Download openssl lib
 #string(TOLOWER "${CMAKE_BUILD_TYPE}" openssl_build_TYPE)
@@ -136,7 +108,7 @@ get_target_property(crypto_LIB crypto IMPORTED_LOCATION)
 get_target_property(ssl_LIB ssl IMPORTED_LOCATION)
 
 # build application's shared lib
-include_directories(${REALM_CORE_DIST_DIR}/include
+include_directories(
     ${CMAKE_SOURCE_DIR}
     ${jni_headers_PATH}
     ${CMAKE_SOURCE_DIR}/object-store/src)


### PR DESCRIPTION
- Separate core library cmake to RealmCore.cmake
- Build core from source code with the new core's cmake build. This is
  much faster than before, it will only build the needed ABI and
  release/debug variant.