### PR TITLE
Increase http timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 * Added `realm.ignoreKotlinNullability` as a kapt argument to disable treating kotlin non-null types as `@Required` (#5412) (introduced in `v3.6.0`).
+* Increased http connect/write timeout for low bandwidth network.
 
 
 ## 4.0.0 (2016-10-16)

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -41,8 +41,8 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     private static final String ACTION_LOOKUP_USER_ID = "users/:provider:/:providerId:"; // Auth end point for looking up user id
 
     private final OkHttpClient client = new OkHttpClient.Builder()
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .writeTimeout(10, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             // using custom Connection Pool to evict idle connection after 5 seconds rather than 5 minutes (which is the default)
             // keeping idle connection on the pool will prevent the ROS to be stopped, since the HttpUtils#stopSyncServer query


### PR DESCRIPTION
Otherwise integration tests would fail when setting the network type to
GSM on emulator.