### PR TITLE
Add support for Multidex to AndroidTests

### DIFF
--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -34,7 +34,7 @@ allprojects {
     projectDependencies.each { key, val ->
         project.ext.set(key, val)
     }
-    project.ext.minSdkVersion = 21 // FIXME: Should be 16. Figure out how to enable MultiDex for ObjectServer tests
+    project.ext.minSdkVersion = 16
     project.ext.compileSdkVersion = 29
     project.ext.buildToolsVersion = projectDependencies.get("ANDROID_BUILD_TOOLS")
     group = 'io.realm'

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -47,6 +47,7 @@ android {
         versionName version
         project.archivesBaseName = "realm-android-library"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
         externalNativeBuild {
             cmake {
                 arguments "-DREALM_CORE_DIST_DIR:STRING=${project.coreDir.getAbsolutePath()}",
@@ -209,6 +210,11 @@ dependencies {
     implementation('io.reactivex.rxjava2:rxandroid:2.1.1') {
         exclude group: 'io.reactivex.rxjava2', module: 'rxjava'
     }
+
+    // TODO: investigate why we can't use the latest multidex version
+    // check baseDebugAndroidTestRuntimeClasspath and objectServerDebugAndroidTestRuntimeClasspath
+    // tasks as they introduce version 2.0.0 strictly, even when specifying 2.0.1 from here
+    androidTestImplementation "androidx.multidex:multidex:2.0.0"
 
     kapt project(':realm-annotations-processor') // See https://github.com/realm/realm-java/issues/5799
     objectServerImplementation 'com.squareup.okhttp3:okhttp:3.12.0' // Going above this requires minSDK 21


### PR DESCRIPTION
Fixes: https://github.com/realm/realm-java/issues/6799

Reverted to minSdkVersion 16
Added support for multidexing - can't use the latest version though, TODO added with explanation in that regard