### PR TITLE
Remove getFieldNames from proxy classes

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -144,7 +144,6 @@ public class RealmProxyClassGenerator {
         emitGetExpectedObjectSchemaInfo(writer);
         emitCreateColumnInfoMethod(writer);
         emitGetSimpleClassNameMethod(writer);
-        emitGetFieldNamesMethod(writer);
         emitCreateOrUpdateUsingJsonObject(writer);
         emitCreateUsingJsonStream(writer);
         emitCopyOrUpdateMethod(writer);
@@ -240,15 +239,6 @@ public class RealmProxyClassGenerator {
         writer.emitEmptyLine()
                 .emitField("OsObjectSchemaInfo", "expectedObjectSchemaInfo",
                 EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL), "createExpectedObjectSchemaInfo()");
-
-        writer.emitField("List<String>", "FIELD_NAMES", EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL));
-        writer.beginInitializer(true)
-            .emitStatement("List<String> fieldNames = new ArrayList<String>(%s)", metadata.getFields().size());
-            for (VariableElement field : metadata.getFields()) {
-                writer.emitStatement("fieldNames.add(\"%s\")", field.getSimpleName().toString());
-            }
-        writer.emitStatement("FIELD_NAMES = Collections.unmodifiableList(fieldNames)")
-            .endInitializer();
     }
     //@formatter:on
 
@@ -835,15 +825,6 @@ public class RealmProxyClassGenerator {
     private void emitGetSimpleClassNameMethod(JavaWriter writer) throws IOException {
         writer.beginMethod("String", "getSimpleClassName", EnumSet.of(Modifier.PUBLIC, Modifier.STATIC))
                 .emitStatement("return \"%s\"", simpleClassName)
-                .endMethod()
-                .emitEmptyLine();
-    }
-    //@formatter:on
-
-    //@formatter:off
-    private void emitGetFieldNamesMethod(JavaWriter writer) throws IOException {
-        writer.beginMethod("List<String>", "getFieldNames", EnumSet.of(Modifier.PUBLIC, Modifier.STATIC))
-                .emitStatement("return FIELD_NAMES")
                 .endMethod()
                 .emitEmptyLine();
     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyMediatorGenerator.java
@@ -98,7 +98,6 @@ public class RealmProxyMediatorGenerator {
         emitFields(writer);
         emitGetExpectedObjectSchemaInfoMap(writer);
         emitCreateColumnInfoMethod(writer);
-        emitGetFieldNamesMethod(writer);
         emitGetSimpleClassNameMethod(writer);
         emitNewInstanceMethod(writer);
         emitGetClassModelList(writer);
@@ -161,24 +160,6 @@ public class RealmProxyMediatorGenerator {
             public void emitStatement(int i, JavaWriter writer) throws IOException {
                 writer.emitStatement("return %s.createColumnInfo(schemaInfo)",
                         qualifiedProxyClasses.get(i));
-            }
-        }, writer);
-        writer.endMethod();
-        writer.emitEmptyLine();
-    }
-
-    private void emitGetFieldNamesMethod(JavaWriter writer) throws IOException {
-        writer.emitAnnotation("Override");
-        writer.beginMethod(
-                "List<String>",
-                "getFieldNames",
-                EnumSet.of(Modifier.PUBLIC),
-                "Class<? extends RealmModel>", "clazz"
-        );
-        emitMediatorShortCircuitSwitch(new ProxySwitchStatement() {
-            @Override
-            public void emitStatement(int i, JavaWriter writer) throws IOException {
-                writer.emitStatement("return %s.getFieldNames()", qualifiedProxyClasses.get(i));
             }
         }, writer);
         writer.endMethod();

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/AllTypesRealmProxy.java
@@ -121,31 +121,6 @@ public class AllTypesRealmProxy extends some.test.AllTypes
     }
 
     private static final OsObjectSchemaInfo expectedObjectSchemaInfo = createExpectedObjectSchemaInfo();
-    private static final List<String> FIELD_NAMES;
-    static {
-        List<String> fieldNames = new ArrayList<String>(20);
-        fieldNames.add("columnString");
-        fieldNames.add("columnLong");
-        fieldNames.add("columnFloat");
-        fieldNames.add("columnDouble");
-        fieldNames.add("columnBoolean");
-        fieldNames.add("columnDate");
-        fieldNames.add("columnBinary");
-        fieldNames.add("columnMutableRealmInteger");
-        fieldNames.add("columnObject");
-        fieldNames.add("columnRealmList");
-        fieldNames.add("columnStringList");
-        fieldNames.add("columnBinaryList");
-        fieldNames.add("columnBooleanList");
-        fieldNames.add("columnLongList");
-        fieldNames.add("columnIntegerList");
-        fieldNames.add("columnShortList");
-        fieldNames.add("columnByteList");
-        fieldNames.add("columnDoubleList");
-        fieldNames.add("columnFloatList");
-        fieldNames.add("columnDateList");
-        FIELD_NAMES = Collections.unmodifiableList(fieldNames);
-    }
 
     private AllTypesColumnInfo columnInfo;
     private ProxyState<some.test.AllTypes> proxyState;
@@ -891,10 +866,6 @@ public class AllTypesRealmProxy extends some.test.AllTypes
 
     public static String getSimpleClassName() {
         return "AllTypes";
-    }
-
-    public static List<String> getFieldNames() {
-        return FIELD_NAMES;
     }
 
     @SuppressWarnings("cast")

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/BooleansRealmProxy.java
@@ -71,15 +71,6 @@ public class BooleansRealmProxy extends some.test.Booleans
     }
 
     private static final OsObjectSchemaInfo expectedObjectSchemaInfo = createExpectedObjectSchemaInfo();
