### PR TITLE
Add optimized first()/last() to RealmList's operator for models

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -482,7 +482,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
         if (isManaged()) {
             checkValidRealm();
             E lastValue = osListOperator.last();
-            if(lastValue != null) {
+            if (lastValue != null) {
                 return lastValue;
             }
         } else if (unmanagedList != null && !unmanagedList.isEmpty()) {
@@ -1350,26 +1350,26 @@ abstract class ManagedListOperator<T> {
 
     @Nullable
     public final T first() {
-        if(forRealmModel()) {
+        if (forRealmModel()) {
             UncheckedRow row = collection.firstUncheckedRow();
             if (row == null) {
                 return null;
             }
             //noinspection unchecked
-            return (E) realm.get((Class<? extends RealmModel>) classSpec, className, row);
+            return (T) realm.get((Class<? extends RealmModel>) clazz, className, row);
         }
         return isEmpty() ? null : get(0);
     }
 
     @Nullable
     public final T last() {
-        if(forRealmModel()) {
+        if (forRealmModel()) {
             UncheckedRow row = collection.lastUncheckedRow();
             if (row == null) {
                 return null;
             }
             //noinspection unchecked
-            return (E) realm.get((Class<? extends RealmModel>) classSpec, className, row);
+            return (T) realm.get((Class<? extends RealmModel>) clazz, className, row);
         }
         return isEmpty() ? null : get(size() - 1);
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -444,8 +444,9 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
     private E firstImpl(boolean shouldThrow, @Nullable E defaultValue) {
         if (isManaged()) {
             checkValidRealm();
-            if (!osListOperator.isEmpty()) {
-                return get(0);
+            E firstValue = osListOperator.first();
+            if (firstValue != null) {
+                return firstValue;
             }
         } else if (unmanagedList != null && !unmanagedList.isEmpty()) {
             return unmanagedList.get(0);
@@ -480,8 +481,9 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
     private E lastImpl(boolean shouldThrow, @Nullable E defaultValue) {
         if (isManaged()) {
             checkValidRealm();
-            if (!osListOperator.isEmpty()) {
-                return get(osListOperator.size() - 1);
+            E lastValue = osListOperator.last();
+            if(lastValue != null) {
+                return lastValue;
             }
         } else if (unmanagedList != null && !unmanagedList.isEmpty()) {
             return unmanagedList.get(unmanagedList.size() - 1);
@@ -1345,6 +1347,32 @@ abstract class ManagedListOperator<T> {
 
     @Nullable
     public abstract T get(int index);
+
+    @Nullable
+    public final T first() {
+        if(forRealmModel()) {
+            UncheckedRow row = collection.firstUncheckedRow();
+            if (row == null) {
+                return null;
+            }
+            //noinspection unchecked
+            return (E) realm.get((Class<? extends RealmModel>) classSpec, className, row);
+        }
+        return isEmpty() ? null : get(0);
+    }
+
+    @Nullable
+    public final T last() {
+        if(forRealmModel()) {
+            UncheckedRow row = collection.lastUncheckedRow();
+            if (row == null) {
+                return null;
+            }
+            //noinspection unchecked
+            return (E) realm.get((Class<? extends RealmModel>) classSpec, className, row);
+        }
+        return isEmpty() ? null : get(size() - 1);
+    }
 
     public final void append(@Nullable Object value) {
         checkValidValue(value);


### PR DESCRIPTION
While I was frantically trying to figure out how to re-introduce the optimization of `first()`/`last()` to `OrderedRealmCollectionImpl` (which was never actually merged), I found that there seems to be a place for optimizing RealmList's first/last methods.

I think it should work, but CI should be run on it.