### PR TITLE
Update Integration Test server to latest version

### DIFF
--- a/dependencies.list
+++ b/dependencies.list
@@ -9,7 +9,7 @@ REALM_OBJECT_SERVER_VERSION=3.28.2
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER_VERSION=2020-04-30
+MONGODB_REALM_SERVER_VERSION=2020-05-13
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=3.6.1

--- a/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncPerson.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncPerson.json
@@ -38,8 +38,7 @@
         "required": [
             "firstName",
             "lastName",
-            "age",
-            "dogs"
+            "age"
         ],
         "title": "SyncPerson"
     }


### PR DESCRIPTION
Updates the version of Stitch we use for Integration tests to latest (as of today) version.