### PR TITLE
Fix copying lists of embedded objects

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -1901,7 +1901,6 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                             emitStatement("%s.updateEmbeddedObject(realm, %sUnmanagedItem, proxyObject, new HashMap<RealmModel, RealmObjectProxy>(), Collections.EMPTY_SET)", Utils.getProxyClassSimpleName(field), fieldName)
                                         endControlFlow()
                                     endControlFlow()
-                                    emitStatement("builder.addObjectList(%s, %sManagedCopy)", fieldColKey, fieldName)
                                 } else {
                                     beginControlFlow("for (int i = 0; i < %sUnmanagedList.size(); i++)", fieldName)
                                         emitStatement("%1\$s %2\$sItem = %2\$sUnmanagedList.get(i)", genericType, fieldName)

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_EmbeddedClassSimpleParentRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_EmbeddedClassSimpleParentRealmProxy.java
@@ -791,7 +791,6 @@ public class some_test_EmbeddedClassSimpleParentRealmProxy extends some.test.Emb
                     some_test_EmbeddedClassRealmProxy.updateEmbeddedObject(realm, childrenUnmanagedItem, proxyObject, new HashMap<RealmModel, RealmObjectProxy>(), Collections.EMPTY_SET);
                 }
             }
-            builder.addObjectList(columnInfo.childrenColKey, childrenManagedCopy);
         } else {
             builder.addObjectList(columnInfo.childrenColKey, new RealmList<some.test.EmbeddedClass>());
         }

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/EmbeddedObjectsTest.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/EmbeddedObjectsTest.kt
@@ -279,8 +279,18 @@ class EmbeddedObjectsTest {
         }
 
         assertEquals(1, realm.where<EmbeddedTreeParent>().count())
+        assertEquals("parent1", realm.where<EmbeddedTreeParent>().findFirst()!!.id)
+
         assertEquals(2, realm.where<EmbeddedTreeNode>().count())
+        val nodeResults = realm.where<EmbeddedTreeNode>().findAll()
+        assertTrue(nodeResults.any { it.id == "node1" })
+        assertTrue(nodeResults.any { it.id == "node2" })
+
         assertEquals(3, realm.where<EmbeddedTreeLeaf>().count())
+        val leafResults = realm.where<EmbeddedTreeLeaf>().findAll()
+        assertTrue(leafResults.any { it.id == "leaf1" })
+        assertTrue(leafResults.any { it.id == "leaf2" })
+        assertTrue(leafResults.any { it.id == "leaf3" })
     }
 
     @Test
@@ -379,8 +389,18 @@ class EmbeddedObjectsTest {
         }
 
         assertEquals(1, realm.where<EmbeddedTreeParent>().count())
+        assertEquals("parent1", realm.where<EmbeddedTreeParent>().findFirst()!!.id)
+
         assertEquals(2, realm.where<EmbeddedTreeNode>().count())
+        val nodeResults = realm.where<EmbeddedTreeNode>().findAll()
+        assertTrue(nodeResults.any { it.id == "node1" })
+        assertTrue(nodeResults.any { it.id == "node2" })
+
         assertEquals(3, realm.where<EmbeddedTreeLeaf>().count())
+        val leafResults = realm.where<EmbeddedTreeLeaf>().findAll()
+        assertTrue(leafResults.any { it.id == "leaf1" })
+        assertTrue(leafResults.any { it.id == "leaf2" })
+        assertTrue(leafResults.any { it.id == "leaf3" })
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a bug when using `copyToRealm` with objects that contains lists of embedded objects.

The bug manifested as all the elements in the list showing up as having no values.
What happened was that the values were correctly written and then wrongly overridden by the bug.