### PR TITLE
PermissionManager should ignore intermittent errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * [ObjectServer] Added `SyncManager.refreshConnections()` that can be used to manually trigger a reconnect for all sessions. This is useful if the device has been offline for a long time or fail to detect that it regained connectivity. (Issue [#259](https://github.com/realm/realm-java-private/issues/259))
 
 ### Fixed
-* [ObjectServer] `PermissionManager` stopped working if an intermittent network error was reported. (Issue [#6492](https://github.com/realm/realm-java/issues/6492))
+* [ObjectServer] `PermissionManager` stopped working if an intermittent network error was reported. (Issue [#6492](https://github.com/realm/realm-java/issues/6492), since 3.7.0)
 
 ### Compatibility
 * Realm Object Server: 3.21.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [ObjectServer] `PermissionManager` stopped working if an intermittent network error was reported. (Issue [#6492](https://github.com/realm/realm-java/issues/6492))
 
 ### Compatibility
-* Realm Object Server: 3.21.1 or later.
+* Realm Object Server: 3.21.0 or later.
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 * APIs are backwards compatible with all previous release of realm-java in the 5.x.y series.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 5.12.0(YYYY-MM-DD)
+
+### Enhancements
+* [ObjectServer] Added `SyncManager.refreshConnections()` that can be used to manually trigger a reconnect for all sessions. This is useful if the device has been offline for a long time or fail to detect that the device regained connectivity. (Issue [#259](https://github.com/realm/realm-java-private/issues/259))
+
+### Fixed
+* [ObjectServer] `PermissionManager` stopped working if an intermittent network error was reported. (Issue [#6492](https://github.com/realm/realm-java/issues/6492))
+
+### Compatibility
+* Realm Object Server: 3.21.1 or later.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* APIs are backwards compatible with all previous release of realm-java in the 5.x.y series.
+
+### Internal
+* None.
+
+
 ## 5.11.0(2019-05-01)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 5.12.0(YYYY-MM-DD)
 
 ### Enhancements
-* [ObjectServer] Added `SyncManager.refreshConnections()` that can be used to manually trigger a reconnect for all sessions. This is useful if the device has been offline for a long time or fail to detect that the device regained connectivity. (Issue [#259](https://github.com/realm/realm-java-private/issues/259))
+* [ObjectServer] Added `SyncManager.refreshConnections()` that can be used to manually trigger a reconnect for all sessions. This is useful if the device has been offline for a long time or fail to detect that it regained connectivity. (Issue [#259](https://github.com/realm/realm-java-private/issues/259))
 
 ### Fixed
 * [ObjectServer] `PermissionManager` stopped working if an intermittent network error was reported. (Issue [#6492](https://github.com/realm/realm-java/issues/6492))

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -594,6 +594,21 @@ public class SyncManager {
         return null;
     }
 
+    /**
+     * Realm will automatically detect when a device gets connectivity after being offline and
+     * resume syncing.
+     * <p>
+     * However, as some of these checks are performed using incremental backoff, this will in some
+     * cases not happen immediately.
+     * <p>
+     * In those cases it can be beneficial to call this method manually, which will force all
+     * sessions to attempt to reconnect immediately and reset any timers they are using for
+     * incremental backoff.
+     */
+    public static void refreshConnections() {
+        notifyNetworkIsBack();
+    }
+
     // Holds the certificate chain (per hostname). We need to keep the order of each certificate
     // according to it's depth in the chain. The depth of the last
     // certificate is 0. The depth of the first certificate is chain

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/PermissionManagerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/PermissionManagerTests.java
@@ -506,7 +506,7 @@ public class PermissionManagerTests extends StandardIntegrationTest {
         // Simulate error in the permission Realm
         Field permissionConfigField = pm.getClass().getDeclaredField("permissionRealmError");
         permissionConfigField.setAccessible(true);
-        final ObjectServerError error = new ObjectServerError(ErrorCode.UNKNOWN, "Boom");
+        final ObjectServerError error = new ObjectServerError(ErrorCode.WRONG_PROTOCOL_VERSION, "Boom");
         permissionConfigField.set(pm, error);
 
         PermissionManager.ApplyPermissionsCallback callback = new PermissionManager.ApplyPermissionsCallback() {
@@ -519,7 +519,7 @@ public class PermissionManagerTests extends StandardIntegrationTest {
             public void onError(ObjectServerError error) {
                 assertTrue(error.getErrorMessage().startsWith("Error occurred in Realm"));
                 assertTrue(error.getErrorMessage().contains("Permission Realm"));
-                assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
+                assertEquals(ErrorCode.WRONG_PROTOCOL_VERSION, error.getErrorCode());
                 looperThread.testComplete();
             }
         };
@@ -535,7 +535,7 @@ public class PermissionManagerTests extends StandardIntegrationTest {
         looperThread.closeAfterTest(pm);
 
         // Simulate error in the permission Realm
-        final ObjectServerError error = new ObjectServerError(ErrorCode.UNKNOWN, "Boom");
+        final ObjectServerError error = new ObjectServerError(ErrorCode.WRONG_PROTOCOL_VERSION, "Boom");
         setRealmError(pm, "managementRealmError", error);
 
         PermissionManager.ApplyPermissionsCallback callback = new PermissionManager.ApplyPermissionsCallback() {
@@ -548,7 +548,7 @@ public class PermissionManagerTests extends StandardIntegrationTest {
             public void onError(ObjectServerError error) {
                 assertTrue(error.getErrorMessage().startsWith("Error occurred in Realm"));
                 assertTrue(error.getErrorMessage().contains("Management Realm"));
-                assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
+                assertEquals(ErrorCode.WRONG_PROTOCOL_VERSION, error.getErrorCode());
                 looperThread.testComplete();
             }
         };
@@ -564,10 +564,10 @@ public class PermissionManagerTests extends StandardIntegrationTest {
         looperThread.closeAfterTest(pm);
 
         // Simulate error in the permission Realm
-        setRealmError(pm, "managementRealmError", new ObjectServerError(ErrorCode.CONNECTION_CLOSED, "Boom1"));
+        setRealmError(pm, "managementRealmError", new ObjectServerError(ErrorCode.WRONG_PROTOCOL_VERSION, "Boom1"));
 
         // Simulate error in the management Realm
-        setRealmError(pm, "permissionRealmError", new ObjectServerError(ErrorCode.CONNECTION_CLOSED, "Boom2"));
+        setRealmError(pm, "permissionRealmError", new ObjectServerError(ErrorCode.WRONG_PROTOCOL_VERSION, "Boom2"));
 
         PermissionManager.ApplyPermissionsCallback callback = new PermissionManager.ApplyPermissionsCallback() {
             @Override
@@ -577,7 +577,7 @@ public class PermissionManagerTests extends StandardIntegrationTest {
 
             @Override
             public void onError(ObjectServerError error) {
-                assertEquals(ErrorCode.CONNECTION_CLOSED, error.getErrorCode());
+                assertEquals(ErrorCode.WRONG_PROTOCOL_VERSION, error.getErrorCode());
                 assertTrue(error.toString().contains("Boom1"));
                 assertTrue(error.toString().contains("Boom2"));
                 looperThread.testComplete();


### PR DESCRIPTION
Closes #6492
Adds functionality for partly working around https://github.com/realm/realm-java-private/issues/259

Before this PR, the `PermissionManager` held on to any error reported, even intermittent network errors. This caused it to stop working once such an error was encountered. 

With this PR, all errors known to be temporary are just ignored, since the end user cannot do anything besides retrying closing/opening the PermissionManager again. Internally we are already retrying sending data which is much more efficient, so no reason to put that burden on the end user.

With this change, only non-recoverable errors should be reported to end users.

