### PR TITLE
Added support for stopping and starting a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 * [ObjectServer] Added support for observing connection changes for a session using `SyncSession.addConnectionChangeListener()` and `SyncSession.removeConnectionChangeListener()`.
 * [ObjectServer] Added Kotlin extension property `Realm.syncSession` for synchronized Realms.
 * [ObjectServer] Added Kotlin extension method `Realm.classPermissions<RealmModel>()`.
- 
+* [ObjectServer] Added support for starting and stopping synchronization using `SyncSession.start()` and `SyncSession.stop()`.
+
 ### Bug Fixes
 
 * Methods and classes requiring synchronized Realms have been removed from the standard AAR package. They are now only visible when enabling synchronized Realms in Gradle. The methods and classes will still be visible in the source files and docs, but annotated with `@ObjectServer` (#5799).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [ObjectServer] Added support for observing connection changes for a session using `SyncSession.addConnectionChangeListener()` and `SyncSession.removeConnectionChangeListener()`.
 * [ObjectServer] Added Kotlin extension property `Realm.syncSession` for synchronized Realms.
 * [ObjectServer] Added Kotlin extension method `Realm.classPermissions<RealmModel>()`.
-* [ObjectServer] Added support for starting and stopping synchronization using `SyncSession.start()` and `SyncSession.stop()`.
+* [ObjectServer] Added support for starting and stopping synchronization using `SyncSession.start()` and `SyncSession.stop()` (#6135).
 
 ### Bug Fixes
 

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SessionTests.java
@@ -469,4 +469,12 @@ public class SessionTests {
         }
     }
 
+    @Test
+    public void close_doesNotThrowIfCalledWhenRealmIsClosed() {
+        Realm realm = Realm.getInstance(configuration);
+        SyncSession session = SyncManager.getSession(configuration);
+        realm.close();
+        session.stop();
+        assertEquals(SyncSession.State.INACTIVE, session.getState());
+    }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_SyncSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_SyncSession.cpp
@@ -330,3 +330,34 @@ JNIEXPORT void JNICALL Java_io_realm_SyncSession_nativeRemoveConnectionListener(
     }
     CATCH_STD()
 }
+
+JNIEXPORT void JNICALL Java_io_realm_SyncSession_nativeStart(JNIEnv* env, jclass, jstring j_local_realm_path)
+{
+    TR_ENTER()
+    try {
+        JStringAccessor local_realm_path(env, j_local_realm_path);
+        auto session = SyncManager::shared().get_existing_session(local_realm_path);
+        if (!session) {
+            // FIXME: We should lift this restriction
+            ThrowException(env, IllegalState,
+            "Cannot call start() before a session is "
+            "created. A session will be created after the first call to Realm.getInstance().");
+            return;
+        }
+        session->revive_if_needed();
+    }
+    CATCH_STD()
+}
+
+JNIEXPORT void JNICALL Java_io_realm_SyncSession_nativeStop(JNIEnv* env, jclass, jstring j_local_realm_path)
+{
+    TR_ENTER()
+    try {
+        JStringAccessor local_realm_path(env, j_local_realm_path);
+        auto session = SyncManager::shared().get_existing_session(local_realm_path);
+        if (session) {
+            session->log_out();
+        }
+    }
+    CATCH_STD()
+}

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -510,6 +510,38 @@ public class SyncSession {
         }
     }
 
+    /**
+     * Attempts to start the session and enable synchronization with the Realm Object Server.
+     * <p>
+     * This happens automatically when opening the Realm instance, so doing it manually should only
+     * be needed if the session was stopped using {@link #stop()}.
+     * <p>
+     * If the session was already started, calling this method will do nothing.
+     * <p>
+     * A session is considered started if {@link #getState()} returns either {@link State#ACTIVE},
+     * {@link State#WAITING_FOR_ACCESS_TOKEN}. If the session is {@link State#DYING}, the session
+     * will be moved back to {@link State#ACTIVE}.
+     *
+     * @see #getState()
+     * @see #stop()
+     */
+    public synchronized void start() {
+        nativeStart(configuration.getPath());
+    }
+
+    /**
+     * Stops the session if it was active. This will stop any synchronization with the Realm
+     * Object Server.
+     * <p>
+     * Synchronization can be re-enabled by calling {@link #start()} again. Otherwise synchronization
+     * will resume when all Realms have been closed and an instance is re-opened.
+     * <p>
+     * If the session is already stopped, calling this method will do nothing.
+     */
+    public synchronized void stop() {
+        nativeStop(configuration.getPath());
+    }
+
     void setResolvedRealmURI(URI resolvedRealmURI) {
         this.resolvedRealmURI = resolvedRealmURI;
     }
