### PR TITLE
Prevent monkey from using system events

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -56,7 +56,7 @@ allprojects {
                 doLast {
                     def numberOfEvents = 2000
                     def appId = getAppId("${project.projectDir}/build.gradle")
-                    def process = "adb shell monkey -p ${appId} ${numberOfEvents}".execute([], project.rootDir)
+                    def process = "adb shell monkey -p ${appId} --pct-syskeys 0 ${numberOfEvents}".execute([], project.rootDir)
 
                     def sout = new StringBuilder(), serr = new StringBuilder()
                     process.consumeProcessOutput(sout, serr)


### PR DESCRIPTION
Before this PR monkey could send system events which regularly caused test failures not related to Realm, e.g. if the monkey switched to the guest account.

With this change, all events should be in-app. It might cause a few subtle errors to never be exposed, but any such errors would be related to us implementing an example project wrong (e.g. with respect to the lifecycle) and not to Realm as such.