### PR TITLE
Fix transform crashing when you delete transformed objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.0.3(YYYY-MM-DD)
 
 ### Enhancements
-* `RealmObjectSchema.transform` now also works for typed Realms instead of throwing a `UnsupportedOperationException`. 
+* None.
 
 ### Fixed
 * `RealmObjectSchema.transform()` would crash if one of the `DynamicRealmObject` provided are deleted from the Realm. (Issue [#6657](https://github.com/realm/realm-java/issues/6657), since 0.86.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 6.0.3(YYYY-MM-DD)
+
+### Enhancements
+* `RealmObjectSchema.transform` now also works for typed Realms instead of throwing a `UnsupportedOperationException`. 
+
+### Fixed
+* `RealmObjectSchema.transform()` would crash if one of the `DynamicRealmObject` provided are deleted from the Realm. (Issue [#6657](https://github.com/realm/realm-java/issues/6657), since 0.86.0)
+
+### Compatibility
+* Realm Object Server: 3.23.1 or later.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* APIs are backwards compatible with all previous release of realm-java in the 6.x.y series.
+
+### Internal
+* None.
+
+
 ## 6.0.2(2019-11-21)
 
 ### Enhancements

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectSchemaTests.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.realm.entities.AllJavaTypes;
+import io.realm.entities.CyclicType;
 import io.realm.entities.Dog;
 import io.realm.entities.NonLatinFieldNames;
 import io.realm.internal.Table;
@@ -1198,28 +1199,30 @@ public class RealmObjectSchemaTests {
 
     @Test
     public void transform() {
-        if (type == ObjectSchemaType.IMMUTABLE) {
-            thrown.expect(UnsupportedOperationException.class);
-            DOG_SCHEMA.transform(new RealmObjectSchema.Function() {
-                @Override
-                public void apply(DynamicRealmObject obj) {
-                }
-            });
-            return;
-        }
-        String className = DOG_SCHEMA.getClassName();
-        DynamicRealmObject dog1 = ((DynamicRealm)realm).createObject(className);
-        dog1.setInt("age", 1);
-        DynamicRealmObject dog2 = ((DynamicRealm)realm).createObject(className);
-        dog2.setInt("age", 2);
+        switch(type) {
+            case MUTABLE: {
+                String className = DOG_SCHEMA.getClassName();
+                DynamicRealmObject dog1 = ((DynamicRealm) realm).createObject(className);
+                dog1.setInt("age", 1);
+                DynamicRealmObject dog2 = ((DynamicRealm) realm).createObject(className);
+                dog2.setInt("age", 2);
 
-        DOG_SCHEMA.transform(new RealmObjectSchema.Function() {
-            @Override
-            public void apply(DynamicRealmObject obj) {
-                obj.setInt("age", obj.getInt("age") + 1);
+                DOG_SCHEMA.transform(obj -> obj.setInt("age", obj.getInt("age") + 1));
+                assertEquals(5, ((DynamicRealm) realm).where("Dog").sum("age").intValue());
+                break;
             }
-        });
-        assertEquals(5, ((DynamicRealm)realm).where("Dog").sum("age").intValue());
+            case IMMUTABLE: {
+                Dog dog1 = ((Realm) realm).createObject(Dog.class);
+                dog1.setAge(1);
+                Dog dog2 = ((Realm) realm).createObject(Dog.class);
+                dog2.setAge(2);
+                DOG_SCHEMA.transform(obj -> obj.setInt("age", obj.getInt("age") + 1));
+                assertEquals(5, ((Realm) realm).where(Dog.class).sum("age").intValue());
+                break;
+            }
+            default:
+                fail();
+        }
     }
 
     @Test
@@ -1241,6 +1244,49 @@ public class RealmObjectSchemaTests {
         });
         //noinspection ConstantConditions
         assertEquals("John", ((DynamicRealm)realm).where("Dog").findFirst().getObject("owner").getString("name"));
+    }
+
+    @Test
+    public void transform_deleteObjects() {
+
+        RealmObjectSchema classSchema = realm.getSchema().get("CyclicType");
+
+        Runnable transform = () -> classSchema.transform(obj -> {
+            if (obj.getInt(CyclicType.FIELD_ID) % 2 == 0) {
+                obj.getObject(CyclicType.FIELD_OBJECT).deleteFromRealm();
+                obj.deleteFromRealm();
+            }
+        });
+
+        switch (type) {
+            case MUTABLE:
+                String className = classSchema.getClassName();
+                for (int i = 0; i < 10; i++) {
+                    DynamicRealmObject parentObj = ((DynamicRealm)realm).createObject(className);
+                    DynamicRealmObject childObj = ((DynamicRealm)realm).createObject(className);
+                    parentObj.setLong(CyclicType.FIELD_ID, i);
+                    parentObj.setObject(CyclicType.FIELD_OBJECT, childObj);
+                    childObj.setLong(CyclicType.FIELD_ID, i + 100);
+                }
+                assertEquals(20, ((DynamicRealm) realm).where((className)).count());
+                transform.run();
+                assertEquals(10, ((DynamicRealm) realm).where((className)).count());
+                break;
+            case IMMUTABLE:
+                for (int i = 0; i < 10; i++) {
+                    CyclicType parentObj = ((Realm)realm).createObject(CyclicType.class);
+                    CyclicType childObj = ((Realm)realm).createObject(CyclicType.class);
+                    parentObj.setId(i);
+                    parentObj.setObject(childObj);
+                    childObj.setId(i + 100);
+                }
+                assertEquals(20, ((Realm) realm).where((CyclicType.class)).count());
+                transform.run();
+                assertEquals(10, ((Realm) realm).where(CyclicType.class).count());
+                break;
+            default:
+                fail();
+        }
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/CyclicType.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/CyclicType.java
@@ -26,6 +26,7 @@ public class CyclicType extends RealmObject {
     public static final String FIELD_NAME = "name";
     public static final String FIELD_ID = "id";
     public static final String FIELD_DATE = "date";
+    public static final String FIELD_OBJECT = "object";
 
     private long id;
     private String name;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsResults.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsResults.cpp
@@ -64,6 +64,22 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_OsResults_nativeCreateResults(JNI
     return reinterpret_cast<jlong>(nullptr);
 }
 
+JNIEXPORT jlong JNICALL Java_io_realm_internal_OsResults_nativeCreateResultsFromTable(JNIEnv* env, jclass,
+                                                                             jlong shared_realm_ptr,
+                                                                             jlong table_ptr)
+{
+    TR_ENTER()
+    try {
+        auto shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
+        auto table = reinterpret_cast<Table*>(table_ptr);
+        Results results(shared_realm, *table);
+        auto wrapper = new ResultsWrapper(results);
+        return reinterpret_cast<jlong>(wrapper);
+    }
+    CATCH_STD()
+    return reinterpret_cast<jlong>(nullptr);
+}
+
 JNIEXPORT jlong JNICALL Java_io_realm_internal_OsResults_nativeCreateSnapshot(JNIEnv* env, jclass, jlong native_ptr)
 {
     TR_ENTER_PTR(native_ptr);

--- a/realm/realm-library/src/main/java/io/realm/ImmutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/ImmutableRealmObjectSchema.java
@@ -101,6 +101,11 @@ class ImmutableRealmObjectSchema extends RealmObjectSchema {
         throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
     }
 
+    @Override
+    public RealmObjectSchema transform(Function function) {
+        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
+    }
+
     /**
      * Returns a field descriptor based on Java field names found in model classes.
      *

--- a/realm/realm-library/src/main/java/io/realm/ImmutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/ImmutableRealmObjectSchema.java
@@ -101,11 +101,6 @@ class ImmutableRealmObjectSchema extends RealmObjectSchema {
         throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
     }
 
-    @Override
-    public RealmObjectSchema transform(Function function) {
-        throw new UnsupportedOperationException(SCHEMA_IMMUTABLE_EXCEPTION_MSG);
-    }
-
     /**
      * Returns a field descriptor based on Java field names found in model classes.
      *

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
@@ -20,7 +20,9 @@ import java.util.Locale;
 
 import javax.annotation.Nonnull;
 
+import io.realm.internal.CheckedRow;
 import io.realm.internal.OsObjectStore;
+import io.realm.internal.OsResults;
 import io.realm.internal.Table;
 import io.realm.internal.fields.FieldDescriptor;
 
@@ -276,6 +278,29 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
     @Override
     public RealmObjectSchema setNullable(String fieldName, boolean nullable) {
         setRequired(fieldName, !nullable);
+        return this;
+    }
+
+    @Override
+    public RealmObjectSchema transform(Function function) {
+        //noinspection ConstantConditions
+        if (function != null) {
+            // Users might delete object being transformed or accidentally delete other objects
+            // in the same table. E.g. cascading deletes if it is referenced by an object being deleted.
+            OsResults results = OsResults.createFromTable(realm.sharedRealm, table).createSnapshot();
+            long original_size = results.size();
+            if (original_size > Integer.MAX_VALUE) {
+                throw new UnsupportedOperationException("Too many results to iterate: " + original_size);
+            }
+            int size = (int) results.size();
+            for (int i = 0; i < size; i++) {
+                DynamicRealmObject obj = new DynamicRealmObject(realm, new CheckedRow(results.getUncheckedRow(i)));
+                if (obj.isValid()) {
+                    function.apply(obj);
+                }
+            }
+        }
+
         return this;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
@@ -279,19 +279,6 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
         return this;
     }
 
-    @Override
-    public RealmObjectSchema transform(Function function) {
-        //noinspection ConstantConditions
-        if (function != null) {
-            long size = table.size();
-            for (long i = 0; i < size; i++) {
-                function.apply(new DynamicRealmObject(realm, table.getCheckedRow(i)));
-            }
-        }
-
-        return this;
-    }
-
     /**
      * Returns a field descriptor based on the internal field names found in the Realm file.
      *

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -402,29 +402,13 @@ public abstract class RealmObjectSchema {
      * Runs a transformation function on each RealmObject instance of the current class. The object will be represented
      * as a {@link DynamicRealmObject}.
      * <p>
-     * There is no guarantees in which order the objects are re
+     * There is no guarantees in which order the objects are returned.
      *
      * @param function transformation function.
      * @return this schema.
      * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public RealmObjectSchema transform(Function function) {
-        //noinspection ConstantConditions
-        if (function != null) {
-            // Users might delete object being transformed or accidentally delete other objects
-            // in the same table. E.g. cascading deletes if it is referenced by an object being deleted.
-            OsResults results = OsResults.createFromTable(realm.sharedRealm, table).createSnapshot();
-            long size = results.size();
-            for (long i = 0; i < size; i++) {
-                DynamicRealmObject obj = new DynamicRealmObject(realm, new CheckedRow(results.getUncheckedRow((int) i)));
-                if (obj.isValid()) {
-                    function.apply(obj);
-                }
-            }
-        }
-
-        return this;
-    }
+    public abstract RealmObjectSchema transform(Function function);
 
     /**
      * Returns the type used by the underlying storage engine to represent this field.

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -27,9 +27,11 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import io.realm.annotations.Required;
+import io.realm.internal.CheckedRow;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.OsObject;
 import io.realm.internal.OsObjectStore;
+import io.realm.internal.OsResults;
 import io.realm.internal.Table;
 import io.realm.internal.fields.FieldDescriptor;
 
@@ -399,12 +401,30 @@ public abstract class RealmObjectSchema {
     /**
      * Runs a transformation function on each RealmObject instance of the current class. The object will be represented
      * as a {@link DynamicRealmObject}.
+     * <p>
+     * There is no guarantees in which order the objects are re
      *
      * @param function transformation function.
      * @return this schema.
      * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
-    public abstract RealmObjectSchema transform(Function function);
+    public RealmObjectSchema transform(Function function) {
+        //noinspection ConstantConditions
+        if (function != null) {
+            // Users might delete object being transformed or accidentally delete other objects
+            // in the same table. E.g. cascading deletes if it is referenced by an object being deleted.
+            OsResults results = OsResults.createFromTable(realm.sharedRealm, table).createSnapshot();
+            long size = results.size();
+            for (long i = 0; i < size; i++) {
+                DynamicRealmObject obj = new DynamicRealmObject(realm, new CheckedRow(results.getUncheckedRow((int) i)));
+                if (obj.isValid()) {
+                    function.apply(obj);
+                }
+            }
+        }
+
+        return this;
+    }
 
     /**
      * Returns the type used by the underlying storage engine to represent this field.

--- a/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CheckedRow.java
@@ -39,7 +39,7 @@ public class CheckedRow extends UncheckedRow {
         super(context, parent, nativePtr);
     }
 
-    private CheckedRow(UncheckedRow row) {
+    public CheckedRow(UncheckedRow row) {
         super(row);
         this.originalRow = row;
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/OsResults.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsResults.java
@@ -298,6 +298,11 @@ public class OsResults implements NativeObject, ObservableCollection {
         return createFromQuery(sharedRealm, query, new DescriptorOrdering());
     }
 
+    public static OsResults createFromTable(OsSharedRealm sharedRealm, Table table) {
+        long ptr = nativeCreateResultsFromTable(sharedRealm.getNativePtr(), table.getNativePtr());
+        return new OsResults(sharedRealm, table, ptr);
+    }
+
     OsResults(OsSharedRealm sharedRealm, Table table, long nativePtr) {
         this.sharedRealm = sharedRealm;
         this.context = sharedRealm.context;
@@ -656,6 +661,8 @@ public class OsResults implements NativeObject, ObservableCollection {
     private static native long nativeGetFinalizerPtr();
 
     protected static native long nativeCreateResults(long sharedRealmNativePtr, long queryNativePtr, long descriptorOrderingPtr);
+
+    private static native long nativeCreateResultsFromTable(long sharedRealmNativePtr, long tablePtr);
 
     private static native long nativeCreateSnapshot(long nativePtr);
 


### PR DESCRIPTION
Closes #6657

Also add support for creating `OsResults` directly from a table, which is much faster than running a query for all objects in a table.