### PR TITLE
Support empty input to in and alwaysTrue and alwaysFalse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.1.0 (YYYY-MM-DD)
+
+### Enhancements
+
+* `RealmQuery.in()` now support `null` which will always return no matches (#4011).
+* Added support for `RealmQuery.alwaysTrue()` and `RealmQuery.alwaysFalse()`.
+
+
 ## 5.0.1 (2018-04-09)
 
 ### Enhancements

--- a/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmQueryExtensions.kt
+++ b/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmQueryExtensions.kt
@@ -25,7 +25,8 @@ import java.util.*
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @param casing how casing is handled. [Case.INSENSITIVE] works only for the Latin-1 characters.
  * @return the query object.
  * @throws java.lang.IllegalArgumentException if the field isn't a String field or `values` is `null` or
@@ -42,9 +43,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Byte field or `values` is `null` or
+ * @throws java.lang.IllegalArgumentException if the field isn't a Byte field.
  * empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
@@ -56,9 +58,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Short field or `values` is `null` or
+ * @throws java.lang.IllegalArgumentException if the field isn't a Short field.
  * empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
@@ -70,9 +73,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Integer field or `values` is `null`
+ * @throws java.lang.IllegalArgumentException if the field isn't a Integer field.
  * or empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
@@ -84,9 +88,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Long field or `values` is `null` or
+ * @throws java.lang.IllegalArgumentException if the field isn't a Long field.
  * empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
@@ -98,9 +103,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Double field or `values` is `null` or
+ * @throws java.lang.IllegalArgumentException if the field isn't a Double field.
  * empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
@@ -113,9 +119,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Float field or `values` is `null` or
+ * @throws java.lang.IllegalArgumentException if the field isn't a Float field.
  * empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
@@ -128,9 +135,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Boolean field or `values` is `null`
+ * @throws java.lang.IllegalArgumentException if the field isn't a Boolean field.
  * or empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
@@ -142,9 +150,10 @@ fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,
  * In comparison. This allows you to test if objects match any value in an array of values.
  *
  * @param fieldName the field to compare.
- * @param values array of values to compare with and it cannot be null or empty.
+ * @param values array of values to compare with. If `null` or the empty array is provided the query will never
+ *               match any results.
  * @return the query object.
- * @throws java.lang.IllegalArgumentException if the field isn't a Date field or `values` is `null` or
+ * @throws java.lang.IllegalArgumentException if the field isn't a Date field.
  * empty.
  */
 fun <T : RealmModel> RealmQuery<T>.oneOf(propertyName: String,

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -700,16 +700,6 @@ public class RealmQueryTests extends QueryTests {
 
     private void doTestForInString(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (String[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new String[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new String[]{"test data 14"}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new String[]{"test data 14", "test data 118", "test data 31", "test data 199"}).findAll();
@@ -720,20 +710,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(196, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new String[]{"TEST data 14", "test data 118", "test data 31", "test DATA 199"}, Case.INSENSITIVE).findAll();
         assertEquals(196, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (String[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new String[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInBoolean(String targetField, int expected1, int expected2, int expected3, int expected4) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Boolean[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Boolean[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Boolean[]{false}).findAll();
         assertEquals(expected1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Boolean[]{true}).findAll();
@@ -742,20 +728,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(expected3, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Boolean[]{true, false}).findAll();
         assertEquals(expected4, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Boolean[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Boolean[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInDate(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Date[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Date[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Date[]{new Date(DECADE_MILLIS * -80)}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Date[]{new Date(0)}).findAll();
@@ -764,20 +746,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(2, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Date[]{new Date(DECADE_MILLIS * -80), new Date(0)}).findAll();
         assertEquals(198, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Date[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Date[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInDouble(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Double[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Double[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Double[]{Math.PI + 1}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Double[]{Math.PI + 2}).findAll();
@@ -786,20 +764,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(2, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Double[]{Math.PI + 1, Math.PI + 2}).findAll();
         assertEquals(198, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Double[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Double[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInFloat(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Float[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Float[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Float[]{1.2345f + 1}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Float[]{1.2345f + 2}).findAll();
@@ -808,20 +782,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(2, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Float[]{1.2345f + 1, 1.2345f + 2}).findAll();
         assertEquals(198, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Float[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Float[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInByte(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Byte[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Byte[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Byte[]{11}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Byte[]{13}).findAll();
@@ -830,20 +800,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(4, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Byte[]{11, 13, 16, 98}).findAll();
         assertEquals(196, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Byte[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Byte[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInShort(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Short[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Short[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Short[]{11}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Short[]{4}).findAll();
@@ -852,20 +818,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(4, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Short[]{2, 4, 5, 8}).findAll();
         assertEquals(196, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Float[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Float[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInInteger(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Integer[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Integer[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Integer[]{11}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Integer[]{1}).findAll();
@@ -874,20 +836,16 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(4, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Integer[]{1, 2, 4, 5}).findAll();
         assertEquals(196, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Integer[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Integer[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     private void doTestForInLong(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Long[]) null).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
-        try {
-            realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Long[]{}).findAll();
-            fail();
-        } catch (IllegalArgumentException ignored) {
-        }
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Long[]{11l}).findAll();
         assertEquals(1, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Long[]{13l}).findAll();
@@ -896,6 +854,12 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(4, resultList.size());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Long[]{13l, 14l, 16l, 98l}).findAll();
         assertEquals(196, resultList.size());
+
+        // Empty input always produces zero resultrs
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Long[]) null).findAll();
+        assertTrue(resultList.isEmpty());
+        resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Long[]{}).findAll();
+        assertTrue(resultList.isEmpty());
     }
 
     @Test
@@ -3486,5 +3450,29 @@ public class RealmQueryTests extends QueryTests {
     @Test(expected = UnsupportedOperationException.class)
     public void endGroup_missingBeginGroup() {
         realm.where(AllTypes.class).endGroup().findAll();
+    }
+
+    @Test
+    public void alwaysTrue() {
+        populateTestRealm();
+        assertEquals(TEST_DATA_SIZE, realm.where(AllTypes.class).alwaysTrue().findAll().size());
+    }
+
+    @Test
+    public  void alwaysTrue_inverted() {
+        populateTestRealm();
+        assertEquals(0, realm.where(AllTypes.class).not().alwaysTrue().findAll().size());
+    }
+
+    @Test
+    public void alwaysFalse() {
+        populateTestRealm();
+        assertEquals(0, realm.where(AllTypes.class).alwaysFalse().findAll().size());
+    }
+
+    @Test
+    public void alwaysFalse_inverted() {
+        populateTestRealm();
+        assertEquals(TEST_DATA_SIZE, realm.where(AllTypes.class).not().alwaysFalse().findAll().size());
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -711,7 +711,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new String[]{"TEST data 14", "test data 118", "test data 31", "test DATA 199"}, Case.INSENSITIVE).findAll();
         assertEquals(196, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (String[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new String[]{}).findAll();
@@ -729,7 +729,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Boolean[]{true, false}).findAll();
         assertEquals(expected4, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Boolean[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Boolean[]{}).findAll();
@@ -747,7 +747,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Date[]{new Date(DECADE_MILLIS * -80), new Date(0)}).findAll();
         assertEquals(198, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Date[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Date[]{}).findAll();
@@ -765,7 +765,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Double[]{Math.PI + 1, Math.PI + 2}).findAll();
         assertEquals(198, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Double[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Double[]{}).findAll();
@@ -783,7 +783,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Float[]{1.2345f + 1, 1.2345f + 2}).findAll();
         assertEquals(198, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Float[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Float[]{}).findAll();
@@ -801,7 +801,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Byte[]{11, 13, 16, 98}).findAll();
         assertEquals(196, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Byte[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Byte[]{}).findAll();
@@ -819,7 +819,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Short[]{2, 4, 5, 8}).findAll();
         assertEquals(196, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Float[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Float[]{}).findAll();
@@ -837,7 +837,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Integer[]{1, 2, 4, 5}).findAll();
         assertEquals(196, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Integer[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Integer[]{}).findAll();
@@ -855,7 +855,7 @@ public class RealmQueryTests extends QueryTests {
         resultList = realm.where(NoPrimaryKeyNullTypes.class).not().in(targetField, new Long[]{13l, 14l, 16l, 98l}).findAll();
         assertEquals(196, resultList.size());
 
-        // Empty input always produces zero resultrs
+        // Empty input always produces zero results
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, (Long[]) null).findAll();
         assertTrue(resultList.isEmpty());
         resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new Long[]{}).findAll();

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -1796,6 +1796,27 @@ Java_io_realm_internal_TableQuery_nativeIsNotEmpty(JNIEnv *env, jobject, jlong n
     CATCH_STD()
 }
 
+JNIEXPORT void JNICALL
+Java_io_realm_internal_TableQuery_nativeAlwaysFalse(JNIEnv *env, jobject, jlong nativeQueryPtr) {
+    TR_ENTER_PTR(nativeQueryPtr);
+    try {
+        Query* query = reinterpret_cast<Query *>(nativeQueryPtr);
+        query->and_query(std::unique_ptr<Expression>(new FalseExpression));
+    }
+    CATCH_STD()
+
+}
+
+JNIEXPORT void JNICALL
+Java_io_realm_internal_TableQuery_nativeAlwaysTrue(JNIEnv *env, jobject, jlong nativeQueryPtr) {
+    TR_ENTER_PTR(nativeQueryPtr);
+    try {
+        Query* query = reinterpret_cast<Query *>(nativeQueryPtr);
+        query->and_query(std::unique_ptr<Expression>(new TrueExpression));
+    }
+    CATCH_STD()
+}
+
 static void finalize_table_query(jlong ptr)
 {
     TR_ENTER_PTR(ptr)

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -521,8 +521,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a String field.
      */
@@ -534,8 +534,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @param casing how casing is handled. {@link Case#INSENSITIVE} works only for the Latin-1 characters.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a String field.
@@ -558,8 +558,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Byte field.
      */
@@ -582,8 +582,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Short field.
      */
@@ -606,8 +606,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Integer field.
      */
@@ -630,8 +630,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Long field.
      * empty.
@@ -655,8 +655,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Double field.
      * empty.
@@ -680,8 +680,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Float field.
      */
@@ -704,8 +704,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Boolean.
      * or empty.
@@ -730,8 +730,8 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
-     *               match any results. and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty array is provided the query will never
+     *               match any results.
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if the field isn't a Date field.
      */

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 
 import io.realm.annotations.Beta;
 import io.realm.annotations.Required;
-import io.realm.internal.ObjectServerFacade;
 import io.realm.internal.OsList;
 import io.realm.internal.OsResults;
 import io.realm.internal.PendingRow;
@@ -522,12 +521,12 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
      * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a String field or {@code values} is {@code null} or
-     * empty.
+     * @throws java.lang.IllegalArgumentException if the field isn't a String field.
      */
-    public RealmQuery<E> in(String fieldName, String[] values) {
+    public RealmQuery<E> in(String fieldName, @Nullable String[] values) {
         return in(fieldName, values, Case.SENSITIVE);
     }
 
@@ -535,18 +534,18 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
      * @param casing how casing is handled. {@link Case#INSENSITIVE} works only for the Latin-1 characters.
      * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a String field or {@code values} is {@code null} or
-     * empty.
+     * @throws java.lang.IllegalArgumentException if the field isn't a String field.
      */
-    public RealmQuery<E> in(String fieldName, String[] values, Case casing) {
+    public RealmQuery<E> in(String fieldName, @Nullable String[] values, Case casing) {
         realm.checkIfValid();
 
-        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
+            alwaysFalse();
+            return this;
         }
         beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0], casing);
         for (int i = 1; i < values.length; i++) {
@@ -559,184 +558,196 @@ public class RealmQuery<E> {
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
      * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Byte field or {@code values} is {@code null} or
-     * empty.
+     * @throws java.lang.IllegalArgumentException if the field isn't a Byte field.
      */
-    public RealmQuery<E> in(String fieldName, Byte[] values) {
+    public RealmQuery<E> in(String fieldName, @Nullable Byte[] values) {
         realm.checkIfValid();
 
-        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
         }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
     }
 
     /**
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
      * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Short field or {@code values} is {@code null} or
-     * empty.
+     * @throws java.lang.IllegalArgumentException if the field isn't a Short field.
      */
-    public RealmQuery<E> in(String fieldName, Short[] values) {
+    public RealmQuery<E> in(String fieldName, @Nullable Short[] values) {
         realm.checkIfValid();
 
-        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
         }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
     }
 
     /**
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
      * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Integer field or {@code values} is {@code null}
+     * @throws java.lang.IllegalArgumentException if the field isn't a Integer field.
+     */
+    public RealmQuery<E> in(String fieldName, @Nullable Integer[] values) {
+        realm.checkIfValid();
+
+        if (values == null || values.length == 0) {
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
+        }
+    }
+
+    /**
+     * In comparison. This allows you to test if objects match any value in an array of values.
+     *
+     * @param fieldName the field to compare.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
+     * @return the query object.
+     * @throws java.lang.IllegalArgumentException if the field isn't a Long field.
+     * empty.
+     */
+    public RealmQuery<E> in(String fieldName, @Nullable Long[] values) {
+        realm.checkIfValid();
+
+        if (values == null || values.length == 0) {
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
+        }
+    }
+
+    /**
+     * In comparison. This allows you to test if objects match any value in an array of values.
+     *
+     * @param fieldName the field to compare.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
+     * @return the query object.
+     * @throws java.lang.IllegalArgumentException if the field isn't a Double field.
+     * empty.
+     */
+    public RealmQuery<E> in(String fieldName, @Nullable Double[] values) {
+        realm.checkIfValid();
+
+        if (values == null || values.length == 0) {
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
+        }
+    }
+
+    /**
+     * In comparison. This allows you to test if objects match any value in an array of values.
+     *
+     * @param fieldName the field to compare.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
+     * @return the query object.
+     * @throws java.lang.IllegalArgumentException if the field isn't a Float field.
+     */
+    public RealmQuery<E> in(String fieldName, @Nullable Float[] values) {
+        realm.checkIfValid();
+
+        if (values == null || values.length == 0) {
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
+        }
+    }
+
+    /**
+     * In comparison. This allows you to test if objects match any value in an array of values.
+     *
+     * @param fieldName the field to compare.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
+     * @return the query object.
+     * @throws java.lang.IllegalArgumentException if the field isn't a Boolean.
      * or empty.
      */
-    public RealmQuery<E> in(String fieldName, Integer[] values) {
+    public RealmQuery<E> in(String fieldName, @Nullable Boolean[] values) {
         realm.checkIfValid();
 
         //noinspection ConstantConditions
         if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
         }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
     }
 
     /**
      * In comparison. This allows you to test if objects match any value in an array of values.
      *
      * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
+     * @param values array of values to compare with. If {@code null} or the empty is parsed in the query will never
+     *               match any results. and it cannot be null or empty.
      * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Long field or {@code values} is {@code null} or
-     * empty.
+     * @throws java.lang.IllegalArgumentException if the field isn't a Date field.
      */
-    public RealmQuery<E> in(String fieldName, Long[] values) {
+    public RealmQuery<E> in(String fieldName, @Nullable Date[] values) {
         realm.checkIfValid();
 
-        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
+            alwaysFalse();
+            return this;
+        } else {
+            beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
+            for (int i = 1; i < values.length; i++) {
+                orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
+            }
+            return endGroupWithoutThreadValidation();
         }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
-    }
-
-    /**
-     * In comparison. This allows you to test if objects match any value in an array of values.
-     *
-     * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
-     * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Double field or {@code values} is {@code null} or
-     * empty.
-     */
-    public RealmQuery<E> in(String fieldName, Double[] values) {
-        realm.checkIfValid();
-
-        //noinspection ConstantConditions
-        if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
-        }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
-    }
-
-    /**
-     * In comparison. This allows you to test if objects match any value in an array of values.
-     *
-     * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
-     * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Float field or {@code values} is {@code null} or
-     * empty.
-     */
-    public RealmQuery<E> in(String fieldName, Float[] values) {
-        realm.checkIfValid();
-
-        //noinspection ConstantConditions
-        if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
-        }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
-    }
-
-    /**
-     * In comparison. This allows you to test if objects match any value in an array of values.
-     *
-     * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
-     * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Boolean field or {@code values} is {@code null}
-     * or empty.
-     */
-    public RealmQuery<E> in(String fieldName, Boolean[] values) {
-        realm.checkIfValid();
-
-        //noinspection ConstantConditions
-        if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
-        }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
-    }
-
-    /**
-     * In comparison. This allows you to test if objects match any value in an array of values.
-     *
-     * @param fieldName the field to compare.
-     * @param values array of values to compare with and it cannot be null or empty.
-     * @return the query object.
-     * @throws java.lang.IllegalArgumentException if the field isn't a Date field or {@code values} is {@code null} or
-     * empty.
-     */
-    public RealmQuery<E> in(String fieldName, Date[] values) {
-        realm.checkIfValid();
-
-        //noinspection ConstantConditions
-        if (values == null || values.length == 0) {
-            throw new IllegalArgumentException(EMPTY_VALUES);
-        }
-        beginGroupWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[0]);
-        for (int i = 1; i < values.length; i++) {
-            orWithoutThreadValidation().equalToWithoutThreadValidation(fieldName, values[i]);
-        }
-        return endGroupWithoutThreadValidation();
     }
 
     /**
@@ -1922,6 +1933,24 @@ public class RealmQuery<E> {
             System.arraycopy(remainingFieldNames, 0, fieldNames, 1, remainingFieldNames.length);
             distinctDescriptor = SortDescriptor.getInstanceForDistinct(getSchemaConnector(), table, fieldNames);
         }
+        return this;
+    }
+
+    /**
+     * This predicate will always match.
+     */
+    public RealmQuery<E> alwaysTrue() {
+        realm.checkIfValid();
+        query.alwaysTrue();
+        return this;
+    }
+
+    /**
+     * This predicate will never match, resulting in the query always returning 0 results.
+     */
+    public RealmQuery<E> alwaysFalse() {
+        realm.checkIfValid();
+        query.alwaysFalse();
         return this;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
@@ -629,6 +629,14 @@ public class TableQuery implements NativeObject {
         throw new IllegalStateException("Mutable method call during read transaction.");
     }
 
+    public void alwaysTrue() {
+        nativeAlwaysTrue(nativePtr);
+    }
+
+    public void alwaysFalse() {
+        nativeAlwaysFalse(nativePtr);
+    }
+
     private native String nativeValidateQuery(long nativeQueryPtr);
 
     private native void nativeGroup(long nativeQueryPtr);
@@ -716,6 +724,10 @@ public class TableQuery implements NativeObject {
     private native void nativeIsEmpty(long nativePtr, long[] columnIndices, long[] tablePtrs);
 
     private native void nativeIsNotEmpty(long nativePtr, long[] columnIndices, long[] tablePtrs);
+
+    private native void nativeAlwaysTrue(long nativeQueryPtr);
+
+    private native void nativeAlwaysFalse(long nativeQueryPtr);
 
     private native long nativeFind(long nativeQueryPtr, long fromTableRow);
 


### PR DESCRIPTION
Closes #4011

This PR will make our `in()` operator mirror Cocoas equivalent where parsing in no values and treat it as "always false".

At the same time I added support for two new predicates: `alwaysTrue()` and `alwaysFalse()`
`alwaysFalse()` is used by `in()`. `alwaysTrue()` isn't terrible useful outside generic code going down a branch in a 'or()` expression, but it also provides symmetri. See https://github.com/realm/realm-java/issues/3238#issue-168877473

Naming the operators wasn't that easy, but in the end, I opted for the naming also used in Guava https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/base/Predicates.html

It seems more descriptive in our query language than both `.trueExpression()` or `.truePredicate()`
