### PR TITLE
Add support for incremental annotation processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,53 @@
-## 5.10.1(YYYY-MM-DD)
+## 5.11.0(YYYY-MM-DD)
 
-## Enhancements 
-* None
+### Enhancements 
+* Added support for incremental annotation processing added in Gradle 4.7. (Issue [#5906](https://github.com/realm/realm-java/issues/5906)).
 
-## Fixed
-*  Native crash happening if bulk updating a field in a `RealmResult` would cause the object to no longer be part of the query result. (Issue [#6478](https://github.com/realm/realm-java/issues/6478), since 5.8.0).
+### Fixed
+* None.
 
-## Compatibility
+### Compatibility
 * Realm Object Server: 3.11.0 or later.
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats).
 * APIs are backwards compatible with all previous release of realm-java in the 5.x.y series.
 
-## Internal
+### Internal
+* None.
+
+
+## 5.10.1(YYYY-MM-DD)
+
+###Enhancements 
+*  None.
+
+### Fixed
+*  Native crash happening if bulk updating a field in a `RealmResult` would cause the object to no longer be part of the query result. (Issue [#6478](https://github.com/realm/realm-java/issues/6478), since 5.8.0).
+
+### Compatibility
+* Realm Object Server: 3.11.0 or later.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats).
+* APIs are backwards compatible with all previous release of realm-java in the 5.x.y series.
+
+### Internal
 * Updated to Object Store commit: cc3db611b1c10d2b890a92fa0f4b8291bc0f3ba2
 
 
 ## 5.10.0(2019-03-22)
 
-## Enhancements
+### Enhancements
 * [ObjectServer] Added 4 new fields to query-based Subscriptions: `createdAt`, `updatedAt`, `expiresAt` and `timeToLive`. These make it possible to better reason about and control current subscriptions. (Issue [#6453](https://github.com/realm/realm-java/issues/6453))
 * [ObjectServer] Added the option of updating the query controlled by a Subscription using either `RealmQuery.findAllAsync(String name, boolean update)`,  `RealmQuery.subscribe(String name, boolean update)` or `Subscription.setQuery(RealmQuery query)`. (Issue [#6453](https://github.com/realm/realm-java/issues/6453))
 * [ObjectServer] Added the option of setting a time-to-live for subscriptions. Setting this will automatically delete the subscription after the provided TTL has expired and the subscription hasn't been used. (Issue [#6453](https://github.com/realm/realm-java/issues/6453))
 
-## Fixed
+### Fixed
 * Dates returned from the Realm file no longer overflow or underflow if they exceed `Long.MAX_VALUE` or `Long.MIN_VALUE` but instead clamp to their respective value. (Issue [#2722](https://github.com/realm/realm-java/issues/2722)) 
 
-## Compatibility
+### Compatibility
 * Realm Object Server: 3.11.0 or later.
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats).
 * APIs are backwards compatible with all previous release of realm-java in the 5.x.y series.
 
-## Internal
+### Internal
 * Updated to Object Store commit: e9819ed9c77ed87b5d7bed416a76cd5bcf255802
 
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.java
@@ -622,26 +622,30 @@ public class RealmProxyClassGenerator {
             @SuppressWarnings("SameParameterValue") String osListVariableName,
             @SuppressWarnings("SameParameterValue") String valueVariableName,
             TypeMirror elementTypeMirror) {
-        if (elementTypeMirror == typeMirrors.STRING_MIRROR) {
+
+        Types typeUtils = processingEnvironment.getTypeUtils();
+        if (typeUtils.isSameType(elementTypeMirror, typeMirrors.STRING_MIRROR)) {
             return osListVariableName + ".addString(" + valueVariableName + ")";
         }
-        if (elementTypeMirror == typeMirrors.LONG_MIRROR || elementTypeMirror == typeMirrors.INTEGER_MIRROR
-                || elementTypeMirror == typeMirrors.SHORT_MIRROR || elementTypeMirror == typeMirrors.BYTE_MIRROR) {
+        if (typeUtils.isSameType(elementTypeMirror, typeMirrors.LONG_MIRROR)
+                || typeUtils.isSameType(elementTypeMirror, typeMirrors.INTEGER_MIRROR)
+                || typeUtils.isSameType(elementTypeMirror, typeMirrors.SHORT_MIRROR)
+                || typeUtils.isSameType(elementTypeMirror, typeMirrors.BYTE_MIRROR)) {
             return osListVariableName + ".addLong(" + valueVariableName + ".longValue())";
         }
-        if (elementTypeMirror.equals(typeMirrors.BINARY_MIRROR)) {
+        if (typeUtils.isSameType(elementTypeMirror, typeMirrors.BINARY_MIRROR)) {
             return osListVariableName + ".addBinary(" + valueVariableName + ")";
         }
-        if (elementTypeMirror == typeMirrors.DATE_MIRROR) {
+        if (typeUtils.isSameType(elementTypeMirror, typeMirrors.DATE_MIRROR)) {
             return osListVariableName + ".addDate(" + valueVariableName + ")";
         }
-        if (elementTypeMirror == typeMirrors.BOOLEAN_MIRROR) {
+        if (typeUtils.isSameType(elementTypeMirror, typeMirrors.BOOLEAN_MIRROR)) {
             return osListVariableName + ".addBoolean(" + valueVariableName + ")";
         }
-        if (elementTypeMirror == typeMirrors.DOUBLE_MIRROR) {
+        if (typeUtils.isSameType(elementTypeMirror, typeMirrors.DOUBLE_MIRROR)) {
             return osListVariableName + ".addDouble(" + valueVariableName + ".doubleValue())";
         }
-        if (elementTypeMirror == typeMirrors.FLOAT_MIRROR) {
+        if (typeUtils.isSameType(elementTypeMirror, typeMirrors.FLOAT_MIRROR)) {
             return osListVariableName + ".addFloat(" + valueVariableName + ".floatValue())";
         }
         throw new RuntimeException("unexpected element type: " + elementTypeMirror.toString());

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/TypeMirrors.java
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/TypeMirrors.java
@@ -30,6 +30,9 @@ import javax.lang.model.util.Types;
 
 /**
  * This class provides {@link TypeMirror} instances used in annotation processor.
+ *
+ * WARNING: Comparing type mirrors using either `==` or `equal()` can break when using incremental
+ * annotation processing. Always use `Types.isSameType()` instead when comparing them.
  */
 class TypeMirrors {
     final TypeMirror STRING_MIRROR;

--- a/realm/realm-annotations-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/realm/realm-annotations-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+io.realm.processor.RealmProcessor,aggregating


### PR DESCRIPTION
Closes #5906 

I don't think there is any way to add automated tests for this so I did smoke tests doing the following:

- [x] Adding / Removing simple String fields
- [x] Adding / Removing Object reference fields
- [x] Adding / Removing model classes
- [x] Modifying non-Realm files.
- [x] Check log output. Especially looking for something like `Gradle may disable incremental compilation as the following annotation processors are not incremental: realm-annotations-processor-5.9.1.jar (io.realm:realm-annotations-processor:5.9.1).`
