### PR TITLE
deleteRealm throwing in loginLogoutResumeSyncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Enhancements
 
 * Added support for mapping between a Java name and the underlying name in the Realm file using `@RealmModule`, `@RealmClass` and `@RealmField` annotations (#5280).
+
+## Bug Fixes
+
 * [ObjectServer] Fixed an issue where login after a logout will not resume Syncing (https://github.com/realm/my-first-realm-app/issues/22).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * Added support for mapping between a Java name and the underlying name in the Realm file using `@RealmModule`, `@RealmClass` and `@RealmField` annotations (#5280).
+* [ObjectServer] Fixed an issue where login after a logout will not resume Syncing (https://github.com/realm/my-first-realm-app/issues/22).
 
 
 ## 4.3.4 (2018-02-06)
@@ -11,7 +12,6 @@
 
 * Added missing `RealmQuery.oneOf()` for Kotlin that accepts non-nullable types (#5717).
 * [ObjectServer] Fixed an issue preventing sync to resume when the network is back (#5677).
-* [ObjectServer] Fixed an issue where login after a logout will not resume Syncing (https://github.com/realm/my-first-realm-app/issues/22).
 
 ## 4.3.3 (2018-01-19)
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmTests.java
@@ -59,6 +59,7 @@ public class SyncedRealmTests extends StandardIntegrationTest {
 
         SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .schema(StringOnly.class)
+                .sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
                 .build();
 
         Realm realm = Realm.getInstance(config);
@@ -68,7 +69,18 @@ public class SyncedRealmTests extends StandardIntegrationTest {
         SyncManager.getSession(config).uploadAllLocalChanges();
         user.logout();
         realm.close();
-        assertTrue(Realm.deleteRealm(config));
+        try {
+            assertTrue(Realm.deleteRealm(config));
+        } catch (IllegalStateException e) {
+            // FIXME: We don't have a way to ensure that the Realm instance on client thread has been
+            //        closed for now.
+            // https://github.com/realm/realm-java/issues/5416
+            if (e.getMessage().contains("It's not allowed to delete the file")) {
+                // retry after 1 second
+                SystemClock.sleep(1000);
+                assertTrue(Realm.deleteRealm(config));
+            }
+        }
 
         user = SyncUser.login(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         SyncConfiguration config2 = new SyncConfiguration.Builder(user, Constants.USER_REALM)


### PR DESCRIPTION
- Fixed Changelog entries
- Workaround deleteRealm throwing in `loginLogoutResumeSyncing` sometimes 
(due to https://github.com/realm/realm-java/issues/5416)