### PR TITLE
Specify distributionType in wrapper task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -478,4 +478,5 @@ release {
 
 task wrapper(type: Wrapper) {
     gradleVersion = project.gradleVersion
+    distributionType = 'all'
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -75,4 +75,5 @@ allprojects {
 
 task wrapper(type: Wrapper) {
     gradleVersion = project.gradleVersion
+    distributionType = 'all'
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -76,6 +76,7 @@ compileJava.dependsOn generateVersionClass
 
 task wrapper(type: Wrapper) {
     gradleVersion = project.gradleVersion
+    distributionType = 'all'
 }
 
 def commonPom = {

--- a/library-benchmarks/build.gradle
+++ b/library-benchmarks/build.gradle
@@ -20,6 +20,7 @@ allprojects {
 
 task wrapper(type: Wrapper) {
     gradleVersion = project.gradleVersion
+    distributionType = 'all'
 }
 
 apply plugin: 'com.android.library'

--- a/realm-annotations/build.gradle
+++ b/realm-annotations/build.gradle
@@ -114,4 +114,5 @@ artifactory {
 
 task wrapper(type: Wrapper) {
     gradleVersion = project.gradleVersion
+    distributionType = 'all'
 }

--- a/realm-transformer/build.gradle
+++ b/realm-transformer/build.gradle
@@ -164,5 +164,6 @@ artifactory {
 
 task wrapper(type: Wrapper) {
     gradleVersion = project.gradleVersion
+    distributionType = 'all'
 }
 

--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -41,4 +41,5 @@ allprojects {
 
 task wrapper(type: Wrapper) {
     gradleVersion = project.gradleVersion
+    distributionType = 'all'
 }

--- a/tools/update_gradle_wrapper.sh
+++ b/tools/update_gradle_wrapper.sh
@@ -14,7 +14,6 @@ for i in $(find $(pwd) -type f -name gradlew); do
     cd $(dirname $i)
     pwd
     ./gradlew wrapper
-    sed -E -i '' s/-bin\\.zip\$/-all.zip/ gradle/wrapper/gradle-wrapper.properties
 done
 
 cd $HERE


### PR DESCRIPTION
No need to edit `gradle-wrapper.properties` after generating the file.