### PR TITLE
Re-enable JavaDoc generation

### DIFF
--- a/realm/build.gradle
+++ b/realm/build.gradle
@@ -45,3 +45,12 @@ allprojects {
         jcenter()
     }
 }
+
+// Disable JavaDoc strict mode: https://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:-missing', '-quiet')
+        }
+    }
+}

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -257,35 +257,36 @@ def betaTag = 'Beta:a:<div style="border-style:solid;border-width:2px">This soft
         'considered at production quality, and should be used with care.</div>'
 
 task javadoc(type: Javadoc) {
-// FIXME: Disable JavaDoc until API Stabilizes a bit more
-//    source android.sourceSets.objectServer.java.srcDirs
-//    source android.sourceSets.main.java.srcDirs
-//    source "../../realm-annotations/src/main/java"
-//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-//    options {
-//        title = "Realm ${project.version}"
-//        memberLevel = JavadocMemberLevel.PUBLIC
-//        docEncoding = 'UTF-8'
-//        encoding = 'UTF-8'
-//        charSet = 'UTF-8'
-//        locale = 'en_US'
-//        overview = 'src/overview.html'
-//
-//        links "https://docs.oracle.com/javase/7/docs/api/"
-//        links "http://reactivex.io/RxJava/javadoc/"
-//        linksOffline "https://developer.android.com/reference/", "${project.android.sdkDirectory}/docs/reference"
-//
-//        tags = [betaTag]
-//    }
-//    exclude '**/internal/**'
-//    exclude '**/BuildConfig.java'
-//    exclude '**/R.java'
-//    doLast {
-//        copy {
-//            from "src/realm-java-overview.png"
-//            into "$buildDir/docs/javadoc"
-//        }
-//    }
+    source android.sourceSets.objectServer.java.srcDirs
+    source android.sourceSets.main.java.srcDirs
+    source "../../realm-annotations/src/main/java"
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    options {
+        title = "Realm ${project.version}"
+        memberLevel = JavadocMemberLevel.PUBLIC
+        docEncoding = 'UTF-8'
+        encoding = 'UTF-8'
+        charSet = 'UTF-8'
+        locale = 'en_US'
+        overview = 'src/overview.html'
+
+        links "https://docs.oracle.com/javase/7/docs/api/"
+        links "http://reactivex.io/RxJava/javadoc/"
+        // TODO We probably need to add the bson.jar to the classpath for these to work
+        links "https://www.javadoc.io/doc/org.mongodb/bson/${properties.getProperty('BSON_DEPENDENCY_VERSION')}/"
+        linksOffline "https://developer.android.com/reference/", "${project.android.sdkDirectory}/docs/reference"
+
+        tags = [betaTag]
+    }
+    exclude '**/internal/**'
+    exclude '**/BuildConfig.java'
+    exclude '**/R.java'
+    doLast {
+        copy {
+            from "src/realm-java-overview.png"
+            into "$buildDir/docs/javadoc"
+        }
+    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -451,7 +451,7 @@ public class RealmResults<E> extends OrderedRealmCollectionImpl<E> {
      *
      * @param fieldName name of the field to update.
      * @param value new value for the field.
-     * @throws IllegalArgumentException if field name doesn't exist, is a primary key property or isn't a {@code ObjectId field.
+     * @throws IllegalArgumentException if field name doesn't exist, is a primary key property or isn't a {@code ObjectId} field.
      */
     public void setObjectId(String fieldName, @Nullable ObjectId value) {
         checkNonEmptyFieldName(fieldName);

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/App.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/App.java
@@ -71,7 +71,7 @@ import io.realm.mongodb.functions.Functions;
  *
  *         App APP;
  *
- *         @Override
+ *         \@Override
  *         public void onCreate() {
  *             super.onCreate();
  *
@@ -106,13 +106,13 @@ import io.realm.mongodb.functions.Functions;
  * With an authorized user you can synchronize data between the local device and the remote Realm
  * App by opening a Realm with a {@link io.realm.mongodb.sync.SyncConfiguration} as indicated below:
  * <pre>
- *     SyncConfiguration syncConfiguration = new SyncConfiguration.Builder(user, "<partition value>")
+ *     SyncConfiguration syncConfiguration = new SyncConfiguration.Builder(user, "&lt;partition value&gt;")
  *              .build();
  *
  *     Realm instance = Realm.getInstance(syncConfiguration);
  *     SyncSession session = APP.getSync().getSession(syncConfiguration);
  *
- *     instance.executeTransaction(realm -> {
+ *     instance.executeTransaction(realm -&gt; {
  *         realm.insert(...);
  *     });
  *     session.uploadAllLocalChanges();
@@ -129,7 +129,7 @@ import io.realm.mongodb.functions.Functions;
  * <pre>
  *     MongoClient client = user.getMongoClient(SERVICE_NAME)
  *     MongoDatabase database = client.getDatabase(DATABASE_NAME)
- *     MongoCollection<DocumentT> collection = database.getCollection(COLLECTION_NAME);
+ *     MongoCollection&lt;DocumentT&gt; collection = database.getCollection(COLLECTION_NAME);
  *     Long count = collection.count().blockingGetResult()
  * </pre>
  * <p>
@@ -599,7 +599,7 @@ public class App {
          * is thrown.
          *
          * @return the response object in case the request was a success.
-         * @throws ObjectServerError provided error in case the request failed.
+         * @throws AppException provided error in case the request failed.
          */
         public T getOrThrow() {
             if (isSuccess()) {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
@@ -35,9 +35,9 @@ import io.realm.mongodb.auth.EmailPasswordAuth;
  * // Example
  * App app = new App("app-id");
  * Credentials credentials = Credentials.emailPassword("email", "password");
- * User user = app.loginAsync(credentials, new App.Callback<User>() {
+ * User user = app.loginAsync(credentials, new App.Callback&lt;User&gt;() {
  *   \@Override
- *   public void onResult(Result<User> result) {
+ *   public void onResult(Result&lt;User&gt; result) {
  *     if (result.isSuccess() {
  *       handleLogin(result.get());
  *     } else {
@@ -45,6 +45,7 @@ import io.realm.mongodb.auth.EmailPasswordAuth;
  *     }
  *   }
  * ));
+ * }
  * }
  * </pre>
  * @see <a href="https://docs.mongodb.com/stitch/authentication/providers/">Authentication Providers</a>

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
@@ -44,7 +44,7 @@ import io.realm.mongodb.push.Push;
 /**
  * A <i>user</i> holds the user's meta data and tokens for accessing Realm App functionality.
  * <p>
- * The user is used to configure Synchronized Realms and gives access to calling Realm App <i>Functions</>
+ * The user is used to configure Synchronized Realms and gives access to calling Realm App <i>Functions</i>
  * through {@link Functions} and accessing remote Realm App <i>Mongo Databases</i> through a
  * {@link MongoClient}.
  *

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/functions/Functions.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/functions/Functions.java
@@ -32,7 +32,7 @@ import io.realm.mongodb.AppException;
 import io.realm.mongodb.User;
 
 /**
- * A <i>Functions<i> manager to call remote Realm functions for the associated Realm App.
+ * A <i>Functions</i> manager to call remote Realm functions for the associated Realm App.
  * <p>
  * Arguments and results are encoded/decoded with the <i>Functions'</i> codec registry either
  * inherited from the {@link AppConfiguration#getDefaultCodecRegistry()} or set explicitly

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/iterable/MongoCursor.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/iterable/MongoCursor.java
@@ -52,7 +52,7 @@ public class MongoCursor<ResultT> implements Iterator<ResultT>, Closeable {
     /**
      * A special {@code next()} case that returns the next document if available or null.
      *
-     * @return A {@link Task} containing the next document if available or null.
+     * @return A {@code Task} containing the next document if available or null.
      */
     public ResultT tryNext() {
         if (!iterator.hasNext()) {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/iterable/MongoIterable.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/mongo/iterable/MongoIterable.java
@@ -38,7 +38,7 @@ import io.realm.mongodb.AppException;
  * {@code aggregate()} query.
  * <p>
  * This class somewhat mimics the behavior of an {@link Iterable} but given its results are
- * obtained asynchronously, its values are wrapped inside a {@link Task}.
+ * obtained asynchronously, its values are wrapped inside a {@code Task}.
  *
  * @param <ResultT> The type to which this iterable will decode documents.
  */
@@ -65,7 +65,7 @@ public abstract class MongoIterable<ResultT> {
     /**
      * Returns a cursor of the operation represented by this iterable.
      * <p>
-     * The result is wrapped in a {@link Task} since the iterator should be capable of
+     * The result is wrapped in a {@code Task} since the iterator should be capable of
      * asynchronously retrieve documents from the server.
      *
      * @return an asynchronous task with cursor of the operation represented by this iterable.
@@ -83,7 +83,7 @@ public abstract class MongoIterable<ResultT> {
     /**
      * Helper to return the first item in the iterator or null.
      * <p>
-     * The result is wrapped in a {@link Task} since the iterator should be capable of
+     * The result is wrapped in a {@code Task} since the iterator should be capable of
      * asynchronously retrieve documents from the server.
      *
      * @return a task containing the first item or null.

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -43,12 +43,12 @@ import io.realm.mongodb.User;
  * <pre>
  *     App app = new App("app-id");
  *     User user = app.login(Credentials.anonymous());
- *     SyncConfiguration syncConfiguration = new SyncConfiguration.Builder(user, "<partition value>")
+ *     SyncConfiguration syncConfiguration = new SyncConfiguration.Builder(user, "&lt;partition value&gt;")
  *              .build();
  *     Realm instance = Realm.getInstance(syncConfiguration);
  *     SyncSession session = app.getSync().getSession(syncConfiguration);
  *
- *     instance.executeTransaction(realm -> {
+ *     instance.executeTransaction(realm -&gt; {
  *         realm.insert(...);
  *     });
  *     session.uploadAllLocalChanges();


### PR DESCRIPTION
* Enables JavaDoc again
* Fixes a number of formatting errors in the JavaDoc
*  Note. I'm disabling strict mode because I saw a lot of errors like this:
```
/Users/cm/Realm/realm-java/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/ApiKeyAuth.java:112: error: reference not found
     * The key is enabled when created. It can be disabled by calling {@link #disableApiKey(ObjectId)}.
```

Even though the generated output created the correct link and you could jump to the class inside Android Studio.

This PR doesn't fix an issue with us linking to 3rd party API's like BSON

![image](https://user-images.githubusercontent.com/406066/84011004-c20b2700-a975-11ea-93de-588259814183.png)

I'll create an issue tracking this.