### PR TITLE
logout logging not resuming sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added missing `RealmQuery.oneOf()` for Kotlin that accepts non-nullable types (#5717).
 * [ObjectServer] Fixed an issue preventing sync to resume when the network is back (#5677).
+* [ObjectServer] Fixed an issue where login after a logout will not resume Syncing (https://github.com/realm/my-first-realm-app/issues/22).
 
 ## 4.3.3 (2018-01-19)
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
@@ -75,7 +75,7 @@ public class SessionTests {
 
     @Test
     public void addDownloadProgressListener_nullThrows() {
-        SyncSession session = SyncManager.getSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration);
         try {
             session.addDownloadProgressListener(ProgressMode.CURRENT_CHANGES, null);
             fail();
@@ -85,7 +85,7 @@ public class SessionTests {
 
     @Test
     public void addUploadProgressListener_nullThrows() {
-        SyncSession session = SyncManager.getSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration);
         try {
             session.addUploadProgressListener(ProgressMode.CURRENT_CHANGES, null);
             fail();
@@ -96,7 +96,7 @@ public class SessionTests {
     @Test
     public void removeProgressListener() {
         Realm realm = Realm.getInstance(configuration);
-        SyncSession session = SyncManager.getSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration);
         ProgressListener[] listeners = new ProgressListener[] {
                 null,
                 progress -> {
@@ -143,7 +143,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
     }
 
     // Check that we can manually execute the Client Reset.
@@ -181,7 +181,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
     }
 
     // Check that we can use the backup SyncConfiguration to open the Realm.
@@ -237,7 +237,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
     }
 
     // Check that we can open the backup file without using the provided SyncConfiguration,
@@ -320,7 +320,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
     }
 
     // make sure the backup file Realm is encrypted with the same key as the original synced Realm.
@@ -381,7 +381,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
     }
 
     @Test
@@ -389,7 +389,7 @@ public class SessionTests {
     public void uploadAllLocalChanges_throwsOnUiThread() throws InterruptedException {
         Realm realm = Realm.getInstance(configuration);
         try {
-            SyncManager.getSession(configuration).uploadAllLocalChanges();
+            SyncManager.getOrCreateSession(configuration).uploadAllLocalChanges();
             fail("Should throw an IllegalStateException on Ui Thread");
         } catch (IllegalStateException ignored) {
         } finally {
@@ -402,7 +402,7 @@ public class SessionTests {
     public void downloadAllServerChanges_throwsOnUiThread() throws InterruptedException {
         Realm realm = Realm.getInstance(configuration);
         try {
-            SyncManager.getSession(configuration).downloadAllServerChanges();
+            SyncManager.getOrCreateSession(configuration).downloadAllServerChanges();
             fail("Should throw an IllegalStateException on Ui Thread");
         } catch (IllegalStateException ignored) {
         } finally {
@@ -424,7 +424,7 @@ public class SessionTests {
                 })
                 .build();
         Realm realm = Realm.getInstance(configuration);
-        SyncSession session = SyncManager.getSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration);
 
         TestHelper.TestLogger testLogger = new TestHelper.TestLogger();
         RealmLog.add(testLogger);

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
@@ -20,6 +20,7 @@ import android.support.test.annotation.UiThreadTest;
 import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,6 +40,7 @@ import static io.realm.util.SyncTestUtils.createTestUser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -436,5 +438,22 @@ public class SessionTests {
         assertEquals("Unknown error code: 3", testLogger.message);
 
         realm.close();
+    }
+
+    @Test
+    public void getSessionThrowsOnNonExistingSession() {
+        Realm realm = Realm.getInstance(configuration);
+        SyncSession session = SyncManager.getSession(configuration);
+        assertEquals(configuration, session.getConfiguration());
+
+        // Closing the Realm should remove the session
+        realm.close();
+        try {
+            SyncManager.getSession(configuration);
+            fail("getSession should throw an ISE");
+        } catch (IllegalStateException expected) {
+            assertThat(expected.getMessage(), CoreMatchers.containsString(
+                    "No SyncSession found using the path : "));
+        }
     }
 }

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
@@ -75,7 +75,7 @@ public class SessionTests {
 
     @Test
     public void addDownloadProgressListener_nullThrows() {
-        SyncSession session = SyncManager.getOrCreateSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration, null);
         try {
             session.addDownloadProgressListener(ProgressMode.CURRENT_CHANGES, null);
             fail();
@@ -85,7 +85,7 @@ public class SessionTests {
 
     @Test
     public void addUploadProgressListener_nullThrows() {
-        SyncSession session = SyncManager.getOrCreateSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration, null);
         try {
             session.addUploadProgressListener(ProgressMode.CURRENT_CHANGES, null);
             fail();
@@ -96,7 +96,7 @@ public class SessionTests {
     @Test
     public void removeProgressListener() {
         Realm realm = Realm.getInstance(configuration);
-        SyncSession session = SyncManager.getOrCreateSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration, null);
         ProgressListener[] listeners = new ProgressListener[] {
                 null,
                 progress -> {
@@ -143,7 +143,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config, null));
     }
 
     // Check that we can manually execute the Client Reset.
@@ -181,7 +181,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config, null));
     }
 
     // Check that we can use the backup SyncConfiguration to open the Realm.
@@ -237,7 +237,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config, null));
     }
 
     // Check that we can open the backup file without using the provided SyncConfiguration,
@@ -320,7 +320,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config, null));
     }
 
     // make sure the backup file Realm is encrypted with the same key as the original synced Realm.
@@ -381,7 +381,7 @@ public class SessionTests {
         looperThread.addTestRealm(realm);
 
         // Trigger error
-        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config));
+        SyncManager.simulateClientReset(SyncManager.getOrCreateSession(config, null));
     }
 
     @Test
@@ -389,7 +389,7 @@ public class SessionTests {
     public void uploadAllLocalChanges_throwsOnUiThread() throws InterruptedException {
         Realm realm = Realm.getInstance(configuration);
         try {
-            SyncManager.getOrCreateSession(configuration).uploadAllLocalChanges();
+            SyncManager.getOrCreateSession(configuration, null).uploadAllLocalChanges();
             fail("Should throw an IllegalStateException on Ui Thread");
         } catch (IllegalStateException ignored) {
         } finally {
@@ -402,7 +402,7 @@ public class SessionTests {
     public void downloadAllServerChanges_throwsOnUiThread() throws InterruptedException {
         Realm realm = Realm.getInstance(configuration);
         try {
-            SyncManager.getOrCreateSession(configuration).downloadAllServerChanges();
+            SyncManager.getOrCreateSession(configuration, null).downloadAllServerChanges();
             fail("Should throw an IllegalStateException on Ui Thread");
         } catch (IllegalStateException ignored) {
         } finally {
@@ -424,7 +424,7 @@ public class SessionTests {
                 })
                 .build();
         Realm realm = Realm.getInstance(configuration);
-        SyncSession session = SyncManager.getOrCreateSession(configuration);
+        SyncSession session = SyncManager.getOrCreateSession(configuration, null);
 
         TestHelper.TestLogger testLogger = new TestHelper.TestLogger();
         RealmLog.add(testLogger);

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -235,7 +235,7 @@ public class SyncManager {
                 // access token, however since the Realm might not be open yet, the wrapObjectStoreSessionIfRequired
                 // will not be invoked to wrap the OS store session with the Java session, the Sync client to not resume
                 // syncing.
-                session.getAccessToken(authServer, null);
+                session.getAccessToken(authServer, "");
                 NetworkStateReceiver.addListener(networkListener);
             }
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -205,7 +205,7 @@ public class SyncManager {
     /**
      * Gets a cached {@link SyncSession} for the given {@link SyncConfiguration} or throw if no one exists yet.
      *
-     * A session should exists after you open a Realm with a {@link SyncConfiguration}.
+     * A session should exist after you open a Realm with a {@link SyncConfiguration}.
      *
      * @param syncConfiguration configuration object for the synchronized Realm.
      * @return the {@link SyncSession} for the specified Realm.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -43,6 +43,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.realm.exceptions.RealmException;
 import io.realm.internal.Keep;
 import io.realm.internal.Util;
 import io.realm.internal.network.AuthenticationServer;
@@ -203,14 +204,43 @@ public class SyncManager {
     }
 
     /**
+     * Gets a cached {@link SyncSession} for the given {@link SyncConfiguration} or throw if no one exists yet.
+     *
+     * A session should exists after your open a Realm with a {@link SyncConfiguration}.
+     *
+     * Note: This is mainly for internal usage, consider using {@link #getSession(SyncConfiguration)} instead.
+     *
+     * @param syncConfiguration configuration object for the synchronized Realm.
+     * @return the {@link SyncSession} for the specified Realm.
+     * @throws IllegalArgumentException if syncConfiguration is {@code null}.
+     * @throws RealmException if the session could not be found using the provided {@code SyncConfiguration}.
+     */
+    public static synchronized SyncSession getSession(SyncConfiguration syncConfiguration) throws RealmException {
+        //noinspection ConstantConditions
+        if (syncConfiguration == null) {
+            throw new IllegalArgumentException("A non-empty 'syncConfiguration' is required.");
+        }
+
+        SyncSession session = sessions.get(syncConfiguration.getPath());
+        if (session == null) {
+            throw new RealmException("No SyncSession found using the path : " + syncConfiguration.getPath()
+            + "\nplease ensure to call this method after you've open the Realm");
+        }
+
+        return session;
+    }
+
+    /**
      * Gets any cached {@link SyncSession} for the given {@link SyncConfiguration} or create a new one if
      * no one exists.
+     *
+     * Note: This is mainly for internal usage, consider using {@link #getSession(SyncConfiguration)} instead.
      *
      * @param syncConfiguration configuration object for the synchronized Realm.
      * @return the {@link SyncSession} for the specified Realm.
      * @throws IllegalArgumentException if syncConfiguration is {@code null}.
      */
-    public static synchronized SyncSession getSession(SyncConfiguration syncConfiguration, URI... resolvedRealmURL) {
+    public static synchronized SyncSession getOrCreateSession(SyncConfiguration syncConfiguration, URI... resolvedRealmURL) {
         // This will not create a new native (Object Store) session, this will only associate a Realm's path
         // with a SyncSession. Object Store's SyncManager is responsible of the life cycle (including creation)
         // of the native session, the provided Java wrap, helps interact with the native session, when reporting error

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -378,7 +378,7 @@ public class SyncSession {
         }
     }
 
-    public void setResolvedRealmURI(URI resolvedRealmURI) {
+    void setResolvedRealmURI(URI resolvedRealmURI) {
         this.resolvedRealmURI = resolvedRealmURI;
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import javax.annotation.Nullable;
 
+import io.realm.exceptions.RealmException;
 import io.realm.internal.RealmNotifier;
 import io.realm.internal.Util;
 import io.realm.internal.android.AndroidCapabilities;
@@ -229,9 +230,11 @@ public class SyncUser {
 
             // invalidate all pending refresh_token queries
             for (SyncConfiguration syncConfiguration : realms.keySet()) {
-                SyncSession session = SyncManager.getSession(syncConfiguration);
-                if (session != null) {
+                try {
+                    SyncSession session = SyncManager.getSession(syncConfiguration);
                     session.clearScheduledAccessTokenRefresh();
+                } catch (RealmException e) {
+                    // No session, either the Realm was not opened or session was removed.
                 }
             }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -233,8 +233,10 @@ public class SyncUser {
                 try {
                     SyncSession session = SyncManager.getSession(syncConfiguration);
                     session.clearScheduledAccessTokenRefresh();
-                } catch (RealmException e) {
-                    // No session, either the Realm was not opened or session was removed.
+                } catch (IllegalStateException e) {
+                    if (!e.getMessage().contains("No SyncSession found")) {
+                        throw e;
+                    }// else no session, either the Realm was not opened or session was removed.
                 }
             }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -106,8 +106,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     @Override
     public void wrapObjectStoreSessionIfRequired(OsRealmConfig config) {
         if (config.getRealmConfiguration() instanceof SyncConfiguration) {
-            SyncSession session = SyncManager.getSession((SyncConfiguration) config.getRealmConfiguration());
-            session.setResolvedRealmURI(config.getResolvedRealmURI());
+            SyncManager.getSession((SyncConfiguration) config.getRealmConfiguration(), config.getResolvedRealmURI());
         }
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -106,7 +106,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     @Override
     public void wrapObjectStoreSessionIfRequired(OsRealmConfig config) {
         if (config.getRealmConfiguration() instanceof SyncConfiguration) {
-            SyncManager.getSession((SyncConfiguration) config.getRealmConfiguration(), config.getResolvedRealmURI());
+            SyncManager.getOrCreateSession((SyncConfiguration) config.getRealmConfiguration(), config.getResolvedRealmURI());
         }
     }
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
@@ -7,7 +7,6 @@ import android.os.SystemClock;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
@@ -40,6 +40,7 @@ import io.realm.util.SyncTestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 
@@ -67,6 +68,7 @@ public class SyncedRealmTests extends StandardIntegrationTest {
         SyncManager.getSession(config).uploadAllLocalChanges();
         user.logout();
         realm.close();
+        assertTrue(Realm.deleteRealm(config));
 
         user = SyncUser.login(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         SyncConfiguration config2 = new SyncConfiguration.Builder(user, Constants.USER_REALM)

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
@@ -79,6 +79,7 @@ public class SyncedRealmTests extends StandardIntegrationTest {
         SyncManager.getSession(config2).downloadAllServerChanges();
         realm2.refresh();
         assertEquals(1, realm2.where(StringOnly.class).count());
+        realm2.close();
     }
 
     @Test


### PR DESCRIPTION
Currently when the user login, the Object Store will try to revive its inactive sessions
(stored previously after a logout). This will cause the OS to call `bindSession` to obtain an access token, however since the Realm might not be open yet, the `wrapObjectStoreSessionIfRequired`will not be invoked to wrap the OS store session with the Java session, which causes the Sync client to not resume syncing.