### PR TITLE
Align Sync API's with Cocoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 * [ObjectServer] Renamed `SyncUser.currentUser()` to `SyncUser.current()`.
-* [ObjectServer] Renamed `SyncUser.login(...)` and `SyncUser.loginAsync(...) to `SyncUser.logIn(...)` and `SyncUser.logInAsync(...)`.
+* [ObjectServer] Renamed `SyncUser.login(...)` and `SyncUser.loginAsync(...)` to `SyncUser.logIn(...)` and `SyncUser.logInAsync(...)`.
 * [ObjectServer] Renamed `SyncUser.logout()` to `SyncUser.logOut()`.
 * The `OrderedCollectionChangeSet` parameter in `OrderedRealmCollectionChangeListener.onChange()` is no longer nullable. Use `changeSet.getState()` instead (#5619).
 * `realm.subscribeForObjects()` have been removed. Use `RealmQuery.findAllAsync(String subscriptionName)` and `RealmQuery.findAllAsync()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Breaking Changes
 
+* [ObjectServer] Renamed `SyncUser.currentUser()` to `SyncUser.current()`.
+* [ObjectServer] Renamed `SyncUser.login(...)` and `SyncUser.loginAsync(...) to `SyncUser.logIn(...)` and `SyncUser.logInAsync(...)`.
+* [ObjectServer] Renamed `SyncUser.logout()` to `SyncUser.logOut()`.
 * The `OrderedCollectionChangeSet` parameter in `OrderedRealmCollectionChangeListener.onChange()` is no longer nullable. Use `changeSet.getState()` instead (#5619).
 * `realm.subscribeForObjects()` have been removed. Use `RealmQuery.findAllAsync(String subscriptionName)` and `RealmQuery.findAllAsync()` instead.
 * Removed previously deprecated `RealmQuery.findAllSorted()`, `RealmQuery.findAllSortedAsync()` `RealmQuery.distinct() and `RealmQuery.distinctAsync()`.

