### PR TITLE
Enable SSL integration tests

### DIFF
--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -91,7 +91,8 @@ use_realm_core(${build_SYNC} "${REALM_CORE_DIST_DIR}" "${CORE_SOURCE_PATH}")
 set(openssl_build_TYPE "release")
 # FIXME Read the openssl version from core when the core/sync release has that information.
 set(openssl_VERSION "1.0.2k")
-set(openssl_FILENAME "openssl-${openssl_build_TYPE}-${openssl_VERSION}-Android-${ANDROID_ABI}")
+set(openssl_BUILD_NUMBER "1")
+set(openssl_FILENAME "openssl-${openssl_build_TYPE}-${openssl_VERSION}-${openssl_BUILD_NUMBER}-Android-${ANDROID_ABI}")
 set(openssl_URL "http://static.realm.io/downloads/openssl/${openssl_VERSION}/Android/${ANDROID_ABI}/${openssl_FILENAME}.tar.gz")
 
 message(STATUS "Downloading OpenSSL...")

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-@Ignore("See https://github.com/realm/ros/issues/240")
 public class SSLConfigurationTests extends StandardIntegrationTest {
 
     @Rule
@@ -65,12 +64,12 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         SystemClock.sleep(TimeUnit.SECONDS.toMillis(2));  // FIXME: Replace with Sync Progress Notifications once available.
         realm.close();
         user.logout();
-        Realm.deleteRealm(configOld);
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
         user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         SyncConfiguration config = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
+                .name("useSsl")
                 .schema(StringOnly.class)
                 .waitForInitialRemoteData()
                 .trustedRootCA("trusted_ca.pem")
@@ -106,12 +105,12 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         SystemClock.sleep(TimeUnit.SECONDS.toMillis(2));  // FIXME: Replace with Sync Progress Notifications once available.
         realm.close();
         user.logout();
-        Realm.deleteRealm(configOld);
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
         user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         SyncConfiguration config = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
+                .name("useSsl")
                 .schema(StringOnly.class)
                 .waitForInitialRemoteData()
                 .disableSSLVerification()
@@ -147,12 +146,12 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         SystemClock.sleep(TimeUnit.SECONDS.toMillis(2));  // FIXME: Replace with Sync Progress Notifications once available.
         realm.close();
         user.logout();
-        Realm.deleteRealm(configOld);
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
         user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         SyncConfiguration config = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
+                .name("useSsl")
                 .schema(StringOnly.class)
                 .build();
         realm = Realm.getInstance(config);
@@ -170,6 +169,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         TestHelper.TestLogger testLogger = new TestHelper.TestLogger();
+        int originalLevel = RealmLog.getLevel();
         RealmLog.add(testLogger);
         RealmLog.setLevel(LogLevel.WARN);
 
@@ -181,6 +181,8 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
 
         assertEquals("SSL Verification is disabled, the provided server certificate will not be used.",
                 testLogger.message);
+        RealmLog.remove(testLogger);
+        RealmLog.setLevel(originalLevel);
     }
 
     @Test

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -90,6 +90,10 @@ function startRealmObjectServer(onSuccess, onError) {
                     ['start',
                         '--data', path,
                         '--loglevel', 'detail',
+                        '--https',
+                        '--https-key', '/127_0_0_1-server.key.pem',
+                        '--https-cert', '/127_0_0_1-chain.crt.pem',
+                        '--https-port', '9443',
                         '--access-token-ttl', '20' //WARNING : Changing this value may impact the timeout of the refresh token test (AuthTests#preemptiveTokenRefresh)
                     ],
                     { env: env, cwd: path});


### PR DESCRIPTION
- Some features were missing which caused ssl tests failures.
  See https://github.com/realm/openssl-android/pull/2
  Linking with pre-build openssl 1.0.2k-1.
- Use a new Realm instead of using deleteRealm()