### PR TITLE
fix secureTokenAndroidKeyStore example to pass monkey test

### DIFF
--- a/examples/secureTokenAndroidKeyStore/src/main/java/io/realm/examples/securetokenandroidkeystore/MainActivity.java
+++ b/examples/secureTokenAndroidKeyStore/src/main/java/io/realm/examples/securetokenandroidkeystore/MainActivity.java
@@ -84,7 +84,7 @@ public class MainActivity extends AppCompatActivity {
     private void buildSyncConf() {
         // the rest of Sync logic ...
         SyncCredentials credentials = SyncCredentials.usernamePassword("username", "password");
-        final String urlAuth = "realm://objectserver.realm.io/default";
+        final String urlAuth = "http://objectserver.realm.io:9080/auth";
         final String url = "realm://objectserver.realm.io/default";
 
         SyncUser.loginAsync(credentials, urlAuth, new SyncUser.Callback<SyncUser>() {

--- a/examples/secureTokenAndroidKeyStore/src/main/java/io/realm/examples/securetokenandroidkeystore/MainActivity.java
+++ b/examples/secureTokenAndroidKeyStore/src/main/java/io/realm/examples/securetokenandroidkeystore/MainActivity.java
@@ -23,18 +23,15 @@ import android.widget.TextView;
 
 import com.example.securetokenandroidkeystore.R;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.security.KeyStoreException;
-import java.util.UUID;
 
+import io.realm.ObjectServerError;
 import io.realm.Realm;
 import io.realm.SyncConfiguration;
+import io.realm.SyncCredentials;
 import io.realm.SyncManager;
 import io.realm.SyncUser;
 import io.realm.android.SecureUserStore;
-import io.realm.internal.objectserver.Token;
 
 /**
  * Activity responsible of unlocking the KeyStore
@@ -86,29 +83,21 @@ public class MainActivity extends AppCompatActivity {
     // build SyncConfiguration with a user store to store encrypted Token.
     private void buildSyncConf() {
         // the rest of Sync logic ...
-        SyncUser user = createTestUser(Long.MAX_VALUE);
-        String url = "realm://objectserver.realm.io/default";
-        SyncConfiguration secureConfig = new SyncConfiguration.Builder(user, url).build();
-        Realm realm = Realm.getInstance(secureConfig);
-        // ...
-    }
+        SyncCredentials credentials = SyncCredentials.usernamePassword("username", "password");
+        final String urlAuth = "realm://objectserver.realm.io/default";
+        final String url = "realm://objectserver.realm.io/default";
 
-    // Helpers
-    private final static String USER_TOKEN = UUID.randomUUID().toString();
+        SyncUser.loginAsync(credentials, urlAuth, new SyncUser.Callback<SyncUser>() {
+            @Override
+            public void onSuccess(SyncUser user) {
+                SyncConfiguration secureConfig = new SyncConfiguration.Builder(user, url).build();
+                Realm realm = Realm.getInstance(secureConfig);
+                // ...
+            }
 
-    private static SyncUser createTestUser(long expires) {
-        Token userToken = new Token(USER_TOKEN, "JohnDoe", null, expires, null);
-        JSONObject obj = new JSONObject();
-        try {
-            JSONObject realmDesc = new JSONObject();
-            realmDesc.put("uri", "realm://objectserver.realm.io/default");
-
-            obj.put("authUrl", "http://objectserver.realm.io/auth");
-            obj.put("userToken", userToken.toJson());
-            return SyncUser.fromJson(obj.toString());
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
+            @Override
+            public void onError(ObjectServerError error) {}
+        });
     }
 
     private void keystoreLockedMessage() {


### PR DESCRIPTION
monkey is not passing for `secureTokenAndroidKeyStore`

```
E/AndroidRuntime(11515): Process: io.realm.examples.securetokenandroidkeystore, PID: 11515
E/AndroidRuntime(11515): java.lang.RuntimeException: Unable to start activity ComponentInfo{io.realm.examples.securetokenandroidkeystore/io.realm.examples.securetokenandroidkeystore.MainActivity}: java.lang.IllegalArgumentException: User not authenticated or authentication expired.
E/AndroidRuntime(11515): 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2325)
E/AndroidRuntime(11515): 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2387)
E/AndroidRuntime(11515): 	at android.app.ActivityThread.access$800(ActivityThread.java:151)
E/AndroidRuntime(11515): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1303)
E/AndroidRuntime(11515): 	at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime(11515): 	at android.os.Looper.loop(Looper.java:135)
E/AndroidRuntime(11515): 	at android.app.ActivityThread.main(ActivityThread.java:5254)
E/AndroidRuntime(11515): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(11515): 	at java.lang.reflect.Method.invoke(Method.java:372)
E/AndroidRuntime(11515): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
E/AndroidRuntime(11515): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
E/AndroidRuntime(11515): Caused by: java.lang.IllegalArgumentException: User not authenticated or authentication expired.
E/AndroidRuntime(11515): 	at io.realm.SyncConfiguration$Builder.validateAndSet(SyncConfiguration.java:467)
E/AndroidRuntime(11515): 	at io.realm.SyncConfiguration$Builder.<init>(SyncConfiguration.java:457)
E/AndroidRuntime(11515): 	at io.realm.SyncConfiguration$Builder.<init>(SyncConfiguration.java:444)
E/AndroidRuntime(11515): 	at io.realm.examples.securetokenandroidkeystore.MainActivity.buildSyncConf(MainActivity.java:91)
E/AndroidRuntime(11515): 	at io.realm.examples.securetokenandroidkeystore.MainActivity.onCreate(MainActivity.java:60)
E/AndroidRuntime(11515): 	at android.app.Activity.performCreate(Activity.java:5990)
E/AndroidRuntime(11515): 	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1106)
E/AndroidRuntime(11515): 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2278)
E/AndroidRuntime(11515): 	... 10 more
W
```

this fix the example to create a valid `SyncUser`