### PR TITLE
Migration that changes primary key deletes rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.0.2 (YYYY-MM-DD)
+
+### Bug Fixes
+
+* Changing a primary key from being nullable to being required could result in objects being deleted (##5899).
+
+
 ## 5.0.1 (2018-04-09)
 
 ### Enhancements

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -33,10 +33,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Locale;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.AnnotationTypes;
 import io.realm.entities.CatOwner;
@@ -334,7 +332,7 @@ public class RealmMigrationTests {
             }
         }
     }
-    
+
     /**
      * Builds a temporary schema to be modified later in a migration. {@link MigrationPrimaryKey} is
      * the base class when specified.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -884,7 +884,7 @@ public class RealmObjectSchemaTests {
         assertEquals(0, list.get(0).length);
         assertArrayEquals(new byte[] {1, 2, 3}, list.get(1));
     }
-    
+
     @Test
     public void setRequired_true_onPrimaryKeyField_containsNullValues_shouldThrow() {
         if (type == ObjectSchemaType.IMMUTABLE) {
@@ -994,6 +994,42 @@ public class RealmObjectSchemaTests {
             return;
         }
         setRequired_onIndexedField(false);
+    }
+
+    // Tests https://github.com/realm/realm-studio/issues/5899
+    @Test
+    public void setRequired_keepExistingRowsIfPrimaryKey() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
+        DynamicRealm dynRealm = (DynamicRealm) realm;
+        String className = "NewClass";
+        String fieldName = "field";
+
+        // Check all primary key types
+        for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
+            if (fieldType.clazz.equals(String.class)) continue;
+            schema.addField(fieldName, fieldType.getType(), FieldAttribute.PRIMARY_KEY); // primary key field
+
+            // Hackish way to add sample data, only treat string differently
+            for (int i = 0; i < 5; i++) {
+                Object primaryKeyValue = (fieldType.getType() == String.class) ? Integer.toString(i) : i;
+                dynRealm.createObject(className, primaryKeyValue);
+            }
+
+            // Verify that sample data is intact before swapping nullability state
+            String errMsg = String.format(String.format("Count mismatch for FieldType = %s and Nullable = %s", fieldType.getType(), schema.isNullable(fieldName)));
+            assertEquals(errMsg, 5, dynRealm.where(className).count());
+
+            // Swap nullability state
+            schema.setRequired(fieldName, !schema.isRequired(fieldName));
+            errMsg = String.format(String.format("Count mismatch for FieldType = %s and Nullable = %s", fieldType.getType(), schema.isNullable(fieldName)));
+            assertEquals(errMsg, 5, dynRealm.where(className).count());
+
+            // Cleanup
+            dynRealm.delete(className);
+            schema.removeField(fieldName);
+        }
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -996,42 +996,6 @@ public class RealmObjectSchemaTests {
         setRequired_onIndexedField(false);
     }
 
-    // Tests https://github.com/realm/realm-studio/issues/5899
-    @Test
-    public void setRequired_keepExistingRowsIfPrimaryKey() {
-        if (type == ObjectSchemaType.IMMUTABLE) {
-            return;
-        }
-        DynamicRealm dynRealm = (DynamicRealm) realm;
-        String className = "NewClass";
-        String fieldName = "field";
-
-        // Check all primary key types
-        for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
-            if (fieldType.clazz.equals(String.class)) continue;
-            schema.addField(fieldName, fieldType.getType(), FieldAttribute.PRIMARY_KEY); // primary key field
-
-            // Hackish way to add sample data, only treat string differently
-            for (int i = 0; i < 5; i++) {
-                Object primaryKeyValue = (fieldType.getType() == String.class) ? Integer.toString(i) : i;
-                dynRealm.createObject(className, primaryKeyValue);
-            }
-
-            // Verify that sample data is intact before swapping nullability state
-            String errMsg = String.format(String.format("Count mismatch for FieldType = %s and Nullable = %s", fieldType.getType(), schema.isNullable(fieldName)));
-            assertEquals(errMsg, 5, dynRealm.where(className).count());
-
-            // Swap nullability state
-            schema.setRequired(fieldName, !schema.isRequired(fieldName));
-            errMsg = String.format(String.format("Count mismatch for FieldType = %s and Nullable = %s", fieldType.getType(), schema.isNullable(fieldName)));
-            assertEquals(errMsg, 5, dynRealm.where(className).count());
-
-            // Cleanup
-            dynRealm.delete(className);
-            schema.removeField(fieldName);
-        }
-    }
-
     @Test
     public void setPrimaryKey_trueAndFalse() {
         if (type == ObjectSchemaType.IMMUTABLE) {
@@ -1384,5 +1348,40 @@ public class RealmObjectSchemaTests {
 
     private interface FieldRunnable {
         void run(String fieldName);
+    }
+
+    // Tests https://github.com/realm/realm-studio/issues/5899
+    @Test
+    public void setRequired_keepExistingRowsIfPrimaryKey() {
+        if (type == ObjectSchemaType.IMMUTABLE) {
+            return;
+        }
+        DynamicRealm dynRealm = (DynamicRealm) realm;
+        String className = "NewClass";
+        String fieldName = "field";
+
+        // Check all primary key types
+        for (PrimaryKeyFieldType fieldType : PrimaryKeyFieldType.values()) {
+            schema.addField(fieldName, fieldType.getType(), FieldAttribute.PRIMARY_KEY); // primary key field
+
+            // Hackish way to add sample data, only treat string differently
+            for (int i = 0; i < 5; i++) {
+                Object primaryKeyValue = (fieldType.getType() == String.class) ? Integer.toString(i) : i;
+                dynRealm.createObject(className, primaryKeyValue);
+            }
+
+            // Verify that sample data is intact before swapping nullability state
+            String errMsg = String.format(String.format("Count mismatch for FieldType = %s and Nullable = %s", fieldType.getType(), schema.isNullable(fieldName)));
+            assertEquals(errMsg, 5, dynRealm.where(className).count());
+
+            // Swap nullability state
+            schema.setRequired(fieldName, !schema.isRequired(fieldName));
+            errMsg = String.format(String.format("Count mismatch for FieldType = %s and Nullable = %s", fieldType.getType(), schema.isNullable(fieldName)));
+            assertEquals(errMsg, 5, dynRealm.where(className).count());
+
+            // Cleanup
+            dynRealm.delete(className);
+            schema.removeField(fieldName);
+        }
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -215,10 +215,13 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsColumnNullable(J
 // 4d. the column to be converted will index shifted one place to column_index + 1
 // 5. search indexing must be preserved
 // 6. removing the original column and renaming the temporary column will make it look like original is being modified
+//
+// WARNING: These methods do NOT work on primary key columns if the Realm is synchronized.
+//
 
 // Converts a table to allow for nullable values
 // Works on both normal table columns and sub tables
-static void convert_column_to_nullable(JNIEnv* env, Table* old_table, size_t old_col_ndx, Table* new_table, size_t new_col_ndx, bool is_primary_key)
+static void convert_column_to_nullable(JNIEnv* env, Table* old_table, size_t old_col_ndx, Table* new_table, size_t new_col_ndx)
 {
     DataType column_type = old_table->get_column_type(old_col_ndx);
     if (old_table != new_table) {
@@ -229,12 +232,7 @@ static void convert_column_to_nullable(JNIEnv* env, Table* old_table, size_t old
             case type_String: {
                 // Payload copy is needed
                 StringData sd(old_table->get_string(old_col_ndx, i));
-                if (is_primary_key) {
-                    new_table->set_string_unique(new_col_ndx, i, sd);
-                }
-                else {
-                    new_table->set_string(new_col_ndx, i, sd);
-                }
+                new_table->set_string(new_col_ndx, i, sd);
                 break;
             }
             case type_Binary: {
@@ -243,12 +241,7 @@ static void convert_column_to_nullable(JNIEnv* env, Table* old_table, size_t old
                 break;
             }
             case type_Int:
-                if (is_primary_key) {
-                    new_table->set_int_unique(new_col_ndx, i, old_table->get_int(old_col_ndx, i));
-                }
-                else {
-                    new_table->set_int(new_col_ndx, i, old_table->get_int(old_col_ndx, i));
-                }
+                new_table->set_int(new_col_ndx, i, old_table->get_int(old_col_ndx, i));
                 break;
             case type_Bool:
                 new_table->set_bool(new_col_ndx, i, old_table->get_bool(old_col_ndx, i));
@@ -352,11 +345,11 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullabl
             for (size_t i = 0; i < table->size(); ++i) {
                 TableRef new_subtable = table->get_subtable(column_index, i);
                 TableRef old_subtable = table->get_subtable(column_index + 1, i);
-                convert_column_to_nullable(env, old_subtable.get(), 0, new_subtable.get(), 0, is_primary_key);
+                convert_column_to_nullable(env, old_subtable.get(), 0, new_subtable.get(), 0);
             }
         }
         else {
-            convert_column_to_nullable(env, table, column_index + 1, table, column_index, is_primary_key);
+            convert_column_to_nullable(env, table, column_index + 1, table, column_index);
         }
 
         // Cleanup
@@ -373,12 +366,14 @@ static void convert_column_to_not_nullable(JNIEnv* env, Table* old_table, size_t
 {
     DataType column_type = old_table->get_column_type(old_col_ndx);
     std::string column_name = old_table->get_column_name(old_col_ndx);
+    size_t no_rows = old_table->size();
     if (old_table != new_table) {
-        new_table->add_empty_row(old_table->size());
+        new_table->add_empty_row(no_rows);
     }
-    for (size_t i = 0; i < old_table->size(); ++i) {
+    for (size_t i = 0; i < no_rows; ++i) {
         switch (column_type) { // FIXME: respect user-specified default values
             case type_String: {
+                // Payload copy is needed
                 StringData sd = old_table->get_string(old_col_ndx, i);
                 if (sd == realm::null()) {
                     if (is_primary_key) {
@@ -390,13 +385,7 @@ static void convert_column_to_not_nullable(JNIEnv* env, Table* old_table, size_t
                     }
                 }
                 else {
-                    // Payload copy is needed
-                    if (is_primary_key) {
-                        new_table->set_string_unique(new_col_ndx, i, sd);
-                    }
-                    else {
-                        new_table->set_string(new_col_ndx, i, sd);
-                    }
+                    new_table->set_string(new_col_ndx, i, sd);
                 }
                 break;
             }
@@ -423,12 +412,7 @@ static void convert_column_to_not_nullable(JNIEnv* env, Table* old_table, size_t
                     }
                 }
                 else {
-                    if (is_primary_key) {
-                        new_table->set_int_unique(new_col_ndx, i, old_table->get_int(old_col_ndx, i));
-                    }
-                    else {
-                        new_table->set_int(new_col_ndx, i, old_table->get_int(old_col_ndx, i));
-                    }
+                    new_table->set_int(new_col_ndx, i, old_table->get_int(old_col_ndx, i));
                 }
                 break;
             case type_Bool:

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -308,6 +308,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullabl
                                                                                   jlong j_column_index,
                                                                                   jboolean)
 {
+#if REALM_ENABLE_SYNC
+    REALM_ASSERT(false);
+#endif
     Table* table = TBL(native_table_ptr);
     if (!TBL_AND_COL_INDEX_VALID(env, table, j_column_index)) {
         return;
@@ -467,6 +470,9 @@ JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNotNull
                                                                                      jlong j_column_index,
                                                                                      jboolean is_primary_key)
 {
+#if REALM_ENABLE_SYNC
+    REALM_ASSERT(false);
+#endif
     try {
         Table* table = TBL(native_table_ptr);
         if (!TBL_AND_COL_INDEX_VALID(env, table, j_column_index)) {

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -306,7 +306,7 @@ static void create_new_column(Table* table, size_t column_index, bool nullable)
 JNIEXPORT void JNICALL Java_io_realm_internal_Table_nativeConvertColumnToNullable(JNIEnv* env, jobject obj,
                                                                                   jlong native_table_ptr,
                                                                                   jlong j_column_index,
-                                                                                  jboolean is_primary_key)
+                                                                                  jboolean)
 {
     Table* table = TBL(native_table_ptr);
     if (!TBL_AND_COL_INDEX_VALID(env, table, j_column_index)) {

--- a/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
@@ -445,10 +445,18 @@ public final class OsSharedRealm implements Closeable, NativeObject {
     }
 
     /**
-     * Returns {@code true} if this Realm is a partially synchronized Realm.
+     * Returns {@code true} if this Realm is a query-based synchronized Realm.
      */
     public boolean isPartial() {
         return nativeIsPartial(nativePtr);
+    }
+
+    /**
+     * Returns {@code true} if this Realm is a synchronized Realm, either query-based or fully
+     * synchronized.
+     */
+    public boolean isSyncRealm() {
+        return osRealmConfig.getResolvedRealmURI() != null;
     }
 
     // addIterator(), detachIterators() and invalidateIterators() are used to make RealmResults stable iterators work.

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -226,6 +226,9 @@ public class Table implements NativeObject {
      * @param columnIndex the column index.
      */
     public void convertColumnToNullable(long columnIndex) {
+        if (sharedRealm.isSyncRealm()) {
+            throw new IllegalStateException("This method is only available for non-synchronized Realms");
+        }
         nativeConvertColumnToNullable(nativePtr, columnIndex, isPrimaryKey(columnIndex));
     }
 
@@ -235,6 +238,9 @@ public class Table implements NativeObject {
      * @param columnIndex the column index.
      */
     public void convertColumnToNotNullable(long columnIndex) {
+        if (sharedRealm.isSyncRealm()) {
+            throw new IllegalStateException("This method is only available for non-synchronized Realms");
+        }
         nativeConvertColumnToNotNullable(nativePtr, columnIndex, isPrimaryKey(columnIndex));
     }
 


### PR DESCRIPTION
Closes #5899 

Root cause:
When changing nullability status on a field, we actually do it by creating a new column, move all data there and then delete the old column. This is a problem in the context of primary keys for the following reason:

Use case: Change primary key int column from nullable to required.

1) create tmp int column: All rows will have the 0 value default value (which actually violates the pk constraint)

2) Start moving values from the old column to the new row by row. This is done using a special `set_unique` instruction. If 0 was present in the old column, we will now do a `set_unique_int(col, row, 0)`, but since all rows have the 0 value, the result is that the rows are collapsed causing data loss.

Solution:
Since changing nullability is only supported for non-sync Realms anyway, there shouldn't be any harm i in not using the `set_unique` method, since the pk invariant is already is already guaranteed for the old column. We just need to be 100% that this method is never called when using Sync. 


