### PR TITLE
Reduce build time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ try {
                 try {
                   backgroundPid = startLogCatCollector()
                   forwardAdbPorts()
-                  gradle('realm', "${instrumentationTestTarget}")
+                  gradle('realm', "${instrumentationTestTarget} ${abiFilter}")
                 } finally {
                   stopLogCatCollector(backgroundPid)
                   storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'
@@ -192,22 +192,31 @@ def forwardAdbPorts() {
   '''
 }
 
-def String startLogCatCollector() {
-  sh '''adb logcat -c
-  adb logcat -v time > "logcat.txt" &
-  echo $! > pid
-  '''
-  return readFile("pid").trim()
+String startLogCatCollector() {
+  // Cancel build quickly if no device is available. The lock acquired already should
+  // ensure we have access to a device. If not, it is most likely a more severe problem.
+  timeout(time: 1, unit: 'MINUTES') {
+    sh 'adb devices'
+    sh """adb logcat -c
+      adb logcat -v time > 'logcat.txt' &
+      echo \$! > pid
+    """
+    return readFile("pid").trim()
+  }
 }
 
 def stopLogCatCollector(String backgroundPid) {
-  sh "kill ${backgroundPid}"
-  zip([
-          'zipFile': 'logcat.zip',
-          'archive': true,
-          'glob' : 'logcat.txt'
-  ])
-  sh 'rm logcat.txt'
+  // The pid might not be available if the build was terminated early or stopped due to
+  // a build error.
+  if (backgroundPid != null) {
+    sh "kill ${backgroundPid}"
+    zip([
+            'zipFile': 'logcat.zip',
+            'archive': true,
+            'glob' : 'logcat.txt'
+    ])
+    sh 'rm logcat.txt'
+  }
 }
 
 def archiveServerLogs(String mongoDbRealmContainerId, String commandServerContainerId) {


### PR DESCRIPTION
This PR separates some changes discovered while working on https://github.com/realm/realm-java/pull/6822

- We accidentally still built all debug ABI's on PR's instead of only armeabi-v7a. (this should save quite some time)
- Quicker exit if the device is not available. Currently, we wait 1.5 hours before timing out the build which would block other builds because we held a resource lock.
- Fixing a bug when tearing down the build. If it was terminated early it would result in the wrong kind of error being reported. 