### PR TITLE
downgrade javassist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.3.3 (YYYY-MM-DD)
+
+### Internal
+
+* Downgrade JavaAssist to 3.21.0-GA to fix an issue with a `ClassNotFoundException` at runtime (#5641).
+
+
 ## 4.3.2 (2018-01-17)
 
 ### Bug Fixes

--- a/realm-transformer/build.gradle
+++ b/realm-transformer/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compile gradleApi()
     compile "io.realm:realm-annotations:${version}"
     compileOnly 'com.android.tools.build:gradle:3.1.0-alpha06'
-    compile 'org.javassist:javassist:3.22.0-GA'
+    compile 'org.javassist:javassist:3.21.0-GA'
 
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude module: 'groovy-all'


### PR DESCRIPTION
We have a [reproducible](https://github.com/realm/realm-java/issues/5641#issuecomment-358617948) crash at runtime (`ClassNotFoundException`)  when a certain setup uses Realm and SLF4J https://github.com/realm/realm-java/issues/5641. 

Downgrading to Javassist `3_21_0_ga` solved the issue, still, need to investigate what changed between https://github.com/jboss-javassist/javassist/compare/rel_3_21_0_ga...rel_3_22_0_ga that causes the issue and why 