### PR TITLE
Add support for configuring sync with the system proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 5.13.1(YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixed
+* [ObjectServer] The C++ networking layer now correctly uses any system defined proxy the same way the Java networking layer does. (Issue [#6574](https://github.com/realm/realm-java/pull/6574)). 
+
+### Internal
+* Updated to Realm Core 5.23.1.
+* Updated to Realm Sync 4.7.1.
+* Updated to Object Store commit: bcc6a7524e52071bfcd35cf740f506e0cc6a595e
+
 ## 5.13.0(2019-07-23)
 
 ### Enhancements

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,7 +1,7 @@
 # Realm Sync release used by Realm Java (This includes Realm Core)
 # https://github.com/realm/realm-sync/releases
-REALM_SYNC_VERSION=4.6.1
-REALM_SYNC_SHA256=eb4fbf83717156fabae6357199b22ef25546f2da24ded5668290351613faf9d0
+REALM_SYNC_VERSION=4.7.1
+REALM_SYNC_SHA256=28c37d53e63d80db6be1f3e566adac7eea291f496be2b5274cfb94658b435d3d.
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,7 +1,7 @@
 # Realm Sync release used by Realm Java (This includes Realm Core)
 # https://github.com/realm/realm-sync/releases
 REALM_SYNC_VERSION=4.7.1
-REALM_SYNC_SHA256=28c37d53e63d80db6be1f3e566adac7eea291f496be2b5274cfb94658b435d3d.
+REALM_SYNC_SHA256=28c37d53e63d80db6be1f3e566adac7eea291f496be2b5274cfb94658b435d3d
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -452,4 +452,29 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeSetSyncConfigS
     CATCH_STD()
 }
 
+static_assert(SyncConfig::ProxyConfig::Type::HTTP == static_cast<SyncConfig::ProxyConfig::Type>(io_realm_internal_OsRealmConfig_PROXYCONFIG_TYPE_VALUE_HTTP),
+              "");
+
+JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeSetSyncConfigProxySettings(
+    JNIEnv* env, jclass, jlong native_ptr, jbyte proxy_type,
+    jstring j_proxy_address, jint proxy_port)
+{
+    TR_ENTER_PTR(native_ptr);
+
+    auto& config = *reinterpret_cast<Realm::Config*>(native_ptr);
+    // To ensure the sync_config has been created and this function won't be called multiple time on the same config.
+    REALM_ASSERT(config.sync_config);
+    REALM_ASSERT(!config.sync_config->proxy_config);
+
+    try {
+        SyncConfig::ProxyConfig proxy_config;
+        proxy_config.type = static_cast<SyncConfig::ProxyConfig::Type>(proxy_type);
+        proxy_config.address = JStringAccessor(env, j_proxy_address);
+        proxy_config.port = proxy_port;
+
+        config.sync_config->proxy_config.emplace(std::move(proxy_config));
+    }
+    CATCH_STD()
+}
+
 #endif


### PR DESCRIPTION
See https://jira.mongodb.org/browse/HELP-10664. Needs realm/realm-object-store#816 and realm/realm-sync#3067.