### PR TITLE
Switch to using Github Docker Registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,26 +42,22 @@ try {
         // FIXME: Had issues moving these into a seperate Stage step. Is this needed?
         buildEnv = docker.build 'realm-java:snapshot'
         // `aws ecr describe-images --repository-name ci/mongodb-realm-images --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]'`
-        def version = "test_server-26e6463b98d8e3f0f4522a70e37f105d34b688a9-race"
-        def mdbRealmImage = docker.image("${env.DOCKER_REGISTRY}/ci/mongodb-realm-images:${version}")
-        def stitchCliImage = docker.image("${env.DOCKER_REGISTRY}/ci/stitch-cli:190")
-        docker.withRegistry("https://${env.DOCKER_REGISTRY}", "ecr:eu-west-1:aws-ci-user") {
+        def version = "latest"
+        def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${version}")
+        docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {
           mdbRealmImage.pull()
-          stitchCliImage.pull()
         }
         def commandServerEnv = docker.build 'mongodb-realm-command-server', "tools/sync_test_server"
 
         try {
           // Prepare Docker containers used by Instrumentation tests
           // TODO: How much of this logic can be moved to start_server.sh for shared logic with local testing.
-
           sh "docker network create ${dockerNetworkId}"
           mongoDbRealmContainer = mdbRealmImage.run("--network ${dockerNetworkId}")
-          mongoDbRealmCLIContainer = stitchCliImage.run("-t --network container:${mongoDbRealmContainer.id}")
           mongoDbRealmCommandServerContainer = commandServerEnv.run("--network container:${mongoDbRealmContainer.id}")
-          sh "docker cp tools/sync_test_server/app_config ${mongoDbRealmCLIContainer.id}:/tmp/app_config"
-          sh "docker cp tools/sync_test_server/setup_mongodb_realm.sh ${mongoDbRealmCLIContainer.id}:/tmp/"
-          sh "docker exec -i ${mongoDbRealmCLIContainer.id} sh /tmp/setup_mongodb_realm.sh"
+          sh "docker cp tools/sync_test_server/app_config ${mongoDbRealmContainer.id}:/tmp/app_config"
+          sh "docker cp tools/sync_test_server/setup_mongodb_realm.sh ${mongoDbRealmContainer.id}:/tmp/"
+          sh "docker exec -i ${mongoDbRealmContainer.id} sh /tmp/setup_mongodb_realm.sh"
 
           buildEnv.inside("-e HOME=/tmp " +
                   "-e _JAVA_OPTIONS=-Duser.home=/tmp " +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,9 +40,9 @@ try {
         // Prepare Docker images
         // FIXME: Had issues moving these into a seperate Stage step. Is this needed?
         buildEnv = docker.build 'realm-java:snapshot'
-        def dependencies = readProperties file: 'dependencies.list'
-        echo "Version in dependencies.list: ${dependencies.MONGODB_REALM_VERSION}"
-        def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${dependencies.MONGODB_REALM_VERSION}")
+        def props = readProperties file: 'dependencies.list'
+        echo "Version in dependencies.list: ${props.MONGODB_REALM_SERVER_VERSION}"
+        def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${props.MONGODB_REALM_SERVER_VERSION}")
         docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {
           mdbRealmImage.pull()
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,9 +40,9 @@ try {
         // Prepare Docker images
         // FIXME: Had issues moving these into a seperate Stage step. Is this needed?
         buildEnv = docker.build 'realm-java:snapshot'
-        // `aws ecr describe-images --repository-name ci/mongodb-realm-images --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]'`
-        def version = "latest"
-        def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${version}")
+        def dependencies = readProperties file: 'dependencies.list'
+        echo "Version in dependencies.list: ${dependencies.MONGODB_REALM_VERSION}"
+        def mdbRealmImage = docker.image("docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${dependencies.MONGODB_REALM_VERSION}")
         docker.withRegistry('https://docker.pkg.github.com', 'github-packages-token') {
           mdbRealmImage.pull()
         }

--- a/dependencies.list
+++ b/dependencies.list
@@ -8,7 +8,8 @@ REALM_SYNC_SHA256=7048eff89f00554aa4014239a25d419fc98d0b22074ff2deadd3e9717a5c4d
 REALM_OBJECT_SERVER_VERSION=3.28.2
 
 # Version of MongoDB Realm used by integration tests
-MONGODB_REALM_SERVER_VERSION=test_server-0ed2349a36352666402d0fb2e8763ac67731768c-race
+# See https://github.com/realm/ci/packages/147854 for available versions
+MONGODB_REALM_SERVER_VERSION=2020-03-25
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=3.6.1

--- a/tools/sync_test_server/setup_mongodb_realm.sh
+++ b/tools/sync_test_server/setup_mongodb_realm.sh
@@ -31,7 +31,7 @@ GROUP_ID=$(curl --header "Authorization: Bearer $ACCESS_TOKEN" http://localhost:
 echo "Group Id: $GROUP_ID"
 
 # 1. Log in to enable Stitch CLI commands
-stitch-cli login --config-path=/tmp/stitch-config \
+yes | stitch-cli login --config-path=/tmp/stitch-config \
                  --base-url=http://localhost:9090 \
                  --auth-provider=local-userpass \
                  --username=unique_user@domain.com \

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -37,7 +37,7 @@ docker login docker.pkg.github.com -u $GITHUB_DOCKER_USER -p $GITHUB_DOCKER_TOKE
 # Run Stitch and Stitch CLI Docker images
 docker network create mongodb-realm-network
 docker build $DOCKERFILE_DIR -t mongodb-realm-command-server || { echo "Failed to build Docker image." ; exit 1 ; }
-ID=$(docker run --rm -i -t -d --network mongodb-realm-network -p 9090:9090 -p 8888:8888 --name mongodb-realm docker.pkg.github.com/realm/ci/mongodb-realm-test-server:latest)
+ID=$(docker run --rm -i -t -d --network mongodb-realm-network -p 9090:9090 -p 8888:8888 --name mongodb-realm docker.pkg.github.com/realm/ci/mongodb-realm-test-server:$MONGODB_REALM_VERSION)
 docker run --rm -i -t -d --network container:$ID -v$TMP_DIR:/tmp --name mongodb-realm-command-server mongodb-realm-command-server
 
 docker cp "$DOCKERFILE_DIR"/app_config mongodb-realm:/tmp/app_config

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 
+# How to use this script:
+#
+# 1. Logging into GitHub
+# 2. Goto "Settings > Developer Settings > Personal access tokens"
+# 3. Press "Generate new Token"
+# 4. Select "read:packages" as Scope. Give it a name and create the token.
+# 5. Store the token in a environment variable called GITHUB_DOCKER_TOKEN.
+# 6. Store the GitHub username in an environment variable called GITHUB_DOCKER_USER.
+# 7. Run this script.
+
 # Verify that Github username and tokens are available as environment vars
-if [[ -z "${GITHUB_USER}" ]]; then
-  echo "Could not find \$GITHUB_USER as an environment variabel"
+if [[ -z "${GITHUB_DOCKER_USER}" ]]; then
+  echo "Could not find \$GITHUB_DOCKER_USER as an environment variabel"
   exit 1
 fi
 
@@ -22,7 +32,7 @@ adb reverse tcp:9090 tcp:9090 && \
 adb reverse tcp:8888 tcp:8888 || { echo "Failed to reverse adb port." ; exit 1 ; }
 
 # Make sure that Docker works correctly with Github Docker Registry by logging in
-docker login docker.pkg.github.com -u $GITHUB_USER -p $GITHUB_DOCKER_TOKEN
+docker login docker.pkg.github.com -u $GITHUB_DOCKER_USER -p $GITHUB_DOCKER_TOKEN
 
 # Run Stitch and Stitch CLI Docker images
 docker network create mongodb-realm-network

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+# Verify that Github username and tokens are available as environment vars
+if [[ -z "${GITHUB_USER}" ]]; then
+  echo "Could not find \$GITHUB_USER as an environment variabel"
+  exit 1
+fi
+
+if [[ -z "${GITHUB_DOCKER_TOKEN}" ]]; then
+  echo "Could not find \$GITHUB_DOCKER_TOKEN as an environment variabel. This is used to download Docker Registry packages."
+  exit 1
+fi
+
 # Get the script dir which contains the Dockerfile
 DOCKERFILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -10,21 +21,16 @@ adb reverse tcp:9080 tcp:9080 && \
 adb reverse tcp:9090 tcp:9090 && \
 adb reverse tcp:8888 tcp:8888 || { echo "Failed to reverse adb port." ; exit 1 ; }
 
-# Make sure that Docker works correctly with AWS by logging in
-DOCKER_LOGIN=$(aws ecr get-login --no-include-email)
-eval $DOCKER_LOGIN
-
-# Work-around for getting latest Stich image
-LATEST_MONGODB_REALM_VERSION=$(aws ecr describe-images --repository-name ci/mongodb-realm-images --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' | cut -d '"' -f 2)
-LATEST_CLI_VERSION="190"
+# Make sure that Docker works correctly with Github Docker Registry by logging in
+docker login docker.pkg.github.com -u $GITHUB_USER -p $GITHUB_DOCKER_TOKEN
 
 # Run Stitch and Stitch CLI Docker images
 docker network create mongodb-realm-network
 docker build $DOCKERFILE_DIR -t mongodb-realm-command-server || { echo "Failed to build Docker image." ; exit 1 ; }
-ID=$(docker run --rm -i -t -d --network mongodb-realm-network  -p 8888:8888 -p 9090:9090 --name mongodb-realm 012067661104.dkr.ecr.eu-west-1.amazonaws.com/ci/mongodb-realm-images:"$LATEST_MONGODB_REALM_VERSION")
+ID=$(docker run --rm -i -t -d --network mongodb-realm-network -p 9090:9090 -p 8888:8888 --name mongodb-realm docker.pkg.github.com/realm/ci/mongodb-realm-test-server:latest)
 docker run --rm -i -t -d --network container:$ID -v$TMP_DIR:/tmp --name mongodb-realm-command-server mongodb-realm-command-server
-docker run --rm -i -t -d --network container:$ID --name mongodb-realm-cli 012067661104.dkr.ecr.eu-west-1.amazonaws.com/ci/stitch-cli:"$LATEST_CLI_VERSION"
 
-docker cp "$DOCKERFILE_DIR"/app_config mongodb-realm-cli:/tmp/app_config
-docker cp "$DOCKERFILE_DIR"/setup_mongodb_realm.sh mongodb-realm-cli:/tmp/
-docker exec -it mongodb-realm-cli sh /tmp/setup_mongodb_realm.sh
+docker cp "$DOCKERFILE_DIR"/app_config mongodb-realm:/tmp/app_config
+docker cp "$DOCKERFILE_DIR"/setup_mongodb_realm.sh mongodb-realm:/tmp/
+docker exec -it mongodb-realm sh /tmp/setup_mongodb_realm.sh
+

--- a/tools/sync_test_server/stop_server.sh
+++ b/tools/sync_test_server/stop_server.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 docker stop mongodb-realm -t0
-docker stop mongodb-realm-cli -t0
 docker stop mongodb-realm-command-server -t0
 docker network rm mongodb-realm-network


### PR DESCRIPTION
Switches the Registry from which we download the Stitch images from AWS to Github. This removes the requirement of having access to our secret AWS credentials.

It also now correctly stores any relevant logs: LogCat, Command Server, MongoDB Realm and MongoDB itself.

After this PR has been merged. You need to create a GitHub access token to run the integration tests. There is a HOWTO in the `start_server.sh` file.