### PR TITLE
JNI BSON Protocol

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,7 @@ try {
                 } finally {
                   storeJunitResults 'realm/realm-annotations-processor/build/test-results/test/TEST-*.xml'
                   storeJunitResults 'examples/unitTestExample/build/test-results/**/TEST-*.xml'
+                  storeJunitResults 'realm/realm-library/build/test-results/**/TEST-*.xml'
                   step([$class: 'LintPublisher'])
                 }
               }

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -97,6 +97,9 @@ android {
     }
 
     sourceSets {
+        testObjectServer {
+            java.srcDirs += ['src/testObjectServer/kotlin']
+        }
         androidTest {
             java.srcDirs += ['src/androidTest/kotlin', 'src/testUtils/java', 'src/testUtils/kotlin']
         }
@@ -213,6 +216,10 @@ dependencies {
     }
     // FIXME: Attempt to find a way to remove this dependency
     objectServerImplementation "com.google.android.gms:play-services-tasks:17.0.2"      // added to support mongo client's asynchronous nature without breaking Stitch's API
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
     // TODO: investigate why we can't use the latest multidex version
     // check baseDebugAndroidTestRuntimeClasspath and objectServerDebugAndroidTestRuntimeClasspath

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
@@ -19,16 +19,20 @@ package io.realm
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.internal.util.BsonConverter
 import org.bson.*
+import org.junit.Before
 import org.junit.Test
 import java.util.stream.Collectors
 import kotlin.test.assertEquals
 
 class RealmFunctionsTest {
 
-    @Test
-    operator fun invoke() {
+    @Before
+    fun setup() {
         Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
+    }
 
+    @Test
+    fun jniBsonOnlyRoundtrip() {
         val functions = RealmFunctions()
         val i32 = 42
         val i64 = 42L

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
@@ -17,11 +17,10 @@
 package io.realm
 
 import androidx.test.platform.app.InstrumentationRegistry
-import org.bson.BsonArray
-import org.bson.BsonInt32
-import org.bson.BsonInt64
-import org.bson.BsonString
+import io.realm.internal.util.BsonConverter
+import org.bson.*
 import org.junit.Test
+import java.util.stream.Collectors
 import kotlin.test.assertEquals
 
 class RealmFunctionsTest {
@@ -35,12 +34,13 @@ class RealmFunctionsTest {
         val i64 = 42L
         val s = "Realm"
 
-        // Return 64 bit integer
-//        assertEquals(i32, functions.invoke(BsonInt32(i32)).asInt32().value)
+        assertEquals(i32, functions.invoke(BsonInt32(i32)).asInt32().value)
         assertEquals(i64, functions.invoke(BsonInt64(i64)).asInt64().value)
         assertEquals(s, functions.invoke(BsonString(s)).asString().value)
-        // Crashes
-//        val invoke = functions.invoke(BsonArray(listOf(BsonInt32(i32), BsonInt64(i64), BsonString(s))))
+        
+        val values = listOf<Any>(BsonInt32(i32), BsonInt64(i64), BsonString(s))
+        val invoke: BsonValue = functions.invoke(BsonConverter.to(values))
+        assertEquals(values, invoke.asArray().values)
     }
 
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm
+
+import androidx.test.platform.app.InstrumentationRegistry
+import org.bson.BsonArray
+import org.bson.BsonInt32
+import org.bson.BsonInt64
+import org.bson.BsonString
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class RealmFunctionsTest {
+
+    @Test
+    operator fun invoke() {
+        Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
+
+        val functions = RealmFunctions()
+        val i32 = 42
+        val i64 = 42L
+        val s = "Realm"
+
+        // Return 64 bit integer
+//        assertEquals(i32, functions.invoke(BsonInt32(i32)).asInt32().value)
+        assertEquals(i64, functions.invoke(BsonInt64(i64)).asInt64().value)
+        assertEquals(s, functions.invoke(BsonString(s)).asString().value)
+        // Crashes
+//        val invoke = functions.invoke(BsonArray(listOf(BsonInt32(i32), BsonInt64(i64), BsonString(s))))
+    }
+
+}

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -108,6 +108,7 @@ if (build_SYNC)
         io.realm.RealmApp
         io.realm.RealmUser
         io.realm.RealmSync
+        io.realm.RealmFunctions
         io.realm.SyncSession
         io.realm.internal.objectstore.OsAppCredentials
         io.realm.internal.objectstore.OsAsyncOpenTask
@@ -198,6 +199,7 @@ if (NOT build_SYNC)
     list(REMOVE_ITEM jni_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_RealmApp.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_RealmUser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_RealmFunctions.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_EmailPasswordAuth.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_ApiKeyAuth.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_ClientResetRequiredError.cpp

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -212,6 +212,7 @@ if (NOT build_SYNC)
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_internal_objectstore_OsRemoteMongoCollection.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_internal_objectstore_OsRemoteMongoDatabase.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/io_realm_internal_objectstore_OsSyncUser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/util_sync.cpp
     )
 endif()
 

--- a/realm/realm-library/src/main/cpp/io_realm_RealmFunctions.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmFunctions.cpp
@@ -13,20 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.realm;
 
-import org.bson.BsonValue;
+#include "io_realm_RealmFunctions.h"
 
-import io.realm.internal.jni.OSJNIBsonProtocol;
+#include "util.hpp"
+#include "util_sync.hpp"
 
-public class RealmFunctions {
+using namespace realm;
 
-    // FIXME Prelimiry implementation to be able to test passing BsonValues through JNI
-    BsonValue invoke(BsonValue arg) {
-        String response = nativeCallFunction(OSJNIBsonProtocol.encode(arg));
-        return OSJNIBsonProtocol.decode(response);
+// FIXME This is just a basic round trip test for passing bson back and forth. Proper implementation
+//  will come with actual Function implementation.
+JNIEXPORT jstring JNICALL Java_io_realm_RealmFunctions_nativeCallFunction
+        (JNIEnv* env, jclass, jstring j_args) {
+    try {
+        bson::Bson bson = jstring_to_bson(env, j_args);
+        return bson_to_jstring(env, bson);
     }
-
-    private static native String nativeCallFunction(String arg);
-
+    CATCH_STD()
+    return NULL;
 }
+

--- a/realm/realm-library/src/main/cpp/util_sync.cpp
+++ b/realm/realm-library/src/main/cpp/util_sync.cpp
@@ -13,20 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.realm;
 
-import org.bson.BsonValue;
+#include "util.hpp"
+#include "util_sync.hpp"
 
-import io.realm.internal.jni.OSJNIBsonProtocol;
+// Must match OSJNIBsonProtocol.VALUE
+static const std::string VALUE("value");
 
-public class RealmFunctions {
+using namespace realm::bson;
 
-    // FIXME Prelimiry implementation to be able to test passing BsonValues through JNI
-    BsonValue invoke(BsonValue arg) {
-        String response = nativeCallFunction(OSJNIBsonProtocol.encode(arg));
-        return OSJNIBsonProtocol.decode(response);
-    }
-
-    private static native String nativeCallFunction(String arg);
-
+Bson jstring_to_bson(JNIEnv* env, jstring arg) {
+    JStringAccessor args_json(env, arg);
+    BsonDocument document(parse(args_json));
+    return document[VALUE];
 }
+
+jstring bson_to_jstring(JNIEnv* env, Bson bson) {
+    BsonDocument document{{VALUE, bson}};
+    std::stringstream buffer;
+    buffer << document;
+    std::string r = buffer.str();
+    return to_jstring(env, r);
+};

--- a/realm/realm-library/src/main/cpp/util_sync.hpp
+++ b/realm/realm-library/src/main/cpp/util_sync.hpp
@@ -13,20 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.realm;
 
-import org.bson.BsonValue;
+#ifndef REALM_UTIL_SYNC_HPP
+#define REALM_UTIL_SYNC_HPP
 
-import io.realm.internal.jni.OSJNIBsonProtocol;
+#include <jni.h>
+#include <util/bson/bson.hpp>
 
-public class RealmFunctions {
+realm::bson::Bson jstring_to_bson(JNIEnv* env, jstring arg);
+jstring bson_to_jstring(JNIEnv* env, realm::bson::Bson bson);
 
-    // FIXME Prelimiry implementation to be able to test passing BsonValues through JNI
-    BsonValue invoke(BsonValue arg) {
-        String response = nativeCallFunction(OSJNIBsonProtocol.encode(arg));
-        return OSJNIBsonProtocol.decode(response);
-    }
-
-    private static native String nativeCallFunction(String arg);
-
-}
+#endif //REALM_UTIL_SYNC_HPP

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmFunctions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmFunctions.java
@@ -17,14 +17,14 @@ package io.realm;
 
 import org.bson.BsonValue;
 
-import io.realm.internal.jni.OSJNIBsonProtocol;
+import io.realm.internal.jni.JniBsonProtocol;
 
 public class RealmFunctions {
 
     // FIXME Prelimiry implementation to be able to test passing BsonValues through JNI
     BsonValue invoke(BsonValue arg) {
-        String response = nativeCallFunction(OSJNIBsonProtocol.encode(arg));
-        return OSJNIBsonProtocol.decode(response);
+        String response = nativeCallFunction(JniBsonProtocol.encode(arg));
+        return JniBsonProtocol.decode(response);
     }
 
     private static native String nativeCallFunction(String arg);

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/jni/JniBsonProtocol.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/jni/JniBsonProtocol.java
@@ -27,7 +27,7 @@ import org.bson.json.JsonWriterSettings;
  * For now this just encapsulated the BSON value in a document with key {@value VALUE}. This
  * overcomes the shortcoming of {@code org.bson.JsonWrite} not being able to serialize single values.
  */
-public class OSJNIBsonProtocol {
+public class JniBsonProtocol {
 
     private static final String VALUE = "value";
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
@@ -18,6 +18,8 @@ package io.realm.internal.jni;
 
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
 
 /**
  * Protocol for passing {@link BsonValue}s to JNI.
@@ -27,12 +29,17 @@ import org.bson.BsonValue;
  */
 public class OSJNIBsonProtocol {
 
+    // FIXME Seems OK to reuse across threads
+    private static JsonWriterSettings writerSettings = JsonWriterSettings.builder()
+                .outputMode(JsonMode.EXTENDED)
+                .build();
+
     private static final String VALUE = "value";
 
     public static String encode(BsonValue bsonValue) {
         BsonDocument document = new BsonDocument();
         document.append(VALUE, bsonValue);
-        return document.toJson();
+        return document.toJson(writerSettings);
     }
 
     public static BsonValue decode(String string) {

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.jni;
+
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+/**
+ * Protocol for passing {@link BsonValue}s to JNI.
+ *
+ * For now this just encapsulated the BSON value in a document with key {@value VALUE}. This
+ * overcomes the shortcoming of {@code org.bson.JsonWrite} not being able to serialize single values.
+ */
+public class OSJNIBsonProtocol {
+
+    private static final String VALUE = "value";
+
+    public static String encode(BsonValue bsonValue) {
+        BsonDocument document = new BsonDocument();
+        document.append(VALUE, bsonValue);
+        return document.toJson();
+    }
+
+    public static BsonValue decode(String string) {
+        BsonDocument document = BsonDocument.parse(string);
+        return document.get("value");
+    }
+
+}

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
@@ -29,16 +29,14 @@ import org.bson.json.JsonWriterSettings;
  */
 public class OSJNIBsonProtocol {
 
-    // FIXME Seems OK to reuse across threads
+    private static final String VALUE = "value";
+
     private static JsonWriterSettings writerSettings = JsonWriterSettings.builder()
                 .outputMode(JsonMode.EXTENDED)
                 .build();
 
-    private static final String VALUE = "value";
-
     public static String encode(BsonValue bsonValue) {
-        BsonDocument document = new BsonDocument();
-        document.append(VALUE, bsonValue);
+        BsonDocument document = new BsonDocument(VALUE, bsonValue);
         return document.toJson(writerSettings);
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OSJNIBsonProtocol.java
@@ -44,7 +44,7 @@ public class OSJNIBsonProtocol {
 
     public static BsonValue decode(String string) {
         BsonDocument document = BsonDocument.parse(string);
-        return document.get("value");
+        return document.get(VALUE);
     }
 
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
@@ -17,15 +17,22 @@
 package io.realm.internal.util;
 
 import org.bson.BsonArray;
+import org.bson.BsonBinary;
 import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
 import org.bson.BsonString;
 import org.bson.BsonType;
 import org.bson.BsonValue;
 import org.bson.conversions.Bson;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -48,20 +55,40 @@ public class BsonConverter {
      */
     // FIXME Review supported types...any obvious types missing?
     public static BsonValue to(Object value) {
-        // Just leave BsonValues as is
         if (value instanceof BsonValue) {
             return (BsonValue) value;
-        } else if (value instanceof List) {
+        }
+        // Convert list to BsonArray
+        else if (value instanceof List) {
             return BsonConverter.to(((List) value).toArray());
-        } else if (value instanceof Boolean) {
-            return new BsonBoolean((Boolean) value);
-        } else if (value instanceof Integer) {
+        }
+        // Native types
+        else if (value instanceof Integer) {
             return new BsonInt32((Integer) value);
         } else if (value instanceof Long) {
             return new BsonInt64((Long) value);
+        } else if (value instanceof Boolean) {
+            return new BsonBoolean((Boolean) value);
         } else if (value instanceof String){
             return new BsonString((String) value);
+        } else if (value instanceof byte[]) {
+            return new BsonBinary((byte[]) value);
         }
+        // Bson values
+        else if (value instanceof ObjectId) {
+            return new BsonObjectId((ObjectId) value);
+        }
+        else if (value instanceof Decimal128) {
+            return new BsonDecimal128((Decimal128) value);
+        }
+        // FIXME Missing Realm types
+        // Date
+        // Float
+        // Double
+        // Object
+        // List
+        // LinkingObject
+        // FIXME Missing Bson value
         throw new IllegalArgumentException("Conversion to BSON value not supported for " + value.getClass().getName());
     }
 
@@ -132,25 +159,25 @@ public class BsonConverter {
         switch (bsonType) {
 //            case END_OF_DOCUMENT:
 //                break;
-            case DOUBLE:
-                result = value.asDouble().getValue();
-                break;
+//            case DOUBLE:
+//                result = value.asDouble().getValue();
+//                break;
             case STRING:
                 result = value.asString().getValue();
                 break;
 //            case DOCUMENT:
 //                break;
-//            case ARRAY:
-//                break;
-//            case BINARY:
-//                break;
+            case ARRAY:
+                result = value.asArray().getValues();
+                break;
+            case BINARY:
+                result = value.asBinary().getData();
+                break;
 //            case UNDEFINED:
 //                break;
-//            case OBJECT_ID:
-//                 FIXME Do we need this...is so, I guess it should be consistently unwrapping all
-//                  other BsonValue's too
-//                result = value.asObjectId().getValue();
-//                break;
+            case OBJECT_ID:
+                result = value.asObjectId().getValue();
+                break;
             case BOOLEAN:
                 result = value.asBoolean().getValue();
                 break;
@@ -176,9 +203,9 @@ public class BsonConverter {
             case INT64:
                 result = value.asInt64().getValue();
                 break;
-//            case DECIMAL128:
-//                result = value.asDecimal128().getValue();
-//                break;
+            case DECIMAL128:
+                result = value.asDecimal128().getValue();
+                break;
 //            case MIN_KEY:
 //                break;
 //            case MAX_KEY:

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.internal.util;
+
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.conversions.Bson;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A <i>BSON converter</i> to handle conversion between native Java types and BSON values.
+ */
+public class BsonConverter {
+
+    /**
+     * Converts value object to BSON value based on type.
+     *
+     * Converts primitive boxed types to the equivalent BSON equivalent value object and {@link List}
+     * of values into {@link BsonArray} of converted values.
+     *
+     * {@link BsonValue} objects are left as is.
+     *
+     * @param value The object to convert.
+     * @return BSON value representation of the origin value object.
+     *
+     * @throws IllegalArgumentException If the object could not be mapped to a BSON type.
+     */
+    // FIXME Review supported types...any obvious types missing?
+    public static BsonValue to(Object value) {
+        // Just leave BsonValues as is
+        if (value instanceof BsonValue) {
+            return (BsonValue) value;
+        } else if (value instanceof List) {
+            return BsonConverter.to(((List) value).toArray());
+        } else if (value instanceof Boolean) {
+            return new BsonBoolean((Boolean) value);
+        } else if (value instanceof Integer) {
+            return new BsonInt32((Integer) value);
+        } else if (value instanceof Long) {
+            return new BsonInt64((Long) value);
+        } else if (value instanceof String){
+            return new BsonString((String) value);
+        }
+        throw new IllegalArgumentException("Conversion to BSON value not supported for " + value.getClass().getName());
+    }
+
+    /**
+     * Converts a list of objects to BSON values.
+     *
+     * @param value List of value objects to convert.
+     * @return A list of BSON values of the converted input arguments.
+     *
+     * @throws IllegalArgumentException If any of the value objects could not be converted to a
+     * BSON type.
+     *
+     * @see #to(Object)
+     */
+    public static BsonArray to(Object... value) {
+        ArrayList result = new ArrayList();
+        for (Object o1 : value) {
+            result.add(to(o1));
+        }
+        return new BsonArray(result);
+    }
+
+    /**
+     *
+     *
+     * @param clz
+     * @param value
+     * @param <T>
+     * @return
+     *
+     */
+    // FIXME Would we rather return null? Would maybe make it cleaner to use with
+    //  functions.callFunctionTyped("sum", BsonString::class.java, "Realm")?.value
+    //  but would also silently hide if expectations of type is wrong
+    private static <T extends BsonValue> T fromToBson(Class<T> clz, BsonValue value) {
+        if (clz.isInstance(value)) {
+            return (T) value;
+        } else {
+            throw new IllegalArgumentException("Cannot convert " + value + " to " + clz.getName());
+        }
+    }
+
+    /**
+     * Unwrap BSON values for types that has to plain Java type .
+     *
+     * @param value The BSON value to convert.
+     * @param <T> The requested result type of the conversion.
+     * @return The converted value object corresponding to the given {@code value}.
+     *
+     * @throws IllegalArgumentException if not able to convert the value to the requested type.
+     * @throws ClassCastException if the BsonValue cannot be converted to the requested type
+     *  parameters.
+     */
+    // FIXME Do we want this at all. Or at least review supported types...should we allow
+    //  unwrapping of all BsonValues as in:
+    //    BsonConverter.from(ObjectId::class.java, bsonObjectId)
+    public static <T> T from(Class<T> clz, BsonValue value) {
+        Object result = null;
+
+        if (BsonValue.class.isAssignableFrom(clz)) {
+            if (clz.isInstance(value)) {
+                return (T) value;
+            } else {
+                throw new ClassCastException("Cannot convert " + value + " to " + clz.getName());
+            }
+        }
+        BsonType bsonType = value.getBsonType();
+        switch (bsonType) {
+//            case END_OF_DOCUMENT:
+//                break;
+            case DOUBLE:
+                result = value.asDouble().getValue();
+                break;
+            case STRING:
+                result = value.asString().getValue();
+                break;
+//            case DOCUMENT:
+//                break;
+//            case ARRAY:
+//                break;
+//            case BINARY:
+//                break;
+//            case UNDEFINED:
+//                break;
+//            case OBJECT_ID:
+//                 FIXME Do we need this...is so, I guess it should be consistently unwrapping all
+//                  other BsonValue's too
+//                result = value.asObjectId().getValue();
+//                break;
+            case BOOLEAN:
+                result = value.asBoolean().getValue();
+                break;
+//            case DATE_TIME:
+//                break;
+//            case NULL:
+//                break;
+//            case REGULAR_EXPRESSION:
+//                break;
+//            case DB_POINTER:
+//                break;
+//            case JAVASCRIPT:
+//                break;
+//            case SYMBOL:
+//                break;
+//            case JAVASCRIPT_WITH_SCOPE:
+//                break;
+            case INT32:
+                result = value.asInt32().getValue();
+                break;
+//            case TIMESTAMP:
+//                break;
+            case INT64:
+                result = value.asInt64().getValue();
+                break;
+//            case DECIMAL128:
+//                result = value.asDecimal128().getValue();
+//                break;
+//            case MIN_KEY:
+//                break;
+//            case MAX_KEY:
+//                break;
+            default:
+                // FIXME
+                throw new IllegalArgumentException("Not able to convert " + value + " to " + clz.getName());
+        }
+        if (clz.isInstance(result)) {
+            return (T) result;
+        } else  {
+            throw new IllegalArgumentException("Not able to convert " + value + " to " + clz.getName());
+        }
+    }
+
+}

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
@@ -115,27 +115,7 @@ public class BsonConverter {
     }
 
     /**
-     *
-     *
-     * @param clz
-     * @param value
-     * @param <T>
-     * @return
-     *
-     */
-    // FIXME Would we rather return null? Would maybe make it cleaner to use with
-    //  functions.callFunctionTyped("sum", BsonString::class.java, "Realm")?.value
-    //  but would also silently hide if expectations of type is wrong
-    private static <T extends BsonValue> T fromToBson(Class<T> clz, BsonValue value) {
-        if (clz.isInstance(value)) {
-            return (T) value;
-        } else {
-            throw new IllegalArgumentException("Cannot convert " + value + " to " + clz.getName());
-        }
-    }
-
-    /**
-     * Unwrap BSON values for types that has to plain Java type .
+     * Unwrap BSON values for types that just wraps another similar Java type.
      *
      * @param value The BSON value to convert.
      * @param <T> The requested result type of the conversion.
@@ -145,9 +125,6 @@ public class BsonConverter {
      * @throws ClassCastException if the BsonValue cannot be converted to the requested type
      *  parameters.
      */
-    // FIXME Do we want this at all. Or at least review supported types...should we allow
-    //  unwrapping of all BsonValues as in:
-    //    BsonConverter.from(ObjectId::class.java, bsonObjectId)
     public static <T> T from(Class<T> clz, BsonValue value) {
         Object result = null;
 

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/util/BsonConverter.java
@@ -21,6 +21,7 @@ import org.bson.BsonBinary;
 import org.bson.BsonBoolean;
 import org.bson.BsonDateTime;
 import org.bson.BsonDecimal128;
+import org.bson.BsonDouble;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonObjectId;
@@ -67,6 +68,10 @@ public class BsonConverter {
             return new BsonInt32((Integer) value);
         } else if (value instanceof Long) {
             return new BsonInt64((Long) value);
+        } else if (value instanceof Float) {
+            return new BsonDouble((Float) value);
+        } else if (value instanceof Double) {
+            return new BsonDouble((Double) value);
         } else if (value instanceof Boolean) {
             return new BsonBoolean((Boolean) value);
         } else if (value instanceof String){
@@ -83,8 +88,6 @@ public class BsonConverter {
         }
         // FIXME Missing Realm types
         // Date
-        // Float
-        // Double
         // Object
         // List
         // LinkingObject
@@ -159,9 +162,9 @@ public class BsonConverter {
         switch (bsonType) {
 //            case END_OF_DOCUMENT:
 //                break;
-//            case DOUBLE:
-//                result = value.asDouble().getValue();
-//                break;
+            case DOUBLE:
+                result = value.asDouble().getValue();
+                break;
             case STRING:
                 result = value.asString().getValue();
                 break;

--- a/realm/realm-library/src/testObjectServer/kotlin/io/realm/BsonTest.kt
+++ b/realm/realm-library/src/testObjectServer/kotlin/io/realm/BsonTest.kt
@@ -17,6 +17,7 @@ package io.realm
 
 import io.realm.internal.util.BsonConverter
 import org.bson.*
+import org.bson.types.Decimal128
 import org.bson.types.ObjectId
 import org.junit.Assert.assertEquals
 import org.junit.Ignore
@@ -71,18 +72,32 @@ class BsonTest {
         val i64 = 32L
         val s = "Realm"
         val oid = ObjectId()
+        val d128 = Decimal128(i64)
+        val bin = byteArrayOf(0, 1, 2, 3)
 
         val bi32 = BsonInt32(15)
         val bOid = BsonObjectId(oid)
         val bDoc = BsonDocument()
 
-//        RealmFunctions()
-        val values = BsonConverter.to(b, i32, i64, s, bi32, bOid, bDoc)
-        assertEquals(listOf(BsonBoolean(b), BsonInt32(i32), BsonInt64(i64), BsonString(s), bi32, bOid, bDoc), values)
+        // To BSONValue
+        assertEquals(BsonBoolean(b), BsonConverter.to(b))
+        assertEquals(BsonInt32(i32), BsonConverter.to(i32))
+        assertEquals(BsonInt64(i64), BsonConverter.to(i64))
+        assertEquals(BsonString(s), BsonConverter.to(s))
+        assertEquals(BsonObjectId(oid), BsonConverter.to(oid))
+        assertEquals(BsonDecimal128(d128), BsonConverter.to(d128))
+        assertEquals(BsonBinary(bin), BsonConverter.to(bin))
+
+        assertEquals(bi32, BsonConverter.to(bi32))
+        assertEquals(bOid, BsonConverter.to(bOid))
+        assertEquals(bDoc, BsonConverter.to(bDoc))
+
+        assertEquals(listOf(BsonBoolean(b), BsonInt32(i32), BsonInt64(i64)), BsonConverter.to(b, i32, i64))
 
         val list = listOf<Any>(BsonInt32(i32), BsonInt64(i64), BsonString(s))
         assertEquals(list, BsonConverter.to(list))
 
+        // From BSONValue
         // BsonValue types are just passed as is
         assertEquals(BsonInt32(i32), BsonConverter.from(BsonInt32::class.java, BsonInt32(i32)))
         assertEquals(BsonInt64(i64), BsonConverter.from(BsonInt64::class.java, BsonInt64(i64)))
@@ -105,10 +120,12 @@ class BsonTest {
             BsonConverter.from(Int::class.java, BsonInt64(i64))
         }
         assertEquals(s, BsonConverter.from(String::class.java, BsonString(s)))
+        assertEquals(oid, BsonConverter.from(ObjectId::class.java, BsonObjectId(oid)))
+        assertEquals(d128, BsonConverter.from(Decimal128::class.java, BsonDecimal128(d128)))
+        assertEquals(bin, BsonConverter.from(ByteArray::class.java, BsonBinary(bin)))
 
-        // FIXME Do we actually want to unwrap all of the BsonValues?
-        //assertEquals(oid, BsonConverter.from(ObjectId::class.java, bOid))
-
+        val listValues = listOf<BsonValue>(BsonInt32(i32), BsonInt64(i64))
+        assertEquals(listValues, BsonConverter.from(List::class.java, BsonArray(listValues)))
     }
 
 }

--- a/realm/realm-library/src/testObjectServer/kotlin/io/realm/BsonTest.kt
+++ b/realm/realm-library/src/testObjectServer/kotlin/io/realm/BsonTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm
+
+import io.realm.internal.util.BsonConverter
+import org.bson.*
+import org.bson.types.ObjectId
+import org.junit.Assert.assertEquals
+import org.junit.Ignore
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class BsonTest {
+
+    /**
+     * Simple test to verify semantics of org.bson JSON encoding and decoding.
+     */
+    @Ignore("Only for Bson API evaluation, not testing Realm functionality")
+    @Test
+    fun bsonRoundtrip() {
+        val valueInt32   = 42
+        val valueInt64   = 42L
+        val valueString  = "Realm"
+        val valueBoolean = true
+        val valueOid     = ObjectId()
+
+        val document = BsonDocument.parse("{}")
+
+        document.append("arg1", BsonInt32(valueInt32))
+        document.append("arg2", BsonInt64(valueInt64))
+        document.append("arg3", BsonString(valueString))
+        document.append("arg4", BsonBoolean(valueBoolean))
+        document.append("arg5", BsonObjectId(valueOid))
+
+        val roundtrip = BsonDocument.parse(document.toJson())
+        assertEquals(valueInt32,   roundtrip.get("arg1")?.asInt32()?.value)
+        assertEquals(valueInt64,   roundtrip.get("arg2")?.asInt64()?.value)
+        assertEquals(valueString,  roundtrip.get("arg3")?.asString()?.value)
+        assertEquals(valueBoolean, roundtrip.get("arg4")?.asBoolean()?.value)
+        assertEquals(valueOid,     roundtrip.get("arg5")?.asObjectId()?.value)
+
+        // We cannot retrieve bson values differently type, not even if it could fit in the type
+        assertFailsWith<RuntimeException> {
+            roundtrip.getInt32("arg2");
+        }
+        assertFailsWith<RuntimeException> {
+            roundtrip.getInt64("arg1");
+        }
+    }
+
+    /**
+     * Simple test of type conversion between native Java object types and BSON types.
+     */
+    @Test
+    fun bsonConversion() {
+        val b = true
+        val i32 = 32
+        val i64 = 32L
+        val s = "Realm"
+        val oid = ObjectId()
+
+        val bi32 = BsonInt32(15)
+        val bOid = BsonObjectId(oid)
+        val bDoc = BsonDocument()
+
+//        RealmFunctions()
+        val values = BsonConverter.to(b, i32, i64, s, bi32, bOid, bDoc)
+        assertEquals(listOf(BsonBoolean(b), BsonInt32(i32), BsonInt64(i64), BsonString(s), bi32, bOid, bDoc), values)
+
+        val list = listOf<Any>(BsonInt32(i32), BsonInt64(i64), BsonString(s))
+        assertEquals(list, BsonConverter.to(list))
+
+        // BsonValue types are just passed as is
+        assertEquals(BsonInt32(i32), BsonConverter.from(BsonInt32::class.java, BsonInt32(i32)))
+        assertEquals(BsonInt64(i64), BsonConverter.from(BsonInt64::class.java, BsonInt64(i64)))
+        assertEquals(BsonString(s),  BsonConverter.from(BsonString::class.java, BsonString(s)))
+
+        // Native types are converted directly from BsonValue to equivalent type
+        // FIXME Howto auto box/wrap as Kotlin's primitive types are not assignable
+        //  (isAssignablefrom) Java's auto boxed types
+        assertEquals(b, BsonConverter.from(java.lang.Boolean::class.java, BsonBoolean(b)))
+        // assertEquals(i32, BsonConverter.from(Int::class.java, BsonInt32(i32)))
+        assertEquals(i32, BsonConverter.from(Integer::class.java, BsonInt32(i32)))
+        // assertEquals(i64, BsonConverter.from(Long::class.java, BsonInt64(i64)))
+        assertEquals(i64, BsonConverter.from(java.lang.Long::class.java, BsonInt64(i64)))
+        // ...not trying to fit wider types event though possible
+        // FIXME Would we like to support this
+        assertFailsWith<IllegalArgumentException> {
+            BsonConverter.from(java.lang.Long::class.java, BsonInt32(i32))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            BsonConverter.from(Int::class.java, BsonInt64(i64))
+        }
+        assertEquals(s, BsonConverter.from(String::class.java, BsonString(s)))
+
+        // FIXME Do we actually want to unwrap all of the BsonValues?
+        //assertEquals(oid, BsonConverter.from(ObjectId::class.java, bOid))
+
+    }
+
+}

--- a/realm/realm-library/src/testObjectServer/kotlin/io/realm/BsonTest.kt
+++ b/realm/realm-library/src/testObjectServer/kotlin/io/realm/BsonTest.kt
@@ -70,6 +70,8 @@ class BsonTest {
         val b = true
         val i32 = 32
         val i64 = 32L
+        val f = 1.24f
+        val d = 2.34.toDouble()
         val s = "Realm"
         val oid = ObjectId()
         val d128 = Decimal128(i64)
@@ -83,6 +85,8 @@ class BsonTest {
         assertEquals(BsonBoolean(b), BsonConverter.to(b))
         assertEquals(BsonInt32(i32), BsonConverter.to(i32))
         assertEquals(BsonInt64(i64), BsonConverter.to(i64))
+        assertEquals(BsonDouble(f.toDouble()), BsonConverter.to(f))
+        assertEquals(BsonDouble(d), BsonConverter.to(d))
         assertEquals(BsonString(s), BsonConverter.to(s))
         assertEquals(BsonObjectId(oid), BsonConverter.to(oid))
         assertEquals(BsonDecimal128(d128), BsonConverter.to(d128))
@@ -111,6 +115,7 @@ class BsonTest {
         assertEquals(i32, BsonConverter.from(Integer::class.java, BsonInt32(i32)))
         // assertEquals(i64, BsonConverter.from(Long::class.java, BsonInt64(i64)))
         assertEquals(i64, BsonConverter.from(java.lang.Long::class.java, BsonInt64(i64)))
+        assertEquals(d, BsonConverter.from(java.lang.Double::class.java, BsonDouble(d)))
         // ...not trying to fit wider types event though possible
         // FIXME Would we like to support this
         assertFailsWith<IllegalArgumentException> {


### PR DESCRIPTION
Passing BSON to JNI by wrapping it in a document with key `value`. 

Java side: `OSJNIBsonProtocol`:
- `public static String encode(BsonValue bsonValue)`
- `public static BsonValue decode(String string)`

JNI side:
- `realm::bson::Bson jstring_to_bson(JNIEnv* env, jstring arg);`
- `jstring bson_to_jstring(JNIEnv* env, realm::bson::Bson bson);`

- 
Conversion does currently not handle the below types as mapping from primitive types is not obvious: 
```
                BsonType.DOCUMENT,
                BsonType.UNDEFINED,
                BsonType.DATE_TIME,
                BsonType.NULL,
                BsonType.REGULAR_EXPRESSION,
                BsonType.SYMBOL,
                BsonType.DB_POINTER,
                BsonType.JAVASCRIPT,
                BsonType.JAVASCRIPT_WITH_SCOPE,
                BsonType.TIMESTAMP,
                BsonType.END_OF_DOCUMENT,
                BsonType.MIN_KEY,
                BsonType.MAX_KEY
```
- [x] Verify format
- [x] Full implementation
- [x] Converter tests (no JNI interaction)
- [x] Basic JNI roundtrip (not covering all BSON types)
