### PR TITLE
Fix a socket timeout issue with test server

### DIFF
--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
@@ -88,7 +88,8 @@ public abstract class BaseIntegrationTest {
     }
 
     /**
-     * Stops the ROS instance used for the test.
+     * Stops the ROS instance used for the test. The {@link #startSyncServer()} will stop the sync server if needed, so
+     * normally there is no need to call this.
      */
     protected static void stopSyncServer() {
         try {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/IsolatedIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/IsolatedIntegrationTests.java
@@ -26,14 +26,12 @@ public class IsolatedIntegrationTests extends BaseIntegrationTest {
         if (!looperThread.isRuleUsed() || looperThread.isTestComplete()) {
             // Non-looper tests can reset here
             restoreEnvironmentAfterTest();
-            stopSyncServer();
         } else {
             // Otherwise we need to wait for the test to complete
             looperThread.runAfterTest(new Runnable() {
                 @Override
                 public void run() {
                     restoreEnvironmentAfterTest();
-                    stopSyncServer();
                 }
             });
         }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/StandardIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/StandardIntegrationTest.java
@@ -35,10 +35,6 @@ public abstract class StandardIntegrationTest extends BaseIntegrationTest {
         startSyncServer();
     }
 
-    @AfterClass
-    public static void tearDownTestClass() throws Exception {
-    }
-
     @Before
     public void setupTest() throws IOException {
         prepareEnvironmentForTest();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/StandardIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/StandardIntegrationTest.java
@@ -37,7 +37,6 @@ public abstract class StandardIntegrationTest extends BaseIntegrationTest {
 
     @AfterClass
     public static void tearDownTestClass() throws Exception {
-        stopSyncServer();
     }
 
     @Before

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/HttpUtils.java
@@ -50,6 +50,9 @@ public class HttpUtils {
     private static final String STOP_SERVER = "http://127.0.0.1:8888/stop";
     public static final String TAG = "IntegrationTestServer";
 
+    /**
+     * Start the sync server. If the server has been started before, stop it first.
+     */
     public static void startSyncServer() throws Exception {
         Request request = new Request.Builder()
                 .url(START_SERVER)
@@ -63,6 +66,10 @@ public class HttpUtils {
         SystemClock.sleep(2000);
     }
 
+    /**
+     * Stop the sync server if it is alive. {@link #startSyncServer()} will implicitly stop the server if needed, so
+     * normally there is no need to call this.
+     */
     public static void stopSyncServer() throws Exception {
         Request request = new Request.Builder()
                 .url(STOP_SERVER)

--- a/tools/sync_test_server/ros-testing-server.js
+++ b/tools/sync_test_server/ros-testing-server.js
@@ -66,6 +66,12 @@ function waitForRosToInitialize(attempts, onSuccess, onError) {
 }
 
 function startRealmObjectServer(onSuccess, onError) {
+    stopRealmObjectServer(() => {
+        doStartRealmObjectServer(onSuccess, onError)
+    }, onError)
+}
+
+function doStartRealmObjectServer(onSuccess, onError) {
     temp.mkdir('ros', function(err, path) {
         if (!err) {
             winston.info("Starting sync server in ", path);
@@ -112,8 +118,8 @@ function startRealmObjectServer(onSuccess, onError) {
 }
 
 function stopRealmObjectServer(onSuccess, onError) {
-    if(syncServerChildProcess == null) {
-        onError("No ROS process found to stop");
+    if(syncServerChildProcess == null || syncServerChildProcess.killed) {
+        onSuccess("No ROS process found or the process has been killed before");
     }
 
     syncServerChildProcess.on('exit', function(code) {


### PR DESCRIPTION
If startRealmObjectServer was called twice without stop in between,
syncServerChildProcess will be overwritten by a terminated process since
the 2nd call of creating sync server will fail and set the syncServerChildProcess.
This would make the stopRealmObjectServer get stuck forever.

In practice, we need to make sure the server has been stopped before
start it. So just treat the "start" as a "restart" command which will
stop the sync server if needed.

Thus, no need to stop in tear down functions in java side anymore.