### PR TITLE
RealmObject.isValid now returns the correct value for the null argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.0.2 (YYYY-MM-DD)
+
+### Bug Fixes
+
+* `RealmObject.isValid()` not correctly returns `false` if `null` is provided as an argument (#5865).
+
+
 ## 5.0.1 (YYYY-MM-DD)
 
 ### Enhancements

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -986,6 +986,12 @@ public class RealmObjectTests {
         assertTrue(allTypes.isValid());
     }
 
+    @Test
+    public void isValid_null() {
+        //noinspection ConstantConditions
+        assertFalse(RealmObject.isValid(null));
+    }
+
     // Stores and retrieves null values for nullable fields.
     @Test
     public void set_get_nullOnNullableFields() {

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -151,7 +151,8 @@ public abstract class RealmObject implements RealmModel, ManagableObject {
             Row row = proxy.realmGet$proxyState().getRow$realm();
             return row != null && row.isAttached();
         } else {
-            return true;
+            //noinspection ConstantConditions
+            return object != null;
         }
     }
 


### PR DESCRIPTION
Fixes #5865 