### PR TITLE
Fix Realm.deleteAll() and Realm.isEmpty()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bug Fixes
 
-* Fixed rare native crash materializing as `Assertion failed: ref + size <= after_ref with (ref, size, after_ref, ndx, m_free_positions.size())` (#5300).
+* Rare native crash materializing as `Assertion failed: ref + size <= after_ref with (ref, size, after_ref, ndx, m_free_positions.size())` (#5300).
+* Calling `Realm.deleteAll()` on a Realm file that contains more classes than in the schema throws exception (#5745).
+* `Realm.isEmpty()` returning false in some cases, even if all tables part of the schema are empty (#5745).
 
 ### Internal
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmTests.java
@@ -96,6 +96,7 @@ import io.realm.entities.PrimaryKeyRequiredAsBoxedLong;
 import io.realm.entities.PrimaryKeyRequiredAsBoxedShort;
 import io.realm.entities.PrimaryKeyRequiredAsString;
 import io.realm.entities.RandomPrimaryKey;
+import io.realm.entities.StringAndInt;
 import io.realm.entities.StringOnly;
 import io.realm.entities.StringOnlyReadOnly;
 import io.realm.exceptions.RealmException;
@@ -3789,6 +3790,41 @@ public class RealmTests {
         assertEquals(0, realm.where(Cat.class).count());
         assertTrue(realm.isEmpty());
     }
+
+    // Test for https://github.com/realm/realm-java/issues/5745
+    @Test
+    public void deleteAll_realmWithMoreTables() {
+        realm.close();
+        RealmConfiguration config1 = configFactory.createConfigurationBuilder()
+                .name("deleteAllTest.realm")
+                .schema(StringOnly.class, StringAndInt.class)
+                .build();
+        realm = Realm.getInstance(config1);
+        realm.executeTransaction(r -> {
+            r.createObject(StringOnly.class);
+            r.createObject(StringAndInt.class);
+        });
+        realm.close();
+
+        RealmConfiguration config2 = configFactory.createConfigurationBuilder()
+                .name("deleteAllTest.realm")
+                .schema(StringOnly.class)
+                .build();
+
+        realm = Realm.getInstance(config2);
+        realm.beginTransaction();
+        realm.deleteAll();
+        realm.commitTransaction();
+        assertTrue(realm.isEmpty());
+        realm.close();
+
+        // deleteAll() will only delete tables part of the schema, so reopening with the old
+        // should reveal the old data
+        realm = Realm.getInstance(config1);
+        assertFalse(realm.isEmpty());
+        assertEquals(1, realm.where(StringAndInt.class).count());
+    }
+
 
     @Test
     public void waitForChange_emptyDataChange() throws InterruptedException {

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -589,10 +589,7 @@ abstract class BaseRealm implements Closeable {
      *
      * @return {@code true} if empty, @{code false} otherwise.
      */
-    public boolean isEmpty() {
-        checkIfValid();
-        return sharedRealm.isEmpty();
-    }
+    abstract public boolean isEmpty();
 
     /**
      * Returns the schema for this Realm.

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -295,6 +295,15 @@ public class DynamicRealm extends BaseRealm {
         return configuration.getRxFactory().from(this);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        checkIfValid();
+        return sharedRealm.isEmpty();
+    }
+
 // FIXME: Depends on a typed schema. Find a work-around
 //    /**
 //     * {@inheritDoc}

--- a/realm/realm-library/src/main/java/io/realm/ImmutableRealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/ImmutableRealmSchema.java
@@ -16,7 +16,11 @@
 
 package io.realm;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import io.realm.internal.ColumnIndices;
+import io.realm.internal.RealmProxyMediator;
 import io.realm.internal.Table;
 
 /**
@@ -41,6 +45,20 @@ class ImmutableRealmSchema extends RealmSchema {
         if (!realm.getSharedRealm().hasTable(internalClassName)) { return null; }
         Table table = realm.getSharedRealm().getTable(internalClassName);
         return new ImmutableRealmObjectSchema(realm, this, table, getColumnInfo(className));
+    }
+
+    @Override
+    public Set<RealmObjectSchema> getAll() {
+        // Only return schema objects for classes defined by the schema in the RealmConfiguration
+        RealmProxyMediator schemaMediator = realm.getConfiguration().getSchemaMediator();
+        Set<Class<? extends RealmModel>> classes = schemaMediator.getModelClasses();
+        Set<RealmObjectSchema> schemas = new LinkedHashSet<>(classes.size());
+        for (Class<? extends RealmModel> clazz : classes) {
+            String className = schemaMediator.getSimpleClassName(clazz);
+            RealmObjectSchema objectSchema = get(className);
+            schemas.add(objectSchema);
+        }
+        return schemas;
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
@@ -16,7 +16,9 @@
 
 package io.realm;
 
+import java.util.LinkedHashSet;
 import java.util.Locale;
+import java.util.Set;
 
 import io.realm.internal.OsObjectStore;
 import io.realm.internal.Table;
@@ -40,6 +42,20 @@ class MutableRealmSchema extends RealmSchema {
         if (!realm.getSharedRealm().hasTable(internalClassName)) { return null; }
         Table table = realm.getSharedRealm().getTable(internalClassName);
         return new MutableRealmObjectSchema(realm, this, table);
+    }
+
+    @Override
+    public Set<RealmObjectSchema> getAll() {
+        // Return all tables prefixed with class__ in the Realm file
+        int tableCount = (int) realm.getSharedRealm().size();
+        Set<RealmObjectSchema> schemas = new LinkedHashSet<>(tableCount);
+        for (int i = 0; i < tableCount; i++) {
+            RealmObjectSchema objectSchema = get(Table.getClassNameForTable(realm.getSharedRealm().getTableName(i)));
+            if (objectSchema != null) {
+                schemas.add(objectSchema);
+            }
+        }
+        return schemas;
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -202,6 +202,20 @@ public class Realm extends BaseRealm {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        checkIfValid();
+        for (RealmObjectSchema clazz : schema.getAll()) {
+            if (clazz.getTable().size() > 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Returns the schema for this Realm. The schema is immutable.
      * Any attempt to modify it will result in an {@link UnsupportedOperationException}.
      * <p>

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -208,7 +208,7 @@ public class Realm extends BaseRealm {
     public boolean isEmpty() {
         checkIfValid();
         for (RealmObjectSchema clazz : schema.getAll()) {
-            if (clazz.getTable().size() > 0) {
+            if (!clazz.getClassName().startsWith("__") && clazz.getTable().size() > 0) {
                 return false;
             }
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 
 import io.realm.internal.ColumnIndices;
 import io.realm.internal.ColumnInfo;
+import io.realm.internal.RealmProxyMediator;
 import io.realm.internal.Table;
 import io.realm.internal.Util;
 import io.realm.internal.util.Pair;
@@ -82,11 +83,26 @@ public abstract class RealmSchema {
      * @return the set of all classes in this Realm or no RealmObject classes can be saved in the Realm.
      */
     public Set<RealmObjectSchema> getAll() {
-        int tableCount = (int) realm.getSharedRealm().size();
-        Set<RealmObjectSchema> schemas = new LinkedHashSet<>(tableCount);
-        for (int i = 0; i < tableCount; i++) {
-            RealmObjectSchema objectSchema = get(Table.getClassNameForTable(realm.getSharedRealm().getTableName(i)));
-            if (objectSchema != null) {
+        Set<RealmObjectSchema> schemas = null;
+        if (realm instanceof DynamicRealm) {
+            // Return all tables when using the Dynamic Realm
+            int tableCount = (int) realm.getSharedRealm().size();
+            schemas = new LinkedHashSet<>(tableCount);
+            for (int i = 0; i < tableCount; i++) {
+                RealmObjectSchema objectSchema = get(Table.getClassNameForTable(realm.getSharedRealm().getTableName(i)));
+                if (objectSchema != null) {
+                    schemas.add(objectSchema);
+                }
+            }
+
+        } else if (realm instanceof Realm) {
+            // Return only classes defined in the schema for a Dynamic Realm
+            RealmProxyMediator schemaMediator = realm.getConfiguration().getSchemaMediator();
+            Set<Class<? extends RealmModel>> classes = schemaMediator.getModelClasses();
+            schemas = new LinkedHashSet<>(classes.size());
+            for (Class<? extends RealmModel> clazz : classes) {
+                String className = schemaMediator.getSimpleClassName(clazz);
+                RealmObjectSchema objectSchema = get(className);
                 schemas.add(objectSchema);
             }
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -82,32 +82,7 @@ public abstract class RealmSchema {
      *
      * @return the set of all classes in this Realm or no RealmObject classes can be saved in the Realm.
      */
-    public Set<RealmObjectSchema> getAll() {
-        Set<RealmObjectSchema> schemas = null;
-        if (realm instanceof DynamicRealm) {
-            // Return all tables when using the Dynamic Realm
-            int tableCount = (int) realm.getSharedRealm().size();
-            schemas = new LinkedHashSet<>(tableCount);
-            for (int i = 0; i < tableCount; i++) {
-                RealmObjectSchema objectSchema = get(Table.getClassNameForTable(realm.getSharedRealm().getTableName(i)));
-                if (objectSchema != null) {
-                    schemas.add(objectSchema);
-                }
-            }
-
-        } else if (realm instanceof Realm) {
-            // Return only classes defined in the schema for a Dynamic Realm
-            RealmProxyMediator schemaMediator = realm.getConfiguration().getSchemaMediator();
-            Set<Class<? extends RealmModel>> classes = schemaMediator.getModelClasses();
-            schemas = new LinkedHashSet<>(classes.size());
-            for (Class<? extends RealmModel> clazz : classes) {
-                String className = schemaMediator.getSimpleClassName(clazz);
-                RealmObjectSchema objectSchema = get(className);
-                schemas.add(objectSchema);
-            }
-        }
-        return schemas;
-    }
+    public abstract Set<RealmObjectSchema> getAll();
 
     /**
      * Adds a new class to the Realm.


### PR DESCRIPTION
Closes #5745

This PR fixes `Realm.deleteAll()` and `Realm.isEmpty()` so they now respect the defined schema. 
This is important if the schema is only a subset of the actual tables found in the Realm.

This means that `deleteAll()` will only delete the schema defined and `isEmpty()` will only return the result based on the defined schema as well.

TODO:
- [ ] Determine what to do about system classes in synced Realms, ie. `__ResultSets` and `__Class`.  In the old behaviour they were ignored for `Realm.isEmpty()` but cleared when doing `Realm.deleteAll()`. This feels inconsistent. I think I lean towards ignoring them in both cases.