-    private static final List<String> FIELD_NAMES;
-    static {
-        List<String> fieldNames = new ArrayList<String>(4);
-        fieldNames.add("done");
-        fieldNames.add("isReady");
-        fieldNames.add("mCompleted");
-        fieldNames.add("anotherBoolean");
-        FIELD_NAMES = Collections.unmodifiableList(fieldNames);
-    }
 
     private BooleansColumnInfo columnInfo;
     private ProxyState<some.test.Booleans> proxyState;
@@ -209,10 +200,6 @@ public class BooleansRealmProxy extends some.test.Booleans
 
     public static String getSimpleClassName() {
         return "Booleans";
-    }
-
-    public static List<String> getFieldNames() {
-        return FIELD_NAMES;
     }
 
     @SuppressWarnings("cast")

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/NullTypesRealmProxy.java
@@ -182,52 +182,6 @@ public class NullTypesRealmProxy extends some.test.NullTypes
     }
 
     private static final OsObjectSchemaInfo expectedObjectSchemaInfo = createExpectedObjectSchemaInfo();
-    private static final List<String> FIELD_NAMES;
-    static {
-        List<String> fieldNames = new ArrayList<String>(41);
-        fieldNames.add("fieldStringNotNull");
-        fieldNames.add("fieldStringNull");
-        fieldNames.add("fieldBooleanNotNull");
-        fieldNames.add("fieldBooleanNull");
-        fieldNames.add("fieldBytesNotNull");
-        fieldNames.add("fieldBytesNull");
-        fieldNames.add("fieldByteNotNull");
-        fieldNames.add("fieldByteNull");
-        fieldNames.add("fieldShortNotNull");
-        fieldNames.add("fieldShortNull");
-        fieldNames.add("fieldIntegerNotNull");
-        fieldNames.add("fieldIntegerNull");
-        fieldNames.add("fieldLongNotNull");
-        fieldNames.add("fieldLongNull");
-        fieldNames.add("fieldFloatNotNull");
-        fieldNames.add("fieldFloatNull");
-        fieldNames.add("fieldDoubleNotNull");
-        fieldNames.add("fieldDoubleNull");
-        fieldNames.add("fieldDateNotNull");
-        fieldNames.add("fieldDateNull");
-        fieldNames.add("fieldObjectNull");
-        fieldNames.add("fieldStringListNotNull");
-        fieldNames.add("fieldStringListNull");
-        fieldNames.add("fieldBinaryListNotNull");
-        fieldNames.add("fieldBinaryListNull");
-        fieldNames.add("fieldBooleanListNotNull");
-        fieldNames.add("fieldBooleanListNull");
-        fieldNames.add("fieldLongListNotNull");
-        fieldNames.add("fieldLongListNull");
-        fieldNames.add("fieldIntegerListNotNull");
-        fieldNames.add("fieldIntegerListNull");
-        fieldNames.add("fieldShortListNotNull");
-        fieldNames.add("fieldShortListNull");
-        fieldNames.add("fieldByteListNotNull");
-        fieldNames.add("fieldByteListNull");
-        fieldNames.add("fieldDoubleListNotNull");
-        fieldNames.add("fieldDoubleListNull");
-        fieldNames.add("fieldFloatListNotNull");
-        fieldNames.add("fieldFloatListNull");
-        fieldNames.add("fieldDateListNotNull");
-        fieldNames.add("fieldDateListNull");
-        FIELD_NAMES = Collections.unmodifiableList(fieldNames);
-    }
 
     private NullTypesColumnInfo columnInfo;
     private ProxyState<some.test.NullTypes> proxyState;
