### PR TITLE
Fix module example

### DIFF
--- a/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
+++ b/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/ModulesExampleActivity.java
@@ -75,7 +75,7 @@ public class ModulesExampleActivity extends Activity {
                 .modules(new ZooAnimalsModule(), new CreepyAnimalsModule())
                 .build();
 
-        // Multiple Realms can be open at the same time
+        // Multiple Realms can be opened at the same time
         showStatus("Opening multiple Realms");
         Realm defaultRealm = Realm.getInstance(defaultConfig);
         final Realm farmRealm = Realm.getInstance(farmAnimalsConfig);

--- a/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/model/Pig.java
+++ b/examples/moduleExample/app/src/main/java/io/realm/examples/appmodules/model/Pig.java
@@ -16,17 +16,11 @@
 
 package io.realm.examples.appmodules.model;
 
-import io.realm.RealmList;
 import io.realm.RealmObject;
-import io.realm.examples.librarymodules.model.Dog;
 
 public class Pig extends RealmObject {
 
     private String name;
-
-    // It is possible for model classes to to reference library model classes as long
-    // as they all are included in the schema when opening the Realm.
-    private RealmList<Dog> afraidOf = new RealmList<>();
 
     public String getName() {
         return name;


### PR DESCRIPTION
This fixes the app module example.

It, unfortunately, does this by reverting the code that tests that app modules can link to library module model classes. The reason for this is that testing this is impossible without seriously complicating the current example (e.g. just using the default configuration is no longer possible).

Creating another example just for this seems a bit much and the chance of the functionality breaking is probably low.

I verified that it worked manually before removing the code, by using the following default config `RealmConfiguration defaultConfig = new RealmConfiguration.Builder().modules(Realm.getDefaultModule(), new DomesticAnimalsModule()).build();`

/cc @nhachicha 


