### PR TITLE
Add support for Decimal128 and ObjectId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: This version bumps the Realm file format to version 10. It is not possible
 * Realm now requires `minSdkVersion` 16. Up from 9.
 
 ### Enhancements
+* Added support for `org.bson.types.Decimal128` and `org.bson.types.ObjectId` as supported fields in model classes.
 * Added `Realm.freeze()`, `RealmObject.freeze()`, `RealmResults.freeze()` and `RealmList.freeze()`. These methods will return a frozen version of the current Realm data. This data can be read from any thread without throwing an `IllegalStateException`, but will never change. All frozen Realms and data can be closed by calling `Realm.close()` on the frozen Realm, but fully closing all live Realms will also close the frozen ones. Frozen data can be queried as normal, but trying to mutate it in any way will throw an `IllegalStateException`. This includes all methods that attempt to refresh or add change listeners. (Issue [#6590](https://github.com/realm/realm-java/pull/6590))
 * Added `Realm.isFrozen()`, `RealmObject.isFrozen()`, `RealmObject.isFrozen(RealmModel)`, `RealmResults.isFrozen()` and `RealmList.isFrozen()`, which returns whether or not the data is frozen.
 * Added `RealmConfiguration.Builder.maxNumberOfActiveVersions(long number)`. Setting this will cause Realm to throw an `IllegalStateException` if too many versions of the Realm data are live at the same time. Having too many versions can dramatically increase the filesize of the Realm.

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -216,6 +216,7 @@ dependencies {
 
     kapt project(':realm-annotations-processor') // See https://github.com/realm/realm-java/issues/5799
     objectServerImplementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    objectServerImplementation 'org.mongodb:bson:3.12.0' // FIXME: Optional?
 
     kaptAndroidTest project(':realm-annotations-processor')
     androidTestImplementation 'io.reactivex.rxjava2:rxjava:2.1.5'

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/MongoDBTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/MongoDBTypes.java
@@ -1,0 +1,11 @@
+package io.realm.entities;
+
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+import io.realm.RealmObject;
+
+public class MongoDBTypes extends RealmObject {
+    public ObjectId id = ObjectId.get();
+    public Decimal128 dec128 = new Decimal128()
+}

--- a/realm/realm-library/src/main/java/io/realm/RealmFieldType.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmFieldType.java
@@ -16,6 +16,9 @@
 
 package io.realm;
 
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
 import java.nio.ByteBuffer;
 
 import io.realm.internal.Keep;
@@ -24,16 +27,15 @@ import io.realm.internal.Property;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_BINARY;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_BOOLEAN;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_DATE;
+import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_DECIMAL128;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_DOUBLE;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_FLOAT;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_INTEGER;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_LINKING_OBJECTS;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_LIST;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_OBJECT;
+import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_OBJECTID;
 import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_STRING;
-import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_UNSUPPORTED_DATE;
-import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_UNSUPPORTED_MIXED;
-import static io.realm.RealmFieldTypeConstants.CORE_TYPE_VALUE_UNSUPPORTED_TABLE;
 import static io.realm.RealmFieldTypeConstants.LIST_OFFSET;
 import static io.realm.RealmFieldTypeConstants.MAX_CORE_TYPE_VALUE;
 
@@ -45,15 +47,14 @@ interface RealmFieldTypeConstants {
     int CORE_TYPE_VALUE_BOOLEAN = 1;
     int CORE_TYPE_VALUE_STRING = 2;
     int CORE_TYPE_VALUE_BINARY = 4;
-    int CORE_TYPE_VALUE_UNSUPPORTED_TABLE = 5;
-    int CORE_TYPE_VALUE_UNSUPPORTED_MIXED = 6;
-    int CORE_TYPE_VALUE_UNSUPPORTED_DATE = 7;
     int CORE_TYPE_VALUE_DATE = 8;
     int CORE_TYPE_VALUE_FLOAT = 9;
     int CORE_TYPE_VALUE_DOUBLE = 10;
     int CORE_TYPE_VALUE_OBJECT = 12;
     int CORE_TYPE_VALUE_LIST = 13;
     int CORE_TYPE_VALUE_LINKING_OBJECTS = 14;
+    int CORE_TYPE_VALUE_DECIMAL128 = 15; // FIXME
+    int CORE_TYPE_VALUE_OBJECTID = 15; // FIXME
 
     int MAX_CORE_TYPE_VALUE = CORE_TYPE_VALUE_LINKING_OBJECTS;
 }
@@ -86,7 +87,11 @@ public enum RealmFieldType {
     BINARY_LIST(CORE_TYPE_VALUE_BINARY + LIST_OFFSET),
     DATE_LIST(CORE_TYPE_VALUE_DATE + LIST_OFFSET),
     FLOAT_LIST(CORE_TYPE_VALUE_FLOAT + LIST_OFFSET),
-    DOUBLE_LIST(CORE_TYPE_VALUE_DOUBLE + LIST_OFFSET);
+    DOUBLE_LIST(CORE_TYPE_VALUE_DOUBLE + LIST_OFFSET),
+
+    DECIMAL128(CORE_TYPE_VALUE_DECIMAL128),
+    OBJECT_ID(CORE_TYPE_VALUE_OBJECTID);
+
 
     // Primitive array for fast mapping between between native values and their Realm type.
     private static final RealmFieldType[] basicTypes = new RealmFieldType[MAX_CORE_TYPE_VALUE + 1];
@@ -140,8 +145,10 @@ public enum RealmFieldType {
                 return (obj instanceof Float);
             case CORE_TYPE_VALUE_DOUBLE:
                 return (obj instanceof Double);
+            case CORE_TYPE_VALUE_DECIMAL128:
+                return (obj instanceof Decimal128);
             case CORE_TYPE_VALUE_OBJECT:
-                return false;
+                return(obj instanceof ObjectId);
             case CORE_TYPE_VALUE_LIST:
                 return false;
             case CORE_TYPE_VALUE_LINKING_OBJECTS:


### PR DESCRIPTION
Closes #6712 
Closes https://github.com/realm/realm-java/issues/6711

This PR adds support for datatype specific to MongoDB, specifically `ObjectId` and `Decimal128`

## TODO
- [ ] Measure the impact of adding a dependency on the BSON library. We probably want to make it optional for non-sync no matter what, but we should also check the impact on the sync variant
- [ ] Core/ObjectId release to depend on

### Annotation processor
- [ ] Allow `Decimal128` as a type in `ClassMetaData`. Indexable: No, Primary key: No
- [ ] Allow `ObjectId` as a type in `ClassMetaData`. Indexable: Yes. Primary Key: Yes
- [ ] Add support for new types when importing from JSON. Unclear how decimal 128/objectId is represented 
- [ ] Verify how `RealmResults.toJson()` works with ObjectId and Decimal128.

### Query-predicates
- [ ] Aggregates are not support for `Decimal128` (limitation of Core)

### Decimal128
- [ ] `equalTo`
- [ ] `notEqualTo`
- [ ] `lessThan`
- [ ] `lessThanOrEqual`
- [ ]  `greater`
- [ ]  `greaterThan`

### ObjectId
- [ ] `equalTo`
- [ ] `notEqualTo`
- [ ] `lessThan`
- [ ] `lessThanOrEqual`
- [ ]  `greater`
- [ ]  `greaterThan`