### PR TITLE
Make ObjectServerExample more accessible

### DIFF
--- a/examples/objectServerExample/build.gradle
+++ b/examples/objectServerExample/build.gradle
@@ -16,7 +16,7 @@ android {
     buildTypes {
         // Go to https://cloud.realm.io and copy the URL to your instance. Insert it below.
         // It will look something like "https://test.us1.cloud.realm.io"
-        def cloudUrl = "https://cmelchior.us1.cloud.realm.io"
+        def cloudUrl = "<INSERT_CLOUD_URL>"
         def realmAuthUrl = "\"${cloudUrl}/auth\""
         def realmUrl = "\"${cloudUrl.replace("https", "realms")}/default\""
 

--- a/examples/objectServerExample/build.gradle
+++ b/examples/objectServerExample/build.gradle
@@ -1,26 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'realm-android'
 
-// Credit: http://jeremie-martinez.com/2015/05/05/inject-host-gradle/
-def getIP() {
-    InetAddress result = null
-    Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces()
-    while (interfaces.hasMoreElements()) {
-        Enumeration<InetAddress> addresses = interfaces.nextElement().getInetAddresses()
-        while (addresses.hasMoreElements()) {
-            InetAddress address = addresses.nextElement()
-            if (!address.isLoopbackAddress()) {
-                if (address.isSiteLocalAddress()) {
-                    return address.getHostAddress()
-                } else if (result == null) {
-                    result = address
-                }
-            }
-        }
-    }
-    return (result != null ? result : InetAddress.getLocalHost()).getHostAddress()
-}
-
 android {
     compileSdkVersion rootProject.sdkVersion
     buildToolsVersion rootProject.buildTools
@@ -34,18 +14,20 @@ android {
     }
 
     buildTypes {
-        // This will automatically try to detect the IP address of the machine
-        // building the example. It is assumed that this machine is also running
-        // the Object Server. If not, replace 'host' with the IP of the machine
-        // hosting the server. In some cases the wrong IP address will also
-        // be detected. In that case also insert the IP address manually.
-        def host = getIP()
+        // Go to https://cloud.realm.io and copy the URL to your instance. Insert it below.
+        // It will look something like "https://test.us1.cloud.realm.io"
+        def cloudUrl = "https://cmelchior.us1.cloud.realm.io"
+        def realmAuthUrl = "\"${cloudUrl}/auth\""
+        def realmUrl = "\"${cloudUrl.replace("https", "realms")}/default\""
+
         debug {
-            buildConfigField "String", "OBJECT_SERVER_IP", "\"${host}\""
+            buildConfigField "String", "REALM_AUTH_URL", "${realmAuthUrl}"
+            buildConfigField "String", "REALM_URL", "${realmUrl}"
             minifyEnabled true
         }
         release {
-            buildConfigField "String", "OBJECT_SERVER_IP", "\"${host}\""
+            buildConfigField "String", "REALM_AUTH_URL", "${realmAuthUrl}"
+            buildConfigField "String", "REALM_URL", "${realmUrl}"
             minifyEnabled true
             signingConfig signingConfigs.debug
         }

--- a/examples/objectServerExample/build.gradle
+++ b/examples/objectServerExample/build.gradle
@@ -16,9 +16,12 @@ android {
     buildTypes {
         // Go to https://cloud.realm.io and copy the URL to your instance. Insert it below.
         // It will look something like "https://test.us1.cloud.realm.io"
-        def cloudUrl = "<INSERT_CLOUD_URL>"
-        def realmAuthUrl = "\"${cloudUrl}/auth\""
-        def realmUrl = "\"${cloudUrl.replace("https", "realms")}/default\""
+        //
+        // If you're running a self-hosted version, use the hostname/IP address of the Realm Object
+        // Server, e.g "http://127.0.0.1:9080".
+        def rosUrl = "<INSERT_REALM_OBJECT_SERVER_URL>"
+        def realmAuthUrl = "\"${rosUrl}/auth\""
+        def realmUrl = "\"${rosUrl.replace("http", "realm")}/default\""
 
         debug {
             buildConfigField "String", "REALM_AUTH_URL", "${realmAuthUrl}"

--- a/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/LoginActivity.java
+++ b/examples/objectServerExample/src/main/java/io/realm/examples/objectserver/LoginActivity.java
@@ -34,8 +34,6 @@ import io.realm.SyncUser;
 
 
 public class LoginActivity extends AppCompatActivity {
-    private static final String REALM_AUTH_URL = "http://" + BuildConfig.OBJECT_SERVER_IP + ":9080/auth";
-
     @BindView(R.id.input_username) EditText username;
     @BindView(R.id.input_password) EditText password;
     @BindView(R.id.button_login) Button loginButton;
@@ -103,7 +101,7 @@ public class LoginActivity extends AppCompatActivity {
             }
         };
 
-        SyncUser.logInAsync(creds, REALM_AUTH_URL, callback);
+        SyncUser.logInAsync(creds, BuildConfig.REALM_AUTH_URL, callback);
     }
 
     @Override


### PR DESCRIPTION
Ran into this while testing https://github.com/realm/realm-java/pull/6110

Previously the example depended on a local version of ROS running, but testing using Cloud is much simpler, so the example was modified to work when you just copy the instance URL from the web UI.

The actual demo actually also didn't work correctly since it used `findFirstAsync()` instead of `findAllAsync()` meaning that no subscription was ever created.