### PR TITLE
Use release version of Sync when testing

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -37,7 +37,7 @@ ext.coreDir = file(project.coreSourcePath ?
 ext.ccachePath = project.findProperty('ccachePath') ?: System.getenv('NDK_CCACHE')
 ext.lcachePath = project.findProperty('lcachePath') ?: System.getenv('NDK_LCACHE')
 // Set to true to enable linking with debug core.
-ext.enableDebugCore = project.hasProperty('enableDebugCore') ? project.getProperty('enableDebugCore') : true
+ext.enableDebugCore = project.hasProperty('enableDebugCore') ? project.getProperty('enableDebugCore') : false //FIXME Use 'false' as default until https://github.com/realm/realm-java/issues/5354 is fixed
 
 android {
     compileSdkVersion 26

--- a/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
@@ -84,16 +84,14 @@ public abstract class CollectionTests {
     protected void populateRealm(Realm realm, int objects) {
         realm.beginTransaction();
         realm.delete(AllJavaTypes.class);
-        // realm.delete(NonLatinFieldNames.class); FIXME Disabled until https://github.com/realm/realm-java/issues/5354 is fixed
+         realm.delete(NonLatinFieldNames.class);
         if (objects > 0) {
             for (int i = 0; i < objects; i++) {
                 AllJavaTypes obj = realm.createObject(AllJavaTypes.class, i);
                 fillObject(i, objects, obj);
-                /** FIXME Disabled until https://github.com/realm/realm-java/issues/5354 is fixed
                 NonLatinFieldNames nonLatinFieldNames = realm.createObject(NonLatinFieldNames.class);
                 nonLatinFieldNames.set델타(i);
                 nonLatinFieldNames.setΔέλτα(i);
-                */
                 // Sets the linked object to itself.
                 obj.setFieldObject(obj);
             }

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
@@ -481,7 +481,6 @@ public class ManagedRealmCollectionTests extends CollectionTests {
     }
 
     @Test
-    @Ignore("See https://github.com/realm/realm-java/issues/5354")
     public void sum_nonLatinColumnNames() {
         OrderedRealmCollection<NonLatinFieldNames> resultList = createNonLatinCollection(realm, collectionClass);
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmAsyncQueryTests.java
@@ -499,7 +499,6 @@ public class RealmAsyncQueryTests {
 
     @Test
     @RunTestInLooperThread
-    @Ignore("See https://github.com/realm/realm-java/issues/5354")
     public void accessingRealmListOnUnloadedRealmObjectShouldThrow() {
         Realm realm = looperThread.getRealm();
         populateTestRealm(realm, 10);

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -1110,7 +1110,6 @@ public class RealmObjectSchemaTests {
     }
 
     @Test
-    @Ignore("See https://github.com/realm/realm-java/issues/5354")
     public void getFieldType_nonLatinName() {
         RealmObjectSchema objSchema = realm.getSchema().get(NonLatinFieldNames.class.getSimpleName());
         assertEquals(RealmFieldType.INTEGER, objSchema.getFieldType(NonLatinFieldNames.FIELD_LONG_GREEK_CHAR));

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -2124,7 +2124,6 @@ public class RealmObjectTests {
     }
 
     @Test
-    @Ignore("See https://github.com/realm/realm-java/issues/5354")
     public void setter_nonLatinFieldName() {
         // Reproduces https://github.com/realm/realm-java/pull/5346
         realm.beginTransaction();


### PR DESCRIPTION
From #5354 

I should have listened to @beeender 
Using the debug version is causing all sorts of crashes. Reverting to using the `release` version until we can fix it.