### PR TITLE
Fix Kotlin Extensions Base tests

### DIFF
--- a/realm/kotlin-extensions/build.gradle
+++ b/realm/kotlin-extensions/build.gradle
@@ -78,8 +78,8 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation "org.mongodb:bson:${properties.getProperty('BSON_DEPENDENCY_VERSION')}"
     kaptAndroidTest project(':realm-annotations-processor')
-    androidTestObjectServerImplementation "org.mongodb:bson:${properties.getProperty('BSON_DEPENDENCY_VERSION')}"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     androidTestObjectServerImplementation 'com.squareup.okhttp3:okhttp:3.9.0'
     androidTestObjectServerImplementation 'io.reactivex.rxjava2:rxjava:2.1.5'


### PR DESCRIPTION
@nhachicha Not entirely sure how this happened as your datatype PR was green. Anyway. This should fix the build failure on `v10`