### PR TITLE
Fix various lifecycle issues with tests

### DIFF
--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -728,6 +728,7 @@ public class SyncManager {
         globalAuthorizationHeaderName = "Authorization";
         hostRestrictedCustomHeaders.clear();
         globalCustomHeaders.clear();
+        authServer.clearCustomHeaderSettings();
     }
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/AuthenticationServer.java
@@ -46,6 +46,11 @@ public interface AuthenticationServer {
     void addHeader(String headerName, String headerValue, @Nullable String host);
 
     /**
+     * Clear any custom header settings (Authorization and others).
+     */
+    void clearCustomHeaderSettings();
+
+    /**
      * Login a User on the Object Server. This will create a "UserToken" (Currently called RefreshToken) that acts as
      * the users credentials.
      */
@@ -108,4 +113,5 @@ public interface AuthenticationServer {
      * Complete an email confirmation by sending the token contained in the email.
      */
     UpdateAccountResponse confirmEmail(String confirmationToken, URL authenticationUrl);
+
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpAuthenticationServer.java
@@ -90,6 +90,10 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
     private Map<String, String> customAuthorizationHeaders = new HashMap<>();
 
     public OkHttpAuthenticationServer() {
+        initHeaders();
+    }
+
+    private void initHeaders() {
         customAuthorizationHeaders.put("", "Authorization"); // Default value for authorization header
         customHeaders.put("", new LinkedHashMap<>()); // Add holder for headers used across all hosts
     }
@@ -115,6 +119,13 @@ public class OkHttpAuthenticationServer implements AuthenticationServer {
             }
             headers.put(headerName, headerValue);
         }
+    }
+
+    @Override
+    public void clearCustomHeaderSettings() {
+        customAuthorizationHeaders.clear();
+        customHeaders.clear();
+        initHeaders();
     }
 
     /**

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/BaseIntegrationTest.java
@@ -56,10 +56,6 @@ public abstract class BaseIntegrationTest {
 
     protected ConfigurationWrapper configurationFactory = new ConfigurationWrapper(looperThread);
 
-    static {
-        // Attempt to combat issues with the sync meta data Realm not being correctly cleaned
-    }
-
     /**
      * Starts a new ROS instance that can be used for testing.
      */

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/AuthTests.java
@@ -59,7 +59,6 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(AndroidJUnit4.class)
-@Ignore("They break CI but run locally when just running this class. We need to investigate what is going")
 public class AuthTests extends StandardIntegrationTest {
 
     @Test

--- a/realm/realm-library/src/syncTestUtils/java/io/realm/SyncTestUtils.java
+++ b/realm/realm-library/src/syncTestUtils/java/io/realm/SyncTestUtils.java
@@ -74,7 +74,7 @@ public class SyncTestUtils {
             SyncManager.reset();
             BaseRealm.applicationContext = null; // Required for Realm.init() to work
         }
-        Realm.init(InstrumentationRegistry.getContext());
+        Realm.init(InstrumentationRegistry.getTargetContext());
         originalLogLevel = RealmLog.getLevel();
         RealmLog.setLevel(LogLevel.DEBUG);
     }


### PR DESCRIPTION
Fixes #6138 
Fixes #6137 

This PR fixes various lifecycle issues with tests introduced with #6131 
It also includes a workaround so we can correctly store ros-logs. However the logs are only pulled once ROS is shut down, so I suspect in some cases we might not get logs. We should continue to investigate ways of seeing the logs in real time.