### PR TITLE
Add executeTransactionCompletable method

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmConfigurationTests.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
+import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -780,6 +781,11 @@ public class RealmConfigurationTests {
 
             @Override
             public <E> Single<RealmQuery<E>> from(DynamicRealm realm, RealmQuery<E> query) {
+                return null;
+            }
+
+            @Override
+            public Completable from(Realm realm, Realm.Transaction transaction) {
                 return null;
             }
         };

--- a/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RxJavaTests.java
@@ -922,10 +922,10 @@ public class RxJavaTests {
 
     @Test
     @RunTestInLooperThread
-    public void realmObject_asyncTransactionCompletes() {
+    public void realmObject_transactionAsCompletable() {
         final Realm realm = looperThread.getRealm();
 
-        Completable c = realm.executeTransactionCompletable((transactionRealm) -> transactionRealm.createObject(AllTypes.class));
+        Completable c = realm.asCompletable((transactionRealm) -> transactionRealm.createObject(AllTypes.class));
 
         subscription = c.subscribe(() -> {
             assertEquals(1, realm.where(AllTypes.class).count());

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
+import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.realm.annotations.Beta;
 import io.realm.exceptions.RealmException;
@@ -74,6 +75,7 @@ import io.realm.internal.Util;
 import io.realm.internal.annotations.ObjectServer;
 import io.realm.internal.async.RealmAsyncTaskImpl;
 import io.realm.log.RealmLog;
+import io.realm.rx.RxObservableFactory;
 import io.realm.sync.permissions.ClassPermissions;
 import io.realm.sync.permissions.ClassPrivileges;
 import io.realm.sync.permissions.RealmPermissions;
@@ -1584,6 +1586,18 @@ public class Realm extends BaseRealm {
         });
 
         return new RealmAsyncTaskImpl(pendingTransaction, asyncTaskExecutor);
+    }
+
+    /**
+     * Invokes transaction on worker thread and returns Completable
+     *
+     * @param transaction {@link io.realm.Realm.Transaction} to execute.
+     * @return {@link Completable} representing asynchronous transaction
+     * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
+     */
+    public Completable executeTransactionCompletable(final Transaction transaction) {
+        RxObservableFactory factory = configuration.getRxFactory();
+        return factory.from(this, transaction);
     }
 
     /**

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1589,13 +1589,13 @@ public class Realm extends BaseRealm {
     }
 
     /**
-     * Invokes transaction on worker thread and returns Completable
+     * Invokes the transaction on a worker thread wrapping the result as a {@link Completable}.
      *
      * @param transaction {@link io.realm.Realm.Transaction} to execute.
-     * @return {@link Completable} representing asynchronous transaction
+     * @return {@link Completable} representing the asynchronous transaction
      * @throws UnsupportedOperationException if the required RxJava framework is not on the classpath.
      */
-    public Completable executeTransactionCompletable(final Transaction transaction) {
+    public Completable asCompletable(final Transaction transaction) {
         RxObservableFactory factory = configuration.getRxFactory();
         return factory.from(this, transaction);
     }

--- a/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/RealmObservableFactory.java
@@ -20,6 +20,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import io.reactivex.BackpressureStrategy;
+import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
 import io.reactivex.FlowableOnSubscribe;
@@ -590,6 +591,11 @@ public class RealmObservableFactory implements RxObservableFactory {
     @Override
     public <E> Single<RealmQuery<E>> from(DynamicRealm realm, RealmQuery<E> query) {
         throw new RuntimeException("RealmQuery not supported yet.");
+    }
+
+    @Override
+    public Completable from(Realm realm, Realm.Transaction transaction) {
+        return Completable.create(e -> realm.executeTransactionAsync(transaction, e::onComplete, e::onError));
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/rx/RxObservableFactory.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/RxObservableFactory.java
@@ -16,6 +16,7 @@
 
 package io.realm.rx;
 
+import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -236,4 +237,12 @@ public interface RxObservableFactory {
      * @param realm {@link DynamicRealm} instance query is coming from.
      */
     <E> Single<RealmQuery<E>> from(DynamicRealm realm, RealmQuery<E> query);
+
+    /**
+     * Creates a Completable from a {@link io.realm.Realm.Transaction}
+     *
+     * @param realm {@link Realm} instance transaction is invoked on
+     */
+    Completable from(Realm realm, Realm.Transaction transaction);
+
 }


### PR DESCRIPTION
fixes #2126

DynamicRealm's transactions are synchronous only, so I've only added Completable support for Realm.