### PR TITLE
Expose SyncSessionStopPolicy in SyncConfiguration

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SchemaTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SchemaTests.java
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith;
 import java.util.Set;
 
 import io.realm.entities.StringOnly;
-import io.realm.rule.TestSyncConfigurationFactory;
 import io.realm.util.SyncTestUtils;
 
 import static junit.framework.Assert.assertEquals;

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
@@ -34,7 +34,6 @@ import io.realm.exceptions.RealmMigrationNeededException;
 import io.realm.objectserver.utils.StringOnlyModule;
 import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
-import io.realm.rule.TestSyncConfigurationFactory;
 
 import static io.realm.util.SyncTestUtils.createTestUser;
 import static org.junit.Assert.assertEquals;

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncConfigurationTests.java
@@ -34,7 +34,6 @@ import java.util.Map;
 
 import io.realm.entities.StringOnly;
 import io.realm.rule.RunInLooperThread;
-import io.realm.rule.TestSyncConfigurationFactory;
 
 import static io.realm.util.SyncTestUtils.createNamedTestUser;
 import static io.realm.util.SyncTestUtils.createTestUser;

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmMigrationTests.java
@@ -21,7 +21,6 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,7 +41,6 @@ import io.realm.internal.OsSchemaInfo;
 import io.realm.internal.SharedRealm;
 import io.realm.exceptions.IncompatibleSyncedFileException;
 import io.realm.objectserver.utils.StringOnlyModule;
-import io.realm.rule.TestSyncConfigurationFactory;
 import io.realm.util.SyncTestUtils;
 
 import static org.junit.Assert.assertEquals;

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/TestSyncConfigurationFactory.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/TestSyncConfigurationFactory.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package io.realm.rule;
+package io.realm;
 
