### PR TITLE
Query-based sync as the default mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.0.0 (YYYY-MM-DD)
+
+### Breaking Changes
+
+* [ObjectServer] Partial sync is now the default mode of synchronization. `SyncConfiguration.Builder.partialRealm()` has been replaced by `SyncConfiguration.Builder.fullSynchronization()`
+
+
 ## 5.0.1 (2018-04-09)
 
 ### Enhancements

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/ObjectLevelPermissionsTest.java
@@ -69,7 +69,6 @@ public class ObjectLevelPermissionsTest {
     public void setUp() {
         user = createTestUser();
         configuration = new SyncConfiguration.Builder(user, REALM_URI)
-                .partialRealm()
                 .modules(new TestModule())
                 .build();
         realm = Realm.getInstance(configuration);

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncManagerTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncManagerTests.java
@@ -83,7 +83,10 @@ public class SyncManagerTests {
     @After
     public void tearDown() {
         UserFactory.logoutAllUsers();
-        SyncManager.reset();
+        UserStore userStore = SyncManager.getUserStore();
+        for (SyncUser syncUser : userStore.allUsers()) {
+            userStore.remove(syncUser.getIdentity(), syncUser.getAuthenticationUrl().toString());
+        }
     }
 
     @Test

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -103,7 +103,10 @@ public class SyncUserTests {
 
     @Before
     public void setUp() {
-        SyncManager.reset();
+        UserStore userStore = SyncManager.getUserStore();
+        for (SyncUser syncUser : userStore.allUsers()) {
+            userStore.remove(syncUser.getIdentity(), syncUser.getAuthenticationUrl().toString());
+        }
     }
 
     @After

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncedRealmTests.java
@@ -62,7 +62,6 @@ public class SyncedRealmTests {
 
     private Realm getPartialRealm() {
         SyncConfiguration config = configFactory.createSyncConfigurationBuilder(SyncTestUtils.createTestUser(), "http://foo.com/fullsync")
-                .partialRealm()
                 .build();
         realm = Realm.getInstance(config);
         return realm;
@@ -70,6 +69,7 @@ public class SyncedRealmTests {
 
     private Realm getFullySyncRealm() {
         SyncConfiguration config = configFactory.createSyncConfigurationBuilder(SyncTestUtils.createTestUser(), "http://foo.com/fullsync")
+                .fullSynchronization()
                 .build();
         realm = Realm.getInstance(config);
         return realm;

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1590,7 +1590,7 @@ public class Realm extends BaseRealm {
      * Deletes all objects of the specified class from the Realm.
      *
      * @param clazz the class which objects should be removed.
-     * @throws IllegalStateException if the corresponding Realm is a partially synchronized Realm, is
+     * @throws IllegalStateException if the corresponding Realm is a query-based synchronized Realm, is
      * closed or called from an incorrect thread.
      */
     public void delete(Class<? extends RealmModel> clazz) {
@@ -1728,7 +1728,7 @@ public class Realm extends BaseRealm {
      * @return a {@link RealmAsyncTask} representing a cancellable task.
      * @throws IllegalArgumentException if no {@code subscriptionName} or {@code callback} was provided.
      * @throws IllegalStateException if called on a non-looper thread.
-     * @throws UnsupportedOperationException if the Realm is not a partially synchronized Realm.
+     * @throws UnsupportedOperationException if the Realm is not a query-based synchronized Realm.
      */
     @Beta
     public RealmAsyncTask unsubscribeAsync(String subscriptionName, Realm.UnsubscribeCallback callback) {
@@ -1741,7 +1741,7 @@ public class Realm extends BaseRealm {
         }
         sharedRealm.capabilities.checkCanDeliverNotification("This method is only available from a Looper thread.");
         if (!ObjectServerFacade.getSyncFacadeIfPossible().isPartialRealm(configuration)) {
-            throw new UnsupportedOperationException("Realm is not a partially synchronized Realm: " + configuration.getPath());
+            throw new UnsupportedOperationException("Realm is fully synchronized Realm. This method is only available when using query-based synchronization: " + configuration.getPath());
         }
 
         return executeTransactionAsync(new Transaction() {
@@ -1944,7 +1944,7 @@ public class Realm extends BaseRealm {
     }
 
     /**
-     * Interface used when canceling partial sync subscriptions.
+     * Interface used when canceling query-based sync subscriptions.
      *
      * @see #unsubscribeAsync(String, UnsubscribeCallback)
      */

--- a/realm/realm-library/src/objectServer/java/io/realm/PermissionManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/PermissionManager.java
@@ -180,6 +180,7 @@ public class PermissionManager implements Closeable {
         threadId = Thread.currentThread().getId();
         managementRealmConfig = new SyncConfiguration.Builder(
                 user, getRealmUrl(RealmType.MANAGEMENT_REALM, user.getAuthenticationUrl()))
+                .fullSynchronization()
                 .errorHandler(new SyncSession.ErrorHandler() {
                     @Override
                     public void onError(SyncSession session, ObjectServerError error) {
@@ -194,6 +195,7 @@ public class PermissionManager implements Closeable {
 
         permissionRealmConfig = new SyncConfiguration.Builder(
                 user, getRealmUrl(RealmType.PERMISSION_REALM, user.getAuthenticationUrl()))
+                .fullSynchronization()
                 .errorHandler(new SyncSession.ErrorHandler() {
                     @Override
                     public void onError(SyncSession session, ObjectServerError error) {
@@ -211,6 +213,7 @@ public class PermissionManager implements Closeable {
 
         defaultPermissionRealmConfig = new SyncConfiguration.Builder(
                 user, getRealmUrl(RealmType.DEFAULT_PERMISSION_REALM, user.getAuthenticationUrl()))
+                .fullSynchronization()
                 .errorHandler(new SyncSession.ErrorHandler() {
                     @Override
                     public void onError(SyncSession session, ObjectServerError error) {

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -224,7 +224,6 @@ public class SyncConfiguration extends RealmConfiguration {
 
     private static SyncConfiguration getDefaultConfig(SyncUser user) {
         return new SyncConfiguration.Builder(user, createUrl(user))
-                .partialRealm()
                 .build();
     }
 
@@ -430,16 +429,12 @@ public class SyncConfiguration extends RealmConfiguration {
     }
 
     /**
-     * Whether this configuration is for a partial synchronization Realm.
-     * <p>
-     * Partial synchronization allows a synchronized Realm to be opened in such a way that
-     * only objects queried by the user are synchronized to the device.
+     * Returns whether this configuration is for a fully synchronized Realm or not.
      *
-     * @return {@code true} to open a partial synchronization Realm {@code false} otherwise.
-     * @see Builder#partialRealm() for more details.
+     * @see Builder#fullSynchronization() for more details.
      */
-    public boolean isPartialRealm() {
-        return isPartial;
+    public boolean isFullySynchronizedRealm() {
+        return !isPartial;
     }
 
     /**
@@ -477,7 +472,7 @@ public class SyncConfiguration extends RealmConfiguration {
         @Nullable
         private String serverCertificateFilePath;
         private OsRealmConfig.SyncSessionStopPolicy sessionStopPolicy = OsRealmConfig.SyncSessionStopPolicy.AFTER_CHANGES_UPLOADED;
-        private boolean isPartial = false;
+        private boolean isPartial = true; // Partial Synchronization is enabled by default
         /**
          * Creates an instance of the Builder for the SyncConfiguration.
          * <p>
@@ -941,11 +936,16 @@ public class SyncConfiguration extends RealmConfiguration {
         }
 
         /**
-         * Setting this will open a partially synchronized Realm.
-         * @see #isPartialRealm()
+         * Define this Realm as a fully synchronized Realm.
+         * <p>
+         * Full synchronization, unlike the default partial synchronization, will transparently
+         * synchronize the entire Realm without needing to subscribe to the data. This option is
+         * useful if all the data in the Realm is used or if it all belongs to the user.
+         *
+         * @see #isFullySynchronizedRealm() ()
          */
-        public SyncConfiguration.Builder partialRealm() {
-            this.isPartial = true;
+        public SyncConfiguration.Builder fullSynchronization() {
+            this.isPartial = false;
             return this;
         }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -92,6 +92,9 @@ import io.realm.rx.RxObservableFactory;
  *
  * Synchronized Realms are created by using {@link Realm#getInstance(RealmConfiguration)} and
  * {@link Realm#getDefaultInstance()} like ordinary unsynchronized Realms.
+ *
+ * @see <a href="https://docs.realm.io/platform/using-synced-realms/syncing-data">The docs</a> for more
+ * information about the two types of synchronization.
  */
 public class SyncConfiguration extends RealmConfiguration {
 

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -46,7 +46,7 @@ import io.realm.rx.RealmObservableFactory;
 import io.realm.rx.RxObservableFactory;
 
 /**
- * An {@link SyncConfiguration} is used to setup a Realm that can be synchronized between devices using the Realm
+ * A {@link SyncConfiguration} is used to setup a Realm that can be synchronized between devices using the Realm
  * Object Server.
  * <p>
  * A valid {@link SyncUser} is required to create a {@link SyncConfiguration}. See {@link SyncCredentials} and
@@ -56,13 +56,32 @@ import io.realm.rx.RxObservableFactory;
  * A minimal {@link SyncConfiguration} can be found below.
  * <pre>
  * {@code
- * SyncConfiguration config = new SyncConfiguration.Builder(context)
- *   .serverUrl("realm://objectserver.realm.io/~/default")
- *   .user(myUser)
- *   .build();
+ * SyncUser user = SyncUser.current();
+ * String url = "realm://myinstance.cloud.realm.io/default";
+ * SyncConfiguration config = new SyncConfiguration.Builder(user, url).build();
  * }
  * </pre>
  *
+ * Synchronized Realms come in two forms:
+ * <ul>
+ *     <li>
+ *         <b>Query-based synchronization:</b>
+ *         This is the default mode. The Realm will only synchronize data you have queried for.
+ *         This means the Realm on the device is initially empty and will gradually fill up as
+ *         you start to query for data. This is useful if the server side Realm is too large
+ *         to fit on the device or contains data from multiple users. Data synchronized this way
+ *         can also be removed from the device again without being deleted on the server.
+ *     </li>
+ *     <li>
+ *         <b>Full synchronization</b></>
+ *         Enable this mode by setting {@link Builder#fullSynchronization()}. In this mode
+ *         the entire Realm is synchronized in the background without having to query for
+ *         data first. This means that data generally will be available quicker but should only
+ *         be used if the server side Realm is small and doesn't contain data the device is not
+ *         allowed to see.
+ *     </li>
+ * </ul>
+ * <p>
  * Synchronized Realms only support additive migrations which can be detected and performed automatically, so
  * the following builder options are not accessible compared to a normal Realm:
  *
@@ -938,9 +957,10 @@ public class SyncConfiguration extends RealmConfiguration {
         /**
          * Define this Realm as a fully synchronized Realm.
          * <p>
-         * Full synchronization, unlike the default partial synchronization, will transparently
-         * synchronize the entire Realm without needing to subscribe to the data. This option is
-         * useful if all the data in the Realm is used or if it all belongs to the user.
+         * Full synchronization, unlike the default query-based synchronization, will transparently
+         * synchronize the entire Realm without needing to query for the data. This option is
+         * useful if the serverside Realm is small and all the data in the Realm should be
+         * available to the user.
          *
          * @see #isFullySynchronizedRealm() ()
          */
@@ -1069,7 +1089,7 @@ public class SyncConfiguration extends RealmConfiguration {
                 }
             }
 
-            // If partial sync is enabled, also add support for Object Level Permissions
+            // If query based sync is enabled, also add support for Object Level Permissions
             if (isPartial) {
                 addModule(new ObjectPermissionsModule());
             }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -94,7 +94,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
             String syncRealmAuthUrl = user.getAuthenticationUrl().toString();
             String rosSerializedUser = user.toJson();
             byte sessionStopPolicy = syncConfig.getSessionStopPolicy().getNativeValue();
-            return new Object[]{rosUserIdentity, rosServerUrl, syncRealmAuthUrl, rosSerializedUser, syncConfig.syncClientValidateSsl(), syncConfig.getServerCertificateFilePath(), sessionStopPolicy, syncConfig.isPartialRealm()};
+            return new Object[]{rosUserIdentity, rosServerUrl, syncRealmAuthUrl, rosSerializedUser, syncConfig.syncClientValidateSsl(), syncConfig.getServerCertificateFilePath(), sessionStopPolicy, !syncConfig.isFullySynchronizedRealm()};
         } else {
             return new Object[8];
         }
@@ -180,7 +180,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     public boolean isPartialRealm(RealmConfiguration configuration) {
         if (configuration instanceof SyncConfiguration) {
             SyncConfiguration syncConfig = (SyncConfiguration) configuration;
-            return syncConfig.isPartialRealm();
+            return !syncConfig.isFullySynchronizedRealm();
         }
         
         return false;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SSLConfigurationTests.java
@@ -58,6 +58,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // 1. Copy a valid Realm to the server
         //noinspection unchecked
         final SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .build();
         Realm realm = Realm.getInstance(syncConfig);
@@ -76,6 +77,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigSSL = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
+                .fullSynchronization()
                 .name("useSsl")
                 .schema(StringOnly.class)
                 .waitForInitialRemoteData()
@@ -103,6 +105,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // 1. Copy a valid Realm to the server
         //noinspection unchecked
         final SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .build();
         Realm realm = Realm.getInstance(syncConfig);
@@ -121,6 +124,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigSSL = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
+                .fullSynchronization()
                 .name("useSsl")
                 .schema(StringOnly.class)
                 .waitForInitialRemoteData()
@@ -238,6 +242,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // 1. Copy a valid Realm to the server using ssl_verify_path option
         //noinspection unchecked
         final SyncConfiguration syncConfigWithCertificate = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .trustedRootCA("trusted_ca.pem")
                 .build();
@@ -257,6 +262,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         //noinspection unchecked
         SyncConfiguration syncConfigDisableSSL = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
+                .fullSynchronization()
                 .name("useSsl")
                 .schema(StringOnly.class)
                 .waitForInitialRemoteData()
@@ -288,6 +294,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         // 1. Copy a valid Realm to the server using ssl_verify_path option
         //noinspection unchecked
         final SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .build();
         Realm realm = Realm.getInstance(syncConfig);
@@ -307,6 +314,7 @@ public class SSLConfigurationTests extends StandardIntegrationTest {
         //noinspection unchecked
         SyncConfiguration syncConfigSecure = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM_SECURE)
                 .name("useSsl")
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .waitForInitialRemoteData()
                 .build();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
@@ -79,6 +79,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
                 .build();
         Realm realm = Realm.getInstance(syncConfiguration);
 
@@ -98,9 +99,11 @@ public class SyncSessionTests extends StandardIntegrationTest {
         SyncUser adminUser = UserFactory.createAdminUser(Constants.AUTH_URL);
         SyncConfiguration userConfig = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
                 .build();
         SyncConfiguration adminConfig = configFactory
                 .createSyncConfigurationBuilder(adminUser, userConfig.getServerUrl().toString())
+                .fullSynchronization()
                 .build();
 
         Realm userRealm = Realm.getInstance(userConfig);
@@ -123,9 +126,11 @@ public class SyncSessionTests extends StandardIntegrationTest {
         SyncUser adminUser = UserFactory.createAdminUser(Constants.AUTH_URL);
         final SyncConfiguration userConfig = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
                 .build();
         final SyncConfiguration adminConfig = configFactory
                 .createSyncConfigurationBuilder(adminUser, userConfig.getServerUrl().toString())
+                .fullSynchronization()
                 .build();
 
         Thread t = new Thread(new Runnable() {
@@ -227,13 +232,14 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
     // A Realm that was opened before a user logged out should be able to resume uploading if the user logs back in.
     @Test
-    public void logBackResumeUpload() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+    public void logBackResumeUpload() throws InterruptedException {
         final String uniqueName = UUID.randomUUID().toString();
         SyncCredentials credentials = SyncCredentials.usernamePassword(uniqueName, "password", true);
         SyncUser user = SyncUser.logIn(credentials, Constants.AUTH_URL);
 
         final SyncConfiguration syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
                 .modules(new StringOnlyModule())
                 .waitForInitialRemoteData()
                 .build();
@@ -275,6 +281,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
                 SyncConfiguration adminConfig = configurationFactory.createSyncConfigurationBuilder(adminUser, syncConfiguration.getServerUrl().toString())
                         .modules(new StringOnlyModule())
+                        .fullSynchronization()
                         .waitForInitialRemoteData()
                         .build();
                 final Realm adminRealm = Realm.getInstance(adminConfig);
@@ -322,6 +329,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
         final SyncConfiguration syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
                 .sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.AFTER_CHANGES_UPLOADED)
                 .modules(new StringOnlyModule())
                 .build();
@@ -348,6 +356,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
                 SyncUser admin = UserFactory.createAdminUser(Constants.AUTH_URL);
 
                 SyncConfiguration adminConfig = configurationFactory.createSyncConfigurationBuilder(admin, syncConfiguration.getServerUrl().toString())
+                        .fullSynchronization()
                         .modules(new StringOnlyModule())
                         .build();
                 final Realm adminRealm = Realm.getInstance(adminConfig);
@@ -383,6 +392,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
 
         final SyncConfiguration syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
                 .modules(new StringOnlyModule())
                 .build();
         Realm realm = Realm.getInstance(syncConfiguration);
@@ -417,6 +427,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
                 SyncUser adminUser = SyncUser.logIn(credentialsAdmin, Constants.AUTH_URL);
 
                 SyncConfiguration adminConfig = configurationFactory.createSyncConfigurationBuilder(adminUser, syncConfiguration.getServerUrl().toString())
+                        .fullSynchronization()
                         .modules(new StringOnlyModule())
                         .waitForInitialRemoteData()
                         .build();
@@ -460,6 +471,7 @@ public class SyncSessionTests extends StandardIntegrationTest {
         final AtomicReference<SyncConfiguration> configRef = new AtomicReference<>(null);
         final SyncConfiguration config = configFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
                 .directory(looperThread.getRoot())
+                .fullSynchronization()
                 .errorHandler(new SyncSession.ErrorHandler() {
                     @Override
                     public void onError(SyncSession session, ObjectServerError error) {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.fail;
 public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
 
     @Test
+    @RunTestInLooperThread
     public void loginLogoutResumeSyncing() throws InterruptedException {
         String username = UUID.randomUUID().toString();
         String password = "password";
@@ -58,6 +59,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
 
         SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .schema(StringOnly.class)
+                .fullSynchronization()
                 .sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
                 .build();
 
@@ -83,6 +85,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
 
         user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         SyncConfiguration config2 = new SyncConfiguration.Builder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .build();
 
@@ -91,6 +94,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
         realm2.refresh();
         assertEquals(1, realm2.where(StringOnly.class).count());
         realm2.close();
+        looperThread.testComplete();
     }
 
     @Test

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
@@ -50,7 +50,6 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
 
-
     @Test
     public void loginLogoutResumeSyncing() throws InterruptedException {
         String username = UUID.randomUUID().toString();
@@ -99,6 +98,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
     public void waitForInitialRemoteData_mainThreadThrows() {
         final SyncUser user = SyncTestUtils.createTestUser(Constants.AUTH_URL);
         SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .waitForInitialRemoteData()
                 .build();
 
@@ -124,6 +124,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
 
         // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)
         final SyncConfiguration configOld = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .sessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
                 .build();
@@ -145,6 +146,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
         user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password), Constants.AUTH_URL);
         SyncConfiguration config = new SyncConfiguration.Builder(user, Constants.USER_REALM)
                 .name("newRealm")
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .waitForInitialRemoteData()
                 .build();
@@ -244,6 +246,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
 
         // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)
         final SyncConfiguration configOld = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .schema(StringOnly.class)
                 .build();
         Realm realm = Realm.getInstance(configOld);
@@ -264,6 +267,7 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
         user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         final SyncConfiguration configNew = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
                 .name("newRealm")
+                .fullSynchronization()
                 .waitForInitialRemoteData()
                 .readOnly()
                 .schema(StringOnly.class)

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/EncryptedSynchronizedRealmTests.java
@@ -48,6 +48,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         final byte[] randomKey = TestHelper.getRandomKey();
 
         SyncConfiguration configWithEncryption = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .modules(new StringOnlyModule())
                 .waitForInitialRemoteData()
                 .errorHandler(new SyncSession.ErrorHandler() {
@@ -75,6 +76,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         // fail
         user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, false), Constants.AUTH_URL);
         SyncConfiguration configWithoutEncryption = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .name("newName")
                 .modules(new StringOnlyModule())
                 .waitForInitialRemoteData()
@@ -165,6 +167,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         final byte[] randomKey = TestHelper.getRandomKey();
 
         SyncConfiguration configWithEncryption = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
                 .modules(new StringOnlyModule())
                 .waitForInitialRemoteData()
                 .errorHandler(new SyncSession.ErrorHandler() {
@@ -195,6 +198,7 @@ public class EncryptedSynchronizedRealmTests extends StandardIntegrationTest {
         final byte[] adminRandomKey = TestHelper.getRandomKey();
 
         SyncConfiguration adminConfigWithEncryption = configurationFactory.createSyncConfigurationBuilder(adminUser, configWithEncryption.getServerUrl().toString())
+                .fullSynchronization()
                 .modules(new StringOnlyModule())
                 .waitForInitialRemoteData()
                 .errorHandler(new SyncSession.ErrorHandler() {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
@@ -117,6 +117,7 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         SyncUser user1 = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration user1SyncConfig = configurationFactory
                 .createSyncConfigurationBuilder(user1, Constants.DEFAULT_REALM)
+                .fullSynchronization()
                 .modules(schemaModules)
                 .build();
         Realm user1Realm = Realm.getInstance(user1SyncConfig);
@@ -147,6 +148,7 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         // Connect with admin user and verify that user1 object is visible (non-partial Realm)
         SyncUser adminUser = UserFactory.createNicknameUser(Constants.AUTH_URL, "admin2", true);
         SyncConfiguration adminConfig = configurationFactory.createSyncConfigurationBuilder(adminUser, Constants.DEFAULT_REALM)
+                .fullSynchronization()
                 .modules(schemaModules)
                 .waitForInitialRemoteData()
                 .build();
@@ -163,6 +165,7 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         // Connect with user 2 and verify that user1 object is not visible
         SyncUser user2 = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration syncConfig2 = configurationFactory.createSyncConfigurationBuilder(user2, Constants.DEFAULT_REALM)
+                .fullSynchronization()
                 .modules(schemaModules)
                 .build();
         Realm user2Realm = Realm.getInstance(syncConfig2);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
@@ -117,7 +117,6 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         SyncUser user1 = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration user1SyncConfig = configurationFactory
                 .createSyncConfigurationBuilder(user1, Constants.DEFAULT_REALM)
-                .fullSynchronization()
                 .modules(schemaModules)
                 .build();
         Realm user1Realm = Realm.getInstance(user1SyncConfig);
@@ -165,7 +164,6 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         // Connect with user 2 and verify that user1 object is not visible
         SyncUser user2 = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration syncConfig2 = configurationFactory.createSyncConfigurationBuilder(user2, Constants.DEFAULT_REALM)
-                .fullSynchronization()
                 .modules(schemaModules)
                 .build();
         Realm user2Realm = Realm.getInstance(syncConfig2);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ObjectLevelPermissionIntegrationTests.java
@@ -72,7 +72,6 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.DEFAULT_REALM)
                 .modules(schemaModule)
-                .partialRealm()
                 .build();
 
         Realm realm = Realm.getInstance(syncConfig);
@@ -119,7 +118,6 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         SyncConfiguration user1SyncConfig = configurationFactory
                 .createSyncConfigurationBuilder(user1, Constants.DEFAULT_REALM)
                 .modules(schemaModules)
-                .partialRealm()
                 .build();
         Realm user1Realm = Realm.getInstance(user1SyncConfig);
         user1Realm.beginTransaction();
@@ -166,7 +164,6 @@ public class ObjectLevelPermissionIntegrationTests extends IsolatedIntegrationTe
         SyncUser user2 = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration syncConfig2 = configurationFactory.createSyncConfigurationBuilder(user2, Constants.DEFAULT_REALM)
                 .modules(schemaModules)
-                .partialRealm()
                 .build();
         Realm user2Realm = Realm.getInstance(syncConfig2);
         looperThread.closeAfterTest(user2Realm);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/PartialSyncTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/PartialSyncTests.java
@@ -42,7 +42,6 @@ public class PartialSyncTests extends StandardIntegrationTest {
     public void invalidQuery() {
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
         final SyncConfiguration partialSyncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
-                .partialRealm()
                 .build();
         final Realm realm = Realm.getInstance(partialSyncConfig);
         looperThread.closeAfterTest(realm);
@@ -68,7 +67,6 @@ public class PartialSyncTests extends StandardIntegrationTest {
     public void listQueries_doNotCreateSubscriptions() {
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
         final SyncConfiguration partialSyncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
-                .partialRealm()
                 .build();
 
         final DynamicRealm dRealm = DynamicRealm.getInstance(partialSyncConfig);
@@ -248,7 +246,7 @@ public class PartialSyncTests extends StandardIntegrationTest {
 
     @Test
     @RunTestInLooperThread
-    public void unsubscribeAsync_nonExistingIdThrows() throws InterruptedException {
+    public void unsubscribeAsync_nonExistingIdThrows() {
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
         Realm realm = getPartialRealm(user);
         looperThread.closeAfterTest(realm);
@@ -271,7 +269,7 @@ public class PartialSyncTests extends StandardIntegrationTest {
 
     @Test
     @RunTestInLooperThread
-    public void clearTable() throws InterruptedException {
+    public void clearTable() {
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
         Realm realm = getPartialRealm(user);
         looperThread.closeAfterTest(realm);
@@ -301,7 +299,6 @@ public class PartialSyncTests extends StandardIntegrationTest {
         final SyncConfiguration partialSyncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
                 .name("partialSync")
                 .modules(new PartialSyncModule())
-                .partialRealm()
                 .build();
         return Realm.getInstance(partialSyncConfig);
     }
@@ -309,7 +306,6 @@ public class PartialSyncTests extends StandardIntegrationTest {
     private void createServerData(SyncUser user, String url) throws InterruptedException {
         final SyncConfiguration syncConfig = configurationFactory.createSyncConfigurationBuilder(user, url)
                 .waitForInitialRemoteData()
-                .partialRealm()
                 .modules(new PartialSyncModule())
                 .build();
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -74,6 +74,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
                 String realmUrl = Constants.SYNC_SERVER_URL;
 
                 final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
+                        .fullSynchronization()
                         .modules(new ProcessCommitTestsModule())
                         .directory(getService().getRoot())
                         .build();
@@ -125,6 +126,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
         final SyncUser user = UserFactory.getInstance().createDefaultUser(Constants.AUTH_URL);
         String realmUrl = Constants.SYNC_SERVER_URL;
         final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user,realmUrl)
+                .fullSynchronization()
                 .modules(new ProcessCommitTestsModule())
                 .directory(looperThread.getRoot())
                 .build();
@@ -205,6 +207,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
         final SyncUser user = UserFactory.getInstance().createDefaultUser(Constants.AUTH_URL);
         String realmUrl = Constants.SYNC_SERVER_URL;
         final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user,realmUrl)
+                .fullSynchronization()
                 .modules(new ProcessCommitTestsModule())
                 .directory(looperThread.getRoot())
                 .build();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProcessCommitTests.java
@@ -160,6 +160,7 @@ public class ProcessCommitTests extends StandardIntegrationTest {
                 String realmUrl = Constants.SYNC_SERVER_URL;
 
                 final SyncConfiguration syncConfig = new SyncConfiguration.Builder(user, realmUrl)
+                        .fullSynchronization()
                         .modules(new ProcessCommitTestsModule())
                         .directory(getService().getRoot())
                         .name(UUID.randomUUID().toString() + ".realm")

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
@@ -61,7 +61,9 @@ public class ProgressListenerTests extends StandardIntegrationTest {
     @Nonnull
     private SyncConfiguration createSyncConfig() {
         SyncUser user = UserFactory.createAdminUser(Constants.AUTH_URL);
-        return configFactory.createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL).build();
+        return configFactory.createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
+                .build();
     }
 
     private void writeSampleData(Realm realm) {
@@ -135,11 +137,14 @@ public class ProgressListenerTests extends StandardIntegrationTest {
         final CountDownLatch allChangesDownloaded = new CountDownLatch(1);
         SyncUser userWithData = UserFactory.createUniqueUser(Constants.AUTH_URL);
         SyncConfiguration userWithDataConfig = configFactory.createSyncConfigurationBuilder(userWithData, Constants.USER_REALM)
+                .fullSynchronization()
                 .build();
         URI serverUrl = createRemoteData(userWithDataConfig);
         SyncUser adminUser = UserFactory.createAdminUser(Constants.AUTH_URL);
 
-        final SyncConfiguration config = configFactory.createSyncConfigurationBuilder(adminUser, serverUrl.toString()).build();
+        final SyncConfiguration config = configFactory.createSyncConfigurationBuilder(adminUser, serverUrl.toString())
+                .fullSynchronization()
+                .build();
         Realm realm = Realm.getInstance(config);
         SyncSession session = SyncManager.getSession(config);
         session.addDownloadProgressListener(ProgressMode.CURRENT_CHANGES, new ProgressListener() {

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
@@ -164,6 +164,7 @@ public class ProgressListenerTests extends StandardIntegrationTest {
         final SyncUser userWithData = UserFactory.createUniqueUser(Constants.AUTH_URL);
         final SyncConfiguration userWithDataConfig = configFactory.createSyncConfigurationBuilder(userWithData, Constants.USER_REALM)
                 .name("remote")
+                .fullSynchronization()
                 .build();
 
         URI serverUrl = createRemoteData(userWithDataConfig);
@@ -182,6 +183,7 @@ public class ProgressListenerTests extends StandardIntegrationTest {
         SyncUser adminUser = UserFactory.createAdminUser(Constants.AUTH_URL);
         final SyncConfiguration adminConfig = configFactory.createSyncConfigurationBuilder(adminUser, serverUrl.toString())
                 .name("local")
+                .fullSynchronization()
                 .build();
         Realm adminRealm = Realm.getInstance(adminConfig);
         SyncSession session = SyncManager.getSession(adminConfig);

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/QueryBasedSyncTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/QueryBasedSyncTests.java
@@ -157,6 +157,7 @@ public class QueryBasedSyncTests extends StandardIntegrationTest {
     public void partialSync_namedSubscriptionThrowsOnNonPartialRealms() {
         SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
         final SyncConfiguration fullSyncConfig = configurationFactory.createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .fullSynchronization()
                 .name("fullySynchronizedRealm")
                 .build();
 

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/QueryBasedSyncTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/QueryBasedSyncTests.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-public class PartialSyncTests extends StandardIntegrationTest {
+public class QueryBasedSyncTests extends StandardIntegrationTest {
 
     private static final int TEST_SIZE = 10;
 


### PR DESCRIPTION
In 6.0 Partial Sync will become the default mode instead of Full Synchronization.

Partial Sync has only been an internal working name for this feature, but the public name will be "Query-based Synchronization" or "Query-based Sync". This PR makes the changes to support that.

Most of the changes are in the unit tests as we can continue to use the old `isPartial` parameter internally. However, there is some value in also refactoring the internal API's just to avoid confusion (like with Backlinks/LinkingObjects). Thoughts @nhachicha ? 