### PR TITLE
Release SNAPSHOT builds from v10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ def buildSuccess = false
 def mongoDbRealmContainer = null
 def mongoDbRealmCommandServerContainer = null
 def dockerNetworkId = UUID.randomUUID().toString()
+def releaseBranches = ['master', 'next-major', 'v10'] // Branches from which we release SNAPSHOT's
 try {
   node('android') {
     timeout(time: 90, unit: 'MINUTES') {
@@ -31,7 +32,7 @@ try {
         // on PR's for even more throughput.
         def abiFilter = ""
         def instrumentationTestTarget = "connectedAndroidTest"
-        if (!['master', 'next-major', 'v10'].contains(env.BRANCH_NAME)) {
+        if (!releaseBranches.contains(env.BRANCH_NAME)) {
           abiFilter = "-PbuildTargetABIs=armeabi-v7a"
           instrumentationTestTarget = "connectedObjectServerDebugAndroidTest"
           // Run in debug more for better error reporting
@@ -140,7 +141,7 @@ try {
                 }
               }
 
-              if (['master', 'next-major', 'v10'].contains(env.BRANCH_NAME)) {
+              if (releaseBranches.contains(env.BRANCH_NAME)) {
                 stage('Publish to OJO') {
                   withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'bintray', passwordVariable: 'BINTRAY_KEY', usernameVariable: 'BINTRAY_USER']]) {
                     sh "chmod +x gradlew && ./gradlew -PbintrayUser=${env.BINTRAY_USER} -PbintrayKey=${env.BINTRAY_KEY} assemble ojoUpload --stacktrace"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ try {
         // on PR's for even more throughput.
         def abiFilter = ""
         def instrumentationTestTarget = "connectedAndroidTest"
-        if (!['master', 'next-major'].contains(env.BRANCH_NAME)) {
+        if (!['master', 'next-major', 'v10'].contains(env.BRANCH_NAME)) {
           abiFilter = "-PbuildTargetABIs=armeabi-v7a"
           instrumentationTestTarget = "connectedObjectServerDebugAndroidTest"
           // Run in debug more for better error reporting
@@ -140,7 +140,7 @@ try {
                 }
               }
 
-              if (['master', 'next-major'].contains(env.BRANCH_NAME)) {
+              if (['master', 'next-major', 'v10'].contains(env.BRANCH_NAME)) {
                 stage('Publish to OJO') {
                   withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'bintray', passwordVariable: 'BINTRAY_KEY', usernameVariable: 'BINTRAY_USER']]) {
                     sh "chmod +x gradlew && ./gradlew -PbintrayUser=${env.BINTRAY_USER} -PbintrayKey=${env.BINTRAY_KEY} assemble ojoUpload --stacktrace"


### PR DESCRIPTION
We should start releasing SNAPSHOT builds from the v10 branch so other teams can more easily consume the merged Stitch/Realm SDK.

This PR changes CI so the `v10` branch is now treated like our other "major" branches, i.e. we run all tests for all architectures on it, and SNAPSHOTs are being released.

The version is `10.0.0-SNAPSHOT` and can be found here once deployed: http://oss.jfrog.org/oss-snapshot-local/io/realm

Howto for using SNAPSHOTs are here: https://github.com/realm/realm-java/blob/master/README.md#using-snapshots
 