### PR TITLE
getDefaultInstance with support for Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-* [ObjectServer] `Realm.getDefaultInstance()` now requires a user to be logged in and will automatically connect to the users remote Realm. This only applies if `syncEnabled = true` is set in Gradle.
+* [ObjectServer] `Realm.getDefaultInstance()` now requires a user to be logged in and will automatically connect to the user's remote Realm. This only applies if `syncEnabled = true` is set in Gradle.
 * The `OrderedCollectionChangeSet` parameter in `OrderedRealmCollectionChangeListener.onChange()` is no longer nullable. Use `changeSet.getState()` instead (#5619).
 * `realm.subscribeForObjects()` have been removed. Use `RealmQuery.findAllAsync(String subscriptionName)` and `RealmQuery.findAllAsync()` instead.
 * Removed previously deprecated `RealmQuery.findAllSorted()`, `RealmQuery.findAllSortedAsync()` `RealmQuery.distinct() and `RealmQuery.distinctAsync()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 ### Breaking Changes
 
+* [ObjectServer] `Realm.getDefaultInstance()` now requires a user to be logged in and will automatically connect to the users remote Realm. This only applies if `syncEnabled = true` is set in Gradle.
 * The `OrderedCollectionChangeSet` parameter in `OrderedRealmCollectionChangeListener.onChange()` is no longer nullable. Use `changeSet.getState()` instead (#5619).
 * `realm.subscribeForObjects()` have been removed. Use `RealmQuery.findAllAsync(String subscriptionName)` and `RealmQuery.findAllAsync()` instead.
 * Removed previously deprecated `RealmQuery.findAllSorted()`, `RealmQuery.findAllSortedAsync()` `RealmQuery.distinct() and `RealmQuery.distinctAsync()`.
 * Renamed `RealmQuery.distinctValues()` to `RealmQuery.distinct()`
+
 
 ### Enhancements
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmTests.java
@@ -18,16 +18,25 @@ package io.realm;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.net.URI;
+
+import io.realm.internal.ObjectServerFacade;
 import io.realm.objectserver.model.PartialSyncObjectA;
 import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 import io.realm.util.SyncTestUtils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -49,6 +58,10 @@ public class SyncedRealmTests {
 
     @After
     public void tearDown() {
+        for (SyncUser syncUser : SyncUser.all().values()) {
+            syncUser.logout();
+        }
+        ObjectServerFacade.getSyncFacadeIfPossible().removeCachedDefaultSyncConfiguration();
         if (realm != null && !realm.isClosed()) {
             realm.close();
         }
@@ -74,6 +87,115 @@ public class SyncedRealmTests {
         realm = Realm.getInstance(config);
         return realm;
     }
+
+    @Test
+    public void getDefaultInstance_noUserThrows() {
+        try {
+            Realm.getDefaultInstance();
+            fail();
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().startsWith("No user is logged in"));
+        }
+    }
+
+    @Test
+    public void getDefaultInstance_multipleUsersThrows() {
+        SyncTestUtils.createTestUser();
+        SyncTestUtils.createTestUser();
+        try {
+            Realm.getDefaultInstance();
+            fail();
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("multiple users are logged in"));
+        }
+    }
+
+
+    @Test
+    public void getDefaultInstance_clearCacheIfNewDefaultUser() {
+        SyncUser user1 = SyncTestUtils.createTestUser();
+        Realm realm1 = Realm.getDefaultInstance();
+        user1.logout();
+
+        SyncUser user2 = SyncTestUtils.createTestUser();
+        Realm realm2 = Realm.getDefaultInstance();
+
+        try {
+            assertNotEquals(user1, user2);
+            assertFalse(realm1 == realm2);
+            assertNotEquals(realm1.getPath(), realm2.getPath());
+        } finally {
+            realm1.close();
+            realm2.close();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("ReferenceEquality")
+    public void getDefaultInstance_rebuildDefaultConfigIfCleared() {
+        // The interaction between `getDefaultInstance` and `getDefaultConfiguration/removeDefaultConfiguration`
+        // is a bit tricky. But the following is implemented:
+        //
+        // Calling `removeDefaultConfiguration` will delete any cached config until `getDefaultInstance()`
+        // is called again, i.e. you can call `removeDefaultConfiguration` and check that `getDefaultConfiguration`
+        // returns `null`
+        SyncTestUtils.createTestUser();
+        Realm realm1 = Realm.getDefaultInstance();
+        RealmConfiguration oldConfig = realm1.getConfiguration();
+
+        Realm.removeDefaultConfiguration();
+        assertNull(Realm.getDefaultConfiguration());
+
+        Realm realm2 = Realm.getDefaultInstance();
+        RealmConfiguration newConfig = realm2.getConfiguration();
+
+        try {
+            assertTrue(realm1  == realm2);
+            assertTrue(oldConfig == newConfig); // We hit the cache, so old config is reused
+            assertEquals(oldConfig, newConfig);
+        } finally {
+            realm1.close();
+            realm2.close();
+        }
+    }
+
+    @Test
+    public void getDefaultInstance() {
+        SyncUser user1 = SyncTestUtils.createTestUser();
+        realm = Realm.getDefaultInstance();
+        assertTrue(realm.isEmpty());
+        assertEquals(user1, ((SyncConfiguration) realm.getConfiguration()).getUser());
+    }
+
+    @Test
+    public void getDefaultInstance_automaticallyConvertUrls() {
+        Object[][] input = {
+                // AuthUrl -> Expected Realm URL
+                { "http://ros.realm.io/auth", "realm://ros.realm.io/default" },
+                { "http://ros.realm.io:7777", "realm://ros.realm.io/default" },
+                { "http://127.0.0.1/auth", "realm://127.0.0.1/default" },
+                { "HTTP://ros.realm.io" , "realm://ros.realm.io/default" },
+
+                { "https://ros.realm.io/auth", "realms://ros.realm.io/default" },
+                { "https://ros.realm.io:7777", "realms://ros.realm.io/default" },
+                { "https://127.0.0.1/auth", "realms://127.0.0.1/default" },
+                { "HTTPS://ros.realm.io" , "realms://ros.realm.io/default" },
+        };
+
+        for (Object[] test : input) {
+            String authUrl = (String) test[0];
+            String realmUrl = (String) test[1];
+
+            SyncUser user = SyncTestUtils.createTestUser(authUrl);
+            Realm realm = Realm.getDefaultInstance();
+            SyncConfiguration config = (SyncConfiguration) realm.getConfiguration();
+            URI url = config.getServerUrl();
+            assertEquals(realmUrl, url.toString());
+            realm.close();
+            user.logout();
+        }
+    }
+
 
     @Test
     public void unsubscribeAsync_nullOrEmptyArgumentsThrows() {

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -149,7 +149,6 @@ public class Realm extends BaseRealm {
     private final RealmSchema schema;
     private static final Object defaultConfigurationLock = new Object();
     // guarded by `defaultConfigurationLock`
-    private static volatile boolean userClearedConfiguration = false;
     private static volatile RealmConfiguration userDefinedDefaultConfiguration;
 
     /**
@@ -332,7 +331,7 @@ public class Realm extends BaseRealm {
      * If sync is enabled, a sync configuration will be used that automatically infer the URL to the
      * default Realm on the server on which the current user is logged in.
      * <p>
-     * if sync is not enabled, a local realm called {@code default.realm} will be created in
+     * if sync is not enabled, a local Realm called {@code default.realm} will be created in
      * {@link Context#getFilesDir()}.
      *
      * @return an instance of the Realm class.
@@ -357,7 +356,6 @@ public class Realm extends BaseRealm {
                     // create it lazily instead. The Facade is responsible for caching it.
                     // This also re-creates it if `removeDefaultConfiguration` was manually called.
                     configuration = ObjectServerFacade.getSyncFacadeIfPossible().getSystemDefaultSyncConfiguration();
-                    userClearedConfiguration = false;
                 } else {
                     throw new IllegalStateException("The default configuration was manually cleared " +
                             "using 'Realm.removeDefaultConfiguration()'. Add a new default configuration " +
@@ -426,7 +424,6 @@ public class Realm extends BaseRealm {
         }
         synchronized (defaultConfigurationLock) {
             userDefinedDefaultConfiguration = configuration;
-            userClearedConfiguration = false;
         }
     }
 
@@ -455,7 +452,6 @@ public class Realm extends BaseRealm {
         synchronized (defaultConfigurationLock) {
             userDefinedDefaultConfiguration = null;
             ObjectServerFacade.getSyncFacadeIfPossible().removeCachedDefaultSyncConfiguration();
-            userClearedConfiguration = true;
         }
     }
 

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -50,7 +50,6 @@ import javax.annotation.Nullable;
 
 import io.reactivex.Flowable;
 import io.realm.annotations.Beta;
-import io.realm.exceptions.DownloadingRealmInterruptedException;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
 import io.realm.exceptions.RealmMigrationNeededException;
@@ -144,7 +143,6 @@ import io.realm.sync.permissions.Role;
 public class Realm extends BaseRealm {
 
     private static final String NULL_CONFIG_MSG = "A non-null RealmConfiguration must be provided";
-    private static final String FATAL_ASSERT_MESSAGE = "This should not happen. Please report this to help@realm.io";
 
     public static final String DEFAULT_REALM_NAME = RealmConfiguration.DEFAULT_REALM_NAME;
 
@@ -341,7 +339,7 @@ public class Realm extends BaseRealm {
      * @throws RealmMigrationNeededException if no migration has been provided by the default configuration and the
      * RealmObject classes or version has has changed so a migration is required.
      * @throws RealmFileException if an error happened when accessing the underlying Realm file.
-     * @throws DownloadingRealmInterruptedException if {@link SyncConfiguration.Builder#waitForInitialRemoteData()}
+     * @throws io.realm.exceptions.DownloadingRealmInterruptedException if {@link SyncConfiguration.Builder#waitForInitialRemoteData()}
      * was set and the thread opening the Realm was interrupted while the download was in progress.
      * @throws IllegalStateException if no default configuration is defined or if the default sync
      * configuration was used, but no user is logged in.

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -275,10 +275,8 @@ final class RealmCache {
      * @param realmClass class of {@link Realm} or {@link DynamicRealm} to be created in or gotten from the cache.
      * @return the {@link Realm} or {@link DynamicRealm} instance.
      */
-    static <E extends BaseRealm> E createRealmOrGetFromCache(RealmConfiguration configuration,
-            Class<E> realmClass) {
+    static <E extends BaseRealm> E createRealmOrGetFromCache(RealmConfiguration configuration, Class<E> realmClass) {
         RealmCache cache = getCache(configuration.getPath(), true);
-
         return cache.doCreateRealmOrGetFromCache(configuration, realmClass);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
@@ -126,4 +126,12 @@ public class ObjectServerFacade {
     public OsResults createSubscriptionAwareResults(OsSharedRealm sharedRealm, TableQuery query, SortDescriptor sortDescriptor, SortDescriptor distinctDescriptor, String name) {
         throw new IllegalStateException("Should only be called by builds supporting Sync");
     }
+
+    public RealmConfiguration getSystemDefaultSyncConfiguration() {
+        throw new IllegalStateException("Should only be called by builds supporting Sync");
+    }
+
+    public void removeCachedDefaultSyncConfiguration() {
+        // Do nothing
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/Util.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Util.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nullable;
 
+import io.realm.BuildConfig;
 import io.realm.RealmConfiguration;
 import io.realm.RealmModel;
 import io.realm.RealmObject;
@@ -138,5 +139,9 @@ public class Util {
             realmDeleted = true;
         }
         return realmDeleted;
+    }
+
+    public static boolean isSyncBuild() {
+        return BuildConfig.FLAVOR.equals("objectServer");
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -514,7 +514,7 @@ public class SyncConfiguration extends RealmConfiguration {
                         serverUrl.getUserInfo(),
                         host,
                         serverUrl.getPort(),
-                        (path != null) ? path.replace(host + "/", "") : null, // Remove host if it accidentially was interpreted as a path segment
+                        (path != null) ? path.replace(host + "/", "") : null, // Remove host if it accidentally was interpreted as a path segment
                         serverUrl.getQuery(),
                         serverUrl.getRawFragment());
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.RealmConfiguration;
 import io.realm.SyncConfiguration;
 import io.realm.SyncManager;
@@ -226,6 +227,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
 
     // Only call this method while under the lock of `Realm.defaultConfigurationLock`
     @Override
+    @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
     public void removeCachedDefaultSyncConfiguration() {
         cachedDefaultConfiguration = null;
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -203,14 +203,15 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
             currentUser = SyncUser.currentUser();
         } catch (IllegalStateException e ) {
             throw new IllegalStateException("Could not create a default sync configuration as " +
-                    "multiple users are logged in. Use Realm.getInstance() instead of se", e);
+                    "multiple users are logged in. Use 'Realm.getInstance()' instead of 'Realm.getDefaultInstance()' " +
+                    "in order to specify the specific users configuration." , e);
         }
 
         if (currentUser == null) {
             throw new IllegalStateException("No user is logged in. Login a user using SyncUser.login() first.");
         }
 
-        // Check if a new user have become the "default" user. In that case, invalidate any
+        // Check if a new user has become the default user. In that case, invalidate any
         // existing configuration as we need to rebuild it.
         if (cachedDefaultConfiguration != null && !currentUser.equals(cachedDefaultConfiguration.getUser())) {
             cachedDefaultConfiguration = null;
@@ -234,7 +235,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
 
     // Infer the URL to the default Realm based on the server used to login the user
     private String createUrl(SyncUser user) {
-        URL url = user.getAuthenticationUrl();
+        URL url     §= user.getAuthenticationUrl();
         String protocol = url.getProtocol();
         String host = url.getHost();
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -23,6 +23,7 @@ import android.net.ConnectivityManager;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URL;
 
 import io.realm.RealmConfiguration;
 import io.realm.SyncConfiguration;
@@ -43,6 +44,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     @SuppressLint("StaticFieldLeak") //
     private static Context applicationContext;
     private static volatile Method removeSessionMethod;
+    private static volatile SyncConfiguration cachedDefaultConfiguration;
 
     @Override
     public void init(Context context) {
@@ -190,5 +192,56 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     @Override
     public void addSupportForObjectLevelPermissions(RealmConfiguration.Builder builder) {
         builder.addModule(new ObjectPermissionsModule());
+    }
+
+    // Only call this method while under the lock of `Realm.defaultConfigurationLock`
+    @Override
+    public RealmConfiguration getSystemDefaultSyncConfiguration() {
+        SyncUser currentUser;
+        try {
+            currentUser = SyncUser.currentUser();
+        } catch (IllegalStateException e ) {
+            throw new IllegalStateException("Could not create a default sync configuration as " +
+                    "multiple users are logged in. Use Realm.getInstance() instead of se", e);
+        }
+
+        if (currentUser == null) {
+            throw new IllegalStateException("No user is logged in. Login a user using SyncUser.login() first.");
+        }
+
+        // Check if a new user have become the "default" user. In that case, invalidate any
+        // existing configuration as we need to rebuild it.
+        if (cachedDefaultConfiguration != null && !currentUser.equals(cachedDefaultConfiguration.getUser())) {
+            cachedDefaultConfiguration = null;
+        }
+
+        if (cachedDefaultConfiguration == null) {
+            cachedDefaultConfiguration = new SyncConfiguration.Builder(currentUser, createUrl(currentUser))
+                    .partialRealm()
+                    .build();
+        }
+
+        return cachedDefaultConfiguration;
+    }
+
+    // Only call this method while under the lock of `Realm.defaultConfigurationLock`
+    @Override
+    public void removeCachedDefaultSyncConfiguration() {
+        cachedDefaultConfiguration = null;
+    }
+
+    // Infer the URL to the default Realm based on the server used to login the user
+    private String createUrl(SyncUser user) {
+        URL url = user.getAuthenticationUrl();
+        String protocol = url.getProtocol();
+        String host = url.getHost();
+
+        if (protocol.equalsIgnoreCase("https")) {
+            protocol = "realms";
+        } else {
+            protocol = "realm";
+        }
+
+        return protocol + "://" + host + "/default";
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -235,7 +235,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
 
     // Infer the URL to the default Realm based on the server used to login the user
     private String createUrl(SyncUser user) {
-        URL url     §= user.getAuthenticationUrl();
+        URL url = user.getAuthenticationUrl();
         String protocol = url.getProtocol();
         String host = url.getHost();
 


### PR DESCRIPTION
Fixes #5806 

This PR changes the meaning of calling `Realm.getDefaultInstance()` when sync is enabled. Instead of creating a local Realm, which is probably not what you want if sync is enabled, it infers the URL from the currently logged in user and creates a default configuration based on that.

This means that calling `Realm.getDefaultConfiguration()` can now fail in new ways and that it potentially can return different instances depending on what user is currently logged in. There should hopefully be tests documenting this behavior.

This also had some consequences for `Realm.getDefaultConfiguration()` and `Realm.removeDefaultConfiguration()`, but essentially they continue to work as before, until you call `getDefaultInstance()`. If the configuration is `null` when doing that it will create a new default sync configuration.

