### PR TITLE
Add realm.ignoreKotlinNullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.0.1 (YYYY-MM-DD)
+
+## Bug Fixes
+
+* Added `realm.ignoreKotlinNullability` as a kapt argument to disable treating kotlin non-null types as `@Required` (#5412) (introduced in `v3.6.0`).
+
+
 ## 4.0.0 (2016-10-16)
 
 ## Breaking Changes

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassMetaData.java
@@ -51,6 +51,8 @@ import io.realm.annotations.Required;
  * Utility class for holding metadata for RealmProxy classes.
  */
 public class ClassMetaData {
+    private static final String OPTION_IGNORE_KOTLIN_NULLABILITY = "realm.ignoreKotlinNullability";
+
     private final TypeElement classType; // Reference to model class.
     private final String className; // Model class simple name.
     private final List<VariableElement> fields = new ArrayList<VariableElement>(); // List of all fields in the class except those @Ignored.
@@ -70,6 +72,8 @@ public class ClassMetaData {
     private final List<TypeMirror> validListValueTypes;
     private final Types typeUtils;
     private final Elements elements;
+
+    private final boolean ignoreKotlinNullability;
 
     public ClassMetaData(ProcessingEnvironment env, TypeMirrors typeMirrors, TypeElement clazz) {
         this.classType = clazz;
@@ -111,6 +115,9 @@ public class ClassMetaData {
                 }
             }
         }
+
+        ignoreKotlinNullability = Boolean.valueOf(
+                env.getOptions().getOrDefault(OPTION_IGNORE_KOTLIN_NULLABILITY, "false"));
     }
 
     @Override
@@ -522,6 +529,10 @@ public class ClassMetaData {
     private boolean isRequiredField(VariableElement field) {
         if (hasRequiredAnnotation(field)) {
             return true;
+        }
+
+        if (ignoreKotlinNullability) {
+            return false;
         }
 
         // Kotlin uses the `org.jetbrains.annotations.NotNull` annotation to mark non-null fields.

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -124,7 +124,7 @@ import io.realm.annotations.RealmModule;
         "io.realm.annotations.RealmModule",
         "io.realm.annotations.Required"
 })
-@SupportedOptions(value = {"realm.suppressWarnings"})
+@SupportedOptions(value = {"realm.suppressWarnings", "realm.ignoreKotlinNullability"})
 public class RealmProcessor extends AbstractProcessor {
 
     // Don't consume annotations. This allows 3rd party annotation processors to run.


### PR DESCRIPTION
To disable treating kotlin non-null types as @Required.
From v3.6.0, all the kotlin RealmModel's non-null field will be set as
required in the schema. However it is a breaking change for the kotlin
project which has a Realm file created before 3.6.0.

To disable this behaviour introduced in 3.6.0, add below things to the
project's build.gradle:

kapt {
  arguments {
    arg("realm.ignoreKotlinNullability", true)
  }
}

Close #5412