### PR TITLE
Transformer strips similar named methods

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -321,7 +321,7 @@ public class Realm extends BaseRealm {
             checkFilesDirAvailable(context);
             RealmCore.loadLibrary(context);
             setDefaultConfiguration(new RealmConfiguration.Builder(context).build());
-            ObjectServerFacade.getSyncFacadeIfPossible().init(context, userAgent);
+            ObjectServerFacade.getSyncFacadeIfPossible().initialize(context, userAgent);
             if (context.getApplicationContext() != null) {
                 BaseRealm.applicationContext = context.getApplicationContext();
             } else {

--- a/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
@@ -56,7 +56,7 @@ public class ObjectServerFacade {
     /**
      * Initializes the Object Server library
      */
-    public void init(Context context, String userAgent) {
+    public void initialize(Context context, String userAgent) {
     }
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -51,7 +51,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
     private static volatile Method removeSessionMethod;
 
     @Override
-    public void init(Context context, String userAgent) {
+    public void initialize(Context context, String userAgent) {
         // Trying to keep things out the public API is no fun :/
         // Just use reflection on init. It is a one-time method call so should be acceptable.
         //noinspection TryWithIdenticalCatches


### PR DESCRIPTION
The library-transformer strips all methods marked `@ObjectServer`. Unfortunately, it seems it also strips similar named methods even though they don't have this annotation. In this case `ObjectServerFacade.init(Context, String)`. Renaming the internal method is the quickest way to make 5.8.0 ready for release.

I'll be making a fix for the behaviour after the release.