### PR TITLE
Update ReLinker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * The Realm Gradle plugin now applies `kapt` when used in Kotlin Multiplatform projects. Note, Realm Java still only works for the Android part of a Kotlin Multiplatform project. (Issue [#6653](https://github.com/realm/realm-java/issues/6653))
+* The error message shown when no native code could be found for the device is now much more descriptive. This is particular helpful if an app is using App Bundle or APK Split and the resulting APK was side-loaded outside the Google Play Store. (Issue [#6673](https://github.com/realm/realm-java/issues/6673))
 
 ### Fixed
 * None.
@@ -12,6 +13,7 @@
 * APIs are backwards compatible with all previous release of realm-java in the 6.x.y series.
 
 ### Internal
+* Updated to ReLinker 1.4.0.
 * Updated to Object Store commit: ad96a4c334b475dd67d50c1ca419e257d7a21e18.
 * Updated to Realm Sync v4.8.3.
 

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -209,7 +209,7 @@ dependencies {
 
     api "io.realm:realm-annotations:${version}"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'com.getkeepsafe.relinker:relinker:1.3.0'
+    implementation 'com.getkeepsafe.relinker:relinker:1.4.0'
 
     kapt project(':realm-annotations-processor') // See https://github.com/realm/realm-java/issues/5799
     objectServerImplementation 'com.squareup.okhttp3:okhttp:3.9.0'

--- a/realm/realm-library/src/androidTest/java/ThreadStressTests.java
+++ b/realm/realm-library/src/androidTest/java/ThreadStressTests.java
@@ -122,7 +122,7 @@ public class ThreadStressTests {
         }
         realmConfig = configFactory.createConfiguration();
         Realm.deleteRealm(realmConfig);
-        executor = Executors.newFixedThreadPool(reuseThreads ? random.nextInt(MAX_THREADS) : MAX_THREADS);
+        executor = Executors.newFixedThreadPool(reuseThreads ? Math.max(random.nextInt(MAX_THREADS), 1) : MAX_THREADS);
     }
 
     @After


### PR DESCRIPTION
Closes #6673 

Updates ReLinker so a better error message is used when no matching ABI was found.