### PR TITLE
Support clearing data using Partial Sync

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/util/SyncTestUtils.java
@@ -25,7 +25,10 @@ import java.util.UUID;
 
 import io.realm.ErrorCode;
 import io.realm.ObjectServerError;
+import io.realm.Realm;
+import io.realm.SyncConfiguration;
 import io.realm.SyncManager;
+import io.realm.SyncSession;
 import io.realm.SyncUser;
 import io.realm.UserStore;
 import io.realm.internal.network.AuthenticateResponse;
@@ -124,5 +127,19 @@ public class SyncTestUtils {
         } catch (InvocationTargetException | IllegalAccessException e) {
             throw new AssertionError(e);
         }
+    }
+
+    // Fully synchronize a Realm with the server by making sure that all changes are uploaded
+    // and downloaded again.
+    public static void syncRealm(Realm realm) {
+        SyncConfiguration config = (SyncConfiguration) realm.getConfiguration();
+        SyncSession session = SyncManager.getSession(config);
+        try {
+            session.uploadAllLocalChanges();
+            session.downloadAllServerChanges();
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+        realm.refresh();
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -537,13 +537,17 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeSize(JNIEnv* env, job
     return static_cast<jlong>(TBL(nativeTablePtr)->size()); // noexcept
 }
 
-JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeClear(JNIEnv* env, jobject, jlong nativeTablePtr)
+JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeClear(JNIEnv* env, jobject, jlong nativeTablePtr, jboolean is_partial_realm)
 {
     if (!TABLE_VALID(env, TBL(nativeTablePtr))) {
         return;
     }
     try {
-        TBL(nativeTablePtr)->clear();
+        if (is_partial_realm) {
+            TBL(nativeTablePtr)->where().find_all().clear(RemoveMode::unordered);
+        } else {
+            TBL(nativeTablePtr)->clear();
+        }
     }
     CATCH_STD()
 }

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -611,8 +611,9 @@ abstract class BaseRealm implements Closeable {
      */
     public void deleteAll() {
         checkIfValid();
+        boolean isPartialRealm = sharedRealm.isPartial();
         for (RealmObjectSchema objectSchema : getSchema().getAll()) {
-            getSchema().getTable(objectSchema.getClassName()).clear();
+            getSchema().getTable(objectSchema.getClassName()).clear(isPartialRealm);
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -227,7 +227,7 @@ public class DynamicRealm extends BaseRealm {
     public void delete(String className) {
         checkIfValid();
         checkIfInTransaction();
-        schema.getTable(className).clear();
+        schema.getTable(className).clear(sharedRealm.isPartial());
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1586,7 +1586,7 @@ public class Realm extends BaseRealm {
      */
     public void delete(Class<? extends RealmModel> clazz) {
         checkIfValid();
-        schema.getTable(clazz).clear();
+        schema.getTable(clazz).clear(sharedRealm.isPartial());
     }
 
 

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -261,10 +261,13 @@ public class Table implements NativeObject {
 
     /**
      * Clears the table i.e., deleting all rows in the table.
+     *
+     * WARNING: This method is not supported by Partial Sync, use `findAll().deleteFromRealm`
+     * instead.
      */
-    public void clear() {
+    public void clear(boolean partialRealm) {
         checkImmutable();
-        nativeClear(nativePtr);
+        nativeClear(nativePtr, partialRealm);
     }
 
     // Column Information.
@@ -724,7 +727,7 @@ public class Table implements NativeObject {
 
     private native long nativeSize(long nativeTablePtr);
 
-    private native void nativeClear(long nativeTablePtr);
+    private native void nativeClear(long nativeTablePtr, boolean partialRealm);
 
     private native long nativeGetColumnCount(long nativeTablePtr);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -262,8 +262,7 @@ public class Table implements NativeObject {
     /**
      * Clears the table i.e., deleting all rows in the table.
      *
-     * WARNING: This method is not supported by Partial Sync, use `findAll().deleteFromRealm`
-     * instead.
+     * If using partial sync, this method will behave similarly to 'findAll().deleteFromRealm()'.
      */
     public void clear(boolean partialRealm) {
         checkImmutable();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/PartialSyncTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/PartialSyncTests.java
@@ -276,7 +276,7 @@ public class PartialSyncTests extends StandardIntegrationTest {
         Realm realm = getPartialRealm(user);
         looperThread.closeAfterTest(realm);
 
-        // Create test data and make it is uploaded to the server
+        // Create test data and make sure it is uploaded to the server
         RealmResults<PartialSyncObjectA> result = realm.where(PartialSyncObjectA.class).findAllAsync();
         realm.executeTransaction(r -> {
             r.createObject(PartialSyncObjectA.class).setString("ObjectA");


### PR DESCRIPTION
Fixes https://github.com/realm/realm-java/issues/5758

Partial Sync does not support the `clearTable` instruction. This fixes it. Due to performance concerns, this code path is only triggered for partially synchronized Realms. 

