### PR TITLE
Expose the per-user private role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Enhancements
 
-* [ObjectServer] `SyncConfiguration.automatic()` will make use of the host port to work out the default Realm URL. 
+* [ObjectServer] `SyncConfiguration.automatic()` will make use of the host port to work out the default Realm URL.
+* [ObjectServer] A role is now automatically created for each user with that user as its only member. This simplifies the common use case of restricting access to specific objects to a single user. This role can be accessed at `PermissionUser.getRole()`.
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
@@ -32,6 +32,7 @@ import io.realm.sync.permissions.ClassPermissions;
 import io.realm.sync.permissions.ClassPrivileges;
 import io.realm.sync.permissions.ObjectPrivileges;
 import io.realm.sync.permissions.Permission;
+import io.realm.sync.permissions.PermissionUser;
 import io.realm.sync.permissions.RealmPermissions;
 import io.realm.sync.permissions.RealmPrivileges;
 import io.realm.sync.permissions.Role;
@@ -39,6 +40,7 @@ import io.realm.sync.permissions.Role;
 import static io.realm.util.SyncTestUtils.createTestUser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -428,6 +430,20 @@ public class ObjectLevelPermissionsTest {
 //            fail();
 //        } catch (IllegalStateException ignore) {
 //        }
+    }
+
+    @Test
+    public void userPrivateRole() {
+        RealmResults<PermissionUser> permissionUsers = realm.where(PermissionUser.class).findAll();
+        assertEquals(1, permissionUsers.size());
+
+        PermissionUser permissionUser = permissionUsers.get(0);
+        assertNotNull(permissionUser);
+        Role role = permissionUser.getRole();
+        assertNotNull(role);
+
+        assertEquals("__User:" + user.getIdentity(), role.getName());
+        assertTrue(role.hasMember(user.getIdentity()));
     }
 
     @Test

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
@@ -457,7 +457,7 @@ public class ObjectLevelPermissionsTest {
         assertNull(builtInRole);
         permissionUser = realm.where(PermissionUser.class).equalTo("id", "id123").findFirst();
         assertNull(permissionUser.getRole());
-        assertNull(permissionUser.getRoles());
+        assertTrue(permissionUser.getRoles().isEmpty());
     }
 
     @Test

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
@@ -440,7 +440,7 @@ public class ObjectLevelPermissionsTest {
 
         PermissionUser permissionUser = permissionUsers.get(0);
         assertNotNull(permissionUser);
-        Role role = permissionUser.getRole();
+        Role role = permissionUser.getPrivateRole();
         assertNotNull(role);
 
         assertEquals("__User:" + user.getIdentity(), role.getName());
@@ -453,10 +453,10 @@ public class ObjectLevelPermissionsTest {
         PermissionUser permissionUser = realm.createObject(PermissionUser.class, "id123");
         realm.commitTransaction();
 
-        Role builtInRole = permissionUser.getRole();
+        Role builtInRole = permissionUser.getPrivateRole();
         assertNull(builtInRole);
         permissionUser = realm.where(PermissionUser.class).equalTo("id", "id123").findFirst();
-        assertNull(permissionUser.getRole());
+        assertNull(permissionUser.getPrivateRole());
         assertTrue(permissionUser.getRoles().isEmpty());
     }
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
@@ -41,6 +41,7 @@ import static io.realm.util.SyncTestUtils.createTestUser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -444,6 +445,19 @@ public class ObjectLevelPermissionsTest {
 
         assertEquals("__User:" + user.getIdentity(), role.getName());
         assertTrue(role.hasMember(user.getIdentity()));
+    }
+
+    @Test
+    public void userPrivateRoleNotAvailableBeforeSyncClientCreated() {
+        realm.beginTransaction();
+        PermissionUser permissionUser = realm.createObject(PermissionUser.class, "id123");
+        realm.commitTransaction();
+
+        Role builtInRole = permissionUser.getRole();
+        assertNull(builtInRole);
+        permissionUser = realm.where(PermissionUser.class).equalTo("id", "id123").findFirst();
+        assertNull(permissionUser.getRole());
+        assertNull(permissionUser.getRoles());
     }
 
     @Test

--- a/realm/realm-library/src/main/java/io/realm/sync/permissions/PermissionUser.java
+++ b/realm/realm-library/src/main/java/io/realm/sync/permissions/PermissionUser.java
@@ -39,6 +39,8 @@ public class PermissionUser extends RealmObject {
     @Required
     private String id;
 
+    private Role role;
+
     @LinkingObjects("members")
     final RealmResults<Role> roles = null;
 
@@ -71,5 +73,19 @@ public class PermissionUser extends RealmObject {
      */
     public @Nullable  RealmResults<Role> getRoles() {
         return roles;
+    }
+
+    /**
+     * The user's private role. This will be initialized to a role named for the user's
+     * identity that contains this user as its only member.
+     *
+     * @return User private {@link Role}.
+     */
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
     }
 }

--- a/realm/realm-library/src/main/java/io/realm/sync/permissions/PermissionUser.java
+++ b/realm/realm-library/src/main/java/io/realm/sync/permissions/PermissionUser.java
@@ -84,8 +84,4 @@ public class PermissionUser extends RealmObject {
     public Role getRole() {
         return role;
     }
-
-    public void setRole(Role role) {
-        this.role = role;
-    }
 }

--- a/realm/realm-library/src/main/java/io/realm/sync/permissions/PermissionUser.java
+++ b/realm/realm-library/src/main/java/io/realm/sync/permissions/PermissionUser.java
@@ -81,7 +81,7 @@ public class PermissionUser extends RealmObject {
      *
      * @return User private {@link Role}.
      */
-    public Role getRole() {
+    public Role getPrivateRole() {
         return role;
     }
 }


### PR DESCRIPTION
Sync is adding a private per-user role in realm/realm-sync#2068. We'll need to update our schema to accommodate.