### PR TITLE
Removed volatile keyword

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/internal/RealmCore.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmCore.java
@@ -37,7 +37,7 @@ public class RealmCore {
     private static final String BINARIES_PATH = "lib" + PATH_SEP + ".." + FILE_SEP + "lib";
     private static final String JAVA_LIBRARY_PATH = "java.library.path";
 
-    private static volatile boolean libraryIsLoaded = false;
+    private static boolean libraryIsLoaded = false;
 
     public static boolean osIsWindows() {
         String os = System.getProperty("os.name").toLowerCase(Locale.getDefault());


### PR DESCRIPTION
Why volatile variable is here?

Look like the variable using only in synchronized block. Synchronized block ensure atomicity and visibility for the variable in this case https://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.4.5 .