### PR TITLE
Array of primitives: DynamicRealm support

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -1024,6 +1024,21 @@ public class DynamicRealmObjectTests {
     }
 
     @Test
+    public void setList_objectsOwnList() {
+        dynamicRealm.beginTransaction();
+
+        // Test model classes
+        int originalSize = dObjDynamic.getList(AllJavaTypes.FIELD_LIST).size();
+        dObjDynamic.setList(AllJavaTypes.FIELD_LIST, dObjDynamic.getList(AllJavaTypes.FIELD_LIST));
+        assertEquals(originalSize, dObjDynamic.getList(AllJavaTypes.FIELD_LIST).size());
+
+        // Smoke test value lists
+        originalSize = dObjDynamic.getList(AllJavaTypes.FIELD_STRING_LIST, String.class).size();
+        dObjDynamic.setList(AllJavaTypes.FIELD_STRING_LIST, dObjDynamic.getList(AllJavaTypes.FIELD_STRING_LIST, String.class));
+        assertEquals(originalSize, dObjDynamic.getList(AllJavaTypes.FIELD_STRING_LIST, String.class).size());
+    }
+
+    @Test
     public void untypedSetter_listWrongTypeThrows() {
         realm.beginTransaction();
         AllTypes wrongObj = realm.createObject(AllTypes.class);

--- a/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/DynamicRealmObjectTests.java
@@ -95,6 +95,13 @@ public class DynamicRealmObjectTests {
         typedObj.setFieldDate(new Date(1000));
         typedObj.setFieldObject(typedObj);
         typedObj.getFieldList().add(typedObj);
+        typedObj.getFieldIntegerList().add(1);
+        typedObj.getFieldStringList().add("str");
+        typedObj.getFieldBooleanList().add(true);
+        typedObj.getFieldFloatList().add(1.23F);
+        typedObj.getFieldDoubleList().add(1.234D);
+        typedObj.getFieldBinaryList().add(new byte[] {1, 2, 3});
+        typedObj.getFieldDateList().add(new Date(1000));
         dObjTyped = new DynamicRealmObject(typedObj);
         realm.commitTransaction();
 
@@ -114,15 +121,16 @@ public class DynamicRealmObjectTests {
 
     // Types supported by the DynamicRealmObject.
     private enum SupportedType {
-        BOOLEAN, SHORT, INT, LONG, BYTE, FLOAT, DOUBLE, STRING, BINARY, DATE, OBJECT, LIST
+        BOOLEAN, SHORT, INT, LONG, BYTE, FLOAT, DOUBLE, STRING, BINARY, DATE, OBJECT, LIST,
+        LIST_INTEGER, LIST_STRING, LIST_BOOLEAN, LIST_FLOAT, LIST_DOUBLE, LIST_BINARY, LIST_DATE
     }
 
     private enum ThreadConfinedMethods {
         GET_BOOLEAN, GET_BYTE, GET_SHORT, GET_INT, GET_LONG, GET_FLOAT, GET_DOUBLE,
-        GET_BLOB, GET_STRING, GET_DATE, GET_OBJECT, GET_LIST, GET,
+        GET_BLOB, GET_STRING, GET_DATE, GET_OBJECT, GET_LIST, GET_PRIMITIVE_LIST, GET,
 
         SET_BOOLEAN, SET_BYTE, SET_SHORT, SET_INT, SET_LONG, SET_FLOAT, SET_DOUBLE,
-        SET_BLOB, SET_STRING, SET_DATE, SET_OBJECT, SET_LIST, SET,
+        SET_BLOB, SET_STRING, SET_DATE, SET_OBJECT, SET_LIST, SET_PRIMITIVE_LIST, SET,
 
         IS_NULL, SET_NULL,
 
@@ -134,33 +142,35 @@ public class DynamicRealmObjectTests {
     @SuppressWarnings({"ResultOfMethodCallIgnored", "EqualsWithItself", "SelfEquals"})
     private static void callThreadConfinedMethod(DynamicRealmObject obj, ThreadConfinedMethods method) {
         switch (method) {
-            case GET_BOOLEAN: obj.getBoolean(AllJavaTypes.FIELD_BOOLEAN); break;
-            case GET_BYTE:    obj.getByte(AllJavaTypes.FIELD_BYTE);       break;
-            case GET_SHORT:   obj.getShort(AllJavaTypes.FIELD_SHORT);     break;
-            case GET_INT:     obj.getInt(AllJavaTypes.FIELD_INT);         break;
-            case GET_LONG:    obj.getLong(AllJavaTypes.FIELD_LONG);       break;
-            case GET_FLOAT:   obj.getFloat(AllJavaTypes.FIELD_FLOAT);     break;
-            case GET_DOUBLE:  obj.getDouble(AllJavaTypes.FIELD_DOUBLE);   break;
-            case GET_BLOB:    obj.getBlob(AllJavaTypes.FIELD_BINARY);     break;
-            case GET_STRING:  obj.getString(AllJavaTypes.FIELD_STRING);   break;
-            case GET_DATE:    obj.getDate(AllJavaTypes.FIELD_DATE);       break;
-            case GET_OBJECT:  obj.getObject(AllJavaTypes.FIELD_OBJECT);   break;
-            case GET_LIST:    obj.getList(AllJavaTypes.FIELD_LIST);       break;
-            case GET:         obj.get(AllJavaTypes.FIELD_LONG);           break;
+            case GET_BOOLEAN:           obj.getBoolean(AllJavaTypes.FIELD_BOOLEAN);                 break;
+            case GET_BYTE:              obj.getByte(AllJavaTypes.FIELD_BYTE);                       break;
+            case GET_SHORT:             obj.getShort(AllJavaTypes.FIELD_SHORT);                     break;
+            case GET_INT:               obj.getInt(AllJavaTypes.FIELD_INT);                         break;
+            case GET_LONG:              obj.getLong(AllJavaTypes.FIELD_LONG);                       break;
+            case GET_FLOAT:             obj.getFloat(AllJavaTypes.FIELD_FLOAT);                     break;
+            case GET_DOUBLE:            obj.getDouble(AllJavaTypes.FIELD_DOUBLE);                   break;
+            case GET_BLOB:              obj.getBlob(AllJavaTypes.FIELD_BINARY);                     break;
+            case GET_STRING:            obj.getString(AllJavaTypes.FIELD_STRING);                   break;
+            case GET_DATE:              obj.getDate(AllJavaTypes.FIELD_DATE);                       break;
+            case GET_OBJECT:            obj.getObject(AllJavaTypes.FIELD_OBJECT);                   break;
+            case GET_LIST:              obj.getList(AllJavaTypes.FIELD_LIST);                       break;
+            case GET_PRIMITIVE_LIST:    obj.getList(AllJavaTypes.FIELD_STRING_LIST, String.class);  break;
+            case GET:                   obj.get(AllJavaTypes.FIELD_LONG);                           break;
 
-            case SET_BOOLEAN: obj.setBoolean(AllJavaTypes.FIELD_BOOLEAN, true);                 break;
-            case SET_BYTE:    obj.setByte(AllJavaTypes.FIELD_BYTE,       (byte) 1);             break;
-            case SET_SHORT:   obj.setShort(AllJavaTypes.FIELD_SHORT,     (short) 1);            break;
-            case SET_INT:     obj.setInt(AllJavaTypes.FIELD_INT,         1);                    break;
-            case SET_LONG:    obj.setLong(AllJavaTypes.FIELD_LONG,       1L);                   break;
-            case SET_FLOAT:   obj.setFloat(AllJavaTypes.FIELD_FLOAT,     1F);                   break;
-            case SET_DOUBLE:  obj.setDouble(AllJavaTypes.FIELD_DOUBLE,   1D);                   break;
-            case SET_BLOB:    obj.setBlob(AllJavaTypes.FIELD_BINARY,     new byte[] {1, 2, 3}); break;
-            case SET_STRING:  obj.setString(AllJavaTypes.FIELD_STRING,   "12345");              break;
-            case SET_DATE:    obj.setDate(AllJavaTypes.FIELD_DATE,       new Date(1L));         break;
-            case SET_OBJECT:  obj.setObject(AllJavaTypes.FIELD_OBJECT,   obj);                  break;
-            case SET_LIST:    obj.setList(AllJavaTypes.FIELD_LIST,       new RealmList<>(obj)); break;
-            case SET:         obj.set(AllJavaTypes.FIELD_LONG,           1L);                   break;
+            case SET_BOOLEAN:           obj.setBoolean(AllJavaTypes.FIELD_BOOLEAN, true);                           break;
+            case SET_BYTE:              obj.setByte(AllJavaTypes.FIELD_BYTE,       (byte) 1);                       break;
+            case SET_SHORT:             obj.setShort(AllJavaTypes.FIELD_SHORT,     (short) 1);                      break;
+            case SET_INT:               obj.setInt(AllJavaTypes.FIELD_INT,         1);                              break;
+            case SET_LONG:              obj.setLong(AllJavaTypes.FIELD_LONG,       1L);                             break;
+            case SET_FLOAT:             obj.setFloat(AllJavaTypes.FIELD_FLOAT,     1F);                             break;
+            case SET_DOUBLE:            obj.setDouble(AllJavaTypes.FIELD_DOUBLE,   1D);                             break;
+            case SET_BLOB:              obj.setBlob(AllJavaTypes.FIELD_BINARY,     new byte[] {1, 2, 3});           break;
+            case SET_STRING:            obj.setString(AllJavaTypes.FIELD_STRING,   "12345");                        break;
+            case SET_DATE:              obj.setDate(AllJavaTypes.FIELD_DATE,       new Date(1L));                   break;
+            case SET_OBJECT:            obj.setObject(AllJavaTypes.FIELD_OBJECT,   obj);                            break;
+            case SET_LIST:              obj.setList(AllJavaTypes.FIELD_LIST,       new RealmList<>(obj));           break;
+            case SET_PRIMITIVE_LIST:    obj.setList(AllJavaTypes.FIELD_STRING_LIST,new RealmList<String>("foo"));   break;
+            case SET:                   obj.set(AllJavaTypes.FIELD_LONG,           1L);                             break;
 
             case IS_NULL:     obj.isNull(AllJavaTypes.FIELD_OBJECT);           break;
             case SET_NULL:    obj.setNull(AllJavaTypes.FIELD_OBJECT);          break;
@@ -326,7 +336,16 @@ public class DynamicRealmObjectTests {
                 case BINARY: target.getBlob(fieldName); break;
                 case DATE: target.getDate(fieldName); break;
                 case OBJECT: target.getObject(fieldName); break;
-                case LIST: target.getList(fieldName); break;
+                case LIST:
+                case LIST_INTEGER:
+                case LIST_STRING:
+                case LIST_BOOLEAN:
+                case LIST_FLOAT:
+                case LIST_DOUBLE:
+                case LIST_BINARY:
+                case LIST_DATE:
+                    target.getList(fieldName);
+                    break;
                 default:
                     fail();
             }
@@ -450,6 +469,13 @@ public class DynamicRealmObjectTests {
                 case DATE: target.getDate(fieldName); break;
                 case OBJECT: target.setObject(fieldName, null); target.setObject(fieldName, target); break;
                 case LIST: target.setList(fieldName, new RealmList<DynamicRealmObject>()); break;
+                case LIST_INTEGER: target.setList(fieldName, new RealmList<Integer>(1)); break;
+                case LIST_STRING: target.setList(fieldName, new RealmList<String>("foo")); break;
+                case LIST_BOOLEAN: target.setList(fieldName, new RealmList<Boolean>(true)); break;
+                case LIST_FLOAT: target.setList(fieldName, new RealmList<Float>(1.23F)); break;
+                case LIST_DOUBLE: target.setList(fieldName, new RealmList<Double>(1.234D)); break;
+                case LIST_BINARY: target.setList(fieldName, new RealmList<byte[]>(new byte[]{})); break;
+                case LIST_DATE: target.setList(fieldName, new RealmList<Date>(new Date())); break;
                 default:
                     fail();
             }
@@ -510,6 +536,13 @@ public class DynamicRealmObjectTests {
                         assertEquals(dObj, dObj.getObject(AllJavaTypes.FIELD_OBJECT));
                         break;
                     case LIST:
+                    case LIST_INTEGER:
+                    case LIST_STRING:
+                    case LIST_BOOLEAN:
+                    case LIST_FLOAT:
+                    case LIST_DOUBLE:
+                    case LIST_BINARY:
+                    case LIST_DATE:
                         // Ignores. See testGetList/testSetList.
                         break;
                     default:
@@ -541,6 +574,55 @@ public class DynamicRealmObjectTests {
                     case LIST:
                         try {
                             dObj.setNull(NullTypes.FIELD_LIST_NULL);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_INTEGER:
+                        try {
+                            dObj.setNull(NullTypes.FIELD_INTEGER_LIST_NULL);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_STRING:
+                        try {
+                            dObj.setNull(NullTypes.FIELD_STRING_LIST_NULL);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_BOOLEAN:
+                        try {
+                            dObj.setNull(NullTypes.FIELD_BOOLEAN_LIST_NULL);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_FLOAT:
+                        try {
+                            dObj.setNull(NullTypes.FIELD_FLOAT_LIST_NULL);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_DOUBLE:
+                        try {
+                            dObj.setNull(NullTypes.FIELD_DOUBLE_LIST_NULL);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_BINARY:
+                        try {
+                            dObj.setNull(NullTypes.FIELD_BINARY_LIST_NULL);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_DATE:
+                        try {
+                            dObj.setNull(NullTypes.FIELD_DATE_LIST_NULL);
                             fail();
                         } catch (IllegalArgumentException ignored) {
                         }
@@ -606,6 +688,13 @@ public class DynamicRealmObjectTests {
                     switch (type) {
                         case OBJECT: continue; // Ignore
                         case LIST: fieldName = NullTypes.FIELD_LIST_NULL; break;
+                        case LIST_INTEGER: fieldName = NullTypes.FIELD_INTEGER_LIST_NULL; break;
+                        case LIST_STRING: fieldName = NullTypes.FIELD_STRING_LIST_NULL; break;
+                        case LIST_BOOLEAN: fieldName = NullTypes.FIELD_BOOLEAN_LIST_NULL; break;
+                        case LIST_FLOAT: fieldName = NullTypes.FIELD_FLOAT_LIST_NULL; break;
+                        case LIST_DOUBLE: fieldName = NullTypes.FIELD_DATE_LIST_NULL; break;
+                        case LIST_BINARY: fieldName = NullTypes.FIELD_BINARY_LIST_NULL; break;
+                        case LIST_DATE: fieldName = NullTypes.FIELD_DATE_LIST_NULL; break;
                         case BOOLEAN: fieldName = NullTypes.FIELD_BOOLEAN_NOT_NULL; break;
                         case BYTE: fieldName = NullTypes.FIELD_BYTE_NOT_NULL; break;
                         case SHORT: fieldName = NullTypes.FIELD_SHORT_NOT_NULL; break;
@@ -647,6 +736,55 @@ public class DynamicRealmObjectTests {
                     case LIST:
                         try {
                             dObj.setList(NullTypes.FIELD_LIST_NULL, null);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_INTEGER:
+                        try {
+                            dObj.setList(NullTypes.FIELD_INTEGER_LIST_NULL, null);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_STRING:
+                        try {
+                            dObj.setList(NullTypes.FIELD_STRING_LIST_NULL, null);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_BOOLEAN:
+                        try {
+                            dObj.setList(NullTypes.FIELD_BOOLEAN_LIST_NULL, null);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_FLOAT:
+                        try {
+                            dObj.setList(NullTypes.FIELD_FLOAT_LIST_NULL, null);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_DOUBLE:
+                        try {
+                            dObj.setList(NullTypes.FIELD_DOUBLE_LIST_NULL, null);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_BINARY:
+                        try {
+                            dObj.setList(NullTypes.FIELD_BINARY_LIST_NULL, null);
+                            fail();
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                        break;
+                    case LIST_DATE:
+                        try {
+                            dObj.setList(NullTypes.FIELD_DATE_LIST_NULL, null);
                             fail();
                         } catch (IllegalArgumentException ignored) {
                         }
@@ -909,6 +1047,7 @@ public class DynamicRealmObjectTests {
     // List is not a simple getter, tests separately.
     @Test
     public void getList() {
+        // FIXME Also fix primitive lists
         realm.beginTransaction();
         AllTypes obj = realm.createObject(AllTypes.class);
         Dog dog = realm.createObject(Dog.class);
@@ -977,7 +1116,7 @@ public class DynamicRealmObjectTests {
                         dObj.set(AllJavaTypes.FIELD_OBJECT, dObj);
                         assertEquals(dObj, dObj.get(AllJavaTypes.FIELD_OBJECT));
                         break;
-                    case LIST:
+                    case LIST: {
                         RealmList<DynamicRealmObject> newList = new RealmList<DynamicRealmObject>();
                         newList.add(dObj);
                         dObj.set(AllJavaTypes.FIELD_LIST, newList);
@@ -985,6 +1124,63 @@ public class DynamicRealmObjectTests {
                         assertEquals(1, list.size());
                         assertEquals(dObj, list.get(0));
                         break;
+                    }
+                    case LIST_INTEGER: {
+                        RealmList<Integer> newList = new RealmList<>(null, 1);
+                        dObj.set(AllJavaTypes.FIELD_INTEGER_LIST, newList);
+                        RealmList<Integer> list = dObj.getList(AllJavaTypes.FIELD_INTEGER_LIST, Integer.class);
+                        assertEquals(2, list.size());
+                        assertArrayEquals(newList.toArray(), list.toArray());
+                        break;
+                    }
+                    case LIST_STRING: {
+                        RealmList<String> newList = new RealmList<>(null, "Foo");
+                        dObj.set(AllJavaTypes.FIELD_STRING_LIST, newList);
+                        RealmList<String> list = dObj.getList(AllJavaTypes.FIELD_STRING_LIST, String.class);
+                        assertEquals(2, list.size());
+                        assertArrayEquals(newList.toArray(), list.toArray());
+                        break;
+                    }
+                    case LIST_BOOLEAN: {
+                        RealmList<Boolean> newList = new RealmList<>(null, true);
+                        dObj.set(AllJavaTypes.FIELD_BOOLEAN_LIST, newList);
+                        RealmList<Boolean> list = dObj.getList(AllJavaTypes.FIELD_BOOLEAN_LIST, Boolean.class);
+                        assertEquals(2, list.size());
+                        assertArrayEquals(newList.toArray(), list.toArray());
+                        break;
+                    }
+                    case LIST_FLOAT: {
+                        RealmList<Float> newList = new RealmList<>(null, 1.23F);
+                        dObj.set(AllJavaTypes.FIELD_FLOAT_LIST, newList);
+                        RealmList<Float> list = dObj.getList(AllJavaTypes.FIELD_FLOAT_LIST, Float.class);
+                        assertEquals(2, list.size());
+                        assertArrayEquals(newList.toArray(), list.toArray());
+                        break;
+                    }
+                    case LIST_DOUBLE: {
+                        RealmList<Double> newList = new RealmList<>(null, 1.24D);
+                        dObj.set(AllJavaTypes.FIELD_DOUBLE_LIST, newList);
+                        RealmList<Double> list = dObj.getList(AllJavaTypes.FIELD_DOUBLE_LIST, Double.class);
+                        assertEquals(2, list.size());
+                        assertArrayEquals(newList.toArray(), list.toArray());
+                        break;
+                    }
+                    case LIST_BINARY: {
+                        RealmList<byte[]> newList = new RealmList<>(null, new byte[] {1, 2, 3});
+                        dObj.set(AllJavaTypes.FIELD_BINARY_LIST, newList);
+                        RealmList<byte[]> list = dObj.getList(AllJavaTypes.FIELD_BINARY_LIST, byte[].class);
+                        assertEquals(2, list.size());
+                        assertArrayEquals(newList.toArray(), list.toArray());
+                        break;
+                    }
+                    case LIST_DATE: {
+                        RealmList<Date> newList = new RealmList<>(null, new Date(1000));
+                        dObj.set(AllJavaTypes.FIELD_DATE_LIST, newList);
+                        RealmList<Date> list = dObj.getList(AllJavaTypes.FIELD_DATE_LIST, Date.class);
+                        assertEquals(2, list.size());
+                        assertArrayEquals(newList.toArray(), list.toArray());
+                        break;
+                    }
                     default:
                         fail();
                 }
@@ -1033,11 +1229,17 @@ public class DynamicRealmObjectTests {
                     // These types don't have a string representation that can be parsed.
                     case OBJECT:
                     case LIST:
+                    case LIST_INTEGER:
+                    case LIST_STRING:
+                    case LIST_BOOLEAN:
+                    case LIST_FLOAT:
+                    case LIST_DOUBLE:
+                    case LIST_BINARY:
+                    case LIST_DATE:
                     case STRING:
                     case BINARY:
                     case BYTE:
                         break;
-
                     default:
                         fail("Unknown type: " + type);
                         break;
@@ -1081,6 +1283,13 @@ public class DynamicRealmObjectTests {
                         case BYTE:
                         case OBJECT:
                         case LIST:
+                        case LIST_INTEGER:
+                        case LIST_STRING:
+                        case LIST_BOOLEAN:
+                        case LIST_FLOAT:
+                        case LIST_DOUBLE:
+                        case LIST_BINARY:
+                        case LIST_DATE:
                         case STRING:
                         case BINARY:
                             continue;
@@ -1200,6 +1409,13 @@ public class DynamicRealmObjectTests {
         assertEquals(RealmFieldType.INTEGER, dObjTyped.getFieldType(AllJavaTypes.FIELD_SHORT));
         assertEquals(RealmFieldType.INTEGER, dObjTyped.getFieldType(AllJavaTypes.FIELD_INT));
         assertEquals(RealmFieldType.INTEGER, dObjTyped.getFieldType(AllJavaTypes.FIELD_LONG));
+        assertEquals(RealmFieldType.INTEGER_LIST, dObjTyped.getFieldType(AllJavaTypes.FIELD_INTEGER_LIST));
+        assertEquals(RealmFieldType.STRING_LIST, dObjTyped.getFieldType(AllJavaTypes.FIELD_STRING_LIST));
+        assertEquals(RealmFieldType.BOOLEAN_LIST, dObjTyped.getFieldType(AllJavaTypes.FIELD_BOOLEAN_LIST));
+        assertEquals(RealmFieldType.FLOAT_LIST, dObjTyped.getFieldType(AllJavaTypes.FIELD_FLOAT_LIST));
+        assertEquals(RealmFieldType.DOUBLE_LIST, dObjTyped.getFieldType(AllJavaTypes.FIELD_DOUBLE_LIST));
+        assertEquals(RealmFieldType.BINARY_LIST, dObjTyped.getFieldType(AllJavaTypes.FIELD_BINARY_LIST));
+        assertEquals(RealmFieldType.DATE_LIST, dObjTyped.getFieldType(AllJavaTypes.FIELD_DATE_LIST));
     }
 
     @Test
@@ -1253,6 +1469,13 @@ public class DynamicRealmObjectTests {
         assertTrue(str.contains(NullTypes.FIELD_DATE_NULL + ":null"));
         assertTrue(str.contains(NullTypes.FIELD_OBJECT_NULL + ":null"));
         assertTrue(str.contains(NullTypes.FIELD_LIST_NULL + ":RealmList<NullTypes>[0]"));
+        assertTrue(str.contains(NullTypes.FIELD_INTEGER_LIST_NULL + ":RealmList<Long>[0]"));
+        assertTrue(str.contains(NullTypes.FIELD_STRING_LIST_NULL + ":RealmList<String>[0]"));
+        assertTrue(str.contains(NullTypes.FIELD_BOOLEAN_LIST_NULL + ":RealmList<Boolean>[0]"));
+        assertTrue(str.contains(NullTypes.FIELD_FLOAT_LIST_NULL + ":RealmList<Float>[0]"));
+        assertTrue(str.contains(NullTypes.FIELD_DOUBLE_LIST_NULL + ":RealmList<Double>[0]"));
+        assertTrue(str.contains(NullTypes.FIELD_BINARY_LIST_NULL + ":RealmList<byte[]>[0]"));
+        assertTrue(str.contains(NullTypes.FIELD_DATE_LIST_NULL + ":RealmList<Date>[0]"));
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -19,7 +19,6 @@ package io.realm;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -813,6 +812,7 @@ public class RealmObjectSchemaTests {
     // when field is set to required.
     private <E> void checkListValueConversionToDefaultValue(Class<E> type, Object defaultValue) {
         schema.addRealmListField("foo", type);
+        schema.setRequired("foo", false);
         DynamicRealmObject obj = ((DynamicRealm) realm).createObject(schema.getClassName());
         RealmList<E> list = new RealmList<>();
         list.add(null);
@@ -967,115 +967,6 @@ public class RealmObjectSchemaTests {
             assertFalse(schema.hasIndex(fieldName));
             schema.removeField(fieldName);
         }
-    }
-
-    // Smoke test to ensure that values are copied and converted correctly when switching
-    // nullability status on their fields
-    @Test
-    public void setRequired_convertPrimitiveLists() {
-        if (type == ObjectSchemaType.IMMUTABLE) {
-            return;
-        }
-        // TODO Move to DynamicRealm once available.
-        RealmConfiguration configuration = configFactory.createConfigurationBuilder()
-                .name("nullableToNonNullable.realm")
-                .build();
-        Realm realm = Realm.getInstance(configuration);
-        realm.beginTransaction();
-
-        // Fill all fields with data including null values
-        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 1);
-        for (FieldListType type : FieldListType.values()) {
-            if (!type.isNullable()) { continue; } // Only test nullable types as they can all be converted
-            switch (type) {
-                case STRING_LIST:
-                    obj.getFieldStringList().addAll(Arrays.asList(null, "abc"));
-                    break;
-                case SHORT_LIST:
-                    obj.getFieldShortList().addAll(Arrays.asList(null, (short) 1));
-                    break;
-                case INT_LIST:
-                    obj.getFieldIntegerList().addAll(Arrays.asList(null, 1));
-                    break;
-                case LONG_LIST:
-                    obj.getFieldLongList().addAll(Arrays.asList(null, (long) 1));
-                    break;
-                case BYTE_LIST:
-                    obj.getFieldByteList().addAll(Arrays.asList(null, (byte) 1));
-                    break;
-                case BOOLEAN_LIST:
-                    obj.getFieldBooleanList().addAll(Arrays.asList(null, true));
-                    break;
-                case FLOAT_LIST:
-                    obj.getFieldFloatList().addAll(Arrays.asList(null, 1.23F));
-                    break;
-                case DOUBLE_LIST:
-                    obj.getFieldDoubleList().addAll(Arrays.asList(null, 1.23D));
-                    break;
-                case BLOB_LIST:
-                    obj.getFieldBinaryList().addAll(Arrays.asList(null, new byte[] {1, 2, 3}));
-                    break;
-                case DATE_LIST:
-                    obj.getFieldDateList().addAll(Arrays.asList(null, new Date()));
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown type: " + type);
-            }
-        }
-        realm.commitTransaction();
-        realm.close();
-
-        DynamicRealm dRealm = DynamicRealm.getInstance(configuration);
-        schema = dRealm.getSchema().get(AllJavaTypes.class.getSimpleName());
-        dRealm.beginTransaction();
-
-        // First set required (converts all null to default values), then back (= should not change data)
-        List<Boolean> modes = Arrays.asList(true, false);
-
-        for (Boolean mode : modes) {
-            for (FieldListType type : FieldListType.values()) {
-                if (!type.isNullable()) { continue; } // Only test nullable types as they can all be converted
-                switch (type) {
-                    case STRING_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_STRING_LIST, mode);
-                        break;
-                    case SHORT_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_SHORT_LIST, mode);
-                        break;
-                    case INT_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_INTEGER_LIST, mode);
-                        break;
-                    case LONG_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_LONG_LIST, mode);
-                        break;
-                    case BYTE_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_BYTE_LIST, mode);
-                        break;
-                    case BOOLEAN_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_BOOLEAN_LIST, mode);
-                        break;
-                    case FLOAT_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_FLOAT_LIST, mode);
-                        break;
-                    case DOUBLE_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_DOUBLE_LIST, mode);
-                        break;
-                    case BLOB_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_BINARY_LIST, mode);
-                        break;
-                    case DATE_LIST:
-                        schema.setRequired(AllJavaTypes.FIELD_DATE_LIST, mode);
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Unknown type: " + type);
-                }
-            }
-        }
-
-        // TODO Not possible to check data efficently without DynamicRealm support
-        // For now, assume that if the test didn't crash that data was moved correctly
-        dRealm.cancelTransaction();
-        dRealm.close();
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -808,22 +808,6 @@ public class RealmObjectSchemaTests {
         }
     }
 
-    @Test
-    public void binaryCopies() {
-        schema.addRealmListField("foo", byte[].class);
-        DynamicRealmObject obj = ((DynamicRealm) realm).createObject(schema.getClassName());
-        RealmList<byte[]> list = obj.getList("foo", byte[].class);
-        assertTrue(list.size() == 0);
-        list.add(null);
-        assertNull(list.get(0));
-        schema.setRequired("foo", true);
-        list = obj.getList("foo", byte[].class);
-        assertEquals(0, list.get(0).length);
-        schema.setRequired("foo", false);
-        list = obj.getList("foo", byte[].class);
-        assertEquals(0, list.get(0).length);
-    }
-
     // Checks that null values in a value list are correctly converted to default values
     // when field is set to required.
     private <E> void checkListValueConversionToDefaultValue(Class<E> type, Object defaultValue) {

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -859,6 +859,9 @@ public class RealmObjectSchemaTests {
     // when moving between nullable and required states.
     @Test
     public void binaryData_nullabilityConversions() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
         schema.addRealmListField("foo", byte[].class);
 
         DynamicRealmObject obj = ((DynamicRealm) realm).createObject(schema.getClassName());

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -197,7 +197,6 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsColumnNullable(J
         return to_jbool(table->is_nullable(S(columnIndex))); // noexcept
     }
     // For primitive list
-    // FIXME: Add test in https://github.com/realm/realm-java/pull/5221 before merging to master
     return to_jbool(table->get_descriptor()->get_subdescriptor(S(columnIndex))->is_nullable(S(0))); // noexcept
 }
 
@@ -239,10 +238,8 @@ static void convert_column_to_nullable(JNIEnv* env, Table* old_table, size_t old
                 break;
             }
             case type_Binary: {
-                // Payload copy is needed
                 BinaryData bd = old_table->get_binary(old_col_ndx, i);
-                std::vector<char> binary_copy(bd.data(), bd.data() + bd.size());
-                new_table->set_binary(new_col_ndx, i, BinaryData(binary_copy.data(), binary_copy.size()));
+                new_table->set_binary(new_col_ndx, i, BinaryData(bd.data(), bd.size()));
                 break;
             }
             case type_Int:

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -338,7 +338,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
     /**
      * Returns the {@link RealmList} of {@link DynamicRealmObject}s being linked from the given field.
      * <p>
-     * If the list only contain primitive types, use {@link #getList(String, Class)} instead.
+     * If the list contains primitive types, use {@link #getList(String, Class)} instead.
      *
      * @param fieldName the name of the field.
      * @return the {@link RealmList} data for this field.

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -70,7 +70,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
     protected String className;
 
     // Always null if RealmList is unmanaged, always non-null if managed.
-    private final ManagedListOperator<E> osListOperator;
+    final ManagedListOperator<E> osListOperator;
     final protected BaseRealm realm;
     private List<E> unmanagedList;
     // Used for listeners on RealmList<RealmModel>

--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -98,17 +98,6 @@ public class CheckedRow extends UncheckedRow {
     }
 
     @Override
-    public OsList getList(long columnIndex) {
-        RealmFieldType fieldType = getTable().getColumnType(columnIndex);
-        if (fieldType != RealmFieldType.LIST) {
-            throw new IllegalArgumentException(
-                    String.format(Locale.US, "Field '%s' is not a 'RealmList'.",
-                            getTable().getColumnName(columnIndex)));
-        }
-        return super.getList(columnIndex);
-    }
-
-    @Override
     public OsList getModelList(long columnIndex) {
         RealmFieldType fieldType = getTable().getColumnType(columnIndex);
         if (fieldType != RealmFieldType.LIST) {

--- a/realm/realm-library/src/main/java/io/realm/internal/InvalidRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/InvalidRow.java
@@ -105,11 +105,6 @@ public enum InvalidRow implements Row {
     }
 
     @Override
-    public OsList getList(long columnIndex) {
-        throw getStubException();
-    }
-
-    @Override
     public OsList getModelList(long columnIndex) {
         throw getStubException();
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
@@ -134,11 +134,6 @@ public class PendingRow implements Row {
     }
 
     @Override
-    public OsList getList(long columnIndex) {
-        throw new IllegalStateException(QUERY_NOT_RETURNED_MESSAGE);
-    }
-
-    @Override
     public OsList getModelList(long columnIndex) {
         throw new IllegalStateException(QUERY_NOT_RETURNED_MESSAGE);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/Row.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Row.java
@@ -81,9 +81,6 @@ public interface Row {
 
     boolean isNullLink(long columnIndex);
 
-    // FIXME remove this in DynamicRealm PR
-    OsList getList(long columnIndex);
-
     OsList getModelList(long columnIndex);
 
     OsList getValueList(long columnIndex, RealmFieldType fieldType);

--- a/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
@@ -173,11 +173,6 @@ public class UncheckedRow implements NativeObject, Row {
     }
 
     @Override
-    public OsList getList(long columnIndex) {
-        return new OsList(this, columnIndex);
-    }
-
-    @Override
     public OsList getModelList(long columnIndex) {
         return new OsList(this, columnIndex);
     }


### PR DESCRIPTION
Part of #5031
This PR adds support for primitive arrays in DynamicRealmObject

TODO
- [x] Cleanup 
- [x] Fix RealmSchema unit tests so they use DynamicRealm instead
- [x] Determine naming. See #5329 . I already made several mistakes with the overloaded `dynamicRealm.getList()`, so I'm probably starting to lean towards having a seperate `get<Primitive/Value>List()` method instead ... People seem to like the overloaded methods best, so lets keep those.

