### PR TITLE
Add @Beta tag to all MongoDB Realm API's

### DIFF
--- a/realm/realm-library/src/objectServer/java/io/realm/exceptions/DownloadingRealmInterruptedException.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/exceptions/DownloadingRealmInterruptedException.java
@@ -16,6 +16,7 @@
 
 package io.realm.exceptions;
 
+import io.realm.annotations.Beta;
 import io.realm.mongodb.sync.SyncConfiguration;
 
 
@@ -23,6 +24,7 @@ import io.realm.mongodb.sync.SyncConfiguration;
  * Exception class used when a Realm was interrupted while downloading the initial data set.
  * This can only happen if {@link SyncConfiguration.Builder#waitForInitialRemoteData()} is set.
  */
+@Beta
 public class DownloadingRealmInterruptedException extends RuntimeException {
     public DownloadingRealmInterruptedException(SyncConfiguration syncConfig, Throwable exception) {
         super("Realm was interrupted while downloading the latest changes from the server: " + syncConfig.getPath(),

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/ApiKeyAuthImpl.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/ApiKeyAuthImpl.java
@@ -18,10 +18,11 @@ package io.realm.mongodb;
 
 import javax.annotation.Nullable;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.objectstore.OsJavaNetworkTransport;
 import io.realm.mongodb.auth.ApiKeyAuth;
 
-
+@Beta
 class ApiKeyAuthImpl extends ApiKeyAuth {
 
     ApiKeyAuthImpl(User user) {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/App.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/App.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.BuildConfig;
 import io.realm.Realm;
+import io.realm.annotations.Beta;
 import io.realm.internal.mongodb.Request;
 import io.realm.mongodb.auth.EmailPasswordAuth;
 import io.realm.RealmAsyncTask;
@@ -53,6 +54,7 @@ import io.realm.mongodb.functions.Functions;
 /**
  * FIXME
  */
+@Beta
 public class App {
 
     static final class SyncImpl extends Sync {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppConfiguration.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import io.realm.Realm;
+import io.realm.annotations.Beta;
 import io.realm.mongodb.sync.SyncSession;
 import io.realm.internal.Util;
 import io.realm.log.RealmLog;
@@ -52,6 +53,7 @@ import io.realm.log.RealmLog;
  * Configuring a App is only required if the default settings are not enough. Otherwise calling
  * {@code new App("app-id")} is sufficient.
  */
+@Beta
 public class AppConfiguration {
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/AuthenticationListener.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/AuthenticationListener.java
@@ -16,9 +16,12 @@
 
 package io.realm.mongodb;
 
+import io.realm.annotations.Beta;
+
 /**
  * Interface describing events related to Users and their authentication
  */
+@Beta
 public interface AuthenticationListener {
     /**
      * A user was logged into the Object Server

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
@@ -16,6 +16,7 @@
 
 package io.realm.mongodb;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.Util;
 import io.realm.internal.objectstore.OsAppCredentials;
 import io.realm.mongodb.auth.EmailPasswordAuth;
@@ -48,6 +49,7 @@ import io.realm.mongodb.auth.EmailPasswordAuth;
  * </pre>
  * @see <a href="https://docs.mongodb.com/stitch/authentication/providers/">Authentication Providers</a>
  */
+@Beta
 public class Credentials {
 
     OsAppCredentials osCredentials;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/EmailPasswordAuthImpl.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/EmailPasswordAuthImpl.java
@@ -16,9 +16,11 @@
 
 package io.realm.mongodb;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.objectstore.OsJavaNetworkTransport;
 import io.realm.mongodb.auth.EmailPasswordAuth;
 
+@Beta
 class EmailPasswordAuthImpl extends EmailPasswordAuth {
 
     EmailPasswordAuthImpl(App app) {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/ErrorCode.java
@@ -19,6 +19,7 @@ package io.realm.mongodb;
 
 import java.util.Locale;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.objectstore.OsJavaNetworkTransport;
 import io.realm.log.RealmLog;
 import io.realm.mongodb.sync.SyncConfiguration;
@@ -26,6 +27,7 @@ import io.realm.mongodb.sync.SyncConfiguration;
 /**
  * This class enumerate all potential errors related to using the Object Server or synchronizing data.
  */
+@Beta
 public enum ErrorCode {
 
     // See Client::Error in https://github.com/realm/realm-sync/blob/master/src/realm/sync/client.hpp#L1230

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/FunctionsImpl.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/FunctionsImpl.java
@@ -15,8 +15,6 @@
  */
 package io.realm.mongodb;
 
-import org.bson.BSONException;
-import org.bson.BsonElement;
 import org.bson.codecs.Decoder;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -24,6 +22,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.Util;
 import io.realm.internal.jni.JniBsonProtocol;
 import io.realm.internal.jni.OsJNIResultCallback;
@@ -35,6 +34,7 @@ import io.realm.mongodb.functions.Functions;
  * Internal implementation of Functions invoking the actual OS function in the context of the
  * {@link User}/{@link App}.
  */
+@Beta
 class FunctionsImpl extends Functions {
 
     FunctionsImpl(User user) {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/ObjectServerError.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/ObjectServerError.java
@@ -18,6 +18,7 @@ package io.realm.mongodb;
 
 import javax.annotation.Nullable;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.Util;
 import io.realm.mongodb.sync.SyncSession;
 
@@ -31,6 +32,7 @@ import io.realm.mongodb.sync.SyncSession;
  *
  * @see ErrorCode for a list of possible errors.
  */
+@Beta
 public class ObjectServerError extends RuntimeException {
 
     // The Java representation of the error.

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.realm.annotations.Beta;
 import io.realm.internal.mongodb.Request;
 import io.realm.internal.objectstore.OsMongoClient;
 import io.realm.mongodb.auth.ApiKeyAuth;
@@ -42,6 +43,7 @@ import io.realm.mongodb.push.Push;
 /**
  * FIXME
  */
+@Beta
 public class User {
 
     OsSyncUser osUser;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/UserIdentity.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/UserIdentity.java
@@ -15,12 +15,15 @@
  */
 package io.realm.mongodb;
 
+import io.realm.annotations.Beta;
+
 /**
  * Each User is represented by 1 or more identities each defined by an
  * {@link Credentials.IdentityProvider}.
  *
  * This class represents the identity defined by a specific provider.
  */
+@Beta
 public class UserIdentity {
 
     private final String userId;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/ApiKeyAuth.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/ApiKeyAuth.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.mongodb.Request;
 import io.realm.mongodb.ObjectServerError;
 import io.realm.RealmAsyncTask;
@@ -39,6 +40,7 @@ import static io.realm.mongodb.App.NETWORK_POOL_EXECUTOR;
 /**
  * This class exposes functionality for a user to manage API keys under their control.
  */
+@Beta
 public abstract class ApiKeyAuth {
 
     private static final int TYPE_CREATE = 1;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/EmailPasswordAuth.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/EmailPasswordAuth.java
@@ -18,6 +18,7 @@ package io.realm.mongodb.auth;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.mongodb.Request;
 import io.realm.mongodb.ObjectServerError;
 import io.realm.RealmAsyncTask;
@@ -36,6 +37,7 @@ import static io.realm.mongodb.App.NETWORK_POOL_EXECUTOR;
  * Class encapsulating functionality provided when {@link User}'s are logged in through the
  * {@link Credentials.IdentityProvider#EMAIL_PASSWORD} provider.
  */
+@Beta
 public abstract class EmailPasswordAuth {
 
     private static final int TYPE_REGISTER_USER = 1;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/UserApiKey.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/UserApiKey.java
@@ -19,6 +19,7 @@ import org.bson.types.ObjectId;
 
 import javax.annotation.Nullable;
 
+import io.realm.annotations.Beta;
 import io.realm.mongodb.App;
 import io.realm.mongodb.User;
 
@@ -32,6 +33,7 @@ import io.realm.mongodb.User;
  * Note that a keys {@link #value} is only available when the key is created, after that it is not
  * visible. So anyone creating an API key is responsible for storing it safely after that.
  */
+@Beta
 public class UserApiKey {
     private final ObjectId id;
     private final String value;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/functions/Functions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/functions/Functions.java
@@ -22,6 +22,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 import java.util.List;
 
 import io.realm.RealmAsyncTask;
+import io.realm.annotations.Beta;
 import io.realm.internal.Util;
 import io.realm.internal.mongodb.Request;
 import io.realm.mongodb.App;
@@ -45,6 +46,7 @@ import io.realm.mongodb.User;
  * @see AppConfiguration
  * @see CodecRegistry
  */
+@Beta
 public abstract class Functions {
 
     protected User user;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoClient.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoClient.java
@@ -18,6 +18,7 @@ package io.realm.mongodb.mongo;
 
 import org.bson.codecs.configuration.CodecRegistry;
 
+import io.realm.annotations.Beta;
 import io.realm.mongodb.User;
 import io.realm.internal.Util;
 import io.realm.internal.objectstore.OsMongoClient;
@@ -25,6 +26,7 @@ import io.realm.internal.objectstore.OsMongoClient;
 /**
  * The remote MongoClient used for working with data in MongoDB remotely via Realm.
  */
+@Beta
 abstract public class MongoClient {
 
     private OsMongoClient osMongoClient;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoCollection.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoCollection.java
@@ -23,6 +23,7 @@ import org.bson.conversions.Bson;
 
 import java.util.List;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.common.TaskDispatcher;
 import io.realm.internal.objectstore.OsMongoCollection;
 import io.realm.mongodb.mongo.options.CountOptions;
@@ -45,6 +46,7 @@ import io.realm.mongodb.mongo.result.UpdateResult;
  *                    to.
  * @see MongoDatabase
  */
+@Beta
 public class MongoCollection<DocumentT> {
 
     private OsMongoCollection<DocumentT> osMongoCollection;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoDatabase.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoDatabase.java
@@ -18,12 +18,14 @@ package io.realm.mongodb.mongo;
 
 import org.bson.Document;
 
+import io.realm.annotations.Beta;
 import io.realm.internal.Util;
 import io.realm.internal.objectstore.OsMongoDatabase;
 
 /**
  * The RemoteMongoDatabase provides access to its {@link Document} {@link MongoCollection}s.
  */
+@Beta
 public class MongoDatabase {
 
     private String databaseName;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoNamespace.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/MongoNamespace.java
@@ -23,6 +23,8 @@ import org.bson.codecs.pojo.annotations.BsonProperty;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.realm.annotations.Beta;
+
 import static java.util.Arrays.asList;
 import static org.bson.assertions.Assertions.isTrueArgument;
 import static org.bson.assertions.Assertions.notNull;
@@ -30,6 +32,7 @@ import static org.bson.assertions.Assertions.notNull;
 /**
  * A MongoDB namespace, which includes a database name and collection name.
  */
+@Beta
 public final class MongoNamespace {
     public static final String COMMAND_COLLECTION_NAME = "$cmd";
 

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/CountOptions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/CountOptions.java
@@ -16,9 +16,12 @@
 
 package io.realm.mongodb.mongo.options;
 
+import io.realm.annotations.Beta;
+
 /**
  * The options for a count operation.
  */
+@Beta
 public class CountOptions {
     private int limit;
 

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/FindOneAndModifyOptions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/FindOneAndModifyOptions.java
@@ -20,10 +20,13 @@ import javax.annotation.Nullable;
 
 import org.bson.conversions.Bson;
 
+import io.realm.annotations.Beta;
+
 /**
  * The options to apply to a findOneAndUpdate, findOneAndReplace, or findOneAndDelete operation
  * (also commonly referred to as findOneAndModify operations).
  */
+@Beta
 public class FindOneAndModifyOptions {
     private Bson projection;
     private Bson sort;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/FindOptions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/FindOptions.java
@@ -20,9 +20,12 @@ import javax.annotation.Nullable;
 
 import org.bson.conversions.Bson;
 
+import io.realm.annotations.Beta;
+
 /**
  * The options to apply to a find operation (also commonly referred to as a query).
  */
+@Beta
 public class FindOptions {
     private int limit;
     private Bson projection;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/InsertManyResult.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/InsertManyResult.java
@@ -20,9 +20,12 @@ import java.util.Map;
 
 import org.bson.BsonValue;
 
+import io.realm.annotations.Beta;
+
 /**
  * The result of an insert many operation.
  */
+@Beta
 public class InsertManyResult {
 
     private final Map<Long, BsonValue> insertedIds;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/UpdateOptions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/options/UpdateOptions.java
@@ -16,9 +16,12 @@
 
 package io.realm.mongodb.mongo.options;
 
+import io.realm.annotations.Beta;
+
 /**
  * The options to apply when updating documents.
  */
+@Beta
 public class UpdateOptions {
     private boolean upsert;
 

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/result/DeleteResult.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/result/DeleteResult.java
@@ -16,9 +16,12 @@
 
 package io.realm.mongodb.mongo.result;
 
+import io.realm.annotations.Beta;
+
 /**
  * The result of a delete operation.
  */
+@Beta
 public class DeleteResult {
 
     private final long deletedCount;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/result/InsertOneResult.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/result/InsertOneResult.java
@@ -18,9 +18,12 @@ package io.realm.mongodb.mongo.result;
 
 import org.bson.BsonValue;
 
+import io.realm.annotations.Beta;
+
 /**
  * The result of an insert one operation.
  */
+@Beta
 public class InsertOneResult {
 
     private final BsonValue insertedId;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/result/UpdateResult.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/result/UpdateResult.java
@@ -20,9 +20,12 @@ import javax.annotation.Nullable;
 
 import org.bson.BsonValue;
 
+import io.realm.annotations.Beta;
+
 /**
  * The result of an update operation.
  */
+@Beta
 public class UpdateResult {
 
     private final long matchedCount;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/push/Push.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/push/Push.java
@@ -15,6 +15,11 @@
  */
 package io.realm.mongodb.push;
 
-// FIXME Javadoc?? Has to be public to live in separate package.
+import io.realm.annotations.Beta;
+
+/**
+ * FIXME: Add Javadoc and implementation
+ */
+@Beta
 public class Push {
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ClientResetRequiredError.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ClientResetRequiredError.java
@@ -18,6 +18,7 @@ package io.realm.mongodb.sync;
 
 import java.io.File;
 
+import io.realm.annotations.Beta;
 import io.realm.mongodb.ErrorCode;
 import io.realm.mongodb.ObjectServerError;
 import io.realm.Realm;
@@ -29,6 +30,7 @@ import io.realm.RealmConfiguration;
  * @see SyncSession.ErrorHandler#onError(SyncSession, ObjectServerError) for more information
  *      about when and why Client Reset occurs and how to deal with it.
  */
+@Beta
 public class ClientResetRequiredError extends ObjectServerError {
 
     private final SyncConfiguration originalConfiguration;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ClientResyncMode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ClientResyncMode.java
@@ -16,6 +16,7 @@
 
 package io.realm.mongodb.sync;
 
+import io.realm.annotations.Beta;
 import io.realm.mongodb.ObjectServerError;
 import io.realm.internal.OsRealmConfig;
 
@@ -28,6 +29,7 @@ import io.realm.internal.OsRealmConfig;
  * <p>
  * <b>IMPORTANT:</b> Just having the device offline will not trigger a Client Resync.
  */
+@Beta
 enum ClientResyncMode {
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ConnectionListener.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ConnectionListener.java
@@ -15,6 +15,8 @@
  */
 package io.realm.mongodb.sync;
 
+import io.realm.annotations.Beta;
+
 /**
  * Interface used when reporting changes that happened to the connection used by the session.
  * <p>
@@ -27,6 +29,7 @@ package io.realm.mongodb.sync;
  * @see SyncSession#isConnected()
  * @see SyncConfiguration.Builder#errorHandler(SyncSession.ErrorHandler)
  */
+@Beta
 public interface ConnectionListener {
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ConnectionState.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ConnectionState.java
@@ -16,9 +16,12 @@
 
 package io.realm.mongodb.sync;
 
+import io.realm.annotations.Beta;
+
 /**
  * Enum describing the states of the underlying connection used by a {@link SyncSession}.
  */
+@Beta
 public enum ConnectionState {
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Progress.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Progress.java
@@ -16,6 +16,7 @@
 
 package io.realm.mongodb.sync;
 
+import io.realm.annotations.Beta;
 import io.realm.log.RealmLog;
 
 
@@ -34,6 +35,7 @@ import io.realm.log.RealmLog;
  * @see SyncSession#addDownloadProgressListener(ProgressMode, ProgressListener)
  * @see SyncSession#addUploadProgressListener(ProgressMode, ProgressListener)
  */
+@Beta
 public class Progress {
 
     private final long transferredBytes;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ProgressListener.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ProgressListener.java
@@ -17,10 +17,13 @@
 package io.realm.mongodb.sync;
 
 
+import io.realm.annotations.Beta;
+
 /**
  * Interface used when interested in updates on data either being uploaded to or downloaded from
  * a Realm Object Server.
  */
+@Beta
 public interface ProgressListener {
     /**
      * This method will be called periodically from the underlying Object Server Client responsible

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ProgressMode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/ProgressMode.java
@@ -16,9 +16,12 @@
 
 package io.realm.mongodb.sync;
 
+import io.realm.annotations.Beta;
+
 /**
  * Enum describing how to listen to progress changes.
  */
+@Beta
 public enum ProgressMode {
     /**
      * When registering the {@link ProgressListener}, it will record the current size of changes, and will only

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.realm.annotations.Beta;
 import io.realm.mongodb.ErrorCode;
 import io.realm.internal.Keep;
 import io.realm.internal.OsRealmConfig;
@@ -40,6 +41,7 @@ import io.realm.mongodb.User;
  */
 @Keep
 @SuppressFBWarnings("MS_CANNOT_BE_FINAL")
+@Beta
 public abstract class Sync {
 
     private final App app;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
@@ -92,6 +92,7 @@ import io.realm.rx.RxObservableFactory;
  * @see <a href="https://docs.realm.io/platform/using-synced-realms/syncing-data">The docs</a> for
  * more information about the two types of synchronization.
  */
+@Beta
 public class SyncConfiguration extends RealmConfiguration {
 
     // The FAT file system has limitations of length. Also, not all characters are permitted.

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.realm.annotations.Beta;
 import io.realm.mongodb.ErrorCode;
 import io.realm.mongodb.ObjectServerError;
 import io.realm.Realm;
@@ -59,6 +60,7 @@ import io.realm.mongodb.User;
  * The {@link SyncSession} object is thread safe.
  */
 @Keep
+@Beta
 public class SyncSession {
     private final static int DIRECTION_DOWNLOAD = 1;
     private final static int DIRECTION_UPLOAD = 2;


### PR DESCRIPTION
This PR mark all public classes under `io.realm.mongodb` with `@Beta`. It is probably unnecessary for some of them, but better safe than sorry.