### PR TITLE
Added junit3 and junit4 instrumentation test examples

### DIFF
--- a/examples/unitTestExample/src/androidTest/java/io/realm/examples/unittesting/jUnit3ExampleInstrumentationTest.java
+++ b/examples/unitTestExample/src/androidTest/java/io/realm/examples/unittesting/jUnit3ExampleInstrumentationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.examples.unittesting;
+
+import android.test.InstrumentationTestCase;
+
+import io.realm.Realm;
+import io.realm.RealmConfiguration;
+import io.realm.examples.unittesting.repository.DogRepository;
+import io.realm.examples.unittesting.repository.DogRepositoryImpl;
+
+public class jUnit3ExampleInstrumentationTest extends InstrumentationTestCase {
+
+    private DogRepository dogRepository;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        Realm.init(getInstrumentation().getContext());
+        dogRepository = new DogRepositoryImpl(new RealmConfiguration.Builder()
+                .name("integrationTest")
+                .inMemory()
+                .build()
+        );
+    }
+
+    public void testShouldBeAbleToLaunchActivityAndSeeRealmResults() {
+        assertNull(dogRepository.findDogNamged("Laika"));
+        dogRepository.createDog("Laika");
+        assertEquals("laika", dogRepository.findDogNamged("Laika").getName());
+    }
+}

--- a/examples/unitTestExample/src/androidTest/java/io/realm/examples/unittesting/jUnit4ExampleInstrumentationTest.java
+++ b/examples/unitTestExample/src/androidTest/java/io/realm/examples/unittesting/jUnit4ExampleInstrumentationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.examples.unittesting;
+
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.realm.Realm;
+import io.realm.RealmConfiguration;
+import io.realm.examples.unittesting.repository.DogRepository;
+import io.realm.examples.unittesting.repository.DogRepositoryImpl;
+
+import static android.support.test.espresso.matcher.ViewMatchers.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(AndroidJUnit4.class)
+public class jUnit4ExampleInstrumentationTest {
+
+    private DogRepository dogRepository;
+
+    @Before
+    public void setUp() {
+        Realm.init(InstrumentationRegistry.getTargetContext());
+        dogRepository = new DogRepositoryImpl(new RealmConfiguration.Builder()
+                .name("integrationTest")
+                .inMemory()
+                .build()
+        );
+    }
+
+    @Test
+    public void testCanCreateAndRetrieveDogWithName() {
+        assertThat(dogRepository.findDogNamged("Laika"), is(equalTo(null)));
+        dogRepository.createDog("Laika");
+        assertThat(dogRepository.findDogNamged("Laika").getName(), is(equalTo("Laika")));
+    }
+}

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepository.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepository.java
@@ -16,6 +16,10 @@
 
 package io.realm.examples.unittesting.repository;
 
+import io.realm.examples.unittesting.model.Dog;
+
 public interface DogRepository {
     void createDog(String name);
+
+    Dog findDogNamged(String name);
 }

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepositoryImpl.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepositoryImpl.java
@@ -17,16 +17,38 @@
 package io.realm.examples.unittesting.repository;
 
 import io.realm.Realm;
+import io.realm.RealmConfiguration;
 import io.realm.examples.unittesting.model.Dog;
 
 public class DogRepositoryImpl implements DogRepository {
+
+    private final RealmConfiguration configuration;
+
+    public DogRepositoryImpl() {
+        this(Realm.getDefaultConfiguration());
+    }
+
+    public DogRepositoryImpl(RealmConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
     @Override
     public void createDog(final String name) {
-        Realm realm = Realm.getDefaultInstance();
+        Realm realm = Realm.getInstance(configuration);
         realm.executeTransaction(r -> {
             Dog dog = r.createObject(Dog.class);
             dog.setName(name);
         });
         realm.close();
+    }
+
+    @Override
+    public Dog findDogNamged(String name) {
+        Realm realm = Realm.getInstance(configuration);
+        try {
+            return realm.where(Dog.class).equalTo("name", name).findFirst();
+        } finally {
+            realm.close();
+        }
     }
 }


### PR DESCRIPTION
# Description

Adds a Junit3 and Junit4 examples for integration tests using Android instrumentation tests.

# TODO

- Confirm with my employer I can sign the CLA as described [here](https://github.com/realm/realm-java/blob/master/CONTRIBUTING.md).
- Had a newer version of Android Studio, couldn't manage to run tests successfully. Is this something someone with experience on this codebase could assist with?
- The example is caleld `unittesting`, however it contains espresso and with this integration tests. Should it be renamed to `testing`?
