### PR TITLE
Add getRealm methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.3.0 (YYYY-MM-DD)
+
+### Enhancements
+
+* Added `RealmQuery.getRealm()`, `RealmResults.getRealm()` annd `RealmList.getRealm()` (#5997).
+
+
 ## 5.2.0 (2018-06-06)
 
 The feature previously named Partial Sync is now called Query-Based Sync and is now the default mode when synchronizing Realms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-* Added `RealmQuery.getRealm()`, `RealmResults.getRealm()` annd `RealmList.getRealm()` (#5997).
+* Added `RealmQuery.getRealm()`, `RealmResults.getRealm()`, `RealmList.getRealm()` and `OrderedRealmCollectionSnapshot.getRealm()` (#5997).
 
 
 ## 5.2.0 (2018-06-06)

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -46,6 +46,7 @@ import io.realm.rule.TestRealmConfigurationFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1112,5 +1113,39 @@ public class RealmListTests extends CollectionTests {
 
         assertNotNull(collection.getOsList());
         assertEquals(collection.getOsList().getTargetTable().getName(), snapshot.getTable().getName());
+    }
+
+    @Test
+    public void getRealm() {
+        assertTrue(realm == collection.getRealm());
+    }
+
+    @Test
+    public void getRealm_throwsIfDynamicRealm() {
+        DynamicRealm dRealm = DynamicRealm.getInstance(realm.getConfiguration());
+        DynamicRealmObject obj = dRealm.where(Owner.CLASS_NAME).findFirst();
+        RealmList<DynamicRealmObject> list = obj.getList("dogs");
+        try {
+            list.getRealm();
+            fail();
+        } catch (IllegalStateException ignore) {
+        } finally {
+            dRealm.close();
+        }
+    }
+
+    @Test
+    public void getRealm_throwsIfRealmClosed() {
+        realm.close();
+        try {
+            collection.getRealm();
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
+
+    @Test
+    public void getRealm_returnsNullForUnmanagedList() {
+        assertNull(new RealmList().getRealm());
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -3475,4 +3475,32 @@ public class RealmQueryTests extends QueryTests {
         populateTestRealm();
         assertEquals(TEST_DATA_SIZE, realm.where(AllTypes.class).not().alwaysFalse().findAll().size());
     }
+
+    @Test
+    public void getRealm() {
+        assertTrue(realm == realm.where(AllTypes.class).getRealm());
+    }
+
+    @Test
+    public void getRealm_throwsIfDynamicRealm() {
+        DynamicRealm dRealm = DynamicRealm.getInstance(realm.getConfiguration());
+        try {
+            dRealm.where(AllTypes.CLASS_NAME).getRealm();
+            fail();
+        } catch (IllegalStateException ignore) {
+        } finally {
+            dRealm.close();
+        }
+    }
+
+    @Test
+    public void getRealm_throwsIfRealmClosed() {
+        RealmQuery<AllTypes> query = realm.where(AllTypes.class);
+        realm.close();
+        try {
+            query.getRealm();
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -678,4 +678,35 @@ public class RealmResultsTests extends CollectionTests {
         assertEquals(1, obj.getFieldList().size());
         assertEquals(fieldListIntValue, obj.getFieldList().first().getFieldInt());
     }
+
+    @Test
+    public void getRealm() {
+        RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
+        assertTrue(realm == collection.getRealm());
+    }
+
+    @Test
+    public void getRealm_throwsIfDynamicRealm() {
+        DynamicRealm dRealm = DynamicRealm.getInstance(realm.getConfiguration());
+        RealmResults<DynamicRealmObject> collection = dRealm.where(AllTypes.CLASS_NAME).findAll();
+
+        try {
+            collection.getRealm();
+            fail();
+        } catch (IllegalStateException ignore) {
+        } finally {
+            dRealm.close();
+        }
+    }
+
+    @Test
+    public void getRealm_throwsIfRealmClosed() {
+        RealmResults<AllTypes> collection = realm.where(AllTypes.class).findAll();
+        realm.close();
+        try {
+            collection.getRealm();
+            fail();
+        } catch (IllegalStateException ignore) {
+        }
+    }
 }

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
@@ -584,8 +584,8 @@ abstract class OrderedRealmCollectionImpl<E>
      * Returns the {@link Realm} instance to which this collection belongs.
      * <p>
      * Calling {@link Realm#close()} on the returned instance is discouraged as it is the same as
-     * calling it on the original Realm instance causing the Realm to fully close invalidating the
-     * collection.
+     * calling it on the original Realm instance which may cause the Realm to fully close invalidating the
+     * query result.
      *
      * @return {@link Realm} instance this collection belongs to.
      * @throws IllegalStateException if the Realm is an instance of {@link DynamicRealm} or the

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
@@ -580,6 +580,25 @@ abstract class OrderedRealmCollectionImpl<E>
         }
     }
 
+    /**
+     * Returns the {@link Realm} instance to which this collection belongs.
+     * <p>
+     * Calling {@link Realm#close()} on the returned instance is discouraged as it is the same as
+     * calling it on the original Realm instance causing the Realm to fully close invalidating the
+     * collection.
+     *
+     * @return {@link Realm} instance this collection belongs to.
+     * @throws IllegalStateException if the Realm is an instance of {@link DynamicRealm} or the
+     * {@link Realm} was already closed.
+     */
+    public Realm getRealm() {
+        realm.checkIfValid();
+        if (!(realm instanceof Realm)) {
+            throw new IllegalStateException("This method is only available for typed Realms");
+        }
+        return (Realm) realm;
+    }
+
     // Custom RealmResults list iterator.
     private class RealmCollectionListIterator extends OsResults.ListIterator<E> {
         RealmCollectionListIterator(int start) {

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -766,6 +766,28 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
         }
     }
 
+    /**
+     * Returns the {@link Realm} instance to which this collection belongs.
+     * <p>
+     * Calling {@link Realm#close()} on the returned instance is discouraged as it is the same as
+     * calling it on the original Realm instance causing the Realm to fully close invalidating the
+     * collection.
+     *
+     * @return {@link Realm} instance this collection belongs to or {@code null} if the collection is unmanaged.
+     * @throws IllegalStateException if the Realm is an instance of {@link DynamicRealm} or the
+     * {@link Realm} was already closed.
+     */
+    public Realm getRealm() {
+        if (realm == null) {
+            return null;
+        }
+        realm.checkIfValid();
+        if (!(realm instanceof Realm)) {
+            throw new IllegalStateException("This method is only available for typed Realms");
+        }
+        return (Realm) realm;
+    }
+
     @Override
     public String toString() {
         final String separator = ",";

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -770,8 +770,8 @@ public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollect
      * Returns the {@link Realm} instance to which this collection belongs.
      * <p>
      * Calling {@link Realm#close()} on the returned instance is discouraged as it is the same as
-     * calling it on the original Realm instance causing the Realm to fully close invalidating the
-     * collection.
+     * calling it on the original Realm instance which may cause the Realm to fully close invalidating the
+     * list.
      *
      * @return {@link Realm} instance this collection belongs to or {@code null} if the collection is unmanaged.
      * @throws IllegalStateException if the Realm is an instance of {@link DynamicRealm} or the

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1951,6 +1951,28 @@ public class RealmQuery<E> {
         return this;
     }
 
+    /**
+     * Returns the {@link Realm} instance to which this query belongs.
+     * <p>
+     * Calling {@link Realm#close()} on the returned instance is discouraged as it is the same as
+     * calling it on the original Realm instance causing the Realm to fully close invalidating the
+     * query.
+     *
+     * @return {@link Realm} instance this query belongs to.
+     * @throws IllegalStateException if the Realm is an instance of {@link DynamicRealm} or the
+     * {@link Realm} was already closed.
+     */
+    public Realm getRealm() {
+        if (realm == null) {
+            return null;
+        }
+        realm.checkIfValid();
+        if (!(realm instanceof Realm)) {
+            throw new IllegalStateException("This method is only available for typed Realms");
+        }
+        return (Realm) realm;
+    }
+
     private boolean isDynamicQuery() {
         return className != null;
     }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1955,7 +1955,7 @@ public class RealmQuery<E> {
      * Returns the {@link Realm} instance to which this query belongs.
      * <p>
      * Calling {@link Realm#close()} on the returned instance is discouraged as it is the same as
-     * calling it on the original Realm instance causing the Realm to fully close invalidating the
+     * calling it on the original Realm instance which may cause the Realm to fully close invalidating the
      * query.
      *
      * @return {@link Realm} instance this query belongs to.


### PR DESCRIPTION
Closes #5997 


We already had `RealmObject.getRealm()` this adds the same methods to `RealmList`, `RealmResults`, `RealmQuery` and `OrderedRealmCollectionSnapshot`.