### PR TITLE
Add support for Device Id and bump Sync/OS to latest version

### DIFF
--- a/dependencies.list
+++ b/dependencies.list
@@ -1,7 +1,7 @@
 # Realm Sync release used by Realm Java (This includes Realm Core)
 # https://github.com/realm/realm-sync/releases
-REALM_SYNC_VERSION=10.0.0-alpha.12
-REALM_SYNC_SHA256=d9ab40f7b73b4438c811adfbbb22ed8da1461d922e77bb46f555f49ae1921748
+REALM_SYNC_VERSION=10.0.0-alpha.14
+REALM_SYNC_SHA256=1d1e9478210f7b26cea882f8e8c8fd5968b7938415ef1120485671a1a4ed2e67
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.
@@ -9,7 +9,7 @@ REALM_OBJECT_SERVER_VERSION=3.28.2
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER_VERSION=2020-05-13
+MONGODB_REALM_SERVER_VERSION=2020-05-22
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=3.6.1

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/KotlinSyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/KotlinSyncedRealmTests.kt
@@ -30,7 +30,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
 
-//@Ignore("FIXME Disabled until dev mode is not causing this to hang")
 @RunWith(AndroidJUnit4::class)
 class KotlinSyncedRealmTests { // FIXME: Rename to SyncedRealmTests once remaining Java tests have been moved
 
@@ -147,7 +146,7 @@ class KotlinSyncedRealmTests { // FIXME: Rename to SyncedRealmTests once remaini
                 val dog = SyncDog()
                 dog.name = "Fido $i"
                 it.insert(dog)
-                person.dogs.add(dog.id)
+                person.dogs.add(dog)
             }
             realm.insert(person)
         }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/KotlinSyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/KotlinSyncedRealmTests.kt
@@ -30,7 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
 
-@Ignore("FIXME Disabled until dev mode is not causing this to hang")
+//@Ignore("FIXME Disabled until dev mode is not causing this to hang")
 @RunWith(AndroidJUnit4::class)
 class KotlinSyncedRealmTests { // FIXME: Rename to SyncedRealmTests once remaining Java tests have been moved
 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmUserTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/RealmUserTests.kt
@@ -274,4 +274,10 @@ class RealmUserTests {
         }
     }
 
+    @Test
+    fun getDeviceId() {
+        // TODO No reason to integration test this. Use a stubbed response instead.
+        val user: RealmUser = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
+        assertTrue(user.deviceId.isNotEmpty() && user.deviceId.length == 24) // Server returns a UUID
+    }
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncPerson.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncPerson.kt
@@ -28,7 +28,7 @@ open class SyncPerson(
         @RealmField(name = "_id")
         var id: ObjectId? = ObjectId(),
         var age: Long = 0,
-        var dogs: RealmList<ObjectId> = RealmList(),
+        var dogs: RealmList<SyncDog> = RealmList(),
         var firstName: String = "",
         var lastName: String = ""
         // This field is not required by clients

--- a/realm/realm-library/src/main/cpp/CMake/RealmCore.cmake
+++ b/realm/realm-library/src/main/cpp/CMake/RealmCore.cmake
@@ -89,9 +89,11 @@ function(use_sync_release enable_sync sync_dist_path)
 
     # -latomic is not set by default for mips and armv5.
     # See https://code.google.com/p/android/issues/detail?id=182094
+    list(APPEND LIB_INCLUDE_DIRS "${sync_dist_path}/include")
+    list(APPEND LIB_INCLUDE_DIRS "${sync_dist_path}/include/realm")
     set_target_properties(lib_realm_core PROPERTIES IMPORTED_LOCATION ${core_lib_path}
         IMPORTED_LINK_INTERFACE_LIBRARIES atomic
-        INTERFACE_INCLUDE_DIRECTORIES "${sync_dist_path}/include")
+        INTERFACE_INCLUDE_DIRECTORIES "${LIB_INCLUDE_DIRS}")
 
     if (enable_sync)
         # Sync static library

