### PR TITLE
Fixes #5677

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug Fixes
 
 * Added missing `RealmQuery.oneOf()` for Kotlin that accepts non-nullable types (#5717).
-* [ObjectServer] fixed an issue preventing sync to resume when the network is back (#5677).
+* [ObjectServer] Fixed an issue preventing sync to resume when the network is back (#5677).
 
 ## 4.3.3 (2018-01-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug Fixes
 
 * Added missing `RealmQuery.oneOf()` for Kotlin that accepts non-nullable types (#5717).
-
+* [ObjectServer] fixed an issue preventing sync to resume when the network is back (#5677).
 
 ## 4.3.3 (2018-01-19)
 


### PR DESCRIPTION
- There was an issue with the `onGoingAccessTokenQuery` logic that causes the call to obtain an `access_token` ignored if previously an attempt was made offline.
- Removed session network listener in `SyncSession` since it's redundant with the `SyncManager ` one 