### PR TITLE
Fix Proguard setup for release builds using R8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.0.2(YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixed
+* The `@RealmModule` annotation would be stripped on an empty class when using R8 resulting in apps crashing on startup with `io.realm.DefaultRealmModule is not a RealmModule. Add @RealmModule to the class definition.`. ([#6449](https://github.com/realm/realm-java/issues/6449))
+
 ## 6.0.1(2019-11-11)
 
 NOTE: Anyone using encrypted Realms are strongly advised to upgrade to this version.

--- a/realm/realm-library/proguard-rules-consumer-common.pro
+++ b/realm/realm-library/proguard-rules-consumer-common.pro
@@ -1,5 +1,7 @@
 -keep class io.realm.annotations.RealmModule
 -keep @io.realm.annotations.RealmModule class *
+-keep @interface io.realm.annotations.RealmModule { *; }
+-keep class io.realm.annotations.RealmModule { *; }
 
 -keep class io.realm.internal.Keep
 -keep @io.realm.internal.Keep class * { *; }


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/6449

This was test manually by upgrading Gradle Build Tools to 3.4.1, installing the `moduleExample` in release mode and running the app. Before this fix, the app would crash on startup. After, it works.