--- a/realm/realm-library/src/main/cpp/io_realm_RealmApp.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_RealmApp.cpp
@@ -91,7 +91,10 @@ JNIEXPORT jlong JNICALL Java_io_realm_RealmApp_nativeCreate(JNIEnv* env, jobject
                                                             jlong j_request_timeout_ms,
                                                             jstring j_sync_base_dir,
                                                             jstring j_user_agent_binding_info,
-                                                            jstring j_user_agent_application_info)
+                                                            jstring j_user_agent_application_info,
+                                                            jstring j_platform,
+                                                            jstring j_platform_version,
+                                                            jstring j_sdk_version)
 {
     try {
 
@@ -108,14 +111,19 @@ JNIEXPORT jlong JNICALL Java_io_realm_RealmApp_nativeCreate(JNIEnv* env, jobject
         JStringAccessor base_url(env, j_base_url);
         JStringAccessor app_name(env, j_app_name);
         JStringAccessor app_version(env, j_app_version);
-
+        JStringAccessor platform(env, j_platform);
+        JStringAccessor platform_version(env, j_platform_version);
+        JStringAccessor sdk_version(env, j_sdk_version);
         auto app_config = App::Config{
                 app_id,
                 transport_generator,
                 util::Optional<std::string>(base_url),
                 util::Optional<std::string>(app_name),
                 util::Optional<std::string>(app_version),
-                util::Optional<std::uint64_t>(j_request_timeout_ms)
+                util::Optional<std::uint64_t>(j_request_timeout_ms),
+                platform,
+                platform_version,
+                sdk_version
         };
 
         // Sync Config

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -245,7 +245,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsRealmConfig_nativeEnableChangeNo
 #if REALM_ENABLE_SYNC
 JNIEXPORT jstring JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSetSyncConfig(
     JNIEnv* env, jclass, jlong native_ptr, jstring j_sync_realm_url, jstring j_auth_url, jstring j_user_id,
-    jstring j_refresh_token, jstring j_access_token, jbyte j_session_stop_policy, jstring j_url_prefix,
+    jstring j_refresh_token, jstring j_access_token, jstring j_device_id, jbyte j_session_stop_policy, jstring j_url_prefix,
     jstring j_custom_auth_header_name, jobjectArray j_custom_headers_array, jbyte j_client_reset_mode,
     jstring j_partion_key_value, jobject j_java_sync_service)
 {
@@ -325,7 +325,8 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSe
             JStringAccessor realm_auth_url(env, j_auth_url);
             JStringAccessor refresh_token(env, j_refresh_token);
             JStringAccessor access_token(env, j_access_token);
-            user = SyncManager::shared().get_user(user_id, auth_url, refresh_token, access_token);
+            JStringAccessor device_id(env, j_device_id);
+            user = SyncManager::shared().get_user(user_id, auth_url, refresh_token, access_token, device_id);
         }
 
         SyncSessionStopPolicy session_stop_policy = static_cast<SyncSessionStopPolicy>(j_session_stop_policy);

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSyncUser.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSyncUser.cpp
@@ -228,3 +228,14 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_objectstore_OsSyncUser_nativeGe
     CATCH_STD();
     return nullptr;
 }
+
+JNIEXPORT jstring JNICALL Java_io_realm_internal_objectstore_OsSyncUser_nativeGetDeviceId(JNIEnv* env, jclass, jlong j_native_ptr)
+{
+    try {
+        auto user = *reinterpret_cast<std::shared_ptr<SyncUser>*>(j_native_ptr);
+        std::string device_id = user->device_id();
+        return to_jstring(env, device_id);
+    }
+    CATCH_STD();
+    return nullptr;
+}

--- a/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
@@ -30,7 +30,7 @@ import io.realm.exceptions.RealmException;
  */
 public class ObjectServerFacade {
 
-    public final static int SYNC_CONFIG_OPTIONS = 14;
+    public final static int SYNC_CONFIG_OPTIONS = 15;
 
     private final static ObjectServerFacade nonSyncFacade = new ObjectServerFacade();
     private static ObjectServerFacade syncFacade = null;

--- a/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
@@ -212,19 +212,20 @@ public class OsRealmConfig implements NativeObject {
         String syncRealmAuthUrl = (String) syncConfigurationOptions[2];
         String syncRefreshToken = (String) syncConfigurationOptions[3];
         String syncAccessToken = (String) syncConfigurationOptions[4];
-        boolean syncClientValidateSsl = (Boolean.TRUE.equals(syncConfigurationOptions[5]));
-        String syncSslTrustCertificatePath = (String) syncConfigurationOptions[6];
-        Byte sessionStopPolicy = (Byte) syncConfigurationOptions[7];
-        String urlPrefix = (String)(syncConfigurationOptions[8]);
-        String customAuthorizationHeaderName = (String)(syncConfigurationOptions[9]);
-        Byte clientResyncMode = (Byte) syncConfigurationOptions[11];
-        String partitionValue = (String) syncConfigurationOptions[12];
-        Object syncService = syncConfigurationOptions[13];
+        String deviceId = (String) syncConfigurationOptions[5];
+        boolean syncClientValidateSsl = (Boolean.TRUE.equals(syncConfigurationOptions[6]));
+        String syncSslTrustCertificatePath = (String) syncConfigurationOptions[7];
+        Byte sessionStopPolicy = (Byte) syncConfigurationOptions[8];
+        String urlPrefix = (String)(syncConfigurationOptions[9]);
+        String customAuthorizationHeaderName = (String)(syncConfigurationOptions[10]);
+        Byte clientResyncMode = (Byte) syncConfigurationOptions[12];
+        String partitionValue = (String) syncConfigurationOptions[13];
+        Object syncService = syncConfigurationOptions[14];
 
         // Convert the headers into a String array to make it easier to send through JNI
         // [key1, value1, key2, value2, ...]
         //noinspection unchecked
-        Map<String, String> customHeadersMap = (Map<String, String>) (syncConfigurationOptions[10]);
+        Map<String, String> customHeadersMap = (Map<String, String>) (syncConfigurationOptions[11]);
         String[] customHeaders = new String[customHeadersMap != null ? customHeadersMap.size() * 2 : 0];
         if (customHeadersMap != null) {
             int i = 0;
@@ -285,6 +286,7 @@ public class OsRealmConfig implements NativeObject {
                     syncUserIdentifier,
                     syncRefreshToken,
                     syncAccessToken,
+                    deviceId,
                     sessionStopPolicy,
                     urlPrefix,
                     customAuthorizationHeaderName,
@@ -386,7 +388,7 @@ public class OsRealmConfig implements NativeObject {
 
     private static native String nativeCreateAndSetSyncConfig(long nativePtr, String syncRealmUrl, String authUrl,
                                                               String userId, String refreshToken, String accessToken,
-                                                              byte sessionStopPolicy, String urlPrefix,
+                                                              String deviceId, byte sessionStopPolicy, String urlPrefix,
                                                               String customAuthorizationHeaderName,
                                                               String[] customHeaders, byte clientResetMode,
                                                               String partionKeyValue, Object syncService);

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmApp.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmApp.java
@@ -126,7 +126,7 @@ public class RealmApp {
                 userAgentBindingInfo,
                 appDefinedUserAgent,
                 "android",
-                Integer.toString(android.os.Build.VERSION.SDK_INT),
+                android.os.Build.VERSION.RELEASE,
                 io.realm.BuildConfig.VERSION_NAME);
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmApp.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmApp.java
@@ -124,7 +124,10 @@ public class RealmApp {
                 config.getRequestTimeoutMs(),
                 syncDir,
                 userAgentBindingInfo,
-                appDefinedUserAgent);
+                appDefinedUserAgent,
+                "android",
+                Integer.toString(android.os.Build.VERSION.SDK_INT),
+                io.realm.BuildConfig.VERSION_NAME);
     }
 
     private String getSyncBaseDirectory() {
@@ -598,7 +601,10 @@ public class RealmApp {
                                      long requestTimeoutMs,
                                      String syncDirPath,
                                      String bindingUserInfo,
-                                     String appUserInfo);
+                                     String appUserInfo,
+                                     String platform,
+                                     String platformVersion,
+                                     String sdkVersion);
     private static native void nativeLogin(long nativeAppPtr, long nativeCredentialsPtr, OsJavaNetworkTransport.NetworkTransportJNIResultCallback callback);
     @Nullable
     private static native Long nativeCurrentUser(long nativePtr);

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmUser.java
@@ -208,6 +208,15 @@ public class RealmUser {
 
 
     /**
+     * Returns a unique identifier for the device the user logged in to.
+     *
+     * @return a unique device identifier for the user.
+     */
+    public String getDeviceId() {
+        return osUser.getDeviceId();
+    }
+
+    /**
      * Returns the {@link RealmApp} this user is associated with.
      *
      * @return the {@link RealmApp} this user is associated with.

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -81,6 +81,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
             String syncRealmAuthUrl = user.getApp().getConfiguration().getBaseUrl().toString();
             String syncUserRefreshToken = user.getRefreshToken();
             String syncUserAccessToken = user.getAccessToken();
+            String deviceId = user.getDeviceId();
             byte sessionStopPolicy = syncConfig.getSessionStopPolicy().getNativeValue();
             String urlPrefix = syncConfig.getUrlPrefix();
             String customAuthorizationHeaderName = app.getConfiguration().getAuthorizationHeaderName();
@@ -106,15 +107,16 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
             configObj[2] = syncRealmAuthUrl;
             configObj[3] = syncUserRefreshToken;
             configObj[4] = syncUserAccessToken;
-            configObj[5] = syncConfig.syncClientValidateSsl();
-            configObj[6] = syncConfig.getServerCertificateFilePath();
-            configObj[7] = sessionStopPolicy;
-            configObj[8] = urlPrefix;
-            configObj[9] = customAuthorizationHeaderName;
-            configObj[10] = customHeaders;
-            configObj[11] = OsRealmConfig.CLIENT_RESYNC_MODE_MANUAL;
-            configObj[12] = partitionValue;
-            configObj[13] = app.getSync();
+            configObj[5] = deviceId;
+            configObj[6] = syncConfig.syncClientValidateSsl();
+            configObj[7] = syncConfig.getServerCertificateFilePath();
+            configObj[8] = sessionStopPolicy;
+            configObj[9] = urlPrefix;
+            configObj[10] = customAuthorizationHeaderName;
+            configObj[11] = customHeaders;
+            configObj[12] = OsRealmConfig.CLIENT_RESYNC_MODE_MANUAL;
+            configObj[13] = partitionValue;
+            configObj[14] = app.getSync();
             return configObj;
         } else {
             return new Object[SYNC_CONFIG_OPTIONS];

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsSyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsSyncUser.java
@@ -99,6 +99,10 @@ public class OsSyncUser implements NativeObject {
         return identities;
     }
 
+    public String getDeviceId() {
+        return nativeGetDeviceId(nativePtr);
+    }
+
     /**
      * @return {@link #STATE_LOGGED_IN}, {@link #STATE_LOGGED_OUT} or {@link #STATE_REMOVED}
      */
@@ -145,4 +149,5 @@ public class OsSyncUser implements NativeObject {
     private static native byte nativeGetState(long nativePtr);
     private static native void nativeSetState(long nativePtr, byte state);
     private static native String nativeGetProviderType(long nativePtr);
+    private static native String nativeGetDeviceId(long nativePtr);
 }

--- a/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncPerson.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncPerson.json
@@ -2,6 +2,14 @@
     "id": "5e9578c1a06f8d660afdaa2d",
     "database": "test_data",
     "collection": "SyncPerson",
+    "relationships": {
+        "dogs": {
+            "ref": "#/stitch/BackingDB/test_data/SyncDog",
+            "source_key": "dogs",
+            "foreign_key": "_id",
+            "is_list": true
+        }
+    },
     "roles": [
         {
             "name": "default",


### PR DESCRIPTION
The primary purpose of this PR was to just upgrade Sync and ObjectStore to latest versions, but resulted in doing a few more things:

* Sync upgraded to latest version (10.0.0-alpha.14)
* ObjectStore at latest commit
* Added support for DeviceID, which required some more metadata to be sent.
* Re-enabled roundtrip tests through MongoDB Realm
* Modified test schema so we now use the proper model lists (these were not supported initially)