### PR TITLE
Fix queries on indexed linked properties

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/entities/Child6522.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/Child6522.java
@@ -1,0 +1,46 @@
+package io.realm.entities;
+
+import java.util.Objects;
+
+import io.realm.RealmObject;
+import io.realm.annotations.Index;
+
+/**
+ * Created by Nickolay Semendyaev on 09.07.2017.
+ */
+public class Child6522 extends RealmObject {
+    @Index
+    private Integer id;
+    @Index
+    private int category;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public int getCategory() {
+        return category;
+    }
+
+    public void setCategory(int category) {
+        this.category = category;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Child6522 that = (Child6522) o;
+        return category == that.category &&
+                Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, category);
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/Parent6522.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/Parent6522.java
@@ -1,0 +1,50 @@
+package io.realm.entities;
+
+
+import java.util.Objects;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+/**
+ * Created by Nickolay Semendyaev on 09.07.2017.
+ */
+public class Parent6522 extends RealmObject {
+    @PrimaryKey
+    private Integer guid;
+    private RealmList<Child6522> reportValues;
+
+    public Parent6522() {
+    }
+
+    public Integer getGuid() {
+        return guid;
+    }
+
+    public void setGuid(Integer guid) {
+        this.guid = guid;
+    }
+
+    public RealmList<Child6522> getReportValues() {
+        return reportValues;
+    }
+
+    public void setReportValues(RealmList<Child6522> reportValues) {
+        this.reportValues = reportValues;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Parent6522 report = (Parent6522) o;
+        return Objects.equals(guid, report.guid) &&
+                Objects.equals(reportValues, report.reportValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(guid, reportValues);
+    }
+}


### PR DESCRIPTION
Closes #6546 

Looks like a bug in Core, which needs to be fixed there. Currently, this PR just exposes the bug from the Java side.

I have not been able to create a repo case directly in Core yet, and playing around with the unit test also seems to indicate that the order of operations has to be really specific to trigger it.

What is clear is that removing the `@Index` on the object in the list being queried fixes it. So most likely this is related to the newly added optimizations for indexes added in Core. This is further supported by the fact that downgrading Realm fixes it. 