### PR TITLE
Support types in other compilation units

### DIFF
--- a/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/model/Pig.java
+++ b/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/model/Pig.java
@@ -16,11 +16,17 @@
 
 package io.realm.examples.appmodules.model;
 
+import io.realm.RealmList;
 import io.realm.RealmObject;
+import io.realm.examples.librarymodules.model.Dog;
 
 public class Pig extends RealmObject {
 
     private String name;
+
+    // It is possible for model classes to to reference library model classes as long
+    // as they all are included in the schema when opening the Realm.
+    private RealmList<Dog> afraidOf = new RealmList<>();
 
     public String getName() {
         return name;

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ModuleMetaData.java
@@ -102,19 +102,19 @@ public class ModuleMetaData {
             }
 
             // Check that allClasses and classes are not set at the same time
-            RealmModule moduleAnnoation = classElement.getAnnotation(RealmModule.class);
+            RealmModule moduleAnnotation = classElement.getAnnotation(RealmModule.class);
             Utils.note("Processing module " + classSimpleName);
-            if (moduleAnnoation.allClasses() && hasCustomClassList(classElement)) {
+            if (moduleAnnotation.allClasses() && hasCustomClassList(classElement)) {
                 Utils.error("Setting @RealmModule(allClasses=true) will override @RealmModule(classes={...}) in " + classSimpleName);
                 return false;
             }
 
             // Validate that naming policies are correctly configured.
-            if (!validateNamingPolicies(globalModuleInfo, classSpecificModuleInfo, (TypeElement) classElement, moduleAnnoation)) {
+            if (!validateNamingPolicies(globalModuleInfo, classSpecificModuleInfo, (TypeElement) classElement, moduleAnnotation)) {
                 return false;
             }
 
-            moduleAnnotations.put(((TypeElement) classElement).getQualifiedName().toString(), moduleAnnoation);
+            moduleAnnotations.put(((TypeElement) classElement).getQualifiedName().toString(), moduleAnnotation);
         }
 
         return true;
@@ -236,7 +236,22 @@ public class ModuleMetaData {
 
         // Check that app and library modules are not mixed
         if (modules.size() > 0 && libraryModules.size() > 0) {
-            Utils.error("Normal modules and library modules cannot be mixed in the same project");
+            StringBuilder sb = new StringBuilder();
+            sb.append("Normal modules and library modules cannot be mixed in the same project.");
+            sb.append('\n');
+            sb.append("Normal module(s):\n");
+            for (String module : modules.keySet()) {
+                sb.append("  ");
+                sb.append(module);
+                sb.append('\n');
+            }
+            sb.append("Library module(s):\n");
+            for (String module : libraryModules.keySet()) {
+                sb.append("  ");
+                sb.append(module);
+                sb.append('\n');
+            }
+            Utils.error(sb.toString());
             return false;
         }
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProcessor.java
@@ -209,7 +209,7 @@ public class RealmProcessor extends AbstractProcessor {
         return moduleMetaData.preProcess(roundEnv.getElementsAnnotatedWith(RealmModule.class));
     }
 
-    // Returns true of modules where succesfully validated, false otherwise
+    // Returns true of modules where successfully validated, false otherwise
     private boolean postProcessModules() {
         return moduleMetaData.postProcess(classCollection);
     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -745,14 +745,14 @@ public class RealmProxyClassGenerator {
                 }
                 case OBJECT: {
                     String fieldTypeQualifiedName = Utils.getFieldTypeQualifiedName(field);
-                    String internalClassName = classCollection.getClassFromQualifiedName(fieldTypeQualifiedName).getInternalClassName();
+                    String internalClassName = Utils.getReferencedTypeInternalClassName(fieldTypeQualifiedName, classCollection);
                     writer.emitStatement("builder.addPersistedLinkProperty(\"%s\", RealmFieldType.OBJECT, \"%s\")",
                             fieldName, internalClassName);
                     break;
                 }
                 case LIST: {
                     String genericTypeQualifiedName = Utils.getGenericTypeQualifiedName(field);
-                    String internalClassName = classCollection.getClassFromQualifiedName(genericTypeQualifiedName).getInternalClassName(); // FIXME support for raw data
+                    String internalClassName = Utils.getReferencedTypeInternalClassName(genericTypeQualifiedName, classCollection);
                     writer.emitStatement("builder.addPersistedLinkProperty(\"%s\", RealmFieldType.LIST, \"%s\")",
                             fieldName, internalClassName);
                     break;
@@ -795,6 +795,8 @@ public class RealmProxyClassGenerator {
             }
         }
         for (Backlink backlink: metadata.getBacklinkFields()) {
+            // Backlinks can only be created between classes in the current round of annotation processing
+            // as the forward link cannot be created unless you know the type already.
             ClassMetaData sourceClass = classCollection.getClassFromQualifiedName(backlink.getSourceClass());
             String targetField = backlink.getTargetField(); // Only in the model, so no internal name exists
             String internalSourceField = sourceClass.getInternalFieldName(backlink.getSourceField());
@@ -838,6 +840,17 @@ public class RealmProxyClassGenerator {
                 .emitStatement("return \"%s\"", internalClassName)
                 .endMethod()
                 .emitEmptyLine();
+
+        // Helper class for the annotation processor so it can access the internal class name
+        // without needing to load the parent class (which we cannot do as it transitively loads
+        // native code, which cannot be loaded on the JVM).
+        writer.beginType(
+                "ClassNameHelper",                       // full qualified name of the item to generate
+                "class",                                                  // the type of the item
+                EnumSet.of(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)); // modifiers to apply
+        writer.emitField("String", "INTERNAL_CLASS_NAME", EnumSet.of(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL), "\""+ internalClassName+"\"");
+        writer.endType();
+        writer.emitEmptyLine();
     }
     //@formatter:on
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -745,15 +745,15 @@ public class RealmProxyClassGenerator {
                 }
                 case OBJECT: {
                     String fieldTypeQualifiedName = Utils.getFieldTypeQualifiedName(field);
-                    String internalClassName = Utils.getReferencedTypeInternalClassName(fieldTypeQualifiedName, classCollection);
-                    writer.emitStatement("builder.addPersistedLinkProperty(\"%s\", RealmFieldType.OBJECT, \"%s\")",
+                    String internalClassName = Utils.getReferencedTypeInternalClassNameStatement(fieldTypeQualifiedName, classCollection);
+                    writer.emitStatement("builder.addPersistedLinkProperty(\"%s\", RealmFieldType.OBJECT, %s)",
                             fieldName, internalClassName);
                     break;
                 }
                 case LIST: {
                     String genericTypeQualifiedName = Utils.getGenericTypeQualifiedName(field);
-                    String internalClassName = Utils.getReferencedTypeInternalClassName(genericTypeQualifiedName, classCollection);
-                    writer.emitStatement("builder.addPersistedLinkProperty(\"%s\", RealmFieldType.LIST, \"%s\")",
+                    String internalClassName = Utils.getReferencedTypeInternalClassNameStatement(genericTypeQualifiedName, classCollection);
+                    writer.emitStatement("builder.addPersistedLinkProperty(\"%s\", RealmFieldType.LIST, %s)",
                             fieldName, internalClassName);
                     break;
                 }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
@@ -1,5 +1,8 @@
 package io.realm.processor;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 
 import javax.annotation.processing.Messager;
@@ -19,11 +22,10 @@ import javax.tools.Diagnostic;
 
 import io.realm.annotations.RealmNamingPolicy;
 import io.realm.processor.nameconverter.CamelCaseConverter;
+import io.realm.processor.nameconverter.IdentityConverter;
 import io.realm.processor.nameconverter.LowerCaseWithSeparatorConverter;
 import io.realm.processor.nameconverter.NameConverter;
-import io.realm.processor.nameconverter.IdentityConverter;
 import io.realm.processor.nameconverter.PascalCaseConverter;
-
 
 /**
  * Utility methods working with the Realm processor.
@@ -355,4 +357,52 @@ public class Utils {
         }
     }
 
+    /**
+     * Tries to find the internal class name for a referenced type. In model classes this can
+     * happen with either direct object references or using `RealmList` or `RealmResults`.
+     * <p>
+     * This name is required by schema builders that operate on internal names and not the public ones.
+     * <p>
+     * Finding the internal name is easy if the referenced type is included in the current round
+     * of annotation processing. In that case the internal name was also calculated in the same round
+     * <p>
+     * If the referenced type was already compiled, e.g being included from library, then we need
+     * to get the name from the proxy class. Fortunately ProGuard should not have obfuscated any
+     * class files at this point, meaning we can look it up dynamically.
+     * <p>
+     * If a name is looked up using the class loader, it also means that developers need to
+     * combine a library and app module of model classes at runtime in the RealmConfiguration, but
+     * this should be a valid use case.
+     *
+     * @param qualifiedClassName type to lookup the internal name for.
+     * @param classCollection collection of classes found in the current round of annotation processing.
+     * @throws IllegalArgumentException If the internal name could not be looked up
+     * @return
+     */
+    public static String getReferencedTypeInternalClassName(String qualifiedClassName, ClassCollection classCollection) {
+
+        // Attempt to lookup internal name in current round
+        if (classCollection.containsQualifiedClass(qualifiedClassName)) {
+            ClassMetaData metadata = classCollection.getClassFromQualifiedName(qualifiedClassName);
+            return metadata.getInternalClassName();
+        }
+
+        // Attempt to lookup internal name in a proxy class using the ClassLoader
+
+        // FIXME: There is indication that loading the class might not work. Most likely because
+        // the compile time classpath for the app is not available to the annotation processor.
+        // This has not been verified yet. For now work around
+        // the case we care about, namely the `__Permission` class.
+        if (qualifiedClassName.equals("io.realm.sync.permissions.Permission")) {
+            return "__Permission";
+        }
+
+        try {
+            Class<?> c = Class.forName("io.realm." + Utils.getProxyClassName(qualifiedClassName) + "$ClassNameHelper");
+            Field field = c.getField("INTERNAL_CLASS_NAME");
+            return (String) field.get(null);
+        } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException e) {
+            throw new IllegalStateException("Could not get the internal class name for: " + qualifiedClassName, e);
+        }
+    }
 }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.java
@@ -390,15 +390,16 @@ public class Utils {
         }
 
         // If we cannot find the name in the current processor round, we have to defer resolving the
-        // name to runtime as we cannot load the content e been obfuscated, which means we have no easy way of finding them.
-        //
+        // name to runtime. The reason being that proxy classes in libraries on the classpath
+        // might already have been obfuscated, which means we have no easy way of finding them.
+        // 
         // Doing it this way unfortunately means that if the class is not on the apps classpath
         // a rather obscure class-not-found exception will be thrown, but since this is probably
         // a very niche use case that is acceptable for now.
         //
         // TODO: We could probably create an internal annotation like `@InternalName("__Permission")`
         // which should make it possible for the annotation processor to read the value from the
-        // proxy class, even for files in other jar files.  
+        // proxy class, even for files in other jar files.
         return "io.realm." + Utils.getProxyClassName(qualifiedClassName) + ".ClassNameHelper.INTERNAL_CLASS_NAME";
     }
 }

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_AllTypesRealmProxy.java
@@ -868,6 +868,10 @@ public class some_test_AllTypesRealmProxy extends some.test.AllTypes
         return "AllTypes";
     }
 
+    public static final class ClassNameHelper {
+        public static final String INTERNAL_CLASS_NAME = "AllTypes";
+    }
+
     @SuppressWarnings("cast")
     public static some.test.AllTypes createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_BooleansRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_BooleansRealmProxy.java
@@ -202,6 +202,10 @@ public class some_test_BooleansRealmProxy extends some.test.Booleans
         return "Booleans";
     }
 
+    public static final class ClassNameHelper {
+        public static final String INTERNAL_CLASS_NAME = "Booleans";
+    }
+
     @SuppressWarnings("cast")
     public static some.test.Booleans createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NamePolicyMixedClassSettingsRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NamePolicyMixedClassSettingsRealmProxy.java
@@ -166,6 +166,10 @@ public class some_test_NamePolicyMixedClassSettingsRealmProxy extends some.test.
         return "customName";
     }
 
+    public static final class ClassNameHelper {
+        public static final String INTERNAL_CLASS_NAME = "customName";
+    }
+
     @SuppressWarnings("cast")
     public static some.test.NamePolicyMixedClassSettings createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NamePolicyModuleDefaultsRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NamePolicyModuleDefaultsRealmProxy.java
@@ -166,6 +166,10 @@ public class some_test_NamePolicyModuleDefaultsRealmProxy extends some.test.Name
         return "NamePolicyModuleDefaults";
     }
 
