### PR TITLE
Fix nullpointer when using RealmTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.4.1 (YYYY-MM-DD)
+
+### Bug Fixes
+
+* Compile time crash if no `targetSdk` was defined in Gradle. This was introduced in 5.4.0 (#6082).
+
+
 ## 5.4.0 (2018-07-22)
 
 ### Enhancements

--- a/realm-transformer/src/main/java/io/realm/transformer/Utils.java
+++ b/realm-transformer/src/main/java/io/realm/transformer/Utils.java
@@ -63,24 +63,9 @@ public class Utils {
         return stringBuilder.toString();
     }
 
-    public static String getTargetSdk(Project project) {
-        return getAndroidExtension(project).getDefaultConfig().getTargetSdkVersion().getApiString();
-    }
-
-    public static String getMinSdk(Project project) {
-        return getAndroidExtension(project).getDefaultConfig().getMinSdkVersion().getApiString();
-    }
-
     public static boolean isSyncEnabled(Project project) {
         RealmPluginExtension realmExtension = (RealmPluginExtension) project.getExtensions().findByName("realm");
         return realmExtension != null && realmExtension.syncEnabled;
     }
 
-    public static List<File> getBootClasspath(Project project) {
-        return getAndroidExtension(project).getBootClasspath();
-    }
-
-    private static BaseExtension getAndroidExtension(Project project) {
-        return (BaseExtension) project.getExtensions().getByName("android");
-    }
 }

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -126,9 +126,9 @@ class RealmTransformer(val project: Project) : Transform() {
      */
     private fun sendAnalytics(inputs: Collection<TransformInput>, outputModelClasses: Set<CtClass>) {
         try {
-            val disableAnalytics: Boolean = "true".equals(System.getenv()["REALM_DISABLE_ANALYTICS"])
+            val disableAnalytics: Boolean = "true".equals(System.getenv()["REALM_DISABLE_ANALYTICS"], ignoreCase = true)
             if (inputs.isEmpty() || disableAnalytics) {
-                // Don't send analytics for incremental builds or if they have ben explicitly disabled.
+                // Don't send analytics for incremental builds or if they have been explicitly disabled.
                 return
             }
 

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -20,6 +20,8 @@ import com.android.build.api.transform.*
 import io.realm.transformer.build.FullBuild
 import io.realm.transformer.build.IncrementalBuild
 import io.realm.transformer.build.BuildTemplate
+import io.realm.transformer.ext.getMinSdk
+import io.realm.transformer.ext.getTargetSdk
 import javassist.CtClass
 import org.gradle.api.Project
 import org.slf4j.Logger
@@ -123,41 +125,46 @@ class RealmTransformer(val project: Project) : Transform() {
      * @param inputModelClasses a list of ctClasses describing the Realm models
      */
     private fun sendAnalytics(inputs: Collection<TransformInput>, outputModelClasses: Set<CtClass>) {
-        val disableAnalytics: Boolean = "true".equals(System.getenv()["REALM_DISABLE_ANALYTICS"])
-        if (inputs.isEmpty() || disableAnalytics) {
-            // Don't send analytics for incremental builds or if they have ben explicitly disabled.
-            return
-        }
+        try {
+            val disableAnalytics: Boolean = "true".equals(System.getenv()["REALM_DISABLE_ANALYTICS"])
+            if (inputs.isEmpty() || disableAnalytics) {
+                // Don't send analytics for incremental builds or if they have ben explicitly disabled.
+                return
+            }
 
-        var containsKotlin = false
+            var containsKotlin = false
 
-        outer@
-        for(input: TransformInput in inputs) {
-            for (di: DirectoryInput in input.directoryInputs) {
-                val path: String = di.file.absolutePath
-                val index: Int = path.indexOf("build${File.separator}intermediates${File.separator}classes")
-                if (index != -1) {
-                    val projectPath: String = path.substring(0, index)
-                    val buildFile = File(projectPath + "build.gradle")
-                    if (buildFile.exists() && buildFile.readText().contains("kotlin")) {
-                        containsKotlin = true
-                        break@outer
+            outer@
+            for(input: TransformInput in inputs) {
+                for (di: DirectoryInput in input.directoryInputs) {
+                    val path: String = di.file.absolutePath
+                    val index: Int = path.indexOf("build${File.separator}intermediates${File.separator}classes")
+                    if (index != -1) {
+                        val projectPath: String = path.substring(0, index)
+                        val buildFile = File(projectPath + "build.gradle")
+                        if (buildFile.exists() && buildFile.readText().contains("kotlin")) {
+                            containsKotlin = true
+                            break@outer
+                        }
                     }
                 }
             }
-        }
 
-        val packages: Set<String> = outputModelClasses.map {
-            it.packageName
-        }.toSet()
+            val packages: Set<String> = outputModelClasses.map {
+                it.packageName
+            }.toSet()
 
-        val targetSdk: String? = Utils.getTargetSdk(project)
-        val minSdk: String?  = Utils.getMinSdk(project)
+            val targetSdk: String? = project.getTargetSdk()
+            val minSdk: String?  = project.getMinSdk()
 
-        if (!disableAnalytics) {
-            val sync: Boolean = Utils.isSyncEnabled(project)
-            val analytics = RealmAnalytics(packages, containsKotlin, sync, targetSdk, minSdk)
-            analytics.execute()
+            if (!disableAnalytics) {
+                val sync: Boolean = Utils.isSyncEnabled(project)
+                val analytics = RealmAnalytics(packages, containsKotlin, sync, targetSdk, minSdk)
+                analytics.execute()
+            }
+        } catch (e: Exception) {
+            // Analytics failing for any reason should not crash the build
+            logger.debug("Could not send analytics: $e")
         }
     }
 

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/build/BuildTemplate.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/build/BuildTemplate.kt
@@ -25,6 +25,7 @@ import io.realm.transformer.BytecodeModifier
 import io.realm.transformer.ManagedClassPool
 import io.realm.transformer.logger
 import io.realm.transformer.Utils
+import io.realm.transformer.ext.getBootClasspath
 import javassist.ClassPool
 import javassist.CtClass
 import org.gradle.api.Project
@@ -147,7 +148,7 @@ abstract class BuildTemplate(val project: Project, val outputProvider: Transform
      */
     private fun addBootClassesToClassPool(classPool: ClassPool) {
         try {
-            Utils.getBootClasspath(project).forEach {
+            project.getBootClasspath().forEach {
                 val path: String = it.absolutePath
                 logger.debug("Add boot class $path to class pool.")
                 classPool.appendClassPath(path)

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/ext/CtClassExt.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/ext/CtClassExt.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.realm.transformer.ext
 
 import javassist.CtClass

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.transformer.ext
+
+import com.android.build.gradle.BaseExtension
+import org.gradle.api.Project
+import java.io.File
+
+/**
+ * Returns the `targetSdk` property for this project if it is available.
+ */
+fun Project.getTargetSdk(): String? {
+    return getAndroidExtension(this).defaultConfig?.targetSdkVersion?.apiString
+}
+
+/**
+ * Returns the `minSdk` property for this project if it is available.
+ */
+fun Project.getMinSdk(): String? {
+    return getAndroidExtension(this).defaultConfig?.minSdkVersion?.apiString
+}
+
+/**
+ * Returns the `bootClasspath` for this project
+ */
+fun Project.getBootClasspath(): List<File> {
+    return getAndroidExtension(this).bootClasspath ?: listOf()
+}
+
+private fun getAndroidExtension(project: Project): BaseExtension {
+    // This will always be present, otherwise the android build would not be able to
+    // trigger the transformer code in the first place.
+    return project.extensions.getByName("android") as BaseExtension
+}
+
+
+
+

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
@@ -46,7 +46,3 @@ private fun getAndroidExtension(project: Project): BaseExtension {
     // trigger the transformer code in the first place.
     return project.extensions.getByName("android") as BaseExtension
 }
-
-
-
-


### PR DESCRIPTION
Closes #6082 

Converts the util functions to Kotlin and added extra crash safety when sending analytics (basically, we should never crash no matter what goes wrong). Now all exceptions are just silently logged to the debug log.