@@ -859,4 +891,6 @@ public class SyncSession {
     private native boolean nativeWaitForUploadCompletion(int callbackId, String localRealmPath);
     private static native byte nativeGetState(String localRealmPath);
     private static native byte nativeGetConnectionState(String localRealmPath);
+    private static native void nativeStart(String localRealmPath);
+    private static native void nativeStop(String localRealmPath);
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -518,7 +518,7 @@ public class SyncSession {
      * <p>
      * If the session was already started, calling this method will do nothing.
      * <p>
-     * A session is considered started if {@link #getState()} returns either {@link State#ACTIVE},
+     * A session is considered started if {@link #getState()} returns either {@link State#ACTIVE} or
      * {@link State#WAITING_FOR_ACCESS_TOKEN}. If the session is {@link State#DYING}, the session
      * will be moved back to {@link State#ACTIVE}.
      *
@@ -530,11 +530,10 @@ public class SyncSession {
     }
 
     /**
-     * Stops the session if it was active. This will stop any synchronization with the Realm
-     * Object Server.
+     * Stops any synchronization with the Realm Object Server until the Realm is re-opened again
+     * after fully closing it.
      * <p>
-     * Synchronization can be re-enabled by calling {@link #start()} again. Otherwise synchronization
-     * will resume when all Realms have been closed and an instance is re-opened.
+     * Synchronization can be re-enabled by calling {@link #start()} again.
      * <p>
      * If the session is already stopped, calling this method will do nothing.
      */

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncSessionTests.java
@@ -36,8 +36,39 @@ import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class SyncSessionTests extends StandardIntegrationTest {
+
     @Rule
     public TestSyncConfigurationFactory configFactory = new TestSyncConfigurationFactory();
+
+    private interface SessionCallback {
+        void onReady(SyncSession session);
+    }
+
+    private SyncSession getSession() {
+        SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
+        SyncConfiguration syncConfiguration = configFactory
+                .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
+                .build();
+        looperThread.closeAfterTest(Realm.getInstance(syncConfiguration));
+        return SyncManager.getSession(syncConfiguration);
+    }
+
+    private void getActiveSession(SessionCallback callback) {
+        SyncSession session = getSession();
+        if (session.isConnected()) {
+            callback.onReady(session);
+        } else {
+            session.addConnectionChangeListener(new ConnectionListener() {
+                @Override
+                public void onChange(ConnectionState oldState, ConnectionState newState) {
+                    if (newState == ConnectionState.CONNECTED) {
+                        session.removeConnectionChangeListener(this);
+                        callback.onReady(session);
+                    }
+                }
+            });
+        }
+    }
 
     @Test(timeout=3000)
     public void getState_active() {
@@ -513,18 +544,13 @@ public class SyncSessionTests extends StandardIntegrationTest {
     @Test
     @RunTestInLooperThread
     public void registerConnectionListener() {
-        SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
-        SyncConfiguration syncConfiguration = configFactory
-                .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
-                .build();
-        Realm realm = Realm.getInstance(syncConfiguration);
-        SyncSession session = SyncManager.getSession(syncConfiguration);
+        SyncSession session = getSession();
         session.addConnectionChangeListener((oldState, newState) -> {
             if (newState == ConnectionState.DISCONNECTED) {
                 looperThread.testComplete();
             }
         });
-        realm.close();
+        session.stop();
     }
 
     @Test
@@ -556,22 +582,47 @@ public class SyncSessionTests extends StandardIntegrationTest {
     @Test
     @RunTestInLooperThread
     public void isConnected() {
-        SyncUser user = UserFactory.createUniqueUser(Constants.AUTH_URL);
-        SyncConfiguration syncConfiguration = configFactory
-                .createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL)
-                .build();
-        looperThread.closeAfterTest(Realm.getInstance(syncConfiguration));
-        SyncSession session = SyncManager.getSession(syncConfiguration);
-        if (session.isConnected()) {
+        getActiveSession(session -> {
+            assertEquals(session.getConnectionState(), ConnectionState.CONNECTED);
+            assertTrue(session.isConnected());
             looperThread.testComplete();
-        } else {
-            session.addConnectionChangeListener(((oldState, newState) -> {
-                if (newState == ConnectionState.CONNECTED) {
-                    assertEquals(session.getConnectionState(), ConnectionState.CONNECTED);
-                    assertTrue(session.isConnected());
-                    looperThread.testComplete();
-                }
-            }));
-        }
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void stopStartSession() {
+        getActiveSession(session -> {
+            assertEquals(SyncSession.State.ACTIVE, session.getState());
+            session.stop();
+            assertEquals(SyncSession.State.INACTIVE, session.getState());
+            session.start();
+            assertNotEquals(SyncSession.State.INACTIVE, session.getState());
+            looperThread.testComplete();
+        });
+    }
+
+    @Test
+    @RunTestInLooperThread
+    public void start_multipleTimes() {
+        getActiveSession(session -> {
+            session.start();
+            assertEquals(SyncSession.State.ACTIVE, session.getState());
+            session.start();
+            assertEquals(SyncSession.State.ACTIVE, session.getState());
+            looperThread.testComplete();
+        });
+    }
+
+
+    @Test
+    @RunTestInLooperThread
+    public void stop_multipleTimes() {
+        SyncSession session = getSession();
+        session.stop();
+        assertEquals(SyncSession.State.INACTIVE, session.getState());
+        session.stop();
+        assertEquals(SyncSession.State.INACTIVE, session.getState());
+        looperThread.testComplete();
     }
 }


### PR DESCRIPTION
Closes: https://github.com/realm/realm-java-private/issues/235

This PR adds support for manually stopping and starting a session. 
The session lifecycle is still tied to the Realm though. Changing that will be a major refactor of the SyncSession in Object Store.

This approach just uses existing methods on the underlying session that already have the semantics we desire. Calling `log_out()` is probably a bit heavy-handed since it will also clear the access token, but caching the token in ObjectStore didn't seem worth it as we probably need to do a full refactor of the Session anyway. 

This means that using this approach there is currently the overhead of an extra HTTP request when calling `stop/start()`.

**TODO:**
- [x] Public API
- [x] Integration tests
- [x] Unit tests
- [x] Cleanup
