### PR TITLE
Remove depreacted RealmProxyMediator.getTableName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.1 (YYYY-MM-DD)
+
+## Bug Fixes
+
+# Fixed the compile warnings of using deprecated method `RealmProxyMediator.getTableName()` in generated mediator classes (#5455).
+
+
 ## 4.1.0 (2017-10-20)
 
 ## Enhancements

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Constants.java
@@ -26,7 +26,6 @@ public class Constants {
     public static final String PROXY_SUFFIX = "RealmProxy";
     public static final String INTERFACE_SUFFIX = "RealmProxyInterface";
     public static final String INDENT = "    ";
-    public static final String TABLE_PREFIX = "class_";
     public static final String DEFAULT_MODULE_CLASS_NAME = "DefaultRealmModule";
     static final String STATEMENT_EXCEPTION_ILLEGAL_NULL_VALUE =
             "throw new IllegalArgumentException(\"Trying to set non-nullable field '%s' to null.\")";

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -144,7 +144,7 @@ public class RealmProxyClassGenerator {
         emitCreateExpectedObjectSchemaInfo(writer);
         emitGetExpectedObjectSchemaInfo(writer);
         emitCreateColumnInfoMethod(writer);
-        emitGetTableNameMethod(writer);
+        emitGetSimpleClassNameMethod(writer);
         emitGetFieldNamesMethod(writer);
         emitCreateOrUpdateUsingJsonObject(writer);
         emitCreateUsingJsonStream(writer);
@@ -833,9 +833,9 @@ public class RealmProxyClassGenerator {
     }
 
     //@formatter:off
-    private void emitGetTableNameMethod(JavaWriter writer) throws IOException {
-        writer.beginMethod("String", "getTableName", EnumSet.of(Modifier.PUBLIC, Modifier.STATIC))
-                .emitStatement("return \"%s%s\"", Constants.TABLE_PREFIX, simpleClassName)
+    private void emitGetSimpleClassNameMethod(JavaWriter writer) throws IOException {
+        writer.beginMethod("String", "getSimpleClassName", EnumSet.of(Modifier.PUBLIC, Modifier.STATIC))
+                .emitStatement("return \"%s\"", simpleClassName)
                 .endMethod()
                 .emitEmptyLine();
     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -80,7 +80,6 @@ public class RealmProxyMediatorGenerator {
                 "io.realm.internal.RealmObjectProxy",
                 "io.realm.internal.RealmProxyMediator",
                 "io.realm.internal.Row",
-                "io.realm.internal.Table",
                 "io.realm.internal.OsSchemaInfo",
                 "io.realm.internal.OsObjectSchemaInfo",
                 "org.json.JSONException",
@@ -101,7 +100,7 @@ public class RealmProxyMediatorGenerator {
         emitGetExpectedObjectSchemaInfoMap(writer);
         emitCreateColumnInfoMethod(writer);
         emitGetFieldNamesMethod(writer);
-        emitGetTableNameMethod(writer);
+        emitGetSimpleClassNameMethod(writer);
         emitNewInstanceMethod(writer);
         emitGetClassModelList(writer);
         emitCopyToRealmMethod(writer);
@@ -187,18 +186,18 @@ public class RealmProxyMediatorGenerator {
         writer.emitEmptyLine();
     }
 
-    private void emitGetTableNameMethod(JavaWriter writer) throws IOException {
+    private void emitGetSimpleClassNameMethod(JavaWriter writer) throws IOException {
         writer.emitAnnotation("Override");
         writer.beginMethod(
                 "String",
-                "getTableName",
+                "getSimpleClassName",
                 EnumSet.of(Modifier.PUBLIC),
                 "Class<? extends RealmModel>", "clazz"
         );
         emitMediatorShortCircuitSwitch(new ProxySwitchStatement() {
             @Override
             public void emitStatement(int i, JavaWriter writer) throws IOException {
-                writer.emitStatement("return %s.getTableName()", qualifiedProxyClasses.get(i));
+                writer.emitStatement("return %s.getSimpleClassName()", qualifiedProxyClasses.get(i));
             }
         }, writer);
         writer.endMethod();

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -190,7 +190,7 @@ public class RealmProxyMediatorGenerator {
         writer.emitAnnotation("Override");
         writer.beginMethod(
                 "String",
-                "getSimpleClassName",
+                "getSimpleClassNameImpl",
                 EnumSet.of(Modifier.PUBLIC),
                 "Class<? extends RealmModel>", "clazz"
         );

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -890,8 +890,8 @@ public class AllTypesRealmProxy extends some.test.AllTypes
         return new AllTypesColumnInfo(schemaInfo);
     }
 
-    public static String getTableName() {
-        return "class_AllTypes";
+    public static String getSimpleClassName() {
+        return "AllTypes";
     }
 
     public static List<String> getFieldNames() {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -208,8 +208,8 @@ public class BooleansRealmProxy extends some.test.Booleans
         return new BooleansColumnInfo(schemaInfo);
     }
 
-    public static String getTableName() {
-        return "class_Booleans";
+    public static String getSimpleClassName() {
+        return "Booleans";
     }
 
     public static List<String> getFieldNames() {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -1750,8 +1750,8 @@ public class NullTypesRealmProxy extends some.test.NullTypes
         return new NullTypesColumnInfo(schemaInfo);
     }
 
-    public static String getTableName() {
-        return "class_NullTypes";
+    public static String getSimpleClassName() {
+        return "NullTypes";
     }
 
     public static List<String> getFieldNames() {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -60,7 +60,7 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public String getSimpleClassName(Class<? extends RealmModel> clazz) {
+    public String getSimpleClassNameImpl(Class<? extends RealmModel> clazz) {
         checkClass(clazz);
 
         if (clazz.equals(some.test.AllTypes.class)) {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -9,7 +9,6 @@ import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.RealmProxyMediator;
 import io.realm.internal.Row;
 import io.realm.internal.SharedRealm;
-import io.realm.internal.Table;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -61,11 +60,11 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public String getTableName(Class<? extends RealmModel> clazz) {
+    public String getSimpleClassName(Class<? extends RealmModel> clazz) {
         checkClass(clazz);
 
         if (clazz.equals(some.test.AllTypes.class)) {
-            return io.realm.AllTypesRealmProxy.getTableName();
+            return io.realm.AllTypesRealmProxy.getSimpleClassName();
         }
         throw getMissingProxyClassException(clazz);
     }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -162,8 +162,8 @@ public class SimpleRealmProxy extends some.test.Simple
         return new SimpleColumnInfo(schemaInfo);
     }
 
-    public static String getTableName() {
-        return "class_Simple";
+    public static String getSimpleClassName() {
+        return "Simple";
     }
 
     public static List<String> getFieldNames() {

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/PrimaryKeyTests.java
@@ -85,7 +85,7 @@ public class PrimaryKeyTests {
         sharedRealm = SharedRealm.getInstance(config);
         sharedRealm.beginTransaction();
         OsObjectStore.setSchemaVersion(sharedRealm,0); // Create meta table
-        Table t = sharedRealm.createTable(Table.getTableNameForClass("class_TestTable"));
+        Table t = sharedRealm.createTable(Table.getTableNameForClass("TestTable"));
         long column = t.addColumn(RealmFieldType.INTEGER, "colName");
         t.addSearchIndex(column);
         OsObjectStore.setPrimaryKeyForObject(sharedRealm, "TestTable", "colName");

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -161,7 +161,7 @@ public class Realm extends BaseRealm {
             RealmProxyMediator mediator = configuration.getSchemaMediator();
             Set<Class<? extends RealmModel>> classes = mediator.getModelClasses();
             for (Class<? extends RealmModel> clazz  : classes) {
-                String tableName = mediator.getTableName(clazz);
+                String tableName = Table.getTableNameForClass(mediator.getSimpleClassName(clazz));
                 if (!sharedRealm.hasTable(tableName)) {
                     sharedRealm.close();
                     throw new RealmMigrationNeededException(configuration.getPath(),

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -182,7 +182,9 @@ public abstract class RealmSchema {
             table = classToTable.get(originalClass);
         }
         if (table == null) {
-            table = realm.getSharedRealm().getTable(realm.getConfiguration().getSchemaMediator().getTableName(originalClass));
+            String tableName = Table.getTableNameForClass(
+                    realm.getConfiguration().getSchemaMediator().getSimpleClassName(originalClass));
+            table = realm.getSharedRealm().getTable(tableName);
             classToTable.put(originalClass, table);
         }
         if (isProxyClass(originalClass, clazz)) {

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
@@ -100,7 +100,7 @@ public final class ColumnIndices {
         if (columnInfo == null) {
             Set<Class<? extends RealmModel>> modelClasses = mediator.getModelClasses();
             for (Class<? extends RealmModel> modelClass : modelClasses) {
-                if (Table.getClassNameForTable(mediator.getTableName(modelClass)).equals(simpleClassName)) {
+                if (mediator.getSimpleClassName(modelClass).equals(simpleClassName)) {
                     columnInfo = getColumnInfo(modelClass);
                     simpleClassNameToColumnInfoMap.put(simpleClassName, columnInfo);
                     break;

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -72,7 +72,7 @@ public abstract class RealmProxyMediator {
      * Returns the name that Realm should use for all its internal tables. This is the un-obfuscated simple name of the
      * class.
      *
-     * @param clazz the {@link RealmObject} or the Realm object proxy class reference.
+     * @param clazz the {@link RealmModel} or the Realm object proxy class reference.
      * @return the simple name of an RealmObject class (before it has been obfuscated).
      */
     public final String getSimpleClassName(Class<? extends RealmModel> clazz) {
@@ -83,7 +83,7 @@ public abstract class RealmProxyMediator {
      * Returns the name that Realm should use for all its internal tables. This is the un-obfuscated simple name of the
      * class.
      *
-     * @param clazz the {@link RealmObject} class reference.
+     * @param clazz the {@link RealmModel} class reference.
      * @return the simple name of an RealmObject class (before it has been obfuscated).
      */
     protected abstract String getSimpleClassNameImpl(Class<? extends RealmModel> clazz);

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -72,10 +72,21 @@ public abstract class RealmProxyMediator {
      * Returns the name that Realm should use for all its internal tables. This is the un-obfuscated simple name of the
      * class.
      *
+     * @param clazz the {@link RealmObject} or the Realm object proxy class reference.
+     * @return the simple name of an RealmObject class (before it has been obfuscated).
+     */
+    public final String getSimpleClassName(Class<? extends RealmModel> clazz) {
+        return getSimpleClassNameImpl(Util.getOriginalModelClass(clazz));
+    }
+
+    /**
+     * Returns the name that Realm should use for all its internal tables. This is the un-obfuscated simple name of the
+     * class.
+     *
      * @param clazz the {@link RealmObject} class reference.
      * @return the simple name of an RealmObject class (before it has been obfuscated).
      */
-    public abstract String getSimpleClassName(Class<? extends RealmModel> clazz);
+    protected abstract String getSimpleClassNameImpl(Class<? extends RealmModel> clazz);
 
     /**
      * Creates a new instance of an {@link RealmObjectProxy} for the given RealmObject class.

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -69,28 +69,13 @@ public abstract class RealmProxyMediator {
     public abstract List<String> getFieldNames(Class<? extends RealmModel> clazz);
 
     /**
-     * Returns the name that Realm should use for all its internal tables. This is the un-obfuscated name of the
-     * class with the Realm table prefix.
-     *
-     * @param clazz the {@link RealmObject} class reference.
-     * @return the simple name of an RealmObject class (before it has been obfuscated) with Realm table prefix.
-     * @throws java.lang.NullPointerException if null is given as argument.
-     * @deprecated use {{@link #getSimpleClassName(Class)}} instead.
-     */
-    @Deprecated
-    public abstract String getTableName(Class<? extends RealmModel> clazz);
-
-    /**
      * Returns the name that Realm should use for all its internal tables. This is the un-obfuscated simple name of the
      * class.
      *
      * @param clazz the {@link RealmObject} class reference.
      * @return the simple name of an RealmObject class (before it has been obfuscated).
      */
-    public String getSimpleClassName(Class<? extends RealmModel> clazz) {
-        Class<? extends RealmModel> originalClass = Util.getOriginalModelClass(clazz);
-        return Table.getClassNameForTable(getTableName(originalClass));
-    }
+    public abstract String getSimpleClassName(Class<? extends RealmModel> clazz);
 
     /**
      * Creates a new instance of an {@link RealmObjectProxy} for the given RealmObject class.

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -699,9 +699,6 @@ public class Table implements NativeObject {
     public static String getTableNameForClass(String name) {
         //noinspection ConstantConditions
         if (name == null) { return null; }
-        if (name.startsWith(TABLE_PREFIX)) {
-            return name;
-        }
         return TABLE_PREFIX + name;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -83,9 +83,9 @@ public class CompositeMediator extends RealmProxyMediator {
     }
 
     @Override
-    public String getTableName(Class<? extends RealmModel> clazz) {
+    public String getSimpleClassName(Class<? extends RealmModel> clazz) {
         RealmProxyMediator mediator = getMediator(clazz);
-        return mediator.getTableName(clazz);
+        return mediator.getSimpleClassName(clazz);
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -83,7 +83,7 @@ public class CompositeMediator extends RealmProxyMediator {
     }
 
     @Override
-    public String getSimpleClassName(Class<? extends RealmModel> clazz) {
+    protected String getSimpleClassNameImpl(Class<? extends RealmModel> clazz) {
         RealmProxyMediator mediator = getMediator(clazz);
         return mediator.getSimpleClassName(clazz);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -98,7 +98,7 @@ public class FilterableMediator extends RealmProxyMediator {
     }
 
     @Override
-    public String getSimpleClassName(Class<? extends RealmModel> clazz) {
+    protected String getSimpleClassNameImpl(Class<? extends RealmModel> clazz) {
         checkSchemaHasClass(clazz);
         return originalMediator.getSimpleClassName(clazz);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -98,9 +98,9 @@ public class FilterableMediator extends RealmProxyMediator {
     }
 
     @Override
-    public String getTableName(Class<? extends RealmModel> clazz) {
+    public String getSimpleClassName(Class<? extends RealmModel> clazz) {
         checkSchemaHasClass(clazz);
-        return originalMediator.getTableName(clazz);
+        return originalMediator.getSimpleClassName(clazz);
     }
 
     @Override


### PR DESCRIPTION
Prefix "class_" should be hide from java layer and handled in Object
Store. Try to that direction step by step.
Close #5455