### PR TITLE
Add ability to use CodecRegistry for passing objects as BSON to JNI

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmFunctionsTest.kt
@@ -17,11 +17,21 @@
 package io.realm
 
 import androidx.test.platform.app.InstrumentationRegistry
+import io.realm.internal.jni.JniBsonProtocol
 import io.realm.internal.util.BsonConverter
 import org.bson.*
+import org.bson.codecs.BsonValueCodecProvider
+import org.bson.codecs.IterableCodecProvider
+import org.bson.codecs.StringCodec
+import org.bson.codecs.ValueCodecProvider
+import org.bson.codecs.configuration.CodecRegistries
+import org.bson.codecs.pojo.PojoCodecProvider
+import org.bson.types.Decimal128
+import org.bson.types.ObjectId
 import org.junit.Before
 import org.junit.Test
-import java.util.stream.Collectors
+import java.time.Instant
+import java.util.*
 import kotlin.test.assertEquals
 
 class RealmFunctionsTest {
@@ -31,6 +41,7 @@ class RealmFunctionsTest {
         Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
     }
 
+    // Test of BSON JNI round trip until superseded with actual public api tests are added.
     @Test
     fun jniBsonOnlyRoundtrip() {
         val functions = RealmFunctions()
@@ -45,6 +56,107 @@ class RealmFunctionsTest {
         val values = listOf<Any>(BsonInt32(i32), BsonInt64(i64), BsonString(s))
         val invoke: BsonValue = functions.invoke(BsonConverter.to(values))
         assertEquals(values, invoke.asArray().values)
+    }
+
+    @Test
+    fun bsonValueCodec() {
+        val functions = RealmFunctions()
+
+        val registry = CodecRegistries.fromRegistries(
+            CodecRegistries.fromProviders(
+                    // For primitive support
+                    ValueCodecProvider(),
+                    // For BSONValue support
+                    BsonValueCodecProvider(),
+                    // For list support
+                    IterableCodecProvider()
+            )
+        )
+
+        for(type in BsonType.values()) {
+            when (type) {
+                BsonType.DOUBLE -> {
+                    assertEquals(java.lang.Double(1.5), functions.invoke(1.5, java.lang.Double::class.java, registry))
+                }
+                BsonType.STRING -> {
+                    val value = "Realm"
+                    assertEquals(value, functions.invoke(value, String::class.java, registry))
+                }
+                BsonType.ARRAY -> {
+                    // FIXME Fails in C++ parsing when boolean values are add...needs investigation
+                    // val listOf = listOf<Any>(1.5, true, "Realm")
+                    val listOf = listOf<Any>(1.5, "Realm")
+                    assertEquals(listOf, functions.invoke(listOf, List::class.java, registry))
+                }
+                BsonType.BINARY -> {
+                    val value = byteArrayOf(1, 2, 3)
+                    assertEquals(value.toList(), functions.invoke(value, ByteArray::class.java, registry).toList())
+                }
+                BsonType.OBJECT_ID -> {
+                    val value = ObjectId()
+                    assertEquals(value, functions.invoke(value, ObjectId::class.java, registry))
+                }
+                BsonType.BOOLEAN -> {
+                    val value = true
+                    assertEquals(value, functions.invoke(value, java.lang.Boolean::class.java, registry).booleanValue())
+                }
+                BsonType.DATE_TIME -> {
+                    val value = Date(Instant.now().toEpochMilli())
+                    assertEquals(value, functions.invoke(value, Date::class.java, registry))
+                }
+                BsonType.INT32 -> {
+                    val value = 32
+                    assertEquals(value, functions.invoke(value, Integer::class.java, registry).toInt())
+                }
+                BsonType.INT64 -> {
+                    val value = 32L
+                    assertEquals(value, functions.invoke(value, java.lang.Long::class.java, registry).toLong())
+                }
+                BsonType.DECIMAL128 -> {
+                    val value = Decimal128(32)
+                    assertEquals(value, functions.invoke(value, Decimal128::class.java, registry))
+                }
+                BsonType.NULL -> {
+                    // No value codec for null
+                    val value = BsonNull()
+                    assertEquals(value, functions.invoke(value, BsonValue::class.java, registry))
+                }
+//                BsonType.DOCUMENT -> TODO()
+//                BsonType.UNDEFINED -> TODO()
+//                BsonType.REGULAR_EXPRESSION -> TODO()
+//                BsonType.DB_POINTER -> TODO()
+//                BsonType.JAVASCRIPT -> TODO()
+//                BsonType.SYMBOL -> TODO()
+//                BsonType.JAVASCRIPT_WITH_SCOPE -> TODO()
+//                BsonType.MIN_KEY -> TODO()
+//                BsonType.MAX_KEY -> TODO()
+//                BsonType.END_OF_DOCUMENT -> TODO()
+//                BsonType.TIMESTAMP -> TODO()
+                else -> {}
+            }
+        }
+    }
+
+    // Test of BSON JNI round trip until superseded with actual public api tests are added.
+    data class Dog(var name: String? = null)
+    @Test
+    fun pojoCodecRegistry() {
+        val functions = RealmFunctions()
+
+        val pojoRegistry = CodecRegistries.fromRegistries(
+                CodecRegistries.fromCodecs(StringCodec()),
+                CodecRegistries.fromProviders(
+                        PojoCodecProvider.builder()
+                                .register(Dog::class.java)
+                                .build()
+                )
+        )
+
+        val input = Dog("PojoFido")
+
+        val actual: Dog = functions.invoke(input, Dog::class.java, pojoRegistry)
+
+        assertEquals(input, actual)
     }
 
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmFunctions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmFunctions.java
@@ -16,15 +16,25 @@
 package io.realm;
 
 import org.bson.BsonValue;
+import org.bson.codecs.configuration.CodecRegistry;
 
 import io.realm.internal.jni.JniBsonProtocol;
 
-public class RealmFunctions {
+// FIXME This class is only a placeholder for JNI round trip as  until actual RealmFunctions
+//  implementation supersedes it.
+class RealmFunctions {
 
     // FIXME Prelimiry implementation to be able to test passing BsonValues through JNI
     BsonValue invoke(BsonValue arg) {
         String response = nativeCallFunction(JniBsonProtocol.encode(arg));
         return JniBsonProtocol.decode(response);
+    }
+
+    // FIXME Prelimiry implementation to be able to test passing BsonValues through JNI
+    <T> T invoke(Object arg, Class<T> resultClass, CodecRegistry registry) {
+        String a = JniBsonProtocol.encode(arg, registry);
+        String s = nativeCallFunction(a);
+        return JniBsonProtocol.decode(s, resultClass, registry);
     }
 
     private static native String nativeCallFunction(String arg);


### PR DESCRIPTION
This add support for passing a `CodecRegistry` to the `JniBsonProtocol` enabling support for using MongoDB codecs for converting values. For example using the `PojoCodecProvider` to send and construct custom java objects as in https://github.com/realm/realm-java/compare/v10...cr/bson-jni-interaction?expand=1#diff-1af7924ad8b59c18ae9d822f88479d3dR143. 

Adding the below methos to `JniBsonProtocol`:
```
public static <T> String encode(T value, CodecRegistry registry)
public static <T> T decode(String string, Class<T> clz, CodecRegistry registry)
```

The `org.bson`'s `ValueCodecProvider`, `BsonValueCodecProvider` and `IterableCodecProvider` can be combined to offer similar convert to the manually implemented `BsonConverter` methods, but cannot, as far as I can see, be used to do conversion without serializing.  

- [ ] Settle API
- [ ] Settle on default CodecRegistry as substitution for `BsonConverter`
- [ ] Test