+    public static final class ClassNameHelper {
+        public static final String INTERNAL_CLASS_NAME = "NamePolicyModuleDefaults";
+    }
+
     @SuppressWarnings("cast")
     public static some.test.NamePolicyModuleDefaults createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NullTypesRealmProxy.java
@@ -1707,6 +1707,10 @@ public class some_test_NullTypesRealmProxy extends some.test.NullTypes
         return "NullTypes";
     }
 
+    public static final class ClassNameHelper {
+        public static final String INTERNAL_CLASS_NAME = "NullTypes";
+    }
+
     @SuppressWarnings("cast")
     public static some.test.NullTypes createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_SimpleRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_SimpleRealmProxy.java
@@ -158,6 +158,10 @@ public class some_test_SimpleRealmProxy extends some.test.Simple
         return "Simple";
     }
 
+    public static final class ClassNameHelper {
+        public static final String INTERNAL_CLASS_NAME = "Simple";
+    }
+
     @SuppressWarnings("cast")
     public static some.test.Simple createOrUpdateUsingJsonObject(Realm realm, JSONObject json, boolean update)
             throws JSONException {


### PR DESCRIPTION
With the support for changing the internal names, we can no longer infer the name from the reference type itself. This turned out to cause problems if the referenced type was in another compilation unit. This PR splits out the fix from https://github.com/realm/realm-java/pull/5729 as the functionality was originally merged to master (but has not yet been released).

Not Changelog as the functionality has not yet been released.

The functionality is being tested in the `moduleExample` where the app now has a reference to a library module class.