### PR TITLE
Keep annotations at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Enhancements
 
-* All Realm annotations are now kept at runtime, allowing runtime tools to access them (#5344).
+* All Realm annotations are now kept at runtime, allowing runtime tools access to them (#5344).
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Enhancements
 
-* All Realm annotations are now kept at runtime, allowing runtime tools to access them (#XXXX).
+* All Realm annotations are now kept at runtime, allowing runtime tools to access them (#5344).
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Enhancements
 
+* All Realm annotations are now kept at runtime, allowing runtime tools to access them (#XXXX).
+
 ## Bug Fixes
 
 ## Internal

--- a/realm-annotations/src/main/java/io/realm/annotations/Beta.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/Beta.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * Moreover, classes, constructors, and methods annotated as beta are not considered at production
  * quality, and should be used with care.
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
 public @interface Beta {
 }

--- a/realm-annotations/src/main/java/io/realm/annotations/Beta.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/Beta.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * Moreover, classes, constructors, and methods annotated as beta are not considered at production
  * quality, and should be used with care.
  */
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
 public @interface Beta {
 }

--- a/realm-annotations/src/main/java/io/realm/annotations/Ignore.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/Ignore.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Ignore {
 

--- a/realm-annotations/src/main/java/io/realm/annotations/Index.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/Index.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * <p>
  * NOTICE: Only String, int, byte, short, long, boolean and Date fields can be indexed.
  */
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Index {
 

--- a/realm-annotations/src/main/java/io/realm/annotations/LinkingObjects.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/LinkingObjects.java
@@ -97,7 +97,7 @@ import java.lang.annotation.Target;
  * equivalent to link queries. Please read <a href="https://realm.io/docs/java/latest/#link-queries">for more
  * information</a>.
  */
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface LinkingObjects {
     /**

--- a/realm-annotations/src/main/java/io/realm/annotations/PrimaryKey.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/PrimaryKey.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * String, Byte, Short, Integer, and Long are also allowed, and further permitted to have {@code null}
  * as a primary key value.
  */
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface PrimaryKey {
 

--- a/realm-annotations/src/main/java/io/realm/annotations/RealmClass.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/RealmClass.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
 public @interface RealmClass {

--- a/realm-annotations/src/main/java/io/realm/annotations/Required.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/Required.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * Fields with primitive types and the {@link io.realm.RealmList} type are required implicitly.
  * Fields with {@link io.realm.RealmObject} type are always nullable.
  */
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Required {
 


### PR DESCRIPTION
Fixes #5344 

Thinking about this, we actually also need to keep these if we at some point support inheritance for model classes as the superclass might exist in another jar file. But for now, the primary driver is giving other library developers better tools for interacting with Realm.

The size increase of this in peoples apps should be minimal.

@Zhuinden does this fix your issue?