-import io.realm.SyncConfiguration;
-import io.realm.SyncUser;
+import io.realm.internal.OsRealmConfig;
+import io.realm.rule.TestRealmConfigurationFactory;
 
 /**
  * Test rule used for creating SyncConfigurations. Will ensure that any Realm files are deleted when the
@@ -26,6 +26,8 @@ import io.realm.SyncUser;
 public class TestSyncConfigurationFactory extends TestRealmConfigurationFactory {
 
     public SyncConfiguration.Builder createSyncConfigurationBuilder(SyncUser user, String url) {
-        return new SyncConfiguration.Builder(user, url).directory(getRoot());
+        return new SyncConfiguration.Builder(user, url)
+                .sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
+                .directory(getRoot());
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -249,7 +249,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeEnableChangeNo
 #if REALM_ENABLE_SYNC
 JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSetSyncConfig(
     JNIEnv* env, jclass, jlong native_ptr, jstring j_sync_realm_url, jstring j_auth_url, jstring j_user_id,
-    jstring j_reresh_token)
+    jstring j_reresh_token, jbyte j_session_stop_policy)
 {
     TR_ENTER_PTR(native_ptr)
     auto& config = *reinterpret_cast<Realm::Config*>(native_ptr);
@@ -320,9 +320,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSetSy
             std::copy_n(config.encryption_key.begin(), 64, sync_encryption_key->begin());
         }
 
+        SyncSessionStopPolicy session_stop_policy = static_cast<SyncSessionStopPolicy>(j_session_stop_policy);
+
         JStringAccessor realm_url(env, j_sync_realm_url);
         config.sync_config = std::make_shared<SyncConfig>(SyncConfig{
-            user, realm_url, SyncSessionStopPolicy::AfterChangesUploaded, std::move(bind_handler), std::move(error_handler),
+            user, realm_url, session_stop_policy, std::move(bind_handler), std::move(error_handler),
             nullptr, sync_encryption_key});
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
@@ -67,7 +67,7 @@ public class ObjectServerFacade {
     }
 
     public Object[] getUserAndServerUrl(RealmConfiguration config) {
-        return new Object[6];
+        return new Object[7];
     }
 
     public static ObjectServerFacade getFacade(boolean needSyncFacade) {

--- a/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
@@ -191,7 +191,7 @@ public class OsRealmConfig implements NativeObject {
         String syncRefreshToken = (String) syncConfigurationOptions[3];
         boolean syncClientValidateSsl = (Boolean.TRUE.equals(syncConfigurationOptions[4]));
         String syncSslTrustCertificatePath = (String) syncConfigurationOptions[5];
-        byte sessionStopPolicy = (byte) syncConfigurationOptions[6];
+        Byte sessionStopPolicy = (Byte) syncConfigurationOptions[6];
 
         // Set encryption key
         byte[] key = config.getEncryptionKey();

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -88,6 +88,7 @@ public class SyncConfiguration extends RealmConfiguration {
     @Nullable
     private final String serverCertificateFilePath;
     private final boolean waitForInitialData;
+    private final OsRealmConfig.SyncSessionStopPolicy sessionStopPolicy;
 
     private SyncConfiguration(File directory,
                                 String filename,
@@ -116,7 +117,8 @@ public class SyncConfiguration extends RealmConfiguration {
                                 String serverCertificateAssetName,
                                 @Nullable
                                 String serverCertificateFilePath,
-                                boolean waitForInitialData
+                                boolean waitForInitialData,
+                                OsRealmConfig.SyncSessionStopPolicy sessionStopPolicy
     ) {
         super(directory,
                 filename,
@@ -143,6 +145,7 @@ public class SyncConfiguration extends RealmConfiguration {
         this.serverCertificateAssetName = serverCertificateAssetName;
         this.serverCertificateFilePath = serverCertificateFilePath;
         this.waitForInitialData = waitForInitialData;
+        this.sessionStopPolicy = sessionStopPolicy;
     }
 
     /**
@@ -346,6 +349,17 @@ public class SyncConfiguration extends RealmConfiguration {
     }
 
     /**
+     * NOTE: Only for internal usage. Maybe change without warning.
+     *
+     * Returns the stop policy for the session for this Realm once the Realm has been closed.
+     *
+     * @return the stop policy used by the session once the Realm is closed.
+     */
+    public OsRealmConfig.SyncSessionStopPolicy getSessionStopPolicy() {
+        return sessionStopPolicy;
+    }
+
+    /**
      * Builder used to construct instances of a SyncConfiguration in a fluent manner.
      */
     public static final class Builder  {
@@ -379,7 +393,7 @@ public class SyncConfiguration extends RealmConfiguration {
         private String serverCertificateAssetName;
         @Nullable
         private String serverCertificateFilePath;
-
+        private OsRealmConfig.SyncSessionStopPolicy sessionStopPolicy = OsRealmConfig.SyncSessionStopPolicy.AFTER_CHANGES_UPLOADED;
         /**
          * Creates an instance of the Builder for the SyncConfiguration.
          * <p>
@@ -612,6 +626,18 @@ public class SyncConfiguration extends RealmConfiguration {
 
             return this;
         }
+
+        /**
+         * DEBUG method. This makes it possible to define different policies for when a session should be stopped when
+         * the Realm is closed.
+         *
+         * @param policy how a session for a Realm should behave when the Realm is closed.
+         */
+        SyncConfiguration.Builder sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy policy) {
+            sessionStopPolicy = policy;
+            return this;
+        }
+
 
         /**
          * Sets the schema version of the Realm.
@@ -937,7 +963,8 @@ public class SyncConfiguration extends RealmConfiguration {
                     syncClientValidateSsl,
                     serverCertificateAssetName,
                     serverCertificateFilePath,
-                    waitForServerChanges
+                    waitForServerChanges,
+                    sessionStopPolicy
             );
         }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -349,7 +349,7 @@ public class SyncConfiguration extends RealmConfiguration {
     }
 
     /**
-     * NOTE: Only for internal usage. Maybe change without warning.
+     * NOTE: Only for internal usage. May change without warning.
      *
      * Returns the stop policy for the session for this Realm once the Realm has been closed.
      *

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -92,9 +92,10 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
             String rosUserIdentity = user.getIdentity();
             String syncRealmAuthUrl = user.getAuthenticationUrl().toString();
             String rosSerializedUser = user.toJson();
-            return new Object[]{rosUserIdentity, rosServerUrl, syncRealmAuthUrl, rosSerializedUser, syncConfig.syncClientValidateSsl(), syncConfig.getServerCertificateFilePath()};
+            byte sessionStopPolicy = syncConfig.getSessionStopPolicy().getNativeValue();
+            return new Object[]{rosUserIdentity, rosServerUrl, syncRealmAuthUrl, rosSerializedUser, syncConfig.syncClientValidateSsl(), syncConfig.getServerCertificateFilePath(), sessionStopPolicy};
         } else {
-            return new Object[6];
+            return new Object[7];
         }
     }
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
@@ -32,7 +32,6 @@ import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.HttpUtils;
 import io.realm.objectserver.utils.UserFactory;
 import io.realm.rule.RunInLooperThread;
-import io.realm.rule.TestSyncConfigurationFactory;
 
 
 /**

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
@@ -18,7 +18,6 @@ package io.realm;
 
 import android.os.SystemClock;
 import android.support.test.runner.AndroidJUnit4;
-import android.text.style.TabStopSpan;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -34,7 +33,6 @@ import io.realm.exceptions.RealmFileException;
 import io.realm.log.LogLevel;
 import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.Constants;
-import io.realm.rule.TestSyncConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
@@ -1,4 +1,4 @@
-package io.realm.objectserver;
+package io.realm;
 
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -16,22 +16,12 @@ import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import io.realm.Realm;
-import io.realm.RealmChangeListener;
-import io.realm.RealmResults;
-import io.realm.StandardIntegrationTest;
-import io.realm.SyncConfiguration;
-import io.realm.SyncCredentials;
-import io.realm.SyncManager;
-import io.realm.SyncSession;
-import io.realm.SyncUser;
-import io.realm.TestHelper;
 import io.realm.entities.AllTypes;
 import io.realm.entities.StringOnly;
+import io.realm.internal.OsRealmConfig;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.StringOnlyModule;
 import io.realm.objectserver.utils.UserFactory;
-import io.realm.rule.TestSyncConfigurationFactory;
 import io.realm.util.SyncTestUtils;
 
 import static org.junit.Assert.assertEquals;
@@ -327,6 +317,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
         final SyncConfiguration syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.AFTER_CHANGES_UPLOADED)
                 .modules(new StringOnlyModule())
                 .build();
         Realm realm = Realm.getInstance(syncConfiguration);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
@@ -43,7 +43,7 @@ import io.realm.entities.AllTypes;
 import io.realm.log.RealmLog;
 import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.UserFactory;
-import io.realm.rule.TestSyncConfigurationFactory;
+import io.realm.TestSyncConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/suite/IntegrationTestSuite.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/suite/IntegrationTestSuite.java
@@ -27,7 +27,7 @@ import io.realm.objectserver.EncryptedSynchronizedRealmTests;
 import io.realm.objectserver.ManagementRealmTests;
 import io.realm.objectserver.ProcessCommitTests;
 import io.realm.objectserver.ProgressListenerTests;
-import io.realm.objectserver.SyncSessionTests;
+import io.realm.SyncSessionTests;
 
 // Test suite includes all integration tests. Makes it easy to run all integration tests in the Android Studio.
 @RunWith(Suite.class)


### PR DESCRIPTION
This PR exposes the SyncSessionStopPolicy in SyncConfiguration.
This will hopefully help combat the test assertions we are seeing with active sessions being present when a test ends. This is especially a problem in the PermissionManager tests that rely on internal Realms.

Only downside is that `SyncConfiguration.getSessionStopPolicy()` had to be made public. I put big fat warnings there though, so hopefully, it is okay?

