### PR TITLE
Fix leaking file handlers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## 4.1.2 (YYYY-MM-DD)
+
+### Bug Fixes
+
+* Leaked file handler in the Realm Transformer (#5521)
+
+### Internal
+
+* Updated JavaAssist to 3.22.0-GA
+
+
 ## 4.1.1 (2017-10-27)
-
-### Breaking Changes
-
-### Enhancements
 
 ### Bug Fixes
 
@@ -13,8 +20,6 @@
 ### Internal
 
 * Updated Realm Sync to 2.1.0
-
-### Credits
 
 
 ## 4.1.0 (2017-10-20)

--- a/realm-transformer/build.gradle
+++ b/realm-transformer/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile gradleApi()
     compile "io.realm:realm-annotations:${version}"
     provided 'com.android.tools.build:gradle:2.1.0'
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.22.0-GA'
 
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude module: 'groovy-all'

--- a/realm-transformer/src/main/groovy/io/realm/transformer/ManagedClassPool.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/ManagedClassPool.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.transformer
+
+import com.android.build.api.transform.TransformInput
+import javassist.ClassPath
+import javassist.ClassPool
+
+/**
+ * This class implements the Transform API provided by the Android Gradle plugin.
+ */
+@SuppressWarnings("GroovyUnusedDeclaration")
+class ManagedClassPool extends ClassPool implements Closeable {
+
+    def List<ClassPath> pathElements = new ArrayList<ClassPath>()
+
+    /**
+     * Constructor for creating and populating the JavAssist class pool.
+     * Remember to class {@link #close()} when done with it to avoid leaking file resources
+     *
+     * @param inputs the inputs provided by the Transform API
+     * @param referencedInputs the referencedInputs provided by the Transform API
+     * @return the populated ClassPool instance
+     */
+    ManagedClassPool(Collection<TransformInput> inputs, Collection<TransformInput> referencedInputs) {
+        // Don't use ClassPool.getDefault(). Doing consecutive builds in the same run (e.g. debug+release)
+        // will use a cached object and all the classes will be frozen.
+        super(null)
+        appendSystemPath()
+
+        inputs.each {
+            it.directoryInputs.each {
+                pathElements.add(appendClassPath(it.file.absolutePath))
+            }
+
+            // JavaAssist is leaking file handles, manually create it
+            // See
+            it.jarInputs.each {
+                pathElements.add(appendClassPath(it.file.absolutePath))
+            }
+        }
+
+        referencedInputs.each {
+            it.directoryInputs.each {
+                pathElements.add(appendClassPath(it.file.absolutePath))
+            }
+
+            it.jarInputs.each {
+                pathElements.add(appendClassPath(it.file.absolutePath))
+            }
+        }
+    }
+
+    /**
+     * Detach all ClassPath elements, effectively closing the class pool.
+     */
+    @Override
+    void close() throws IOException {
+        // Cleanup class pool. Internally it keeps a list of JarFile references that are only
+        // cleaned up if the the ClassPath element wrapping it is manually removed.
+        // See https://github.com/jboss-javassist/javassist/issues/165
+        def iter = pathElements.iterator()
+        while (iter.hasNext()) {
+            def cp = iter.next()
+            removeClassPath(cp)
+            iter.remove()
+        }
+    }
+}

--- a/realm-transformer/src/main/groovy/io/realm/transformer/ManagedClassPool.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/ManagedClassPool.groovy
@@ -47,8 +47,6 @@ class ManagedClassPool extends ClassPool implements Closeable {
                 pathElements.add(appendClassPath(it.file.absolutePath))
             }
 
-            // JavaAssist is leaking file handles, manually create it
-            // See
             it.jarInputs.each {
                 pathElements.add(appendClassPath(it.file.absolutePath))
             }

--- a/realm-transformer/src/main/groovy/io/realm/transformer/ManagedClassPool.groovy
+++ b/realm-transformer/src/main/groovy/io/realm/transformer/ManagedClassPool.groovy
@@ -21,7 +21,8 @@ import javassist.ClassPath
 import javassist.ClassPool
 
 /**
- * This class implements the Transform API provided by the Android Gradle plugin.
+ * This class is a wrapper around JavaAssists {@code ClassPool} class that allows for correct cleanup
+ * of the resources used.
  */
 @SuppressWarnings("GroovyUnusedDeclaration")
 class ManagedClassPool extends ClassPool implements Closeable {
@@ -30,7 +31,7 @@ class ManagedClassPool extends ClassPool implements Closeable {
 
     /**
      * Constructor for creating and populating the JavAssist class pool.
-     * Remember to class {@link #close()} when done with it to avoid leaking file resources
+     * Remember to call {@link #close()} when done with it to avoid leaking file resources
      *
      * @param inputs the inputs provided by the Transform API
      * @param referencedInputs the referencedInputs provided by the Transform API


### PR DESCRIPTION
Fixes #5521 

I don't have a Windows machine to verify this on, but by doing code review it does appear that file handlers are being leaked. Unfortunately one of the leaks are inside JavaAssist, so I reported that upstream while implementing a workaround in our end for the time being.