### PR TITLE
Upgrade to latest Sync alpha.4 release + ObjectStore

### DIFF
--- a/dependencies.list
+++ b/dependencies.list
@@ -1,7 +1,7 @@
 # Realm Sync release used by Realm Java (This includes Realm Core)
 # https://github.com/realm/realm-sync/releases
-REALM_SYNC_VERSION=10.0.0-alpha.2
-REALM_SYNC_SHA256=02b78b8961936c61b3f09667ced0c2738de7ed84b299ddeecfbb660ceb227dc9
+REALM_SYNC_VERSION=10.0.0-alpha.4
+REALM_SYNC_SHA256=7048eff89f00554aa4014239a25d419fc98d0b22074ff2deadd3e9717a5c4dee
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.

--- a/realm/kotlin-extensions/build.gradle
+++ b/realm/kotlin-extensions/build.gradle
@@ -104,18 +104,16 @@ dokka {
     outputFormat = 'html'
     outputDirectory = "$buildDir/docs"
     configuration {
-        externalDocumentationLink {
-            noJdkLink = true
-            noStdlibLink = true
-            noAndroidSdkLink = true
-            // Workaround until https://github.com/Kotlin/dokka/issues/709 is fixed
-            url = new URL("https://kotlinlang.org/api/latest/jvm/stdlib/")
-            packageListUrl = new URL("file://${rootDir}/kotlin-extensions/lib/package-list.txt")
-        }
+// FIXME:
+//        externalDocumentationLink {
+//            noJdkLink = true
+//            noStdlibLink = true
+//            noAndroidSdkLink = true
+//        }
     }
 }
 
-task javadocJar(type: Jar, dependsOn: dokka) {
+task javadocJar(type: Jar/* FIXME: , dependsOn: dokka*/) {
     classifier = 'javadoc'
     from "$buildDir/dokka"
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -341,13 +341,13 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSe
         // Get logged in user
         JStringAccessor user_id(env, j_user_id);
         JStringAccessor auth_url(env, j_auth_url);
-        SyncUserIdentifier sync_user_identifier = {user_id, auth_url};
-        std::shared_ptr<SyncUser> user = SyncManager::shared().get_existing_logged_in_user(sync_user_identifier);
+        std::shared_ptr<SyncUser> user = SyncManager::shared().get_existing_logged_in_user(user_id);
         if (!user) {
             JStringAccessor realm_auth_url(env, j_auth_url);
             JStringAccessor refresh_token(env, j_refresh_token);
             JStringAccessor access_token(env, j_access_token);
-            user = SyncManager::shared().get_user(sync_user_identifier, refresh_token, access_token);
+            // FIXME RealmApp refactor
+            user = SyncManager::shared().get_user(user_id, auth_url, refresh_token, access_token);
         }
 
         SyncSessionStopPolicy session_stop_policy = static_cast<SyncSessionStopPolicy>(j_session_stop_policy);

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsSharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsSharedRealm.cpp
@@ -480,40 +480,6 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsSharedRealm_nativeRegisterSchema
     }
 }
 
-#if REALM_ENABLE_SYNC
-JNIEXPORT jint JNICALL Java_io_realm_internal_OsSharedRealm_nativeGetRealmPrivileges(
-    JNIEnv*, jclass, jlong shared_realm_ptr)
-{
-    auto& shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-    return static_cast<jint>(shared_realm->get_privileges());
-}
-
-JNIEXPORT jint JNICALL Java_io_realm_internal_OsSharedRealm_nativeGetClassPrivileges(
-    JNIEnv* env, jclass, jlong shared_realm_ptr, jstring j_class_name)
-{
-    try {
-        auto& shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        JStringAccessor class_name(env, j_class_name);
-        return static_cast<jint>(shared_realm->get_privileges(StringData(class_name)));
-    }
-    CATCH_STD()
-    return 0;
-}
-
-JNIEXPORT jint JNICALL Java_io_realm_internal_OsSharedRealm_nativeGetObjectPrivileges(
-    JNIEnv* env, jclass, jlong shared_realm_ptr, jlong row_ptr)
-{
-    try {
-        auto& shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        auto r = reinterpret_cast<Obj*>(row_ptr);
-        auto obj = r->get_table()->get_object(r->get_key());
-        return static_cast<jint>(shared_realm->get_privileges(obj));
-    }
-    CATCH_STD()
-    return 0;
-}
-#endif
-
 JNIEXPORT jboolean JNICALL Java_io_realm_internal_OsSharedRealm_nativeIsPartial(JNIEnv*, jclass, jlong /*shared_realm_ptr*/)
 {
     // No throws

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -859,6 +859,6 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_Table_nativeFreeze(JNIEnv*, jclas
 {
     auto& shared_realm = *(reinterpret_cast<SharedRealm*>(j_frozen_shared_realm_ptr));
     TableRef table = TableRef(TBL_REF(j_table_ptr));
-    TableRef* frozen_table = new TableRef(shared_realm->transaction().import_copy_of(table));
+    TableRef* frozen_table = new TableRef(shared_realm->import_copy_of(table));
     return reinterpret_cast<jlong>(frozen_table);
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_UncheckedRow.cpp
@@ -395,7 +395,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_UncheckedRow_nativeFreeze(JNIEnv*
     try {
         Obj* obj = reinterpret_cast<Obj*>(j_native_row_ptr);
         auto frozen_realm = *(reinterpret_cast<SharedRealm*>(j_frozen_realm_native_ptr));
-        auto frozen_obj = new Obj(frozen_realm->transaction().import_copy_of(*obj));
+        auto frozen_obj = new Obj(frozen_realm->import_copy_of(*obj));
         return reinterpret_cast<jlong>(frozen_obj);
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
@@ -370,17 +370,19 @@ public final class OsSharedRealm implements Closeable, NativeObject {
 
     @ObjectServer
     public int getPrivileges() {
-        return nativeGetRealmPrivileges(nativePtr);
+        // FIXME: Remove
+        return 0;
     }
 
     @ObjectServer
     public int getClassPrivileges(String className) {
-        return nativeGetClassPrivileges(nativePtr, className);
+        // FIXME: Remove
+        return 0;
     }
 
     @ObjectServer
     public int getObjectPrivileges(UncheckedRow row) {
-        return nativeGetObjectPrivileges(nativePtr, ((UncheckedRow) row).getNativePtr());
+        return 0;
     }
 
     public boolean isClosed() {
@@ -624,12 +626,6 @@ public final class OsSharedRealm implements Closeable, NativeObject {
     private static native long nativeGetSchemaInfo(long nativePtr);
 
     private static native void nativeRegisterSchemaChangedCallback(long nativePtr, SchemaChangedCallback callback);
-
-    private static native int nativeGetRealmPrivileges(long nativePtr);
-
-    private static native int nativeGetClassPrivileges(long nativePtr, String className);
-
-    private static native int nativeGetObjectPrivileges(long nativePtr, long rowNativePtr);
 
     private static native boolean nativeIsFrozen(long nativePtr);
 


### PR DESCRIPTION
Upgrade to latest Sync release + ObjectStore.

Unclear why Dokka suddenly starts to fail, so it is temporarily disabled. A task to re-enable it has been added to https://github.com/realm/realm-java/pull/6756