### PR TITLE
Add script to help unrolling crash reports

### DIFF
--- a/tools/unroll_stacktrace.sh
+++ b/tools/unroll_stacktrace.sh
@@ -44,7 +44,7 @@ STRIPPED_LIBS_DIR=""
 
 find_ndkstack() {
 	PROPS_FILE="$REALM_JAVA_TOOLS_DIR/../realm/local.properties"
-	if [ ! -f $PROPS_FILE ]; then
+	if [ ! -f "$PROPS_FILE" ]; then
     	echo "$PROPS_FILE not found! NDK location cannot be determined"
     	exit 1
 	fi
@@ -61,27 +61,27 @@ download_and_unzip_stripped_libs() {
 
 	# Check if we already have the unstripped libs downloaded
 	STRIPPED_LIBS_FILE="$CACHED_LIBS_DIR/realm-java-jni-libs-unstripped-$VERSION.zip"
-	if [ ! -f $STRIPPED_LIBS_FILE ]; then
+	if [ ! -f "$STRIPPED_LIBS_FILE" ]; then
     	echo "$STRIPPED_LIBS_FILE not found! Downloading from S3"
 		STRIPPED_LIBS_DOWNLOAD_LOCATION="https://static.realm.io/downloads/java/realm-java-jni-libs-unstripped-$VERSION.zip"
-		curl -o $STRIPPED_LIBS_FILE $STRIPPED_LIBS_DOWNLOAD_LOCATION 
+		curl -o "$STRIPPED_LIBS_FILE" "$STRIPPED_LIBS_DOWNLOAD_LOCATION" 
 	fi
 
 	# Exact files if needed
 	STRIPPED_LIBS_DIR="$CACHED_LIBS_DIR/realm-java-jni-libs-unstripped-$VERSION"
 	if [ ! -d "$STRIPPED_LIBS_DIR" ]; then
 		echo "Extracting archive file with unstripped libraries"
-		unzip $STRIPPED_LIBS_FILE -d $STRIPPED_LIBS_DIR
+		unzip "$STRIPPED_LIBS_FILE" -d "$STRIPPED_LIBS_DIR"
 	fi
 }
 
 unroll_stacktrace() {
-	DIR=$STRIPPED_LIBS_DIR/$FLAVOR/$ABI
-	if [ ! -d $DIR ]; then
+	DIR="$STRIPPED_LIBS_DIR/$FLAVOR/$ABI"
+	if [ ! -d "$DIR" ]; then
 		echo "Directory containing .so file could not be found: ${DIR}"
 		exit 1
 	fi
-	$NDK_STACK -sym $DIR -dump $STACKTRACE
+	$NDK_STACK -sym "$DIR" -dump "$STACKTRACE"
 }
 
 echo "Unrolling $STACKTRACE from Realm Java $VERSION ($FLAVOR) using ABI $ABI"

--- a/tools/unroll_stacktrace.sh
+++ b/tools/unroll_stacktrace.sh
@@ -5,8 +5,6 @@
 #
 # The location of ndk-stack will be infered from the ndk.dir property in `<root>/realm/local.properties`.
 #
-#
-#
 # Usage: > sh unroll_stacktrace.sh <version> <abi> <stacktrace_file>
 # Example: > sh unroll_stacktrace.sh 5.0.0 armeabi-v7a ./dump.txt
 #
@@ -72,7 +70,7 @@ download_and_unzip_stripped_libs() {
 	# Exact files if needed
 	STRIPPED_LIBS_DIR="$CACHED_LIBS_DIR/realm-java-jni-libs-unstripped-$VERSION"
 	if [ ! -d "$STRIPPED_LIBS_DIR" ]; then
-		echo "Extracting archive file with stripped libraries"
+		echo "Extracting archive file with unstripped libraries"
 		unzip $STRIPPED_LIBS_FILE -d $STRIPPED_LIBS_DIR
 	fi
 }

--- a/tools/unroll_stacktrace.sh
+++ b/tools/unroll_stacktrace.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# This script will attempt to manually unroll a stack trace using the unstripped jni libs that are available on S3.
+# It will do so using ndk-stack, so read https://developer.android.com/ndk/guides/ndk-stack.html first
+#
+# The location of ndk-stack will be infered from the ndk.dir property in `<root>/realm/local.properties`.
+#
+#
+#
+# Usage: > sh unroll_stacktrace.sh <version> <abi> <stacktrace_file>
+# Example: > sh unroll_stacktrace.sh 5.0.0 armeabi-v7a ./dump.txt
+#
+
+set -euo pipefail
+IFS=$'\n\t'
+
+usage() {
+cat <<EOF
+Usage: $0 <version> <abi> <flavor> <stacktrace>
+ - version: version number on Bintray
+ - abi: armeabi, armeabi-v7a, arm64-v8a, x86, x86_64, mips
+ - flavor: base, objectServer
+ - stacktrace: Path to file with dump
+
+Example: $0 base 5.0.0 armeabi-v7a ./dump.txt
+EOF
+}
+
+######################################
+# Input Validation
+######################################
+
+if [ "$#" -eq 0 ] || [ "$#" -lt 4 ] ; then
+    usage
+    exit 1
+fi
+
+HERE=$(pwd)
+REALM_JAVA_TOOLS_DIR=`dirname "$0"`
+FLAVOR="$1"
+VERSION="$2"
+ABI="$3"
+STACKTRACE="$HERE/$4"
+NDK_STACK=""
+STRIPPED_LIBS_DIR=""
+
+find_ndkstack() {
+	PROPS_FILE="$REALM_JAVA_TOOLS_DIR/../realm/local.properties"
+	if [ ! -f $PROPS_FILE ]; then
+    	echo "$PROPS_FILE not found! NDK location cannot be determined"
+    	exit 1
+	fi
+	NDK_STACK=$(grep "ndk.dir" $PROPS_FILE | cut -d = -f2)/ndk-stack
+}
+
+download_and_unzip_stripped_libs() {
+	# Define location for unstripped libs. 
+	# Use the standard REALM_CORE if defined, otherwise treat it as a temporary file.
+	CACHED_LIBS_DIR="$REALM_CORE_DOWNLOAD_DIR"
+	if [[ -z "${REALM_CORE_DOWNLOAD_DIR}" ]]; then
+  		CACHED_LIBS_DIR="/tmp"
+	fi
+
+	# Check if we already have the unstripped libs downloaded
+	STRIPPED_LIBS_FILE="$CACHED_LIBS_DIR/realm-java-jni-libs-unstripped-$VERSION.zip"
+	if [ ! -f $STRIPPED_LIBS_FILE ]; then
+    	echo "$STRIPPED_LIBS_FILE not found! Downloading from S3"
+		STRIPPED_LIBS_DOWNLOAD_LOCATION="https://static.realm.io/downloads/java/realm-java-jni-libs-unstripped-$VERSION.zip"
+		curl -o $STRIPPED_LIBS_FILE $STRIPPED_LIBS_DOWNLOAD_LOCATION 
+	fi
+
+	# Exact files if needed
+	STRIPPED_LIBS_DIR="$CACHED_LIBS_DIR/realm-java-jni-libs-unstripped-$VERSION"
+	if [ ! -d "$STRIPPED_LIBS_DIR" ]; then
+		echo "Extracting archive file with stripped libraries"
+		unzip $STRIPPED_LIBS_FILE -d $STRIPPED_LIBS_DIR
+	fi
+}
+
+unroll_stacktrace() {
+	DIR=$STRIPPED_LIBS_DIR/$FLAVOR/$ABI
+	if [ ! -d $DIR ]; then
+		echo "Directory containing .so file could not be found: ${DIR}"
+		exit 1
+	fi
+	$NDK_STACK -sym $DIR -dump $STACKTRACE
+}
+
+echo "Unrolling $STACKTRACE from Realm Java $VERSION ($FLAVOR) using ABI $ABI"
+find_ndkstack
+download_and_unzip_stripped_libs
+unroll_stacktrace

--- a/tools/unroll_stacktrace.sh
+++ b/tools/unroll_stacktrace.sh
@@ -34,7 +34,7 @@ if [ "$#" -eq 0 ] || [ "$#" -lt 4 ] ; then
 fi
 
 HERE=$(pwd)
-REALM_JAVA_TOOLS_DIR=`dirname "$0"`
+REALM_JAVA_TOOLS_DIR=$(dirname "$0")
 FLAVOR="$1"
 VERSION="$2"
 ABI="$3"
@@ -48,7 +48,7 @@ find_ndkstack() {
     	echo "$PROPS_FILE not found! NDK location cannot be determined"
     	exit 1
 	fi
-	NDK_STACK=$(grep "ndk.dir" $PROPS_FILE | cut -d = -f2)/ndk-stack
+	NDK_STACK=$(grep "ndk.dir" "$PROPS_FILE" | cut -d = -f2)/ndk-stack
 }
 
 download_and_unzip_stripped_libs() {


### PR DESCRIPTION
This script is a helper script when unrolling stacktraces provided by users making the process a lot less manual, as it is especially tedious to find and download the unstripped versions of Realm.

Example of usage:
```
 => sh unroll_stacktrace.sh base 3.5.0 armeabi-v7a ./dump.txt
Unrolling /Users/cm/Realm/realm-java/tools/./dump.txt from Realm Java 3.5.0 (base) using ABI armeabi-v7a
********** Crash dump: **********
Build fingerprint: 'google/sailfish/sailfish:7.1.2/NJH47F/4146041:user/release-keys'
pid: 28302, tid: 28302, name: com.anghami  >>> com.anghami <<<
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0xae47ffff
Stack frame #00 pc 00018acc  /system/lib/libc.so (memmove+444)
Stack frame #01 pc 0012fc8d  /data/app/com.anghami-1/lib/arm/librealm-jni.so: Routine realm::ArrayBlob::replace(unsigned int, unsigned int, char const*, unsigned int, bool) at libgcc2.c:?
Stack frame #02 pc 00130323  /data/app/com.anghami-1/lib/arm/librealm-jni.so: Routine realm::ArrayStringLong::insert(unsigned int, realm::StringData) at libgcc2.c:?
Stack frame #03 pc 00130673  /data/app/com.anghami-1/lib/arm/librealm-jni.so: Routine realm::ArrayStringLong::bptree_leaf_insert(unsigned int, realm::StringData, realm::TreeInsertBase&) at libgcc2.c:?
Stack frame #04 pc 00133e63  /data/app/com.anghami-1/lib/arm/librealm-jni.so: Routine realm::StringColumn::bptree_insert(unsigned int, realm::StringData, unsigned int) at libgcc2.c:?
Stack frame #05 pc 00133f2d  /data/app/com.anghami-1/lib/arm/librealm-jni.so: Routine realm::StringColumn::do_insert(unsigned int, realm::StringData, unsigned int, bool) at libgcc2.c:?
Stack frame #06 pc 00133f79  /data/app/com.anghami-1/lib/arm/librealm-jni.so: Routine realm::StringColumn::insert_rows(unsigned int, unsigned int, unsigned int, bool) at libgcc2.c:?
Stack frame #07 pc 00126045  /data/app/com.anghami-1/lib/arm/librealm-jni.so: Routine realm::Table::insert_empty_row(unsigned int, unsigned int) at libgcc2.c:?
Stack frame #08 pc 0002adb9  /data/app/com.anghami-1/lib/arm/librealm-jni.so (Java_io_realm_internal_OsObject_nativeCreateNewObjectWithStringPrimaryKey+88): Routine Java_io_realm_internal_OsObject_nativeCreateNewObjectWithStringPrimaryKey at ??:?
Stack frame #09 pc 00f613b1  /data/app/com.anghami-1/oat/arm/base.odex (offset 0xe4f000)
```

