### PR TITLE
Realm plugin: consider kotlin-multiplatform plugin

### DIFF
--- a/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
+++ b/gradle-plugin/src/main/groovy/io/realm/gradle/Realm.groovy
@@ -43,7 +43,7 @@ class Realm implements Plugin<Project> {
 
         def syncEnabledDefault = false
         def usesAptPlugin = project.plugins.findPlugin('com.neenbedankt.android-apt') != null
-        def isKotlinProject = project.plugins.findPlugin('kotlin-android') != null
+        def isKotlinProject = project.plugins.findPlugin('kotlin-android') != null || project.plugins.findPlugin("kotlin-multiplatform") != null
         def useKotlinExtensionsDefault = isKotlinProject
         def hasAnnotationProcessorConfiguration = project.getConfigurations().findByName('annotationProcessor') != null
         // TODO add a parameter in 'realm' block if this should be specified by users


### PR DESCRIPTION
Using the Kotlin multiplatform plugin instead of the "kotlin-android" one currently, lead to the kapt dependencies not being applied.