### PR TITLE
Querying the existence of data

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -1500,6 +1500,25 @@ public class RealmQuery<E> {
         return this;
     }
 
+    /**
+     * Equal to {@code query.count() > 0}
+     *
+     * @return {@code true} if data found in this query condition.
+     * @see #count()
+     */
+    public boolean exists() {
+        return count() > 0
+    }
+
+    /**
+     * Equal to {@code query.count() == 0}
+     *
+     * @return {@code true} if no data found in this query condition.
+     * @see #count()
+     */
+    public boolean noData() {
+        return count() == 0
+    }
 
     /**
      * Begin grouping of conditions ("left parenthesis"). A group must be closed with a call to {@code endGroup()}.


### PR DESCRIPTION
I am very often using this query to check if Realm contains specific data in a table. We could prevent code repetition using these two methods.

In many lines, I usually write the following code:
```java
if (realm.where(Purchase.class).equalTo("sku", "pro").equalTo("purchased", true).exists()) {
    // activate paid items
}
```