### PR TITLE
Fix AAR size not being reported correctly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,6 +145,10 @@ def archiveRosLog(String id) {
 }
 
 def sendMetrics(String metricName, String metricValue, Map<String, String> tags) {
+  def tagsString = getTagsString(tags)
+  withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '5b8ad2d9-61a4-43b5-b4df-b8ff6b1f16fa', passwordVariable: 'influx_pass', usernameVariable: 'influx_user']]) {
+    sh "echo 'https://greatscott-pinheads-70.c.influxdb.com:8086/write?db=realm' --data-binary '${metricName},${tagsString} value=${metricValue}i' --user 'XXX:XXX'"
+  }
 }
 
 @NonCPS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ try {
                 // TODO: add support for running monkey on the example apps
                 stage('Build') {
                   withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                    sh "chmod +x gradlew && ./gradlew assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
+                    sh "chmod +x gradlew && ./gradlew clean assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
                   }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ try {
                 // TODO: add support for running monkey on the example apps
                 stage('Build') {
                   withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                    sh "chmod +x gradlew && ./gradlew assembleExamples assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
+                    sh "chmod +x gradlew && ./gradlew assembleExamples assemble"
                   }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ try {
                 // TODO: add support for running monkey on the example apps
                 stage('Build') {
                   withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                    sh "chmod +x gradlew && ./gradlew clean installRealmJava -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
+                    sh "chmod +x gradlew && ./gradlew assembleExamples assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
                   }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ try {
                 // TODO: add support for running monkey on the example apps
                 stage('Build') {
                   withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                    sh "chmod +x gradlew && ./gradlew clean assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
+                    sh "cd realm && chmod +x gradlew && ./gradlew clean assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
                   }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ try {
                 // TODO: add support for running monkey on the example apps
                 stage('Build') {
                   withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                    sh "chmod +x gradlew && ./gradlew assembleRelease -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
+                    sh "chmod +x gradlew && ./gradlew assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
                   }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,12 @@ try {
         // A full build is done on `master`.
         // TODO Once Android emulators are available on all nodes, we can switch to x86 builds
         // on PR's for even more throughput.
-        def ABIs = ""
+        def abiFilter = ""
         def instrumentationTestTarget = "connectedAndroidTest"
+        if (!['master', 'next-major'].contains(env.BRANCH_NAME)) {
+            abiFilter = "-PbuildTargetABIs=armeabi-v7a"
+            instrumentationTestTarget = "connectedObjectServerDebugAndroidTest" // Run in debug more for better error reporting
+        }
 
         def buildEnv
         def rosEnv
@@ -41,7 +45,7 @@ try {
           rosEnv = docker.build 'ros:snapshot', "--build-arg ROS_DE_VERSION=${rosDeVersion} tools/sync_test_server"
         }
 
-	    rosContainer = rosEnv.run()
+      rosContainer = rosEnv.run()
 
         try {
               buildEnv.inside("-e HOME=/tmp " +
@@ -53,17 +57,72 @@ try {
                   "-v ${env.HOME}/ccache:/tmp/.ccache " +
                   "-e REALM_CORE_DOWNLOAD_DIR=/tmp/.gradle " +
                   "--network container:${rosContainer.id}") {
-
-                // TODO: add support for running monkey on the example apps
-                stage('Build') {
-                  withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                    sh "chmod +x gradlew && ./gradlew assembleExamples assemble"
+                stage('JVM tests') {
+                  try {
+                    withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
+                      sh "chmod +x gradlew && ./gradlew assemble check javadoc -Ps3cfg=${env.S3CFG} ${abiFilter}"
+                    }
+                  } finally {
+                    storeJunitResults 'realm/realm-annotations-processor/build/test-results/test/TEST-*.xml'
+                    storeJunitResults 'examples/unitTestExample/build/test-results/**/TEST-*.xml'
+                    step([$class: 'LintPublisher'])
                   }
                 }
 
-                stage('Collect metrics') {
-                  collectAarMetrics()
+                stage('Gradle plugin tests') {
+                  try {
+                    gradle('gradle-plugin', 'check')
+                  } finally {
+                    storeJunitResults 'gradle-plugin/build/test-results/test/TEST-*.xml'
+                  }
                 }
+
+                stage('Realm Transformer tests') {
+                  try {
+                    gradle('realm-transformer', 'check')
+                  } finally {
+                    storeJunitResults 'realm-transformer/build/test-results/test/TEST-*.xml'
+                  }
+                }
+
+                stage('Static code analysis') {
+                  try {
+                    gradle('realm', 'findbugs pmd checkstyle ${abiFilter}')
+                  } finally {
+                    publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/findbugs', reportFiles: 'findbugs-output.html', reportName: 'Findbugs issues'])
+                    publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/reports/pmd', reportFiles: 'pmd.html', reportName: 'PMD Issues'])
+                    step([$class: 'CheckStylePublisher',
+                  canComputeNew: false,
+                  defaultEncoding: '',
+                  healthy: '',
+                  pattern: 'realm/realm-library/build/reports/checkstyle/checkstyle.xml',
+                  unHealthy: ''
+                 ])
+                  }
+                }
+
+                stage('Run instrumented tests') {
+                  lock("${env.NODE_NAME}-android") {
+                    String backgroundPid
+                    try {
+                      backgroundPid = startLogCatCollector()
+                      forwardAdbPorts()
+                      gradle('realm', "${instrumentationTestTarget}")
+                    } finally {
+                      stopLogCatCollector(backgroundPid)
+                      storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'
+                      storeJunitResults 'realm/kotlin-extensions/build/outputs/androidTest-results/connected/**/TEST-*.xml'
+                    }
+                  }
+                }
+
+                // TODO: add support for running monkey on the example apps
+
+                if (!['master'].contains(env.BRANCH_NAME)) {
+                  stage('Collect metrics') {
+                    collectAarMetrics()
+                  }
+                }   
 
                 if (['master', 'next-major'].contains(env.BRANCH_NAME)) {
                   stage('Publish to OJO') {
@@ -92,14 +151,14 @@ try {
     node {
       withCredentials([[$class: 'StringBinding', credentialsId: 'slack-java-url', variable: 'SLACK_URL']]) {
         def payload = JsonOutput.toJson([
-	    username: 'Mr. Jenkins',
-	    icon_emoji: ':jenkins:',
-	    attachments: [[
-	        'title': "The ${env.BRANCH_NAME} branch is broken!",
-		'text': "<${env.BUILD_URL}|Click here> to check the build.",
-		'color': "danger"
-	    ]]
-	])
+      username: 'Mr. Jenkins',
+      icon_emoji: ':jenkins:',
+      attachments: [[
+          'title': "The ${env.BRANCH_NAME} branch is broken!",
+    'text': "<${env.BUILD_URL}|Click here> to check the build.",
+    'color': "danger"
+      ]]
+  ])
         sh "curl -X POST --data-urlencode \'payload=${payload}\' ${env.SLACK_URL}"
       }
     }
@@ -143,7 +202,7 @@ def archiveRosLog(String id) {
 def sendMetrics(String metricName, String metricValue, Map<String, String> tags) {
   def tagsString = getTagsString(tags)
   withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '5b8ad2d9-61a4-43b5-b4df-b8ff6b1f16fa', passwordVariable: 'influx_pass', usernameVariable: 'influx_user']]) {
-    sh "echo 'https://greatscott-pinheads-70.c.influxdb.com:8086/write?db=realm' --data-binary '${metricName},${tagsString} value=${metricValue}i' --user 'XXX:XXX'"
+    sh "echo curl -i -XPOST 'https://greatscott-pinheads-70.c.influxdb.com:8086/write?db=realm' --data-binary '${metricName},${tagsString} value=${metricValue}i' --user 'XXX:XXX'"
   }
 }
 
@@ -154,7 +213,7 @@ def getTagsString(Map<String, String> tags) {
 
 def storeJunitResults(String path) {
   step([
-	 $class: 'JUnitResultArchiver',
+   $class: 'JUnitResultArchiver',
      allowEmptyResults: true,
      testResults: path
    ])
@@ -166,29 +225,23 @@ def collectAarMetrics() {
     def flavor = flavors[i]
     sh """set -xe
       cd realm/realm-library/build/outputs/aar
-      unzip -l realm-android-library-${flavor}-release.aar
       unzip realm-android-library-${flavor}-release.aar -d unzipped${flavor}
-      ls -ll unzipped${flavor}
       find \$ANDROID_HOME -name dx | sort -r | head -n 1 > dx
       \$(cat dx) --dex --output=temp${flavor}.dex unzipped${flavor}/classes.jar
       cat temp${flavor}.dex | head -c 92 | tail -c 4 | hexdump -e '1/4 \"%d\"' > methods${flavor}
     """
 
     def methods = readFile("realm/realm-library/build/outputs/aar/methods${flavor}")
-    sh "echo Methods: ${methods}, flavor: ${flavor}"
     sendMetrics('methods', methods, ['flavor':flavor])
 
     def aarFile = findFiles(glob: "realm/realm-library/build/outputs/aar/realm-android-library-${flavor}-release.aar")[0]
-    sh "echo AarSize: ${aarFile.length as String}, flavor: ${flavor}"
     sendMetrics('aar_size', aarFile.length as String, ['flavor':flavor])
 
-    def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/**/librealm-jni.so")
-    sh "echo files: ${soFiles.size()}"
+    def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/jni/*/librealm-jni.so")
     for (def j = 0; j < soFiles.size(); j++) {
       def soFile = soFiles[j]
       def abiName = soFile.path.tokenize('/')[-2]
       def libSize = soFile.length as String
-      sh "echo soFile: ${soFile}, abiName: ${abiName}, size: ${libSize}"
       sendMetrics('abi_size', libSize, ['flavor':flavor, 'type':abiName])
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,6 +167,7 @@ def collectAarMetrics() {
     sh """set -xe
       cd realm/realm-library/build/outputs/aar
       unzip realm-android-library-${flavor}-release.aar -d unzipped${flavor}
+      ls -ll unzipped${flavor}
       find \$ANDROID_HOME -name dx | sort -r | head -n 1 > dx
       \$(cat dx) --dex --output=temp${flavor}.dex unzipped${flavor}/classes.jar
       cat temp${flavor}.dex | head -c 92 | tail -c 4 | hexdump -e '1/4 \"%d\"' > methods${flavor}
@@ -180,7 +181,7 @@ def collectAarMetrics() {
     sh "echo AarSize: ${aarFile.length as String}, flavor: ${flavor}"
     sendMetrics('aar_size', aarFile.length as String, ['flavor':flavor])
 
-    def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/jni/**/librealm-jni.so")
+    def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/**/librealm-jni.so")
     sh "echo files: ${soFiles.size()}"
     for (def j = 0; j < soFiles.size(); j++) {
       def soFile = soFiles[j]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,6 +166,7 @@ def collectAarMetrics() {
     def flavor = flavors[i]
     sh """set -xe
       cd realm/realm-library/build/outputs/aar
+      unzip -l realm-android-library-${flavor}-release.aar
       unzip realm-android-library-${flavor}-release.aar -d unzipped${flavor}
       ls -ll unzipped${flavor}
       find \$ANDROID_HOME -name dx | sort -r | head -n 1 > dx

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,8 @@ def collectAarMetrics() {
     sh "echo AarSize: ${aarFile.length as String}, flavor: ${flavor}"
     sendMetrics('aar_size', aarFile.length as String, ['flavor':flavor])
 
-    def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/jni/*/librealm-jni.so")
+    def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/jni/**/librealm-jni.so")
+    sho "echo files: ${soFiles.size()}"
     for (def j = 0; j < soFiles.size(); j++) {
       def soFile = soFiles[j]
       def abiName = soFile.path.tokenize('/')[-2]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,7 @@ def collectAarMetrics() {
     sendMetrics('aar_size', aarFile.length as String, ['flavor':flavor])
 
     def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/jni/**/librealm-jni.so")
-    sho "echo files: ${soFiles.size()}"
+    sh "echo files: ${soFiles.size()}"
     for (def j = 0; j < soFiles.size(); j++) {
       def soFile = soFiles[j]
       def abiName = soFile.path.tokenize('/')[-2]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,8 @@ try {
                   "-v ${env.HOME}/ccache:/tmp/.ccache " +
                   "-e REALM_CORE_DOWNLOAD_DIR=/tmp/.gradle " +
                   "--network container:${rosContainer.id}") {
+
+/* Disable while testing
                 stage('JVM tests') {
                   try {
                     withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
@@ -115,14 +117,15 @@ try {
                     }
                   }
                 }
+*/
 
                 // TODO: add support for running monkey on the example apps
 
-                if (['master'].contains(env.BRANCH_NAME)) {
+//               if (['master'].contains(env.BRANCH_NAME)) {
                   stage('Collect metrics') {
                     collectAarMetrics()
                   }
-                }   
+//                }   
 
                 if (['master', 'next-major'].contains(env.BRANCH_NAME)) {
                   stage('Publish to OJO') {
@@ -200,10 +203,12 @@ def archiveRosLog(String id) {
 }
 
 def sendMetrics(String metricName, String metricValue, Map<String, String> tags) {
+/* Disable while testing
   def tagsString = getTagsString(tags)
   withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '5b8ad2d9-61a4-43b5-b4df-b8ff6b1f16fa', passwordVariable: 'influx_pass', usernameVariable: 'influx_user']]) {
     sh "curl -i -XPOST 'https://greatscott-pinheads-70.c.influxdb.com:8086/write?db=realm' --data-binary '${metricName},${tagsString} value=${metricValue}i' --user '${env.influx_user}:${env.influx_pass}'"
   }
+*/  
 }
 
 @NonCPS
@@ -240,8 +245,11 @@ def collectAarMetrics() {
     def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/jni/*/librealm-jni.so")
     for (def j = 0; j < soFiles.size(); j++) {
       def soFile = soFiles[j]
+      sh "echo soFile: ${soFile}"
       def abiName = soFile.path.tokenize('/')[-2]
+      sh "echo abiName: ${abiName}"
       def libSize = soFile.length as String
+      sh "echo Lib size: ${libSize}"
       sendMetrics('abi_size', libSize, ['flavor':flavor, 'type':abiName])
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ try {
                 // TODO: add support for running monkey on the example apps
                 stage('Build') {
                   withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                    sh "cd realm && chmod +x gradlew && ./gradlew clean assemble -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
+                    sh "chmod +x gradlew && ./gradlew clean installRealmJava -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
                   }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ try {
 
                 stage('Static code analysis') {
                   try {
-                    gradle('realm', 'findbugs pmd checkstyle ${abiFilter}')
+                    gradle('realm', "findbugs pmd checkstyle ${abiFilter}")
                   } finally {
                     publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/findbugs', reportFiles: 'findbugs-output.html', reportName: 'Findbugs issues'])
                     publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/reports/pmd', reportFiles: 'pmd.html', reportName: 'PMD Issues'])
@@ -118,7 +118,7 @@ try {
 
                 // TODO: add support for running monkey on the example apps
 
-                if (!['master'].contains(env.BRANCH_NAME)) {
+                if (['master'].contains(env.BRANCH_NAME)) {
                   stage('Collect metrics') {
                     collectAarMetrics()
                   }
@@ -151,14 +151,14 @@ try {
     node {
       withCredentials([[$class: 'StringBinding', credentialsId: 'slack-java-url', variable: 'SLACK_URL']]) {
         def payload = JsonOutput.toJson([
-      username: 'Mr. Jenkins',
-      icon_emoji: ':jenkins:',
-      attachments: [[
-          'title': "The ${env.BRANCH_NAME} branch is broken!",
-    'text': "<${env.BUILD_URL}|Click here> to check the build.",
-    'color': "danger"
-      ]]
-  ])
+          username: 'Mr. Jenkins',
+          icon_emoji: ':jenkins:',
+          attachments: [[
+            'title': "The ${env.BRANCH_NAME} branch is broken!",
+            'text': "<${env.BUILD_URL}|Click here> to check the build.",
+            'color': "danger"
+          ]]
+        ])
         sh "curl -X POST --data-urlencode \'payload=${payload}\' ${env.SLACK_URL}"
       }
     }
@@ -213,10 +213,10 @@ def getTagsString(Map<String, String> tags) {
 
 def storeJunitResults(String path) {
   step([
-   $class: 'JUnitResultArchiver',
-     allowEmptyResults: true,
-     testResults: path
-   ])
+    $class: 'JUnitResultArchiver',
+      allowEmptyResults: true,
+      testResults: path
+    ])
 }
 
 def collectAarMetrics() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ try {
           rosEnv = docker.build 'ros:snapshot', "--build-arg ROS_DE_VERSION=${rosDeVersion} tools/sync_test_server"
         }
 
-      rosContainer = rosEnv.run()
+	    rosContainer = rosEnv.run()
 
         try {
               buildEnv.inside("-e HOME=/tmp " +
@@ -122,7 +122,7 @@ try {
                   stage('Collect metrics') {
                     collectAarMetrics()
                   }
-                }   
+                }
 
                 if (['master', 'next-major'].contains(env.BRANCH_NAME)) {
                   stage('Publish to OJO') {
@@ -151,14 +151,14 @@ try {
     node {
       withCredentials([[$class: 'StringBinding', credentialsId: 'slack-java-url', variable: 'SLACK_URL']]) {
         def payload = JsonOutput.toJson([
-          username: 'Mr. Jenkins',
-          icon_emoji: ':jenkins:',
-          attachments: [[
-            'title': "The ${env.BRANCH_NAME} branch is broken!",
-            'text': "<${env.BUILD_URL}|Click here> to check the build.",
-            'color': "danger"
-          ]]
-        ])
+	    username: 'Mr. Jenkins',
+	    icon_emoji: ':jenkins:',
+	    attachments: [[
+	        'title': "The ${env.BRANCH_NAME} branch is broken!",
+		'text': "<${env.BUILD_URL}|Click here> to check the build.",
+		'color': "danger"
+	    ]]
+	])
         sh "curl -X POST --data-urlencode \'payload=${payload}\' ${env.SLACK_URL}"
       }
     }
@@ -202,7 +202,7 @@ def archiveRosLog(String id) {
 def sendMetrics(String metricName, String metricValue, Map<String, String> tags) {
   def tagsString = getTagsString(tags)
   withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '5b8ad2d9-61a4-43b5-b4df-b8ff6b1f16fa', passwordVariable: 'influx_pass', usernameVariable: 'influx_user']]) {
-    sh "echo curl -i -XPOST 'https://greatscott-pinheads-70.c.influxdb.com:8086/write?db=realm' --data-binary '${metricName},${tagsString} value=${metricValue}i' --user 'XXX:XXX'"
+    sh "curl -i -XPOST 'https://greatscott-pinheads-70.c.influxdb.com:8086/write?db=realm' --data-binary '${metricName},${tagsString} value=${metricValue}i' --user '${env.influx_user}:${env.influx_pass}'"
   }
 }
 
@@ -213,10 +213,10 @@ def getTagsString(Map<String, String> tags) {
 
 def storeJunitResults(String path) {
   step([
-    $class: 'JUnitResultArchiver',
-      allowEmptyResults: true,
-      testResults: path
-    ])
+	 $class: 'JUnitResultArchiver',
+     allowEmptyResults: true,
+     testResults: path
+   ])
 }
 
 def collectAarMetrics() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,6 @@ try {
         // on PR's for even more throughput.
         def ABIs = ""
         def instrumentationTestTarget = "connectedAndroidTest"
-        if (!['master', 'next-major'].contains(env.BRANCH_NAME)) {
-            ABIs = "armeabi-v7a"
-            instrumentationTestTarget = "connectedObjectServerDebugAndroidTest" // Run in debug more for better error reporting
-        }
 
         def buildEnv
         def rosEnv

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,19 +173,19 @@ def collectAarMetrics() {
     """
 
     def methods = readFile("realm/realm-library/build/outputs/aar/methods${flavor}")
+    sh "echo Methods: ${methods}, flavor: ${flavor}"
     sendMetrics('methods', methods, ['flavor':flavor])
 
     def aarFile = findFiles(glob: "realm/realm-library/build/outputs/aar/realm-android-library-${flavor}-release.aar")[0]
+    sh "echo AarSize: ${aarFile.length as String}, flavor: ${flavor}"
     sendMetrics('aar_size', aarFile.length as String, ['flavor':flavor])
 
     def soFiles = findFiles(glob: "realm/realm-library/build/outputs/aar/unzipped${flavor}/jni/*/librealm-jni.so")
     for (def j = 0; j < soFiles.size(); j++) {
       def soFile = soFiles[j]
-      sh "echo soFile: ${soFile}"
       def abiName = soFile.path.tokenize('/')[-2]
-      sh "echo abiName: ${abiName}"
       def libSize = soFile.length as String
-      sh "echo Lib size: ${libSize}"
+      sh "echo soFile: ${soFile}, abiName: ${abiName}, size: ${libSize}"
       sendMetrics('abi_size', libSize, ['flavor':flavor, 'type':abiName])
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,74 +58,11 @@ try {
                   "-e REALM_CORE_DOWNLOAD_DIR=/tmp/.gradle " +
                   "--network container:${rosContainer.id}") {
 
-/* Disable while testing
-                stage('JVM tests') {
-                  try {
-                    withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
-                      sh "chmod +x gradlew && ./gradlew assemble check javadoc -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
-                    }
-                  } finally {
-                    storeJunitResults 'realm/realm-annotations-processor/build/test-results/test/TEST-*.xml'
-                    storeJunitResults 'examples/unitTestExample/build/test-results/**/TEST-*.xml'
-                    step([$class: 'LintPublisher'])
-                  }
-                }
-
-                stage('Gradle plugin tests') {
-                  try {
-                    gradle('gradle-plugin', 'check')
-                  } finally {
-                    storeJunitResults 'gradle-plugin/build/test-results/test/TEST-*.xml'
-                  }
-                }
-
-                stage('Realm Transformer tests') {
-                  try {
-                    gradle('realm-transformer', 'check')
-                  } finally {
-                    storeJunitResults 'realm-transformer/build/test-results/test/TEST-*.xml'
-                  }
-                }
-
-                stage('Static code analysis') {
-                  try {
-                    gradle('realm', 'findbugs pmd checkstyle -PbuildTargetABIs=${ABIs}')
-                  } finally {
-                    publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/findbugs', reportFiles: 'findbugs-output.html', reportName: 'Findbugs issues'])
-                    publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'realm/realm-library/build/reports/pmd', reportFiles: 'pmd.html', reportName: 'PMD Issues'])
-                    step([$class: 'CheckStylePublisher',
-                  canComputeNew: false,
-                  defaultEncoding: '',
-                  healthy: '',
-                  pattern: 'realm/realm-library/build/reports/checkstyle/checkstyle.xml',
-                  unHealthy: ''
-                 ])
-                  }
-                }
-
-                stage('Run instrumented tests') {
-                  lock("${env.NODE_NAME}-android") {
-                    String backgroundPid
-                    try {
-                      backgroundPid = startLogCatCollector()
-                      forwardAdbPorts()
-                      gradle('realm', "${instrumentationTestTarget}")
-                    } finally {
-                      stopLogCatCollector(backgroundPid)
-                      storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'
-                      storeJunitResults 'realm/kotlin-extensions/build/outputs/androidTest-results/connected/**/TEST-*.xml'
-                    }
-                  }
-                }
-*/
-
                 // TODO: add support for running monkey on the example apps
 
-//               if (['master'].contains(env.BRANCH_NAME)) {
-                  stage('Collect metrics') {
-                    collectAarMetrics()
-                  }
-//                }   
+                stage('Collect metrics') {
+                  collectAarMetrics()
+                }
 
                 if (['master', 'next-major'].contains(env.BRANCH_NAME)) {
                   stage('Publish to OJO') {
@@ -203,12 +140,6 @@ def archiveRosLog(String id) {
 }
 
 def sendMetrics(String metricName, String metricValue, Map<String, String> tags) {
-/* Disable while testing
-  def tagsString = getTagsString(tags)
-  withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '5b8ad2d9-61a4-43b5-b4df-b8ff6b1f16fa', passwordVariable: 'influx_pass', usernameVariable: 'influx_user']]) {
-    sh "curl -i -XPOST 'https://greatscott-pinheads-70.c.influxdb.com:8086/write?db=realm' --data-binary '${metricName},${tagsString} value=${metricValue}i' --user '${env.influx_user}:${env.influx_pass}'"
-  }
-*/  
 }
 
 @NonCPS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,11 @@ try {
                   "--network container:${rosContainer.id}") {
 
                 // TODO: add support for running monkey on the example apps
+                stage('Build') {
+                  withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 'S3CFG']]) {
+                    sh "chmod +x gradlew && ./gradlew assembleRelease -Ps3cfg=${env.S3CFG} -PbuildTargetABIs=${ABIs}"
+                  }
+                }
 
                 stage('Collect metrics') {
                   collectAarMetrics()


### PR DESCRIPTION
10 steps back and 11 forward.

After a lot of detours I discovered that Zaki added a small optimization which meant that if `PbuildTargetABIs` was set to to the empty string, all ABI's where being filtered, resulting in only metrics for the Java code being sent to the server (which also explains why only a a few hundred kb was being reported for the full AAR).

To fix this, we now only set `PbuildTargetABIs` if it has a value.