### PR TITLE
Life cycle of temp OsSharedRealm in callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added missing `toString()` for the implementation of `OrderedCollectionChangeSet`.
 * Sync queries are evaluated immediately to solve the performance issue when the query results are huge, `RealmResults.size()` takes too long time (#5387).
+* Close the temporary Realm instances properly during construction to avoid `IllegalStateException` when delete Realm in the catch block (#5570).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Added missing `toString()` for the implementation of `OrderedCollectionChangeSet`.
 * Sync queries are evaluated immediately to solve the performance issue when the query results are huge, `RealmResults.size()` takes too long time (#5387).
-* Close the temporary Realm instances properly during construction to avoid `IllegalStateException` when delete Realm in the catch block (#5570).
+* Correctly close the Realm instance if an exception was thrown while opening it. This avoids `IllegalStateException` when deleting the Realm in the catch block (#5570).
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -110,7 +110,6 @@ import io.realm.objectid.NullPrimaryKey;
 import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.rule.TestRealmConfigurationFactory;
-import io.realm.util.ExceptionHolder;
 import io.realm.util.RealmThread;
 
 import static io.realm.TestHelper.testNoObjectFound;
@@ -4465,6 +4464,30 @@ public class RealmTests {
             realm = Realm.getInstance(config);
             fail();
         } catch (RealmMigrationNeededException ignored) {
+        }
+    }
+
+    // https://github.com/realm/realm-java/issues/5570
+    @Test
+    public void getInstance_migrationExceptionThrows_migrationBlockDefiend_realmInstancesShouldBeClosed() {
+        RealmConfiguration config = configFactory.createConfigurationBuilder()
+                .name("readonly.realm")
+                .schema(StringOnlyReadOnly.class, AllJavaTypes.class)
+                .schemaVersion(2)
+                .assetFile("readonly.realm")
+                .migration(new RealmMigration() {
+                    @Override
+                    public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+                    }
+                })
+                .build();
+
+        try {
+            realm = Realm.getInstance(config);
+            fail();
+        } catch (RealmMigrationNeededException ignored) {
+            // No Realm instance should be opened at this time.
+            Realm.deleteRealm(config);
         }
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -155,10 +155,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeSetSchemaConfi
                                               reinterpret_cast<jlong>(new_shared_realm_ptr), config_global.get(), obj,
                                               old_realm->schema_version());
                 });
-                // Close the OsSharedRealm. Otherwise it will only be closed when the Java OsSharedRealm gets GCed. And
-                // that will be too late.
-                TERMINATE_JNI_IF_JAVA_EXCEPTION_OCCURRED(
-                    env, [&new_shared_realm_ptr]() { (*new_shared_realm_ptr)->close(); });
+                TERMINATE_JNI_IF_JAVA_EXCEPTION_OCCURRED(env, nullptr);
             };
         }
         else {
@@ -230,10 +227,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeSetInitializat
                                               reinterpret_cast<jlong>(new_shared_realm_ptr), config_global_ref.get(),
                                               obj);
                 });
-                // Close the OsSharedRealm. Otherwise it will only be closed when the Java OsSharedRealm gets GCed. And
-                // that will be too late.
-                TERMINATE_JNI_IF_JAVA_EXCEPTION_OCCURRED(
-                    env, [&new_shared_realm_ptr]() { (*new_shared_realm_ptr)->close(); });
+                TERMINATE_JNI_IF_JAVA_EXCEPTION_OCCURRED(env, nullptr);
             };
         }
         else {

--- a/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
@@ -160,6 +160,14 @@ public final class OsSharedRealm implements Closeable, NativeObject {
     // JNI will only hold a weak global ref to this.
     public final RealmNotifier realmNotifier;
     public final Capabilities capabilities;
+    // For the Java callbacks during constructing in Object Store, some temporary OsSharedRealm objects need to be
+    // created as the parameter of the callback. The native pointers of those temp OsSharedRealm objects have to be
+    // valid during the whole life cycle of the Java object. The living native pointers still hold a ref-count to the
+    // SharedRealm which means the SharedRealm won't be closed automatically if there is any exception throws during
+    // construction. GC will clear them later, but that would be too late. So we are tracking the temp OsSharedRealm
+    // during the construction stage and manually close them if exception throws.
+    private final static List<OsSharedRealm> sharedRealmsUnderConstruction = new CopyOnWriteArrayList<OsSharedRealm>();
+    private final List<OsSharedRealm> tempSharedRealmsForCallback = new ArrayList<OsSharedRealm>();
 
     private final List<WeakReference<PendingRow>> pendingRows = new CopyOnWriteArrayList<>();
     // Package protected for testing
@@ -169,10 +177,25 @@ public final class OsSharedRealm implements Closeable, NativeObject {
         Capabilities capabilities = new AndroidCapabilities();
         RealmNotifier realmNotifier = new AndroidRealmNotifier(this, capabilities);
 
-        this.nativePtr = nativeGetSharedRealm(osRealmConfig.getNativePtr(), realmNotifier);
+        // SharedRealms under constructions are identified by the Context.
+        this.context = osRealmConfig.getContext();
+        sharedRealmsUnderConstruction.add(this);
+        try {
+            this.nativePtr = nativeGetSharedRealm(osRealmConfig.getNativePtr(), realmNotifier);
+        } catch (Throwable t) {
+            // The SharedRealm instances have to be closed before throw.
+            for (OsSharedRealm sharedRealm: tempSharedRealmsForCallback) {
+                if (!sharedRealm.isClosed()) {
+                    sharedRealm.close();
+                }
+            }
+            throw t;
+        } finally {
+            tempSharedRealmsForCallback.clear();
+            sharedRealmsUnderConstruction.remove(this);
+        }
         this.osRealmConfig = osRealmConfig;
         this.schemaInfo = new OsSchemaInfo(nativeGetSchemaInfo(nativePtr), this);
-        this.context = osRealmConfig.getContext();
         this.context.addReference(this);
 
         this.capabilities = capabilities;
@@ -198,6 +221,18 @@ public final class OsSharedRealm implements Closeable, NativeObject {
         // This instance should never need notifications.
         this.realmNotifier = null;
         nativeSetAutoRefresh(nativePtr, false);
+
+        boolean foundParentSharedRealm = false;
+        for (OsSharedRealm sharedRealm : sharedRealmsUnderConstruction) {
+            if (sharedRealm.context == osRealmConfig.getContext())  {
+                foundParentSharedRealm = true;
+                sharedRealm.tempSharedRealmsForCallback.add(this);
+                break;
+            }
+        }
+        if (!foundParentSharedRealm) {
+            throw new IllegalStateException("Cannot find the parent 'OsSharedRealm' which is under construction.");
+        }
     }
 
 


### PR DESCRIPTION
Every temp OsSharedRealm created during construction for the callbacks
have to be closed before the exception throws to users.
close #5570