--- a/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/CounterActivity.java
+++ b/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/CounterActivity.java
@@ -146,7 +146,7 @@ public class CounterActivity extends AppCompatActivity {
         switch(item.getItemId()) {
             case R.id.action_logout:
                 closeRealm();
-                user.logout();
+                user.logOut();
                 user = getLoggedInUser();
                 return true;
 
@@ -198,7 +198,7 @@ public class CounterActivity extends AppCompatActivity {
     private SyncUser getLoggedInUser() {
         SyncUser user = null;
 
-        try { user = SyncUser.currentUser(); }
+        try { user = SyncUser.current(); }
         catch (IllegalStateException ignore) { }
 
         if (user == null) {

--- a/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/LoginActivity.java
+++ b/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/LoginActivity.java
@@ -103,7 +103,7 @@ public class LoginActivity extends AppCompatActivity {
             }
         };
 
-        SyncUser.loginAsync(creds, REALM_AUTH_URL, callback);
+        SyncUser.logInAsync(creds, REALM_AUTH_URL, callback);
     }
 
     @Override

--- a/examples/secureTokenAndroidKeyStore/src/main/java/io/realm/examples/securetokenandroidkeystore/MainActivity.java
+++ b/examples/secureTokenAndroidKeyStore/src/main/java/io/realm/examples/securetokenandroidkeystore/MainActivity.java
@@ -87,7 +87,7 @@ public class MainActivity extends AppCompatActivity {
         final String urlAuth = "http://objectserver.realm.io:9080/auth";
         final String url = "realm://objectserver.realm.io/default";
 
-        SyncUser.loginAsync(credentials, urlAuth, new SyncUser.Callback<SyncUser>() {
+        SyncUser.logInAsync(credentials, urlAuth, new SyncUser.Callback<SyncUser>() {
             @Override
             public void onSuccess(SyncUser user) {
                 SyncConfiguration secureConfig = new SyncConfiguration.Builder(user, url).build();

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/AuthenticateRequestTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/AuthenticateRequestTests.java
@@ -78,7 +78,7 @@ public class AuthenticateRequestTests {
         SyncManager.setAuthServerImpl(authServer);
 
         try {
-            SyncUser.login(SyncCredentials.facebook("foo"), "http://foo.bar/auth");
+            SyncUser.logIn(SyncCredentials.facebook("foo"), "http://foo.bar/auth");
             fail();
         } catch (ObjectServerError e) {
             assertEquals(ErrorCode.ACCESS_DENIED, e.getErrorCode());

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -141,8 +141,8 @@ public class SyncUserTests {
     public void equals_loggedOutUser() {
         final SyncUser user1 = createFakeUser("id_value");
         final SyncUser user2 = createFakeUser("id_value");
-        user1.logout();
-        user2.logout();
+        user1.logOut();
+        user2.logOut();
         assertTrue(user1.equals(user2));
     }
 
@@ -155,7 +155,7 @@ public class SyncUserTests {
     @Test
     public void hashCode_loggedOutUser() {
         final SyncUser user = createFakeUser("id_value");
-        user.logout();
+        user.logOut();
         assertNotEquals(0, user.hashCode());
     }
 
@@ -174,7 +174,7 @@ public class SyncUserTests {
         userStore.put(SyncTestUtils.createTestUser(Long.MIN_VALUE));
 
         // Invalid users should not be returned when asking the for the current user
-        assertNull(SyncUser.currentUser());
+        assertNull(SyncUser.current());
     }
 
     @Test
@@ -191,12 +191,12 @@ public class SyncUserTests {
                     return getNewRandomUser();
                 }
             });
-            SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
-            SyncUser.login(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
+            SyncUser.logIn(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
+            SyncUser.logIn(SyncCredentials.facebook("foo"), "http:/test.realm.io/auth");
 
-            // 2. Verify currentUser() now throws
+            // 2. Verify current() now throws
             try {
-                SyncUser.currentUser();
+                SyncUser.current();
                 fail();
             } catch (IllegalStateException ignore) {
             }
@@ -220,11 +220,11 @@ public class SyncUserTests {
         UserStore userStore = SyncManager.getUserStore();
         userStore.put(user);
 
-        SyncUser savedUser = SyncUser.currentUser();
+        SyncUser savedUser = SyncUser.current();
         assertEquals(user, savedUser);
         assertNotNull(savedUser);
-        savedUser.logout();
-        assertNull(SyncUser.currentUser());
+        savedUser.logOut();
+        assertNull(SyncUser.current());
     }
 
     // `all()` returns an empty list if no users are logged in
@@ -275,8 +275,8 @@ public class SyncUserTests {
         AuthenticationServer authServer = Mockito.mock(AuthenticationServer.class);
         when(authServer.loginUser(any(SyncCredentials.class), any(URL.class))).thenReturn(SyncTestUtils.createLoginResponse(Long.MAX_VALUE));
 
-        SyncUser user = SyncUser.login(SyncCredentials.facebook("foo"), "http://bar.com/auth");
-        assertEquals(user, SyncUser.currentUser());
+        SyncUser user = SyncUser.logIn(SyncCredentials.facebook("foo"), "http://bar.com/auth");
+        assertEquals(user, SyncUser.current());
     }
 
     @Test
@@ -295,7 +295,7 @@ public class SyncUserTests {
         SyncManager.setAuthServerImpl(authServer);
         try {
             SyncCredentials credentials = SyncCredentials.accessToken("foo", "bar");
-            SyncUser user = SyncUser.login(credentials, "http://ros.realm.io/auth");
+            SyncUser user = SyncUser.logIn(credentials, "http://ros.realm.io/auth");
             assertTrue(user.isValid());
         } finally {
             SyncManager.setAuthServerImpl(originalServer);
@@ -324,9 +324,9 @@ public class SyncUserTests {
                 String input = url[0];
                 String normalizedInput = url[1];
                 SyncCredentials credentials = SyncCredentials.accessToken("token", UUID.randomUUID().toString());
-                SyncUser user = SyncUser.login(credentials, input);
+                SyncUser user = SyncUser.logIn(credentials, input);
                 assertEquals(normalizedInput, user.getAuthenticationUrl().toString());
-                user.logout();
+                user.logOut();
             }
         } finally {
             SyncManager.setAuthServerImpl(originalServer);
@@ -446,8 +446,8 @@ public class SyncUserTests {
         } finally {
             pm1.close();
             pm2.close();
-            user1.logout();
-            user2.logout();
+            user1.logOut();
+            user2.logOut();
         }
     }
 
@@ -553,7 +553,7 @@ public class SyncUserTests {
                 realm.createObject(StringOnly.class).setChars("1");
             }
         });
-        user.logout();
+        user.logOut();
         realm.close();
 
         final File realmPath = new File (syncConfiguration.getPath());

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -42,8 +42,6 @@ import io.realm.internal.sync.permissions.ObjectPermissionsModule;
 import io.realm.log.RealmLog;
 import io.realm.rx.RealmObservableFactory;
 import io.realm.rx.RxObservableFactory;
-import io.realm.sync.permissions.PermissionUser;
-import io.realm.sync.permissions.Role;
 
 /**
  * An {@link SyncConfiguration} is used to setup a Realm that can be synchronized between devices using the Realm
@@ -903,7 +901,7 @@ public class SyncConfiguration extends RealmConfiguration {
 
         /**
          * Setting this will cause the local Realm file used to synchronize changes to be deleted if the {@link SyncUser}
-         * owning this Realm logs out from the device using {@link SyncUser#logout()}.
+         * owning this Realm logs out from the device using {@link SyncUser#logOut()}.
          * <p>
          * The default behavior is that the Realm file is allowed to stay behind, making it possible for users to log
          * in again and have access to their data faster.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -48,7 +48,7 @@ import io.realm.rx.RxObservableFactory;
  * Object Server.
  * <p>
  * A valid {@link SyncUser} is required to create a {@link SyncConfiguration}. See {@link SyncCredentials} and
- * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)} for more information on
+ * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)} for more information on
  * how to get a user object.
  * <p>
  * A minimal {@link SyncConfiguration} can be found below.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -204,7 +204,7 @@ public class SyncCredentials {
     /**
      * Creates credentials from an existing access token. Since an access token is the proof that a user already
      * has logged in. Credentials created this way are automatically assumed to have successfully logged in.
-     * This means that providing these credentials to {@link SyncUser#login(SyncCredentials, String)} will always
+     * This means that providing these credentials to {@link SyncUser#logIn(SyncCredentials, String)} will always
      * succeed, but accessing any Realm after might fail if the token is no longer valid.
      * <p>
      * It is assumed that this user is not an administrator. Otherwise use {@link #accessToken(String, String, boolean)}.
@@ -221,7 +221,7 @@ public class SyncCredentials {
     /**
      * Creates credentials from an existing access token. Since an access token is the proof that a user already
      * has logged in. Credentials created this way are automatically assumed to have successfully logged in.
-     * This means that providing these credentials to {@link SyncUser#login(SyncCredentials, String)} will always
+     * This means that providing these credentials to {@link SyncUser#logIn(SyncCredentials, String)} will always
      * succeed, but accessing any Realm after might fail if the token is no longer valid.
      *
      * @param accessToken user's access token.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -78,7 +78,7 @@ public class SyncCredentials {
      *
      * @param facebookToken a facebook userIdentifier acquired by logging into Facebook.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
     public static SyncCredentials facebook(String facebookToken) {
@@ -91,7 +91,7 @@ public class SyncCredentials {
      *
      * @param googleToken a google userIdentifier acquired by logging into Google.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
     public static SyncCredentials google(String googleToken) {
@@ -104,7 +104,7 @@ public class SyncCredentials {
      *
      * @param jwtToken a JWT token that identifies the user.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if the token is either {@code null} or empty.
      */
     public static SyncCredentials jwt(String jwtToken) {
@@ -119,7 +119,7 @@ public class SyncCredentials {
      *  and it isn't possible to share the user details across devices.
      *
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      */
     public static SyncCredentials anonymous() {
         return new SyncCredentials("", IdentityProvider.ANONYMOUS, null);
@@ -134,7 +134,7 @@ public class SyncCredentials {
      *
      * @param nickname that identifies a user
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if the nickname is either {@code null} or empty.
      */
     public static SyncCredentials nickname(String nickname, boolean isAdmin) {
@@ -154,7 +154,7 @@ public class SyncCredentials {
      * create a user twice when logging in, so this flag should only be set to {@code true} the first
      * time a users log in.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
     public static SyncCredentials usernamePassword(String username, String password, boolean createUser) {
@@ -172,7 +172,7 @@ public class SyncCredentials {
      * @param username username of the user.
      * @param password the users password.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if user name is either {@code null} or empty.
      */
     public static SyncCredentials usernamePassword(String username, String password) {
@@ -189,7 +189,7 @@ public class SyncCredentials {
      * data will be serialized to JSON, so all values must be mappable to a valid JSON data type. Custom
      * classes will be converted using {@code toString()}.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if any parameter is either {@code null} or empty.
      */
     public static SyncCredentials custom(String userIdentifier, String identityProvider, @Nullable Map<String, Object> userInfo) {
@@ -212,7 +212,7 @@ public class SyncCredentials {
      * @param accessToken user's access token.
      * @param identifier user identifier.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}
      */
     public static SyncCredentials accessToken(String accessToken, String identifier) {
         return accessToken(accessToken, identifier, false);
@@ -230,7 +230,7 @@ public class SyncCredentials {
      * non-privileged users. It is to <i>not</i> possible to upgrade a non-admin token to an admin token by setting this
      * value. It is purely informational.
      * @return a set of credentials that can be used to log into the Object Server using
-     * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}
+     * {@link SyncUser#logInAsync(SyncCredentials, String, SyncUser.Callback)}
      */
     public static SyncCredentials accessToken(String accessToken, String identifier, boolean isAdmin) {
         HashMap<String, Object> userInfo = new HashMap<String, Object>();

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -148,7 +148,7 @@ public class SyncManager {
 
     /**
      * Set the {@link UserStore} used by the Realm Object Server to save user information.
-     * If no Userstore is specified {@link SyncUser#currentUser()} will always return {@code null}.
+     * If no Userstore is specified {@link SyncUser#current()} will always return {@code null}.
      *
      * @param userStore {@link UserStore} to use.
      * @throws IllegalArgumentException if {@code userStore} is {@code null}.

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -188,7 +188,7 @@ public class SyncUser {
      * @return representation of the async task that can be used to cancel it if needed.
      * @throws IllegalArgumentException if not on a Looper thread.
      */
-    public static RealmAsyncTask loginAsync(final SyncCredentials credentials, final String authenticationUrl, final Callback<SyncUser> callback) {
+    public static RealmAsyncTask logInAsync(final SyncCredentials credentials, final String authenticationUrl, final Callback<SyncUser> callback) {
         checkLooperThread("Asynchronous login is only possible from looper threads.");
         return new Request<SyncUser>(SyncManager.NETWORK_POOL_EXECUTOR, callback) {
             @Override

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import javax.annotation.Nullable;
 
-import io.realm.exceptions.RealmException;
 import io.realm.internal.RealmNotifier;
 import io.realm.internal.Util;
 import io.realm.internal.android.AndroidCapabilities;
@@ -80,7 +79,7 @@ public class SyncUser {
      * expired.
      * @throws IllegalStateException if multiple users are logged in.
      */
-    public static SyncUser currentUser() {
+    public static SyncUser current() {
         SyncUser user = SyncManager.getUserStore().getCurrent();
         if (user != null && user.isValid()) {
             return user;
@@ -135,7 +134,7 @@ public class SyncUser {
      * @throws ObjectServerError if the login failed.
      * @throws IllegalArgumentException if the URL is malformed.
      */
-    public static SyncUser login(final SyncCredentials credentials, final String authenticationUrl) throws ObjectServerError {
+    public static SyncUser logIn(final SyncCredentials credentials, final String authenticationUrl) throws ObjectServerError {
         URL authUrl;
         try {
             authUrl = new URL(authenticationUrl);
@@ -194,7 +193,7 @@ public class SyncUser {
         return new Request<SyncUser>(SyncManager.NETWORK_POOL_EXECUTOR, callback) {
             @Override
             public SyncUser run() throws ObjectServerError {
-                return login(credentials, authenticationUrl);
+                return logIn(credentials, authenticationUrl);
             }
         }.start();
     }
@@ -218,7 +217,7 @@ public class SyncUser {
 //     */
     // this is a fire and forget, end user should not worry about the state of the async query
     @SuppressWarnings("FutureReturnValueIgnored")
-    public void logout() {
+    public void logOut() {
         // Acquire lock to prevent users creating new instances
         synchronized (Realm.class) {
             if (!SyncManager.getUserStore().isActive(identity, authenticationUrl.toString())) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
@@ -53,7 +53,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
     public void trustedRootCA() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         // 1. Copy a valid Realm to the server
         //noinspection unchecked
@@ -69,11 +69,11 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // make sure the changes gets to the server
         SyncManager.getSession(syncConfig).uploadAllLocalChanges();
         realm.close();
-        user.logout();
+        user.logOut();
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigSSL = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
                 .name("useSsl")
@@ -98,7 +98,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
     public void withoutSSLVerification() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         // 1. Copy a valid Realm to the server
         //noinspection unchecked
@@ -114,11 +114,11 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // make sure the changes gets to the server
         SyncManager.getSession(syncConfig).uploadAllLocalChanges();
         realm.close();
-        user.logout();
+        user.logOut();
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigSSL = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
                 .name("useSsl")
@@ -143,7 +143,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
     public void trustedRootCA_syncShouldFailWithoutTrustedCA() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         // 1. Copy a valid Realm to the server
         //noinspection unchecked
@@ -159,11 +159,11 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // make sure the changes gets to the server
         SyncManager.getSession(syncConfig).uploadAllLocalChanges();
         realm.close();
-        user.logout();
+        user.logOut();
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigSSL = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
                 .name("useSsl")
@@ -186,7 +186,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
     public void combining_trustedRootCA_and_withoutSSLVerification_willThrow() {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         TestHelper.TestLogger testLogger = new TestHelper.TestLogger();
         int originalLevel = RealmLog.getLevel();
@@ -213,7 +213,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
     public void trustedRootCA_notExisting_certificate_willThrow() {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
                 .schema(StringOnly.class)
@@ -233,7 +233,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
     public void combiningTrustedRootCA_and_disableSSLVerification() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         // 1. Copy a valid Realm to the server using ssl_verify_path option
         //noinspection unchecked
@@ -250,11 +250,11 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // make sure the changes gets to the server
         SyncManager.getSession(syncConfigWithCertificate).uploadAllLocalChanges();
         realm.close();
-        user.logout();
+        user.logOut();
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigDisableSSL = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
                 .name("useSsl")
@@ -283,7 +283,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
     public void sslVerifyCallback_isUsed() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         // 1. Copy a valid Realm to the server using ssl_verify_path option
         //noinspection unchecked
@@ -299,11 +299,11 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // make sure the changes gets to the server
         SyncManager.getSession(syncConfig).uploadAllLocalChanges();
         realm.close();
-        user.logout();
+        user.logOut();
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes.
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigSecure = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
                 .name("useSsl")

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
@@ -67,7 +67,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
         SyncSession session = SyncManager.getSession(syncConfiguration);
         realm.close();
-        user.logout();
+        user.logOut();
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("Could not find session, Realm was probably closed");
         session.getState();
@@ -83,7 +83,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
         SyncSession session = SyncManager.getSession(syncConfiguration);
 
-        user.logout();
+        user.logOut();
 
         SyncSession.State state = session.getState();
         assertEquals(SyncSession.State.INACTIVE, state);
@@ -180,7 +180,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
     public void logout_sameSyncUserMultipleSessions() {
         String uniqueName = UUID.randomUUID().toString();
         SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
-        SyncUser user =  SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user =  SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         SyncConfiguration syncConfiguration1 = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
@@ -206,13 +206,13 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
         assertEquals(session1.getUser(), session2.getUser());
 
-        user.logout();
+        user.logOut();
 
         assertEquals(SyncSession.State.INACTIVE, session1.getState());
         assertEquals(SyncSession.State.INACTIVE, session2.getState());
 
         credentials = SyncCredentials.usernamePassword(uniqueName, "password", false);
-        SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         // reviving the sessions. The state could be changed concurrently.
         assertTrue(session1.getState() == SyncSession.State.WAITING_FOR_ACCESS_TOKEN ||
@@ -229,7 +229,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
     public void logBackResumeUpload() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
         final String uniqueName = UUID.randomUUID().toString();
         SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         final SyncConfiguration syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
@@ -247,7 +247,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
         final SyncSession session = SyncManager.getSession(syncConfiguration);
         session.uploadAllLocalChanges();
 
-        user.logout();
+        user.logOut();
 
         // add a commit while we're still offline
         realm.executeTransaction(new Realm.Transaction() {
@@ -270,7 +270,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
                 // when the offline commits get synchronized
                 SyncUser admin = UserFactory.createAdminUser(Constants.AUTH_URL);
                 SyncCredentials credentialsAdmin = SyncCredentials.accessToken(SyncTestUtils.getRefreshToken(admin).value(), "custom-admin-user");
-                SyncUser adminUser = SyncUser.login(credentialsAdmin, Constants.AUTH_URL);
+                SyncUser adminUser = SyncUser.logIn(credentialsAdmin, Constants.AUTH_URL);
 
                 SyncConfiguration adminConfig = configurationFactory.createSyncConfigurationBuilder(adminUser, syncConfiguration.getServerUrl().toString())
                         .modules(new StringOnlyModule())
@@ -298,7 +298,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
                 // this login will re-activate the logged out user, and resume all it's pending sessions
                 // the OS will trigger bindSessionWithConfig with the new refresh_token, in order to obtain
                 // a new access_token.
-                SyncUser.login(credentials, Constants.AUTH_URL);
+                SyncUser.logIn(credentials, Constants.AUTH_URL);
             }
         });
 
@@ -313,7 +313,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
         final List<Object> strongRefs = new ArrayList<>();
         final String uniqueName = UUID.randomUUID().toString();
         SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         final char[] chars = new char[1_000_000];// 2MB
         Arrays.fill(chars, '.');
@@ -346,7 +346,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
                 // using an admin user to open the Realm on different path on the device to monitor when all the uploads are done
                 SyncUser admin = UserFactory.createAdminUser(Constants.AUTH_URL);
                 SyncCredentials credentialsAdmin = SyncCredentials.accessToken(SyncTestUtils.getRefreshToken(admin).value(), "custom-admin-user");
-                SyncUser adminUser = SyncUser.login(credentialsAdmin, Constants.AUTH_URL);
+                SyncUser adminUser = SyncUser.logIn(credentialsAdmin, Constants.AUTH_URL);
 
                 SyncConfiguration adminConfig = configurationFactory.createSyncConfigurationBuilder(adminUser, syncConfiguration.getServerUrl().toString())
                         .modules(new StringOnlyModule())
@@ -374,7 +374,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
         TestHelper.awaitOrFail(testCompleted, 60);
         handlerThread.join();
 
-        user.logout();
+        user.logOut();
     }
 
     // A Realm that was opened before a user logged out should be able to resume downloading if the user logs back in.
@@ -382,7 +382,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
     public void downloadChangesWhenRealmOutOfScope() throws InterruptedException {
         final String uniqueName = UUID.randomUUID().toString();
         SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         final SyncConfiguration syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
@@ -398,11 +398,11 @@ public class SyncSessionTests extends StandardIntegrationTest {
         session.uploadAllLocalChanges();
 
         // Log out the user.
-        user.logout();
+        user.logOut();
 
         // Log the user back in.
         credentials = SyncCredentials.usernamePassword(uniqueName, "password", false);
-        SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         // now let the admin upload some commits
         final CountDownLatch backgroundUpload = new CountDownLatch(1);
@@ -417,7 +417,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
                 // using an admin user to open the Realm on different path on the device then some commits
                 SyncUser admin = UserFactory.createAdminUser(Constants.AUTH_URL);
                 SyncCredentials credentialsAdmin = SyncCredentials.accessToken(SyncTestUtils.getRefreshToken(admin).value(), "custom-admin-user");
-                SyncUser adminUser = SyncUser.login(credentialsAdmin, Constants.AUTH_URL);
+                SyncUser adminUser = SyncUser.logIn(credentialsAdmin, Constants.AUTH_URL);
 
                 SyncConfiguration adminConfig = configurationFactory.createSyncConfigurationBuilder(adminUser, syncConfiguration.getServerUrl().toString())
                         .modules(new StringOnlyModule())
@@ -458,7 +458,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
     public void clientReset_manualTriggerAllowSessionToRestart() {
         final String uniqueName = UUID.randomUUID().toString();
         SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         final AtomicReference<SyncConfiguration> configRef = new AtomicReference<>(null);
         final SyncConfiguration config = configFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
@@ -55,7 +55,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
     public void loginLogoutResumeSyncing() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .schema(StringOnly.class)
@@ -66,11 +66,11 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
         realm.createObject(StringOnly.class).setChars("Foo");
         realm.commitTransaction();
         SyncManager.getSession(config).uploadAllLocalChanges();
-        user.logout();
+        user.logOut();
         realm.close();
         assertTrue(Realm.deleteRealm(config));
 
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         SyncConfiguration config2 = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .schema(StringOnly.class)
                 .build();
@@ -108,7 +108,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
     public void waitForInitialRemoteData() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)
         final SyncConfiguration configOld = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
@@ -126,11 +126,11 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
         });
         SyncManager.getSession(configOld).uploadAllLocalChanges();
         realm.close();
-        user.logout();
+        user.logOut();
 
         // 2. Local state should now be completely reset. Open the same sync Realm but different local name again with
         // a new configuration which should download the uploaded changes (pray it managed to do so within the time frame).
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .name("newRealm")
                 .schema(StringOnly.class)
@@ -161,7 +161,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
             " https://github.com/realm/realm-java/issues/5416")
     public void waitForInitialData_resilientInCaseOfRetries() throws InterruptedException {
         SyncCredentials credentials = SyncCredentials.usernamePassword(UUID.randomUUID().toString(), "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         final SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .waitForInitialRemoteData()
                 .build();
@@ -198,7 +198,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
     @Ignore("See https://github.com/realm/realm-java/issues/5373")
     public void waitForInitialData_resilientInCaseOfRetriesAsync() {
         SyncCredentials credentials = SyncCredentials.usernamePassword(UUID.randomUUID().toString(), "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         final SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
                 .directory(configurationFactory.getRoot())
@@ -228,7 +228,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
     public void waitForInitialRemoteData_readOnlyTrue() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)
         final SyncConfiguration configOld = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
@@ -245,11 +245,11 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
         });
         SyncManager.getSession(configOld).uploadAllLocalChanges();
         realm.close();
-        user.logout();
+        user.logOut();
 
         // 2. Local state should now be completely reset. Open the Realm again with a new configuration which should
         // download the uploaded changes (pray it managed to do so within the time frame).
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         final SyncConfiguration configNew = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
                 .name("newRealm")
                 .waitForInitialRemoteData()
@@ -261,13 +261,13 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
         realm = Realm.getInstance(configNew);
         assertEquals(10, realm.where(StringOnly.class).count());
         realm.close();
-        user.logout();
+        user.logOut();
     }
     
     @Test
     public void waitForInitialRemoteData_readOnlyTrue_throwsIfWrongServerSchema() {
         SyncCredentials credentials = SyncCredentials.usernamePassword(UUID.randomUUID().toString(), "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         final SyncConfiguration configNew = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
                 .waitForInitialRemoteData()
                 .readOnly()
@@ -286,14 +286,14 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
             if (realm != null) {
                 realm.close();
             }
-            user.logout();
+            user.logOut();
         }
     }
 
     @Test
     public void waitForInitialRemoteData_readOnlyFalse_upgradeSchema() {
         SyncCredentials credentials = SyncCredentials.usernamePassword(UUID.randomUUID().toString(), "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         final SyncConfiguration config = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
                 .waitForInitialRemoteData() // Not readonly so Client should be allowed to write schema
                 .schema(StringOnly.class) // This schema should be written when opening the empty Realm.
@@ -306,7 +306,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
             assertEquals(0, realm.where(StringOnly.class).count());
         } finally {
             realm.close();
-            user.logout();
+            user.logOut();
         }
     }
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -65,7 +65,7 @@ public class AuthTests extends StandardIntegrationTest {
     public void login_userNotExist() {
         SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
         try {
-            SyncUser.login(credentials, Constants.AUTH_URL);
+            SyncUser.logIn(credentials, Constants.AUTH_URL);
             fail();
         } catch (ObjectServerError expected) {
             assertEquals(ErrorCode.INVALID_CREDENTIALS, expected.getErrorCode());
@@ -264,17 +264,17 @@ public class AuthTests extends StandardIntegrationTest {
         String username = UUID.randomUUID().toString();
         String originalPassword = "password";
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, originalPassword, true);
-        SyncUser userOld = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser userOld = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(userOld.isValid());
 
         // Change password and try to log in with new password
         String newPassword = "new-password";
         userOld.changePassword(newPassword);
-        userOld.logout();
+        userOld.logOut();
 
         // Make sure old password doesn't work
         try {
-            SyncUser.login(SyncCredentials.usernamePassword(username, originalPassword, false), Constants.AUTH_URL);
+            SyncUser.logIn(SyncCredentials.usernamePassword(username, originalPassword, false), Constants.AUTH_URL);
             fail();
         } catch (ObjectServerError e) {
             assertEquals(ErrorCode.INVALID_CREDENTIALS, e.getErrorCode());
@@ -282,7 +282,7 @@ public class AuthTests extends StandardIntegrationTest {
 
         // Then login with new password
         credentials = SyncCredentials.usernamePassword(username, newPassword, false);
-        SyncUser userNew = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser userNew = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(userNew.isValid());
         assertEquals(userOld.getIdentity(), userNew.getIdentity());
     }
@@ -292,7 +292,7 @@ public class AuthTests extends StandardIntegrationTest {
         String username = UUID.randomUUID().toString();
         String originalPassword = "password";
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, originalPassword, true);
-        SyncUser userOld = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser userOld = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(userOld.isValid());
 
         // Login an admin user
@@ -305,9 +305,9 @@ public class AuthTests extends StandardIntegrationTest {
         adminUser.changePassword(userOld.getIdentity(), newPassword);
 
         // Try to log in with new password
-        userOld.logout();
+        userOld.logOut();
         credentials = SyncCredentials.usernamePassword(username, newPassword, false);
-        SyncUser userNew = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser userNew = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         assertTrue(userNew.isValid());
         assertEquals(userOld.getIdentity(), userNew.getIdentity());
@@ -319,7 +319,7 @@ public class AuthTests extends StandardIntegrationTest {
         final String username = UUID.randomUUID().toString();
         final String originalPassword = "password";
         final SyncCredentials credentials = SyncCredentials.usernamePassword(username, originalPassword, true);
-        final SyncUser userOld = SyncUser.login(credentials, Constants.AUTH_URL);
+        final SyncUser userOld = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(userOld.isValid());
 
         // Login an admin user
@@ -335,9 +335,9 @@ public class AuthTests extends StandardIntegrationTest {
                 assertEquals(adminUser, administratorUser);
 
                 // Try to log in with new password
-                userOld.logout();
+                userOld.logOut();
                 SyncCredentials credentials = SyncCredentials.usernamePassword(username, newPassword, false);
-                SyncUser userNew = SyncUser.login(credentials, Constants.AUTH_URL);
+                SyncUser userNew = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
                 assertTrue(userNew.isValid());
                 assertEquals(userOld.getIdentity(), userNew.getIdentity());
@@ -358,7 +358,7 @@ public class AuthTests extends StandardIntegrationTest {
         String username = UUID.randomUUID().toString();
         String password = "password";
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         SyncManager.addAuthenticationListener(new AuthenticationListener() {
             @Override
             public void loggedIn(SyncUser user) {
@@ -388,7 +388,7 @@ public class AuthTests extends StandardIntegrationTest {
                 looperThread.testComplete();
             }
         });
-        user.logout();
+        user.logOut();
     }
 
     @Test
@@ -397,7 +397,7 @@ public class AuthTests extends StandardIntegrationTest {
         String password = "password";
 
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        final SyncUser user = spy(SyncUser.login(credentials, Constants.AUTH_URL));
+        final SyncUser user = spy(SyncUser.logIn(credentials, Constants.AUTH_URL));
 
         when(user.isValid()).thenReturn(true, false);
 
@@ -427,7 +427,7 @@ public class AuthTests extends StandardIntegrationTest {
 
         realm.close();
         cachedInstance.close();
-        user.logout();
+        user.logOut();
     }
 
     @Test
@@ -436,9 +436,9 @@ public class AuthTests extends StandardIntegrationTest {
         String password = "password";
 
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
-        SyncUser currentUser = SyncUser.currentUser();
-        user.logout();
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
+        SyncUser currentUser = SyncUser.current();
+        user.logOut();
 
         assertFalse(user.isValid());
 
@@ -466,9 +466,9 @@ public class AuthTests extends StandardIntegrationTest {
         String password = "password";
 
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         RealmConfiguration configuration = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM).build();
-        user.logout();
+        user.logOut();
         assertFalse(user.isValid());
         Realm instance = Realm.getInstance(configuration);
         instance.close();
@@ -477,9 +477,9 @@ public class AuthTests extends StandardIntegrationTest {
     @Test
     public void logout_currentUserMoreThanOne() {
         UserFactory.createUniqueUser(Constants.AUTH_URL);
-        SyncUser.currentUser().logout();
+        SyncUser.current().logOut();
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
-        assertEquals(user, SyncUser.currentUser());
+        assertEquals(user, SyncUser.current());
     }
 
     // logging out 'user' should have the same impact on other instance(s) of the same user
@@ -489,36 +489,36 @@ public class AuthTests extends StandardIntegrationTest {
         String password = "password";
 
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
-        SyncUser currentUser = SyncUser.currentUser();
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
+        SyncUser currentUser = SyncUser.current();
 
         assertTrue(user.isValid());
         assertEquals(user, currentUser);
 
-        user.logout();
+        user.logOut();
 
         assertFalse(user.isValid());
         assertFalse(currentUser.isValid());
     }
 
-    // logging out 'currentUser' should have the same impact on other instance(s) of the user
+    // logging out 'current' should have the same impact on other instance(s) of the user
     @Test
     public void loggingOutCurrentUserShouldImpactOtherInstances() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
 
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
-        SyncUser currentUser = SyncUser.currentUser();
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
+        SyncUser currentUser = SyncUser.current();
 
         assertTrue(user.isValid());
         assertEquals(user, currentUser);
 
-        SyncUser.currentUser().logout();
+        SyncUser.current().logOut();
 
         assertFalse(user.isValid());
         assertFalse(currentUser.isValid());
-        assertNull(SyncUser.currentUser());
+        assertNull(SyncUser.current());
     }
 
     // verify that multiple users can be logged in at the same time
@@ -530,7 +530,7 @@ public class AuthTests extends StandardIntegrationTest {
         for (int i = 0; i < users.length; i++) {
             SyncCredentials credentials = SyncCredentials.usernamePassword(UUID.randomUUID().toString(), password,
                     true);
-            users[i] = SyncUser.login(credentials, Constants.AUTH_URL);
+            users[i] = SyncUser.logIn(credentials, Constants.AUTH_URL);
         }
 
         for (int i = 0; i < users.length; i++) {
@@ -538,7 +538,7 @@ public class AuthTests extends StandardIntegrationTest {
         }
 
         for (int i = 0; i < users.length; i++) {
-            users[i].logout();
+            users[i].logOut();
         }
 
         for (int i = 0; i < users.length; i++) {
@@ -555,17 +555,17 @@ public class AuthTests extends StandardIntegrationTest {
         // register the user the first time
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
 
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(user.isValid());
-        user.logout();
+        user.logOut();
         assertFalse(user.isValid());
 
         // on subsequent logins, the user is already registered.
         credentials = credentials = SyncCredentials.usernamePassword(username, password, false);
         for (int i = 0; i < 3; i++) {
-            user = SyncUser.login(credentials, Constants.AUTH_URL);
+            user = SyncUser.logIn(credentials, Constants.AUTH_URL);
             assertTrue(user.isValid());
-            user.logout();
+            user.logOut();
             assertFalse(user.isValid());
         }
     }
@@ -576,7 +576,7 @@ public class AuthTests extends StandardIntegrationTest {
         final String uniqueName = UUID.randomUUID().toString();
 
         final SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
-        SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         final Token revokedRefreshToken = SyncTestUtils.getRefreshToken(user);
 
         SyncManager.addAuthenticationListener(new AuthenticationListener() {
@@ -588,7 +588,7 @@ public class AuthTests extends StandardIntegrationTest {
             @Override
             public void loggedOut(SyncUser user) {
                 SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", false);
-                SyncUser loggedInUser = SyncUser.login(credentials, Constants.AUTH_URL);
+                SyncUser loggedInUser = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
                 Token token = SyncTestUtils.getRefreshToken(loggedInUser);
                 // still comparing the same user
@@ -601,7 +601,7 @@ public class AuthTests extends StandardIntegrationTest {
             }
         });
 
-        user.logout();
+        user.logOut();
         TestHelper.awaitOrFail(userLoggedInAgain);
     }
 
@@ -684,7 +684,7 @@ public class AuthTests extends StandardIntegrationTest {
         final String username = UUID.randomUUID().toString();
         final String password = "password";
         final SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        final SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        final SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(user.isValid());
 
         String identity = user.getIdentity();
@@ -708,7 +708,7 @@ public class AuthTests extends StandardIntegrationTest {
         final String username = UUID.randomUUID().toString();
         final String password = "password";
         final SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        final SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        final SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         final String identity = user.getIdentity();
 
         // unless the refresh_token is revoked (via logout) the admin user can still retrieve the user
@@ -746,7 +746,7 @@ public class AuthTests extends StandardIntegrationTest {
 
             }
         });
-        user.logout();
+        user.logOut();
     }
 
     @Test
@@ -762,7 +762,7 @@ public class AuthTests extends StandardIntegrationTest {
         final String username = UUID.randomUUID().toString();
         final String password = "password";
         final SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        final SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        final SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(user.isValid());
 
         SyncUserInfo userInfo = adminUser.retrieveInfoForUser("username", "invalid");
@@ -774,13 +774,13 @@ public class AuthTests extends StandardIntegrationTest {
         final String username1 = UUID.randomUUID().toString();
         final String password1 = "password";
         final SyncCredentials credentials1 = SyncCredentials.usernamePassword(username1, password1, true);
-        final SyncUser user1 = SyncUser.login(credentials1, Constants.AUTH_URL);
+        final SyncUser user1 = SyncUser.logIn(credentials1, Constants.AUTH_URL);
         assertTrue(user1.isValid());
 
         final String username2 = UUID.randomUUID().toString();
         final String password2 = "password";
         final SyncCredentials credentials2 = SyncCredentials.usernamePassword(username2, password2, true);
-        final SyncUser user2 = SyncUser.login(credentials2, Constants.AUTH_URL);
+        final SyncUser user2 = SyncUser.logIn(credentials2, Constants.AUTH_URL);
         assertTrue(user2.isValid());
 
         // trying to lookup user2 using user1 should not work (requires admin token)
@@ -797,7 +797,7 @@ public class AuthTests extends StandardIntegrationTest {
         final String username = UUID.randomUUID().toString();
         final String password = "password";
         final SyncCredentials credentials = SyncCredentials.usernamePassword(username, password, true);
-        final SyncUser user = SyncUser.login(credentials, Constants.AUTH_URL);
+        final SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
         assertTrue(user.isValid());
 
         // Login an admin user

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -76,7 +76,7 @@ public class AuthTests extends StandardIntegrationTest {
     @RunTestInLooperThread
     public void loginAsync_userNotExist() {
         SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
-        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
+        SyncUser.logInAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
             @Override
             public void onSuccess(SyncUser user) {
                 fail();
@@ -95,7 +95,7 @@ public class AuthTests extends StandardIntegrationTest {
     public void login_newUser() {
         String userId = UUID.randomUUID().toString();
         SyncCredentials credentials = SyncCredentials.usernamePassword(userId, "password", true);
-        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
+        SyncUser.logInAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
             @Override
             public void onSuccess(SyncUser user) {
                 assertFalse(user.isAdmin());
@@ -119,7 +119,7 @@ public class AuthTests extends StandardIntegrationTest {
     public void login_withAccessToken() {
         SyncUser adminUser = UserFactory.createAdminUser(Constants.AUTH_URL);
         SyncCredentials credentials = SyncCredentials.accessToken(SyncTestUtils.getRefreshToken(adminUser).value(), "custom-admin-user", adminUser.isAdmin());
-        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
+        SyncUser.logInAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
             @Override
             public void onSuccess(SyncUser user) {
                 assertTrue(user.isAdmin());
@@ -144,7 +144,7 @@ public class AuthTests extends StandardIntegrationTest {
     @RunTestInLooperThread
     public void login_withAnonymous() {
         SyncCredentials credentials = SyncCredentials.anonymous();
-        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
+        SyncUser.logInAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
             @Override
             public void onSuccess(SyncUser user) {
                 assertFalse(user.isAdmin());
@@ -170,7 +170,7 @@ public class AuthTests extends StandardIntegrationTest {
     @RunTestInLooperThread
     public void login_withNickname() {
         SyncCredentials credentials = SyncCredentials.nickname("foo", false);
-        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
+        SyncUser.logInAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
             @Override
             public void onSuccess(SyncUser user) {
                 assertFalse(user.isAdmin());
@@ -196,7 +196,7 @@ public class AuthTests extends StandardIntegrationTest {
     @RunTestInLooperThread
     public void login_withNicknameAsAdmin() {
         SyncCredentials credentials = SyncCredentials.nickname("foo", true);
-        SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
+        SyncUser.logInAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
             @Override
             public void onSuccess(SyncUser user) {
                 assertTrue(user.isAdmin());
@@ -234,7 +234,7 @@ public class AuthTests extends StandardIntegrationTest {
                         @Override
                         public void run() {
                             SyncCredentials credentials = SyncCredentials.usernamePassword("IWantToHackYou", "GeneralPassword", false);
-                            SyncUser.loginAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
+                            SyncUser.logInAsync(credentials, Constants.AUTH_URL, new SyncUser.Callback<SyncUser>() {
                                 @Override
                                 public void onSuccess(SyncUser user) {
                                     fail();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
@@ -43,7 +43,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         // STEP 1: open a synced Realm using a local encryption key
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         final byte[] randomKey = TestHelper.getRandomKey();
 
@@ -69,11 +69,11 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         // STEP 2:  make sure the changes gets to the server
         SystemClock.sleep(TimeUnit.SECONDS.toMillis(2));  // FIXME: Replace with Sync Progress Notifications once available.
         realm.close();
-        user.logout();
+        user.logOut();
 
         // STEP 3: try to open again the same sync Realm but different local name without the encryption key should not
         // fail
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         SyncConfiguration configWithoutEncryption = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
                 .name("newName")
                 .modules(new StringOnlyModule())
@@ -92,7 +92,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         assertEquals("Hi Alice", all.get(0).getChars());
 
         realm.close();
-        user.logout();
+        user.logOut();
     }
 
     // If an encrypted synced Realm is re-opened with the wrong key, throw an exception.
@@ -101,7 +101,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         // STEP 1: open a synced Realm using a local encryption key
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         final byte[] randomKey = TestHelper.getRandomKey();
 
@@ -128,10 +128,10 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         SyncManager.getSession(configWithEncryption).uploadAllLocalChanges();
 
         realm.close();
-        user.logout();
+        user.logOut();
 
         // STEP 3: try to open again the Realm without the encryption key should fail
-        user = SyncUser.login(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
+        user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         SyncConfiguration configWithoutEncryption = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
                 .modules(new StringOnlyModule())
                 .waitForInitialRemoteData()
@@ -160,7 +160,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         // STEP 1: prepare a synced Realm for client A
         String username = UUID.randomUUID().toString();
         String password = "password";
-        SyncUser user = SyncUser.login(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
 
         final byte[] randomKey = TestHelper.getRandomKey();
 
@@ -190,7 +190,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         // STEP 3: prepare a synced Realm for client B (admin user)
         SyncUser admin = UserFactory.createAdminUser(Constants.AUTH_URL);
         SyncCredentials credentials = SyncCredentials.accessToken(SyncTestUtils.getRefreshToken(admin).value(), "custom-admin-user");
-        SyncUser adminUser = SyncUser.login(credentials, Constants.AUTH_URL);
+        SyncUser adminUser = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         final byte[] adminRandomKey = TestHelper.getRandomKey();
 
@@ -235,9 +235,9 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         assertEquals("Hi Bob", allSortedAdmin.get(1).getChars());
 
         adminRealm.close();
-        adminUser.logout();
+        adminUser.logOut();
 
         realm.close();
-        user.logout();
+        user.logOut();
     }
 }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
@@ -17,10 +17,8 @@ package io.realm.objectserver;
 
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.Looper;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -266,7 +264,7 @@ public class ObjectLevelPermissionIntegrationTests extends StandardIntegrationTe
                                 AndroidCapabilities.EMULATE_MAIN_THREAD = oldValue;
                                 pm.close();
                                 realm.close();
-                                adminUser.logout();
+                                adminUser.logOut();
                                 setupRealm.countDown();
                             });
                         }

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -33,7 +33,6 @@ import io.realm.RealmResults;
 import io.realm.StandardIntegrationTest;
 import io.realm.SyncConfiguration;
 import io.realm.SyncManager;
-import io.realm.SyncSession;
 import io.realm.SyncUser;
 import io.realm.TestHelper;
 import io.realm.annotations.RealmModule;
@@ -108,7 +107,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
             @Override
             protected void run() {
                 getService().getRealm().close();
-                user.logout();
+                user.logOut();
             }
         };
     }
@@ -138,7 +137,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
                 assertEquals(1, all.size());
                 assertEquals("Background_Process1", all.get(0).getName());
                 realm.close();
-                user.logout();
+                user.logOut();
 
                 remoteService.triggerServiceStep(SimpleCommitRemoteService.stepB_closeRealmAndLogOut);
 
@@ -186,7 +185,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
             @Override
             protected void run() {
                 getService().getRealm().close();
-                user.logout();
+                user.logOut();
             }
         };
     }
@@ -228,7 +227,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
                 if (counter == 10) {
                     remoteService.triggerServiceStep(ALotCommitsRemoteService.stepC_closeRealm);
                     realm.close();
-                    user.logout();
+                    user.logOut();
                     looperThread.testComplete();
                 } else {
                     remoteService.triggerServiceStep(ALotCommitsRemoteService.stepB_createObjects);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
@@ -219,8 +219,8 @@ public class ProgressListenerTests extends StandardIntegrationTest {
         adminRealm.close();
         // worker thread will hang if logout happens before listener triggered.
         worker.join();
-        userWithData.logout();
-        adminUser.logout();
+        userWithData.logOut();
+        adminUser.logOut();
     }
 
     // Make sure that a ProgressListener continues to report the correct thing, even if it crashed

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/utils/UserFactory.java
@@ -18,20 +18,14 @@ package io.realm.objectserver.utils;
 
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.SystemClock;
 
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import io.realm.AuthenticationListener;
-import io.realm.ErrorCode;
-import io.realm.ObjectServerError;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import io.realm.SyncCredentials;
-import io.realm.SyncManager;
 import io.realm.SyncUser;
 import io.realm.TestHelper;
 import io.realm.internal.ObjectServerFacade;
@@ -62,7 +56,7 @@ public class UserFactory {
 
     public SyncUser loginWithDefaultUser(String authUrl) {
         SyncCredentials credentials = SyncCredentials.usernamePassword(userName, PASSWORD, false);
-        return SyncUser.login(credentials, authUrl);
+        return SyncUser.logIn(credentials, authUrl);
     }
 
     /**
@@ -83,25 +77,25 @@ public class UserFactory {
 
     private static SyncUser createUser(String username, String authUrl) {
         SyncCredentials credentials = SyncCredentials.usernamePassword(username, PASSWORD, true);
-        return SyncUser.login(credentials, authUrl);
+        return SyncUser.logIn(credentials, authUrl);
     }
 
 
     public SyncUser createDefaultUser(String authUrl) {
         SyncCredentials credentials = SyncCredentials.usernamePassword(userName, PASSWORD, true);
-        return SyncUser.login(credentials, authUrl);
+        return SyncUser.logIn(credentials, authUrl);
     }
 
     public static SyncUser createAdminUser(String authUrl) {
         // `admin` required as user identifier to be granted admin rights.
         // ROS 2.0 comes with a default admin user named "realm-admin" with password "".
         SyncCredentials credentials = SyncCredentials.usernamePassword("realm-admin", "", false);
-        return SyncUser.login(credentials, authUrl);
+        return SyncUser.logIn(credentials, authUrl);
     }
 
     public static SyncUser createNicknameUser(String authUrl, String nickname, boolean isAdmin) {
         SyncCredentials credentials = SyncCredentials.nickname(nickname, isAdmin);
-        return SyncUser.login(credentials, authUrl);
+        return SyncUser.logIn(credentials, authUrl);
     }
 
     // Since we don't have a reliable way to reset the sync server and client, just use a new user factory for every
@@ -156,7 +150,7 @@ public class UserFactory {
             public void run() {
                 Map<String, SyncUser> users = SyncUser.all();
                 for (SyncUser user : users.values()) {
-                    user.logout();
+                    user.logOut();
                 }
                 allUsersLoggedOut.countDown();
 


### PR DESCRIPTION
Align Sync API's with Cocoa.

Reasoning:
> “Log in” is a phrasal verb, while “login” is a noun. Given that the method in question performs an action, the verb is the correct choice.