### PR TITLE
Add instructions for building Realm from a local source

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ E.g in the case where where the `realm-java` and `realm-core` repos are checked 
 git clone https://github.com/realm/realm-java.git
 git clone https://github.com/realm/realm-core.git
 cd realm-java/realm
-./gradlew assembleBase -PcoreSourcePath=../realm-core
+./gradlew assembleBase -PcoreSourcePath=../../realm-core
 ```
 
 Note: If the `realm-core` project has already been compiled for non-Android builds and CMake files been generated, this might conflict with `realm-java` trying to build it. Cleanup the `realm-core` project by calling `git clean -xfd` inside it (beware that all unsaved changes will be lost).

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The full build may take an hour or more, to complete.
 
 It is possible to build Realm Java against a local checked out version of Realm Core. This is done by providing the following parameter when building: `-PcoreSourcePath=<path>`.
 
-E.g in the case where where the `realm-java` and `realm-core` repos are checked out next to each other you can build from source using:
+E.g in the case where the `realm-java` and `realm-core` repos are checked out next to each other you can build from source using:
 
 ```
 git clone https://github.com/realm/realm-java.git
@@ -160,7 +160,7 @@ cd realm-java/realm
 ./gradlew assembleBase -PcoreSourcePath=../../realm-core
 ```
 
-Note: If the `realm-core` project has already been compiled for non-Android builds and CMake files been generated, this might conflict with `realm-java` trying to build it. Cleanup the `realm-core` project by calling `git clean -xfd` inside it (beware that all unsaved changes will be lost).
+Note: If the `realm-core` project has already been compiled for non-Android builds and CMake files have been generated, this might conflict with `realm-java` trying to build it. Cleanup the `realm-core` project by calling `git clean -xfd` inside it (beware that all unsaved changes will be lost).
 
 Note: Building from source with Realm Sync is not enabled yet. Only building the `Base` variant is supported.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,25 @@ That command will generate:
 
 The full build may take an hour or more, to complete.
 
+### Building from source
+
+It is possible to build Realm Java against a local checked out version of Realm Core. This is done by providing the following parameter when building: `-PcoreSourcePath=<path>`.
+
+E.g in the case where where the `realm-java` and `realm-core` repos are checked out next to each other you can build from source using:
+
+```
+git clone https://github.com/realm/realm-java.git
+git clone https://github.com/realm/realm-core.git
+cd realm-java/realm
+./gradlew assembleBase -PcoreSourcePath=../realm-core
+```
+
+Note: If the `realm-core` project has already been compiled for non-Android builds and CMake files been generated, this might conflict with `realm-java` trying to build it. Cleanup the `realm-core` project by calling `git clean -xfd` inside it (beware that all unsaved changes will be lost).
+
+Note: Building from source with Realm Sync is not enabled yet. Only building the `Base` variant is supported.
+
+Note: If you want to build from source inside Android Studio, you need to update the Gradle parameters by going into the Realm projects settings `Settings > Build, Execution, Deployment > Compiler > Command-line options` and add `-PcoreSourcePath=<path>` to it.
+
 ### Other Commands
 
  * `./gradlew tasks` will show all the available tasks

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -19,21 +19,19 @@ properties.load(new FileInputStream("${projectDir}/../../dependencies.list"))
 ext.coreVersion = properties.getProperty('REALM_SYNC_VERSION')
 // empty or comment out this to disable hash checking
 ext.coreSha256Hash = properties.getProperty('REALM_SYNC_SHA256')
-ext.forceDownloadCore =
-        project.hasProperty('forceDownloadCore') ? project.getProperty('forceDownloadCore').toBoolean() : false
+ext.forceDownloadCore = project.hasProperty('forceDownloadCore') ? project.getProperty('forceDownloadCore').toBoolean() : false
+
 // Set the core source code path. By setting this, the core will be built from source. And coreVersion will be read from
 // core source code.
-ext.coreSourcePath = project.hasProperty('coreSourcePath') ? project.getProperty('coreSourcePath') : null
-// The location of core archive.
+ext.coreSourcePath = project.hasProperty('coreSourcePath') ? file(project.getProperty('coreSourcePath')) : null
+// The location of pre-compiled Realm Core/Sync archive.
 ext.coreArchiveDir = System.getenv("REALM_CORE_DOWNLOAD_DIR")
 if (!ext.coreArchiveDir) {
     ext.coreArchiveDir = ".."
 }
 ext.coreArchiveFile = rootProject.file("${ext.coreArchiveDir}/realm-sync-android-${project.coreVersion}.tar.gz")
 ext.coreDistributionDir = file("${projectDir}/distribution/realm-core/")
-ext.coreDir = file(project.coreSourcePath ?
-        "${project.coreSourcePath}/android-lib" :
-        "${project.coreDistributionDir.getAbsolutePath()}/core-${project.coreVersion}")
+ext.coreDir = file("${project.coreDistributionDir.getAbsolutePath()}/core-${project.coreVersion}")
 ext.ccachePath = project.findProperty('ccachePath') ?: System.getenv('NDK_CCACHE')
 ext.lcachePath = project.findProperty('lcachePath') ?: System.getenv('NDK_LCACHE')
 // Set to true to enable linking with debug core.
@@ -61,7 +59,7 @@ android {
                         "-DENABLE_DEBUG_CORE=$project.enableDebugCore"
                 if (project.ccachePath) arguments "-DNDK_CCACHE=$project.ccachePath"
                 if (project.lcachePath) arguments "-DNDK_LCACHE=$project.lcachePath"
-                if (project.coreSourcePath) arguments "-DCORE_SOURCE_PATH=$project.coreSourcePath"
+                if (project.coreSourcePath) arguments "-DCORE_SOURCE_PATH=${project.coreSourcePath.getAbsolutePath()}"
                 if (project.hasProperty('buildTargetABIs') && !project.getProperty('buildTargetABIs').trim().isEmpty()) {
                     abiFilters(*project.getProperty('buildTargetABIs').trim().split('\\s*,\\s*'))
                 } else {

--- a/realm/realm-library/src/main/cpp/CMake/RealmCore.cmake
+++ b/realm/realm-library/src/main/cpp/CMake/RealmCore.cmake
@@ -25,6 +25,8 @@ function(build_existing_realm_core core_source_path)
         add_compile_options(-DNDEBUG)
     endif()
 
+    # We mirror relevant flags from this script
+    # https://github.com/realm/realm-core/blob/master/tools/cross_compile.sh#L68
     ExternalProject_Add(realm-core
         SOURCE_DIR ${core_source_path}
         PREFIX ${core_source_path}/build-android-${ANDROID_ABI}-${CMAKE_BUILD_TYPE}
@@ -118,6 +120,7 @@ endfunction()
 # FIXME: Build from sync source is not supported yet.
 function(use_realm_core enable_sync sync_dist_path core_source_path)
     if (core_source_path)
+        message("Building Realm Core from local source in ${core_source_path}.")
         build_existing_realm_core(${core_source_path})
     else()
         use_sync_release(${enable_sync} ${sync_dist_path})

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -21,11 +21,10 @@
 #include <sync/sync_config.hpp>
 #include <sync/sync_manager.hpp>
 #include <sync/sync_session.hpp>
-
+#include <realm/util/misc_ext_errors.hpp>
 #endif
 
 #include <linux/errno.h>
-#include <realm/util/misc_ext_errors.hpp>
 
 #include "java_accessor.hpp"
 #include "util.hpp"


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/6444

Fixed a few bugs for building with a local copy of Realm and added instructions on how to do it practice. This will enable better debugging for native code where we should now be able to better follow code paths that ends up in Core.

We also now accept both relative and absolute paths to Realm Core, before only absolute paths really worked.

