### PR TITLE
Avoid crash if looking up NetworkTransport response class from C++ thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The old Realm Cloud legacy API's have undergone significant refactoring. The new
 * None
 
 ### Fixed
-* [RealmApp] When opening asynced Realm with a cached user, and the user access token had expired. It would crash the app with `Assertion failed: cls with (class_name) = ["io/realm/internal/objectstore/OsJavaNetworkTransport$Response"]`. (Issue [#6937](https://github.com/realm/realm-java/issues/6937), since 10.0.0-BETA.1)
+* [RealmApp] Opening a synced Realm for a cached user with expired access token would crash the app with `Assertion failed: cls with (class_name) = ["io/realm/internal/objectstore/OsJavaNetworkTransport$Response"]`. (Issue [#6937](https://github.com/realm/realm-java/issues/6937), since 10.0.0-BETA.1)
 
 ### Compatibility
 * File format: Generates Realms with format v11 (Reads and upgrades all previous formats from Realm Java 2.0 and later).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 10.0.0-BETA.4 (YYYY-MM-DD)
+
+We no longer support Realm Cloud (legacy), but instead the new MongoDB Realm Cloud. MongoDB Realm is a serverless platform that enables developers to quickly build applications without having to set up server infrastructure. MongoDB Realm is built on top of MongoDB Atlas, automatically integrating the connection to your database.
+
+The old Realm Cloud legacy API's have undergone significant refactoring. The new API's are all located in the `io.realm.mongodb` package with `io.realm.mongodb.App` as the entry point.
+
+### Breaking Changes 
+* None
+
+### Enhancements
+* None
+
+### Fixed
+* [RealmApp] When opening asynced Realm with a cached user, and the user access token had expired. It would crash the app with `Assertion failed: cls with (class_name) = ["io/realm/internal/objectstore/OsJavaNetworkTransport$Response"]`. (Issue [#6937](https://github.com/realm/realm-java/issues/6937), since 10.0.0-BETA.1)
+
+### Compatibility
+* File format: Generates Realms with format v11 (Reads and upgrades all previous formats from Realm Java 2.0 and later).
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 and above is required to open Realms created by this version.
+
+### Internal
+* None.
+
+
 ## 10.0.0-BETA.3 (2020-06-09)
 
 We no longer support Realm Cloud (legacy), but instead the new MongoDB Realm Cloud. MongoDB Realm is a serverless platform that enables developers to quickly build applications without having to set up server infrastructure. MongoDB Realm is built on top of MongoDB Atlas, automatically integrating the connection to your database.

--- a/realm/realm-library/src/main/cpp/java_class_global_def.hpp
+++ b/realm/realm-library/src/main/cpp/java_class_global_def.hpp
@@ -55,6 +55,9 @@ private:
         , m_realm_notifier(env, "io/realm/internal/RealmNotifier", false)
         , m_bson_decimal128(env, "org/bson/types/Decimal128", false)
         , m_bson_object_id(env, "org/bson/types/ObjectId", false)
+#if REALM_ENABLE_SYNC
+        , m_network_transport_response(env, "io/realm/internal/objectstore/OsJavaNetworkTransport$Response", false)
+#endif
     {
     }
 
@@ -70,6 +73,10 @@ private:
     jni_util::JavaClass m_realm_notifier;
     jni_util::JavaClass m_bson_decimal128;
     jni_util::JavaClass m_bson_object_id;
+
+#if REALM_ENABLE_SYNC
+    jni_util::JavaClass m_network_transport_response;
+#endif
 
     inline static std::unique_ptr<JavaClassGlobalDef>& instance()
     {
@@ -181,6 +188,13 @@ public:
     {
         return instance()->m_java_lang_object;
     }
+
+#if REALM_ENABLE_SYNC
+    inline static const jni_util::JavaClass& network_transport_response_class()
+    {
+        return instance()->m_network_transport_response;
+    }
+#endif
 };
 
 } // namespace realm

--- a/realm/realm-library/src/main/cpp/java_network_transport.hpp
+++ b/realm/realm-library/src/main/cpp/java_network_transport.hpp
@@ -84,11 +84,10 @@ struct JavaNetworkTransport : public app::GenericNetworkTransport {
             return;
         } else {
             // Read response
-            static JavaClass responseClass(env, "io/realm/internal/objectstore/OsJavaNetworkTransport$Response");
-            static JavaMethod get_http_code_method(env, responseClass, "getHttpResponseCode", "()I");
-            static JavaMethod get_custom_code_method(env, responseClass, "getCustomResponseCode", "()I");
-            static JavaMethod get_headers_method(env, responseClass, "getJNIFriendlyHeaders", "()[Ljava/lang/String;");
-            static JavaMethod get_body_method(env, responseClass, "getBody", "()Ljava/lang/String;");
+            static JavaMethod get_http_code_method(env, JavaClassGlobalDef::network_transport_response_class(), "getHttpResponseCode", "()I");
+            static JavaMethod get_custom_code_method(env, JavaClassGlobalDef::network_transport_response_class(), "getCustomResponseCode", "()I");
+            static JavaMethod get_headers_method(env, JavaClassGlobalDef::network_transport_response_class(), "getJNIFriendlyHeaders", "()[Ljava/lang/String;");
+            static JavaMethod get_body_method(env, JavaClassGlobalDef::network_transport_response_class(), "getBody", "()Ljava/lang/String;");
 
             jint http_code = env->CallIntMethod(response, get_http_code_method);
             jint custom_code = env->CallIntMethod(response, get_custom_code_method);

--- a/realm/realm-library/src/main/cpp/java_network_transport.hpp
+++ b/realm/realm-library/src/main/cpp/java_network_transport.hpp
@@ -84,10 +84,11 @@ struct JavaNetworkTransport : public app::GenericNetworkTransport {
             return;
         } else {
             // Read response
-            static JavaMethod get_http_code_method(env, JavaClassGlobalDef::network_transport_response_class(), "getHttpResponseCode", "()I");
-            static JavaMethod get_custom_code_method(env, JavaClassGlobalDef::network_transport_response_class(), "getCustomResponseCode", "()I");
-            static JavaMethod get_headers_method(env, JavaClassGlobalDef::network_transport_response_class(), "getJNIFriendlyHeaders", "()[Ljava/lang/String;");
-            static JavaMethod get_body_method(env, JavaClassGlobalDef::network_transport_response_class(), "getBody", "()Ljava/lang/String;");
+            static const JavaClass& response_class(JavaClassGlobalDef::network_transport_response_class());
+            static JavaMethod get_http_code_method(env, response_class, "getHttpResponseCode", "()I");
+            static JavaMethod get_custom_code_method(env, response_class, "getCustomResponseCode", "()I");
+            static JavaMethod get_headers_method(env, response_class, "getJNIFriendlyHeaders", "()[Ljava/lang/String;");
+            static JavaMethod get_body_method(env, response_class, "getBody", "()Ljava/lang/String;");
 
             jint http_code = env->CallIntMethod(response, get_http_code_method);
             jint custom_code = env->CallIntMethod(response, get_custom_code_method);


### PR DESCRIPTION
Fixes #6937 

The underlying problem is that if the first network request comes from the Sync Client C++ thread, it will attempt to load the JavaClass into the static variable. But the Sync thread is started from C++ and doesn't have access to the Java class loader (see https://developer.android.com/training/articles/perf-jni#native-libraries), so it will crash with class-not-found.

If any Java call managed to get here first, this would not crash and all subsequent calls would succeed.

The fixes move the class lookup to JNI_Onload and stores it in our `JavaClassGlobalDef` wrapper which is guaranteed to be called from Java.

Unfortunately, it isn't possible to create a unit test for this as the static variable is preserved across all unit tests, but the fix has been verified manually by:

1) Create a new app
2) Log a user in and open a synced Realm
3) Let the user access token expire (30 minutes)
4) Kill the app and restart it. 
5) If the app uses `App.currentUser()` to directly open the synced Realm, the first network request will be from the Sync thread trying to refresh the token. Previously this crashed. With this fix, it doesn't.

 