### PR TITLE
Fixing Plugin Test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,14 @@ try {
                   }
                 }
 
+                stage('Gradle plugin tests') {
+                  try {
+                    gradle('gradle-plugin', 'check')
+                  } finally {
+                    storeJunitResults 'gradle-plugin/build/test-results/test/TEST-*.xml'
+                  }
+                }
+
                 stage('Static code analysis') {
                   try {
                     gradle('realm', 'findbugs pmd checkstyle')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,14 @@ try {
                   }
                 }
 
+                stage('Realm Transformer tests') {
+                  try {
+                    gradle('realm-transformer', 'check')
+                  } finally {
+                    storeJunitResults 'realm-transformer/build/test-results/test/TEST-*.xml'
+                  }
+                }
+
                 stage('Static code analysis') {
                   try {
                     gradle('realm', 'findbugs pmd checkstyle')

--- a/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
+++ b/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
@@ -16,6 +16,8 @@
 
 package io.realm.gradle
 
+import io.realm.transformer.RealmTransformer
+
 import com.android.build.api.transform.Transform
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -30,7 +32,6 @@ import org.junit.Before
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 import static org.junit.Assert.fail
 
@@ -40,13 +41,13 @@ class PluginTest {
     private String currentVersion
 
     @Before
-    public void setUp() {
+    void setUp() {
         project = ProjectBuilder.builder().build()
         currentVersion = new File("../version.txt").text.trim()
     }
 
     @Test
-    public void pluginAddsRightDependencies() {
+    void pluginAddsRightDependencies() {
         project.buildscript {
             repositories {
                 mavenLocal()
@@ -62,8 +63,6 @@ class PluginTest {
         project.apply plugin: 'com.android.application'
         project.apply plugin: 'realm-android'
 
-        assertTrue(containsUrl(project.repositories, 'https://jitpack.io'))
-
         assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-android-library', currentVersion))
         assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-annotations', currentVersion))
 
@@ -71,7 +70,7 @@ class PluginTest {
     }
 
     @Test
-    public void pluginFailsWithoutAndroidPlugin() {
+    void pluginFailsWithoutAndroidPlugin() {
         project.buildscript {
             repositories {
                 mavenLocal()
@@ -107,7 +106,7 @@ class PluginTest {
         def configurationContainerField = DefaultDependencyHandler.class.getDeclaredField("configurationContainer")
         configurationContainerField.setAccessible(true)
         def configurationContainer = configurationContainerField.get(dependencies)
-        def compileConfiguration = configurationContainer.findByName("compile")
+        def compileConfiguration = configurationContainer.findByName("api")
 
         def DependencySet dependencySet = compileConfiguration.getDependencies()
         for (Dependency dependency in dependencySet) {

--- a/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
+++ b/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
@@ -63,7 +63,7 @@ class PluginTest {
         project.apply plugin: 'com.android.application'
         project.apply plugin: 'realm-android'
 
-        assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-android-library', currentVersion))
+        assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-android-libraryBUG', currentVersion))
         assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-annotations', currentVersion))
 
         assertTrue(containsTransform(project.android.transforms, RealmTransformer.class))

--- a/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
+++ b/gradle-plugin/src/test/groovy/io/realm/gradle/PluginTest.groovy
@@ -63,7 +63,7 @@ class PluginTest {
         project.apply plugin: 'com.android.application'
         project.apply plugin: 'realm-android'
 
-        assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-android-libraryBUG', currentVersion))
+        assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-android-library', currentVersion))
         assertTrue(containsDependency(project.dependencies, 'io.realm', 'realm-annotations', currentVersion))
 
         assertTrue(containsTransform(project.android.transforms, RealmTransformer.class))


### PR DESCRIPTION
The Gradle plugin tests are not part of the CI checks, so for instance `jitpack` dependency was removed in https://github.com/realm/realm-java/commit/d00ddcaa4a2ab7d86616b5c01fcd28df077ceeba#diff-fbc37097ca151e18a6db623e59ebdba8 which should break the tests. 

- [x] Fixing tests
- [x] Adding the plugin test as part of CI checks
<img width="715" alt="screen shot 2018-01-10 at 18 27 40" src="https://user-images.githubusercontent.com/1793238/34790053-63bc2f84-f638-11e7-9a93-03341851bfea.png">

- [x] Adding the Transformer tests as part of CI checks
<img width="675" alt="screen shot 2018-01-10 at 18 58 41" src="https://user-images.githubusercontent.com/1793238/34790063-6e06245e-f638-11e7-8f48-1e292ee4e360.png">