@@ -1751,10 +1705,6 @@ public class NullTypesRealmProxy extends some.test.NullTypes
 
     public static String getSimpleClassName() {
         return "NullTypes";
-    }
-
-    public static List<String> getFieldNames() {
-        return FIELD_NAMES;
     }
 
     @SuppressWarnings("cast")

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/RealmDefaultModuleMediator.java
@@ -48,16 +48,6 @@ class DefaultRealmModuleMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<String> getFieldNames(Class<? extends RealmModel> clazz) {
-        checkClass(clazz);
-
-        if (clazz.equals(some.test.AllTypes.class)) {
-            return io.realm.AllTypesRealmProxy.getFieldNames();
-        }
-        throw getMissingProxyClassException(clazz);
-    }
-
-    @Override
     public String getSimpleClassNameImpl(Class<? extends RealmModel> clazz) {
         checkClass(clazz);
 

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/SimpleRealmProxy.java
@@ -65,13 +65,6 @@ public class SimpleRealmProxy extends some.test.Simple
     }
 
     private static final OsObjectSchemaInfo expectedObjectSchemaInfo = createExpectedObjectSchemaInfo();
-    private static final List<String> FIELD_NAMES;
-    static {
-        List<String> fieldNames = new ArrayList<String>(2);
-        fieldNames.add("name");
-        fieldNames.add("age");
-        FIELD_NAMES = Collections.unmodifiableList(fieldNames);
-    }
 
     private SimpleColumnInfo columnInfo;
     private ProxyState<some.test.Simple> proxyState;
@@ -163,10 +156,6 @@ public class SimpleRealmProxy extends some.test.Simple
 
     public static String getSimpleClassName() {
         return "Simple";
-    }
-
-    public static List<String> getFieldNames() {
-        return FIELD_NAMES;
     }
 
     @SuppressWarnings("cast")

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -61,14 +61,6 @@ public abstract class RealmProxyMediator {
     public abstract ColumnInfo createColumnInfo(Class<? extends RealmModel> clazz, OsSchemaInfo osSchemaInfo);
 
     /**
-     * Returns a map of non-obfuscated object field names to their internal Realm name.
-     *
-     * @param clazz the {@link RealmObject} class reference.
-     * @return The simple name of an RealmObject class (before it has been obfuscated).
-     */
-    public abstract List<String> getFieldNames(Class<? extends RealmModel> clazz);
-
-    /**
      * Returns the name that Realm should use for all its internal tables. This is the un-obfuscated simple name of the
      * class.
      *

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -77,12 +77,6 @@ public class CompositeMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<String> getFieldNames(Class<? extends RealmModel> clazz) {
-        RealmProxyMediator mediator = getMediator(clazz);
-        return mediator.getFieldNames(clazz);
-    }
-
-    @Override
     protected String getSimpleClassNameImpl(Class<? extends RealmModel> clazz) {
         RealmProxyMediator mediator = getMediator(clazz);
         return mediator.getSimpleClassName(clazz);

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -92,12 +92,6 @@ public class FilterableMediator extends RealmProxyMediator {
     }
 
     @Override
-    public List<String> getFieldNames(Class<? extends RealmModel> clazz) {
-        checkSchemaHasClass(clazz);
-        return originalMediator.getFieldNames(clazz);
-    }
-
-    @Override
     protected String getSimpleClassNameImpl(Class<? extends RealmModel> clazz) {
         checkSchemaHasClass(clazz);
         return originalMediator.getSimpleClassName(clazz);


### PR DESCRIPTION
These are no longer used since we moved to the Object Store schema concept. I found this while working on #5280 