### PR TITLE
Evaluate queries immediately for sync queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * Added missing `toString()` for the implementation of `OrderedCollectionChangeSet`.
+* Sync queries are evaluated immediately to solve the performance issue when the query results are huge, `RealmResults.size()` takes too long time (#5387).
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionTests.java
@@ -428,7 +428,12 @@ public class OrderedRealmCollectionTests extends CollectionTests {
                 break;
             case MANAGED_REALMLIST:
             case REALMRESULTS:
-                assertEquals(collection.size(), snapshot.size());
+                int sizeBeforeChange = collection.size();
+                realm.beginTransaction();
+                collection.deleteLastFromRealm();
+                realm.commitTransaction();
+                assertEquals(sizeBeforeChange - 1, collection.size());
+                assertEquals(sizeBeforeChange, snapshot.size());
                 break;
             default:
                 break;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/OsResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/OsResultsTests.java
@@ -152,7 +152,7 @@ public class OsResultsTests {
     @Test
     public void constructor_withDistinct() {
         SortDescriptor distinctDescriptor = SortDescriptor.getInstanceForDistinct(null, table, "firstName");
-        OsResults osResults = new OsResults(sharedRealm, table.where(), null, distinctDescriptor);
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where(), null, distinctDescriptor);
 
         assertEquals(3, osResults.size());
         assertEquals("John", osResults.getUncheckedRow(0).getString(0));
@@ -164,7 +164,7 @@ public class OsResultsTests {
     @Test(expected = UnsupportedOperationException.class)
     public void constructor_queryIsValidated() {
         // OsResults's constructor should call TableQuery.validateQuery()
-        new OsResults(sharedRealm, table.where().or());
+        OsResults.createFromQuery(sharedRealm, table.where().or());
     }
 
     @Test
@@ -175,20 +175,20 @@ public class OsResultsTests {
         sharedRealm.commitTransaction();
         // Query should be checked before creating OS Results.
         thrown.expect(IllegalStateException.class);
-        new OsResults(sharedRealm, query);
+        OsResults.createFromQuery(sharedRealm, query);
     }
 
     @Test
     public void size() {
-        OsResults osResults = new OsResults(sharedRealm, table.where());
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         assertEquals(4, osResults.size());
     }
 
     @Test
     public void where() {
-        OsResults osResults = new OsResults(sharedRealm, table.where());
-        OsResults osResults2 = new OsResults(sharedRealm, osResults.where().equalTo(new long[] {0}, oneNullTable, "John"));
-        OsResults osResults3 = new OsResults(sharedRealm, osResults2.where().equalTo(new long[] {1}, oneNullTable, "Anderson"));
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
+        OsResults osResults2 = OsResults.createFromQuery(sharedRealm, osResults.where().equalTo(new long[] {0}, oneNullTable, "John"));
+        OsResults osResults3 = OsResults.createFromQuery(sharedRealm, osResults2.where().equalTo(new long[] {1}, oneNullTable, "Anderson"));
 
         // A new native Results should be created.
         assertTrue(osResults.getNativePtr() != osResults2.getNativePtr());
@@ -201,7 +201,7 @@ public class OsResultsTests {
 
     @Test
     public void sort() {
-        OsResults osResults = new OsResults(sharedRealm, table.where().greaterThan(new long[] {2}, oneNullTable, 1));
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where().greaterThan(new long[] {2}, oneNullTable, 1));
         SortDescriptor sortDescriptor = SortDescriptor.getTestInstance(table, new long[] {2});
 
         OsResults osResults2 = osResults.sort(sortDescriptor);
@@ -218,7 +218,7 @@ public class OsResultsTests {
     @Test
     public void clear() {
         assertEquals(4, table.size());
-        OsResults osResults = new OsResults(sharedRealm, table.where());
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         sharedRealm.beginTransaction();
         osResults.clear();
         sharedRealm.commitTransaction();
@@ -227,7 +227,7 @@ public class OsResultsTests {
 
     @Test
     public void contains() {
-        OsResults osResults = new OsResults(sharedRealm, table.where());
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         UncheckedRow row = table.getUncheckedRow(0);
         assertTrue(osResults.contains(row));
     }
@@ -236,14 +236,14 @@ public class OsResultsTests {
     public void indexOf() {
         SortDescriptor sortDescriptor = SortDescriptor.getTestInstance(table, new long[] {2});
 
-        OsResults osResults = new OsResults(sharedRealm, table.where(), sortDescriptor);
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where(), sortDescriptor, null);
         UncheckedRow row = table.getUncheckedRow(0);
         assertEquals(3, osResults.indexOf(row));
     }
 
     @Test
     public void distinct() {
-        OsResults osResults = new OsResults(sharedRealm, table.where().lessThan(new long[] {2}, oneNullTable, 4));
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where().lessThan(new long[] {2}, oneNullTable, 4));
 
         SortDescriptor distinctDescriptor = SortDescriptor.getTestInstance(table, new long[] {2});
         OsResults osResults2 = osResults.distinct(distinctDescriptor);
@@ -266,7 +266,7 @@ public class OsResultsTests {
         populateData(sharedRealm);
         Table table = getTable(sharedRealm);
 
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         looperThread.keepStrongReference(osResults);
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
             @Override
@@ -287,7 +287,7 @@ public class OsResultsTests {
         final OsSharedRealm sharedRealm = getSharedRealm();
         Table table = getTable(sharedRealm);
 
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
             @Override
             public void onChange(OsResults osResults1) {
@@ -304,7 +304,7 @@ public class OsResultsTests {
     @Test
     public void addListener_shouldBeCalledWhenRefreshAfterLocalCommit() {
         final CountDownLatch latch = new CountDownLatch(2);
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         assertEquals(4, osResults.size()); // See `populateData()`
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
             @Override
@@ -332,7 +332,7 @@ public class OsResultsTests {
     @Test
     public void addListener_triggeredByRefresh() {
         final CountDownLatch latch = new CountDownLatch(1);
-        OsResults osResults = new OsResults(sharedRealm, table.where());
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         osResults.size();
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
             @Override
@@ -356,7 +356,7 @@ public class OsResultsTests {
         populateData(sharedRealm);
         Table table = getTable(sharedRealm);
 
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         looperThread.keepStrongReference(osResults);
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
             @Override
@@ -378,7 +378,7 @@ public class OsResultsTests {
         populateData(sharedRealm);
         Table table = getTable(sharedRealm);
 
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         looperThread.keepStrongReference(osResults);
         assertEquals(4, osResults.size()); // Trigger the query to run.
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
@@ -404,7 +404,7 @@ public class OsResultsTests {
         Table table = getTable(sharedRealm);
         final AtomicInteger listenerCounter = new AtomicInteger(0);
 
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         looperThread.keepStrongReference(osResults);
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
             @Override
@@ -451,7 +451,7 @@ public class OsResultsTests {
 
     @Test
     public void collectionIterator_detach_byBeginTransaction() {
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         TestIterator iterator = new TestIterator(osResults);
         assertFalse(iterator.isDetached(sharedRealm));
         sharedRealm.beginTransaction();
@@ -463,14 +463,14 @@ public class OsResultsTests {
     @Test
     public void collectionIterator_detach_createdInTransaction() {
         sharedRealm.beginTransaction();
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         TestIterator iterator = new TestIterator(osResults);
         assertTrue(iterator.isDetached(sharedRealm));
     }
 
     @Test
     public void collectionIterator_invalid_nonLooperThread_byRefresh() {
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         TestIterator iterator = new TestIterator(osResults);
         assertFalse(iterator.isDetached(sharedRealm));
         sharedRealm.refresh();
@@ -484,7 +484,7 @@ public class OsResultsTests {
         final OsSharedRealm sharedRealm = getSharedRealmForLooper();
         populateData(sharedRealm);
         Table table = getTable(sharedRealm);
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         final TestIterator iterator = new TestIterator(osResults);
         looperThread.keepStrongReference(osResults);
         assertFalse(iterator.isDetached(sharedRealm));
@@ -506,7 +506,7 @@ public class OsResultsTests {
 
     @Test
     public void collectionIterator_newInstance_throwsWhenSharedRealmIsClosed() {
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         sharedRealm.close();
         thrown.expect(IllegalStateException.class);
         new TestIterator(osResults);
@@ -514,7 +514,7 @@ public class OsResultsTests {
 
     @Test
     public void getMode() {
-        OsResults osResults = new OsResults(sharedRealm, table.where());
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         assertTrue(OsResults.Mode.QUERY == osResults.getMode());
         osResults.firstUncheckedRow(); // Run the query
         assertTrue(OsResults.Mode.TABLEVIEW == osResults.getMode());
@@ -522,7 +522,7 @@ public class OsResultsTests {
 
     @Test
     public void createSnapshot() {
-        OsResults osResults = new OsResults(sharedRealm, table.where());
+        OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         OsResults snapshot = osResults.createSnapshot();
         assertTrue(OsResults.Mode.TABLEVIEW == snapshot.getMode());
         thrown.expect(IllegalStateException.class);
@@ -539,7 +539,7 @@ public class OsResultsTests {
         final OsSharedRealm sharedRealm = getSharedRealmForLooper();
         looperThread.closeAfterTest(sharedRealm);
         populateData(sharedRealm);
-        final OsResults osResults = new OsResults(sharedRealm, table.where());
+        final OsResults osResults = OsResults.createFromQuery(sharedRealm, table.where());
         osResults.addListener(osResults, new RealmChangeListener<OsResults>() {
             @Override
             public void onChange(OsResults element) {

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsResults.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsResults.cpp
@@ -70,27 +70,6 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_OsResults_nativeCreateResults(JNI
     return reinterpret_cast<jlong>(nullptr);
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_internal_OsResults_nativeCreateResultsFromList(JNIEnv* env, jclass,
-                                                                                          jlong shared_realm_ptr,
-                                                                                          jlong list_ptr,
-                                                                                          jobject j_sort_desc)
-{
-    TR_ENTER()
-    try {
-        auto& list_wrapper = *reinterpret_cast<ObservableCollectionWrapper<List>*>(list_ptr);
-        auto& list = list_wrapper.collection();
-        auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        Results results = j_sort_desc ?
-            list.sort(JavaSortDescriptor(env, j_sort_desc).sort_descriptor()) :
-            list.as_results();
-        auto wrapper = new ResultsWrapper(results);
-
-        return reinterpret_cast<jlong>(wrapper);
-    }
-    CATCH_STD()
-    return reinterpret_cast<jlong>(nullptr);
-}
-
 JNIEXPORT jlong JNICALL Java_io_realm_internal_OsResults_nativeCreateSnapshot(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr);
@@ -420,4 +399,16 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_OsResults_nativeCreateResultsFrom
     }
     CATCH_STD()
     return reinterpret_cast<jlong>(nullptr);
+}
+
+JNIEXPORT void JNICALL Java_io_realm_internal_OsResults_nativeEvaluateQueryIfNeeded(JNIEnv* env, jclass,
+                                                                                    jlong native_ptr,
+                                                                                    jboolean wants_notifications)
+{
+    TR_ENTER_PTR(native_ptr)
+    try {
+        auto wrapper = reinterpret_cast<ResultsWrapper*>(native_ptr);
+        wrapper->collection().evaluate_query_if_needed(wants_notifications);
+    }
+    CATCH_STD()
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -758,14 +758,14 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
         if (className != null) {
             return new OrderedRealmCollectionSnapshot<>(
                     realm,
-                    new OsResults(realm.sharedRealm, osListOperator.getOsList(), null),
+                    OsResults.createFromQuery(realm.sharedRealm, osListOperator.getOsList().getQuery()),
                     className);
         } else {
             // 'clazz' is non-null when 'dynamicClassName' is null.
             //noinspection ConstantConditions
             return new OrderedRealmCollectionSnapshot<>(
                     realm,
-                    new OsResults(realm.sharedRealm, osListOperator.getOsList(), null),
+                    OsResults.createFromQuery(realm.sharedRealm, osListOperator.getOsList().getQuery()),
                     clazz);
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -2014,7 +2014,7 @@ public class RealmQuery<E> {
         if (realm.isInTransaction()) {
             // It is not possible to create async query inside a transaction. So immediately query the first object.
             // See OS Results::prepare_async()
-            row = new OsResults(realm.sharedRealm, query).firstUncheckedRow();
+            row = OsResults.createFromQuery(realm.sharedRealm, query).firstUncheckedRow();
         } else {
             // prepares an empty reference of the RealmObject which is backed by a pending query,
             // then update it once the query complete in the background.
@@ -2050,7 +2050,7 @@ public class RealmQuery<E> {
             @Nullable SortDescriptor distinctDescriptor,
             boolean loadResults) {
         RealmResults<E> results;
-        OsResults osResults = new OsResults(realm.sharedRealm, query, sortDescriptor, distinctDescriptor);
+        OsResults osResults = OsResults.createFromQuery(realm.sharedRealm, query, sortDescriptor, distinctDescriptor);
         if (isDynamicQuery()) {
             results = new RealmResults<>(realm, osResults, className);
         } else {

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -68,7 +68,7 @@ public class RealmResults<E> extends OrderedRealmCollectionImpl<E> {
         Table srcTable = realm.getSchema().getTable(srcTableType);
         return new RealmResults<>(
                 realm,
-                OsResults.createBacklinksCollection(realm.sharedRealm, uncheckedRow, srcTable, srcFieldName),
+                OsResults.createForBacklinks(realm.sharedRealm, uncheckedRow, srcTable, srcFieldName),
                 srcTableType);
     }
 
@@ -78,7 +78,7 @@ public class RealmResults<E> extends OrderedRealmCollectionImpl<E> {
         //noinspection ConstantConditions
         return new RealmResults<>(
                 realm,
-                OsResults.createBacklinksCollection(realm.sharedRealm, row, srcTable, srcFieldName),
+                OsResults.createForBacklinks(realm.sharedRealm, row, srcTable, srcFieldName),
                 srcClassName);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
@@ -511,7 +511,7 @@ public final class OsSharedRealm implements Closeable, NativeObject {
         } else {
             @SuppressWarnings("ConstantConditions")
             Table table = getTable(Table.getTableNameForClass(callback.className));
-            OsResults results = new OsResults(this, table, nativeResultsPtr, true);
+            OsResults results = new OsResults(this, table, nativeResultsPtr);
             callback.onSuccess(results);
         }
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
@@ -40,7 +40,7 @@ public class PendingRow implements Row {
     public PendingRow(OsSharedRealm sharedRealm, TableQuery query, @Nullable SortDescriptor sortDescriptor,
                       final boolean returnCheckedRow) {
         this.sharedRealm = sharedRealm;
-        pendingOsResults = new OsResults(sharedRealm, query, sortDescriptor, null);
+        pendingOsResults = OsResults.createFromQuery(sharedRealm, query, sortDescriptor, null);
 
         listener = new RealmChangeListener<PendingRow>() {
             @Override

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
     public static final String USER_REALM_2 = "realm://" + HOST + ":9080/~/tests2";
     public static final String USER_REALM_SECURE = "realms://" + HOST + ":9443/~/tests";
     public static final String SYNC_SERVER_URL = "realm://" + HOST + ":9080/~/tests";
-    public static final String SYNC_SERVER_URL_2 = "realm://" + HOST + "/~/tests2";
+    public static final String SYNC_SERVER_URL_2 = "realm://" + HOST + ":9080/~/tests2";
 
     public static final String AUTH_SERVER_URL = "http://" + HOST + ":9080/";
     public static final String AUTH_URL = AUTH_SERVER_URL + "auth";


### PR DESCRIPTION
- OsResults.load() actually does evaluate queries if needed now by using
  newly exposed OS method Results.evaluate_query_if_needed(). So the
  Results's mode will be changed to TABLEVIEW from QUERY. This matches
  the old async query behaviour and solved the performance issues when
  the query results are huge, the size() method took unnecessary long
  time even the Results accessor will be called at the next line.
  close #5328 close #5387
- Update Object Store to 3eb19c014fdf .
- Refactor the APIs for creating OsResults.