### PR TITLE
Using a specific version of winston library

### DIFF
--- a/tools/sync_test_server/Dockerfile
+++ b/tools/sync_test_server/Dockerfile
@@ -10,7 +10,7 @@ ARG ROS_DE_VERSION
 RUN npm install -g realm-object-server@$ROS_DE_VERSION -S
 
 # Install test server dependencies
-RUN npm install winston temp httpdispatcher@1.0.0 fs-extra moment
+RUN npm install winston@2.4.0 temp httpdispatcher@1.0.0 fs-extra moment
 
 COPY keys/public.pem keys/private.pem keys/127_0_0_1-server.key.pem keys/127_0_0_1-chain.crt.pem configuration.yml /
 COPY ros-testing-server.js /usr/bin/


### PR DESCRIPTION
CI failure which may be related to the latest `winston` dependency. Now specifying an exact version when building ROS for integration test  
