### PR TITLE
Added notification to OsList instead of OsResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Bug Fixes
 
+* Added missing `toString()` for the implementation of `OrderedCollectionChangeSet`.
+
 ### Internal
+
+* Use `OsList` instead of `OsResults` to add notification token on for `RealmList<RealmModel>`.
 
 ### Credits
 

--- a/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedCollectionChangeSet.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import java.util.Locale;
+
 /**
  * This interface describes the changes made to a collection during the last update.
  * <p>
@@ -94,6 +96,11 @@ public interface OrderedCollectionChangeSet {
         public Range(int startIndex, int length) {
             this.startIndex = startIndex;
             this.length = length;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ENGLISH, "startIndex: %d, length: %d", startIndex, length);
         }
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -63,7 +63,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
 
     private static final String ONLY_IN_MANAGED_MODE_MESSAGE = "This method is only available in managed mode.";
     static final String ALLOWED_ONLY_FOR_REALM_MODEL_ELEMENT_MESSAGE = "This feature is available only when the element type is implementing RealmModel.";
-    public static final String REMOVE_OUTSIDE_TRANSACTION_ERROR = "Objects can only be removed from inside a write transaction.";
+    private static final String REMOVE_OUTSIDE_TRANSACTION_ERROR = "Objects can only be removed from inside a write transaction.";
 
     @Nullable
     protected Class<E> clazz;
@@ -71,11 +71,9 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
     protected String className;
 
     // Always null if RealmList is unmanaged, always non-null if managed.
-    final ManagedListOperator<E> osListOperator;
+    private final ManagedListOperator<E> osListOperator;
     final protected BaseRealm realm;
     private List<E> unmanagedList;
-    // Used for listeners on RealmList<RealmModel>
-    private OsResults osResults;
 
     /**
      * Creates a RealmList in unmanaged mode, where the elements are not controlled by a Realm.
@@ -966,11 +964,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
      */
     public void addChangeListener(OrderedRealmCollectionChangeListener<RealmList<E>> listener) {
         checkForAddRemoveListener(listener, true);
-        if (osListOperator.forRealmModel()) {
-            getOrCreateOsResultsForListener().addListener(this, listener);
-        } else {
-            osListOperator.getOsList().addListener(this, listener);
-        }
+        osListOperator.getOsList().addListener(this, listener);
     }
 
     /**
@@ -983,11 +977,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
      */
     public void removeChangeListener(OrderedRealmCollectionChangeListener<RealmList<E>> listener) {
         checkForAddRemoveListener(listener, true);
-        if (osListOperator.forRealmModel()) {
-            getOrCreateOsResultsForListener().removeListener(this, listener);
-        } else {
-            osListOperator.getOsList().removeListener(this, listener);
-        }
+        osListOperator.getOsList().removeListener(this, listener);
     }
 
     /**
@@ -1025,11 +1015,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
      */
     public void addChangeListener(RealmChangeListener<RealmList<E>> listener) {
         checkForAddRemoveListener(listener, true);
-        if (osListOperator.forRealmModel()) {
-            getOrCreateOsResultsForListener().addListener(this, listener);
-        } else {
-            osListOperator.getOsList().addListener(this, listener);
-        }
+        osListOperator.getOsList().addListener(this, listener);
     }
 
     /**
@@ -1042,11 +1028,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
      */
     public void removeChangeListener(RealmChangeListener<RealmList<E>> listener) {
         checkForAddRemoveListener(listener, true);
-        if (osListOperator.forRealmModel()) {
-            getOrCreateOsResultsForListener().removeListener(this, listener);
-        } else {
-            osListOperator.getOsList().removeListener(this, listener);
-        }
+        osListOperator.getOsList().removeListener(this, listener);
     }
 
     /**
@@ -1057,11 +1039,7 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
      */
     public void removeAllChangeListeners() {
         checkForAddRemoveListener(null, false);
-        if (osListOperator.forRealmModel()) {
-            getOrCreateOsResultsForListener().removeAllListeners();
-        } else {
-            osListOperator.getOsList().removeAllListeners();
-        }
+        osListOperator.getOsList().removeAllListeners();
     }
 
     // Custom RealmList iterator.
@@ -1280,20 +1258,6 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
             return (ManagedListOperator<E>) new DateListOperator(realm, osList, (Class<Date>) clazz);
         }
         throw new IllegalArgumentException("Unexpected value class: " + clazz.getName());
-    }
-
-    // TODO: Object Store is not able to merge change set for links list. Luckily since we were still using LinkView
-    // when ship the fine grain notifications, the listener on RealmList is actually added to a OS Results which is
-    // created from the link view. OS Results is computing the change set by comparing the old/new collection. So it
-    // will give the right results if you remove all elements from a RealmList then add all them back and add one more
-    // new element. By right results it means the change set only include one insertion. But if the listener is on the
-    // OS List, the change set will include all ranges of th list. So we keep the old behaviour for
-    // RealmList<RealmModel> for now. See https://github.com/realm/realm-object-store/issues/541
-    private OsResults getOrCreateOsResultsForListener() {
-        if (osResults == null) {
-            this.osResults = new OsResults(realm.sharedRealm, osListOperator.getOsList(), null);
-        }
-        return osResults;
     }
 }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/OsCollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsCollectionChangeSet.java
@@ -16,6 +16,8 @@
 
 package io.realm.internal;
 
+import java.util.Arrays;
+
 import javax.annotation.Nullable;
 
 import io.realm.OrderedCollectionChangeSet;
@@ -132,4 +134,22 @@ public class OsCollectionChangeSet implements OrderedCollectionChangeSet, Native
 
     // Returns the indices array.
     private native static int[] nativeGetIndices(long nativePtr, int type);
+
+    @Override
+    public String toString() {
+        if (nativePtr == 0)  {
+            return "Change set is empty.";
+        }
+
+        String string = "Deletion Ranges: " +
+                Arrays.toString(getDeletionRanges()) +
+                "\n" +
+                "Insertion Ranges: " +
+                Arrays.toString(getInsertionRanges()) +
+                "\n" +
+                "Change Ranges: " +
+                Arrays.toString(getChangeRanges());
+        return string;
+
+    }
 }


### PR DESCRIPTION
- The notification token for RealmList<RealmModel> will be added to the
  underlying OsList instead of the OsResults created from the list. This
  will have a different behavior for a corner case,
  see https://github.com/realm/realm-object-store/pull/602 . Thus the
  test cases needs to be modified accordingly.
- This would be the precondition of using
  https://github.com/realm/realm-object-store/pull/601
- Add toString() for OrderedCollectionChangeSet.