### PR TITLE
Correctly copy JAR files in the Realm transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 5.13.1(YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixed
+* The Realm bytecode transformer now works correctly with Android Gradle Plugin 3.6.0-alpha01 and beyond. (Issue [#6531](https://github.com/realm/realm-java/issues/6531)).
+
+### Compatibility
+* Realm Object Server: 3.21.0 or later.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* APIs are backwards compatible with all previous release of realm-java in the 5.x.y series.
+
+### Internal
+* Updated JavaAssist in the Realm Transformer to 3.25.0-GA.
+
+
 ## 5.13.0(2019-07-23)
 
 ### Enhancements

--- a/realm-transformer/build.gradle
+++ b/realm-transformer/build.gradle
@@ -47,9 +47,7 @@ configurations {
 sourceSets {
     main {
         compileClasspath += configurations.provided
-        java {
-            srcDirs += ['build/generated-src/main/java', 'src/main/kotlin']
-        }
+        java.srcDirs += ['build/generated-src/main/java', 'src/main/kotlin']
     }
 }
 
@@ -58,7 +56,7 @@ dependencies {
     compile "io.realm:realm-annotations:${version}"
     compileOnly "com.android.tools.build:gradle:${properties.get("GRADLE_BUILD_TOOLS")}"
     compileOnly 'com.android.tools.build:gradle:3.1.1'
-    compile 'org.javassist:javassist:3.21.0-GA'
+    compile 'org.javassist:javassist:3.25.0-GA'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
 
     testCompile 'junit:junit:4.12'

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -150,10 +150,7 @@ class RealmTransformer(val project: Project) : Transform() {
                 }
             }
 
-            val packages: Set<String> = outputModelClasses.map {
-                it.packageName
-            }.toSet()
-
+            val packages: Set<String> = outputModelClasses.map { it.packageName }.toSet()
             val targetSdk: String? = project.getTargetSdk()
             val minSdk: String?  = project.getMinSdk()
 

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/build/BuildTemplate.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/build/BuildTemplate.kt
@@ -125,21 +125,34 @@ abstract class BuildTemplate(val project: Project, val outputProvider: Transform
                 it.file.walkTopDown().forEach {
                     if (it.isFile) {
                         if (!it.absolutePath.endsWith(SdkConstants.DOT_CLASS)) {
-                            logger.debug("  Copying resource $it")
-                            val dest = File(getOutputFile(outputProvider), it.absolutePath.substring(dirPath.length))
+                            logger.debug("  Copying resource file: $it")
+                            val dest = File(getOutputFile(outputProvider, Format.DIRECTORY), it.absolutePath.substring(dirPath.length))
                             dest.parentFile.mkdirs()
                             Files.copy(it, dest)
                         }
                     }
                 }
             }
-            // no need to implement the code for `it.jarInputs.each` since PROJECT SCOPE does not use jar input.
+
+            it.jarInputs.forEach {
+                logger.debug("Found JAR file: ${it.file.absolutePath}")
+                val dirPath: String = it.file.absolutePath
+                it.file.walkTopDown().forEach {
+                    if (it.isFile) {
+                        if (it.absolutePath.endsWith(SdkConstants.DOT_JAR)) {
+                            logger.debug("  Copying jar file: $it")
+                            val dest = File(getOutputFile(outputProvider, Format.JAR), it.absolutePath.substring(dirPath.length))
+                            dest.parentFile.mkdirs()
+                            Files.copy(it, dest)
+                        }
+                    }
+                }
+            }
         }
     }
 
-    protected fun getOutputFile(outputProvider: TransformOutputProvider): File {
-        return outputProvider.getContentLocation(
-                "realm", transform.inputTypes, transform.scopes, Format.DIRECTORY)
+    protected fun getOutputFile(outputProvider: TransformOutputProvider, format: Format): File {
+        return outputProvider.getContentLocation("realm", transform.inputTypes, transform.scopes, format)
     }
 
     /**

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/build/FullBuild.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/build/FullBuild.kt
@@ -17,6 +17,7 @@
 package io.realm.transformer.build
 
 import com.android.SdkConstants
+import com.android.build.api.transform.Format
 import com.android.build.api.transform.TransformInput
 import com.android.build.api.transform.TransformOutputProvider
 import io.realm.transformer.BytecodeModifier
@@ -130,10 +131,14 @@ class FullBuild(project: Project, outputProvider: TransformOutputProvider, trans
 
         // Use accessors instead of direct field access
         outputClassNames.forEach {
-            logger.debug("Modify accessors in class: $it")
-            val ctClass: CtClass = classPool.getCtClass(it)
-            BytecodeModifier.useRealmAccessors(classPool, ctClass, allManagedFields)
-            ctClass.writeFile(getOutputFile(outputProvider).canonicalPath)
+            logger.debug("Modifying accessors in class: $it")
+            try {
+                val ctClass: CtClass = classPool.getCtClass(it)
+                BytecodeModifier.useRealmAccessors(classPool, ctClass, allManagedFields)
+                ctClass.writeFile(getOutputFile(outputProvider, Format.DIRECTORY).canonicalPath)
+            } catch (e: Exception) {
+                throw RuntimeException("Failed to transform $it.", e)
+            }
         }
     }
 

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/build/IncrementalBuild.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/build/IncrementalBuild.kt
@@ -17,6 +17,7 @@
 package io.realm.transformer.build
 
 import com.android.SdkConstants
+import com.android.build.api.transform.Format
 import com.android.build.api.transform.Status
 import com.android.build.api.transform.TransformInput
 import com.android.build.api.transform.TransformOutputProvider
@@ -51,11 +52,9 @@ class IncrementalBuild(project: Project, outputProvider: TransformOutputProvider
             logger.debug("Modify accessors in class: $it")
             val ctClass: CtClass = classPool.getCtClass(it)
             BytecodeModifier.useRealmAccessors(classPool, ctClass, null)
-            ctClass.writeFile(getOutputFile(outputProvider).canonicalPath)
+            ctClass.writeFile(getOutputFile(outputProvider, Format.DIRECTORY).canonicalPath)
         }
-
     }
-
 
     /**
      * Categorize the transform input into its two main categorizes: `directoryFiles` which are


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/6531

Test by compilling and running all all examples in the repo with `3.6.0-alpha05` (latest release). Before this PR some of the examples would crash at runtime, now they all run.

Reason being that in 3.6.0 the R file is now generated inside a seperate JAR file that needs to be copied as well.