### PR TITLE
CI fails without exporting the logcat.zip

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,6 @@ try {
 
                 stage('Run instrumented tests') {
                   lock("${env.NODE_NAME}-android") {
-                    boolean archiveLog = true
                     String backgroundPid
                     try {
                       backgroundPid = startLogCatCollector()
@@ -95,7 +94,7 @@ try {
                       gradle('realm', "${instrumentationTestTarget}")
                       archiveLog = false;
                     } finally {
-                      stopLogCatCollector(backgroundPid, archiveLog)
+                      stopLogCatCollector(backgroundPid)
                       storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'
                     }
                   }
@@ -162,14 +161,12 @@ def String startLogCatCollector() {
   return readFile("pid").trim()
 }
 
-def stopLogCatCollector(String backgroundPid, boolean archiveLog) {
+def stopLogCatCollector(String backgroundPid) {
   sh "kill ${backgroundPid}"
   if (archiveLog) {
-    zip([
-	  'zipFile': 'logcat.zip',
+	 'zipFile': 'logcat.zip',
 	 'archive': true,
 	 'glob' : 'logcat.txt'
-	])
   }
   sh 'rm logcat.txt'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,6 @@ try {
                       backgroundPid = startLogCatCollector()
                       forwardAdbPorts()
                       gradle('realm', "${instrumentationTestTarget}")
-                      archiveLog = false;
                     } finally {
                       stopLogCatCollector(backgroundPid)
                       storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'
@@ -163,11 +162,11 @@ def String startLogCatCollector() {
 
 def stopLogCatCollector(String backgroundPid) {
   sh "kill ${backgroundPid}"
-  if (archiveLog) {
-	 'zipFile': 'logcat.zip',
-	 'archive': true,
-	 'glob' : 'logcat.txt'
-  }
+  zip([
+    'zipFile': 'logcat.zip',
+    'archive': true,
+    'glob' : 'logcat.txt'
+  ])
   sh 'rm logcat.txt'
 }
 


### PR DESCRIPTION
The _logcat_ is collected on CI but only archived if the tests fail.

sometimes the CI fails with `Expected X tests, received Y` ([example](https://ci.realm.io/job/realm/job/realm-java/job/PR-5511/21/consoleFull)) which doesn't provide the _logcat_ to investigate what happened. This PR allow archive  the _logcat_ regardless of the test  

