### PR TITLE
Add server API key and custom function credentials for user authentication

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
@@ -43,7 +43,6 @@ class CredentialsTests {
         @JvmStatic
         fun setUp() {
             Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
-            RealmLog.setLevel(LogLevel.DEBUG)
         }
     }
 
@@ -58,21 +57,21 @@ class CredentialsTests {
     @Test
     fun anonymous() {
         val creds = Credentials.anonymous()
-        assertEquals(Credentials.IdentityProvider.ANONYMOUS.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.ANONYMOUS, creds.identityProvider)
         assertTrue(creds.asJson().contains("anon-user")) // Treat the JSON as an opaque value.
     }
 
     @Test
     fun apiKey() {
         val creds = Credentials.apiKey("token")
-        assertEquals(Credentials.IdentityProvider.SERVER_API_KEY.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.API_KEY, creds.identityProvider)
         assertTrue(creds.asJson().contains("token")) // Treat the JSON as an opaque value.
     }
 
     @Test
     fun serverApiKey() {
         val creds = Credentials.serverApiKey("token")
-        assertEquals(Credentials.IdentityProvider.API_KEY.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.SERVER_API_KEY, creds.identityProvider)
         assertTrue(creds.asJson().contains("token")) // Treat the JSON as an opaque value.
     }
 
@@ -91,7 +90,7 @@ class CredentialsTests {
     @Test
     fun apple() {
         val creds = Credentials.apple("apple-token")
-        assertEquals(Credentials.IdentityProvider.APPLE.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.APPLE, creds.identityProvider)
         assertTrue(creds.asJson().contains("apple-token")) // Treat the JSON as a largely opaque value.
     }
 
@@ -109,7 +108,7 @@ class CredentialsTests {
                 "mail" to "myfakemail@mongodb.com",
                 "id" to 666
         ).let { Credentials.customFunction(Document(it)) }
-        assertEquals(Credentials.IdentityProvider.CUSTOM_FUNCTION.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.CUSTOM_FUNCTION, creds.identityProvider)
         assertTrue(creds.asJson().contains(mail))
         assertTrue(creds.asJson().contains(id.toString()))
     }
@@ -122,7 +121,7 @@ class CredentialsTests {
     @Test
     fun emailPassword() {
         val creds = Credentials.emailPassword("foo@bar.com", "secret")
-        assertEquals(Credentials.IdentityProvider.EMAIL_PASSWORD.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.EMAIL_PASSWORD, creds.identityProvider)
         // Treat the JSON as a largely opaque value.
         assertTrue(creds.asJson().contains("foo@bar.com"))
         assertTrue(creds.asJson().contains("secret"))
@@ -139,7 +138,7 @@ class CredentialsTests {
     @Test
     fun facebook() {
         val creds = Credentials.facebook("fb-token")
-        assertEquals(Credentials.IdentityProvider.FACEBOOK.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.FACEBOOK, creds.identityProvider)
         assertTrue(creds.asJson().contains("fb-token"))
     }
 
@@ -152,7 +151,7 @@ class CredentialsTests {
     @Test
     fun google() {
         val creds = Credentials.google("google-token")
-        assertEquals(Credentials.IdentityProvider.GOOGLE.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.GOOGLE, creds.identityProvider)
         assertTrue(creds.asJson().contains("google-token"))
     }
 
@@ -166,7 +165,7 @@ class CredentialsTests {
     @Test
     fun jwt() {
         val creds = Credentials.google("jwt-token")
-        assertEquals(Credentials.IdentityProvider.JWT.id, creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.JWT, creds.identityProvider)
         assertTrue(creds.asJson().contains("jwt-token"))
     }
 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
@@ -15,9 +15,14 @@
  */
 package io.realm
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.realm.admin.ServerAdmin
+import io.realm.log.LogLevel
+import io.realm.log.RealmLog
 import io.realm.mongodb.*
+import io.realm.mongodb.auth.UserApiKey
+import org.bson.Document
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.BeforeClass
@@ -30,13 +35,15 @@ import kotlin.test.assertFailsWith
 class CredentialsTests {
 
     private lateinit var app: App
-
+    private lateinit var admin: ServerAdmin
 
     companion object {
+
         @BeforeClass
         @JvmStatic
         fun setUp() {
             Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
+            RealmLog.setLevel(LogLevel.DEBUG)
         }
     }
 
@@ -51,15 +58,21 @@ class CredentialsTests {
     @Test
     fun anonymous() {
         val creds = Credentials.anonymous()
-        assertEquals("anon-user", creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.ANONYMOUS.id, creds.identityProvider.id)
         assertTrue(creds.asJson().contains("anon-user")) // Treat the JSON as an opaque value.
     }
 
-    @Ignore("FIXME: Awaiting ObjectStore support")
     @Test
     fun apiKey() {
         val creds = Credentials.apiKey("token")
-        assertEquals("anon-user", creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.SERVER_API_KEY.id, creds.identityProvider.id)
+        assertTrue(creds.asJson().contains("token")) // Treat the JSON as an opaque value.
+    }
+
+    @Test
+    fun serverApiKey() {
+        val creds = Credentials.serverApiKey("token")
+        assertEquals(Credentials.IdentityProvider.API_KEY.id, creds.identityProvider.id)
         assertTrue(creds.asJson().contains("token")) // Treat the JSON as an opaque value.
     }
 
@@ -70,9 +83,15 @@ class CredentialsTests {
     }
 
     @Test
+    fun serverApiKey_invalidInput() {
+        assertFailsWith<IllegalArgumentException> { Credentials.serverApiKey("") }
+        assertFailsWith<IllegalArgumentException> { Credentials.serverApiKey(TestHelper.getNull()) }
+    }
+
+    @Test
     fun apple() {
         val creds = Credentials.apple("apple-token")
-        assertEquals("oauth2-apple", creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.APPLE.id, creds.identityProvider.id)
         assertTrue(creds.asJson().contains("apple-token")) // Treat the JSON as a largely opaque value.
     }
 
@@ -82,22 +101,28 @@ class CredentialsTests {
         assertFailsWith<IllegalArgumentException> { Credentials.apple(TestHelper.getNull()) }
     }
 
-    @Ignore("FIXME: Awaiting ObjectStore support")
     @Test
     fun customFunction() {
-        TODO()
+        val mail = "myfakemail@mongodb.com"
+        val id = 666
+        val creds = mapOf(
+                "mail" to "myfakemail@mongodb.com",
+                "id" to 666
+        ).let { Credentials.customFunction(Document(it)) }
+        assertEquals(Credentials.IdentityProvider.CUSTOM_FUNCTION.id, creds.identityProvider.id)
+        assertTrue(creds.asJson().contains(mail))
+        assertTrue(creds.asJson().contains(id.toString()))
     }
 
-    @Ignore("FIXME: Awaiting ObjectStore support")
     @Test
     fun customFunction_invalidInput() {
-        TODO()
+        assertFailsWith<IllegalArgumentException> { Credentials.customFunction(null) }
     }
 
     @Test
     fun emailPassword() {
         val creds = Credentials.emailPassword("foo@bar.com", "secret")
-        assertEquals("local-userpass", creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.EMAIL_PASSWORD.id, creds.identityProvider.id)
         // Treat the JSON as a largely opaque value.
         assertTrue(creds.asJson().contains("foo@bar.com"))
         assertTrue(creds.asJson().contains("secret"))
@@ -114,7 +139,7 @@ class CredentialsTests {
     @Test
     fun facebook() {
         val creds = Credentials.facebook("fb-token")
-        assertEquals("oauth2-facebook", creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.FACEBOOK.id, creds.identityProvider.id)
         assertTrue(creds.asJson().contains("fb-token"))
     }
 
@@ -127,7 +152,7 @@ class CredentialsTests {
     @Test
     fun google() {
         val creds = Credentials.google("google-token")
-        assertEquals("oauth2-google", creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.GOOGLE.id, creds.identityProvider.id)
         assertTrue(creds.asJson().contains("google-token"))
     }
 
@@ -141,7 +166,7 @@ class CredentialsTests {
     @Test
     fun jwt() {
         val creds = Credentials.google("jwt-token")
-        assertEquals("jwt", creds.identityProvider.id)
+        assertEquals(Credentials.IdentityProvider.JWT.id, creds.identityProvider.id)
         assertTrue(creds.asJson().contains("jwt-token"))
     }
 
@@ -151,33 +176,43 @@ class CredentialsTests {
         assertFailsWith<IllegalArgumentException> { Credentials.jwt(TestHelper.getNull()) }
     }
 
-    fun expectErrorCode(app: App, expectedCode: ErrorCode, credentials: Credentials) {
-        try {
-            app.login(credentials)
-            fail()
-        } catch (error: AppException) {
-            assertEquals(expectedCode, error.errorCode)
-        }
-    }
-
     @Test
     fun loginUsingCredentials() {
         app = TestApp()
+        admin = ServerAdmin()
+
         Credentials.IdentityProvider.values().forEach { provider ->
-            when(provider) {
+            when (provider) {
                 Credentials.IdentityProvider.ANONYMOUS -> {
                     val user = app.login(Credentials.anonymous())
                     assertNotNull(user)
                 }
                 Credentials.IdentityProvider.API_KEY -> {
-                    // FIXME: Wait for API Key support in OS
-//                        val user: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
-//                        val key: UserApiKey = app.apiKeyAuthProvider.createApiKey("my-key");
-//                        val apiKeyUser = app.login(Credentials.apiKey(key.value!!))
-//                        assertNotNull(apiKeyUser)
+                    // Log in, create an API key, log out, log in with the key, compare users
+                    val user: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
+                    val key: UserApiKey = user.apiKeyAuth.createApiKey("my-key");
+                    user.logOut()
+                    val apiKeyUser = app.login(Credentials.apiKey(key.value!!))
+                    assertEquals(user, apiKeyUser)
+                }
+                Credentials.IdentityProvider.SERVER_API_KEY -> {
+                    // Create key using the admin API and then log in
+                    val serverKey = admin.createServerApiKey()
+                    val serverKeyUser = app.login(Credentials.serverApiKey(serverKey))
+                    assertNotNull(serverKeyUser)
                 }
                 Credentials.IdentityProvider.CUSTOM_FUNCTION -> {
-                    // FIXME Wait for Custom Function support
+                    val customFunction = mapOf(
+                            "mail" to "myfakemail@mongodb.com",
+                            "id" to 666
+                    ).let {
+                        Credentials.customFunction(Document(it))
+                    }
+
+                    // We are not testing the authentication function itself, but rather that the
+                    // credentials work
+                    val functionUser = app.login(customFunction)
+                    assertNotNull(functionUser)
                 }
                 Credentials.IdentityProvider.EMAIL_PASSWORD -> {
                     val email = TestHelper.getRandomEmail()
@@ -200,13 +235,22 @@ class CredentialsTests {
                 Credentials.IdentityProvider.GOOGLE -> {
                     expectErrorCode(app, ErrorCode.INVALID_SESSION, Credentials.google("google-token"))
                 }
-                Credentials.IdentityProvider.JWT ->  {
+                Credentials.IdentityProvider.JWT -> {
                     expectErrorCode(app, ErrorCode.INVALID_SESSION, Credentials.jwt("jwt-token"))
                 }
                 Credentials.IdentityProvider.UNKNOWN -> {
                     // Ignore
                 }
             }
+        }
+    }
+
+    private fun expectErrorCode(app: App, expectedCode: ErrorCode, credentials: Credentials) {
+        try {
+            app.login(credentials)
+            fail()
+        } catch (error: AppException) {
+            assertEquals(expectedCode, error.errorCode)
         }
     }
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
@@ -164,7 +164,7 @@ class CredentialsTests {
     @Ignore("FIXME: Awaiting ObjectStore support")
     @Test
     fun jwt() {
-        val creds = Credentials.google("jwt-token")
+        val creds = Credentials.jwt("jwt-token")
         assertEquals(Credentials.IdentityProvider.JWT, creds.identityProvider)
         assertTrue(creds.asJson().contains("jwt-token"))
     }
@@ -192,7 +192,7 @@ class CredentialsTests {
                     val key: UserApiKey = user.apiKeyAuth.createApiKey("my-key");
                     user.logOut()
                     val apiKeyUser = app.login(Credentials.apiKey(key.value!!))
-                    assertEquals(user, apiKeyUser)
+                    assertEquals(user.id, apiKeyUser.id)
                 }
                 Credentials.IdentityProvider.SERVER_API_KEY -> {
                     // Create key using the admin API and then log in

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/CredentialsTests.kt
@@ -18,8 +18,6 @@ package io.realm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.admin.ServerAdmin
-import io.realm.log.LogLevel
-import io.realm.log.RealmLog
 import io.realm.mongodb.*
 import io.realm.mongodb.auth.UserApiKey
 import org.bson.Document

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/admin/ServerAdmin.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/admin/ServerAdmin.kt
@@ -188,4 +188,16 @@ class ServerAdmin {
         }
         return providerId!!
     }
+
+    /**
+     * Creates an admin API key that can be used for testing purposes.
+     */
+    fun createServerApiKey(): String {
+        val body = mapOf(Pair("name", "SERVER_KEY"))
+        val builder = Request.Builder()
+                .url("$baseUrl/groups/$groupId/apps/$appId/api_keys")
+                .post(RequestBody.create(json, JSONObject(body).toString()))
+        val result = JSONObject(executeRequest(builder))
+        return result.getString("key")
+    }
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/push/PushTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/push/PushTest.kt
@@ -115,20 +115,20 @@ class PushTest {
 
     @Test
     fun deregisterDevice() {
-        user.getPush(SERVICE_NAME).deregisterDevice(SAMPLE_TOKEN)
+        user.getPush(SERVICE_NAME).deregisterDevice()
     }
 
     @Test
     fun deregisterDevice_twice() {
         // the API allows registering/deregistering twice, just checking we don't get errors
-        user.getPush(SERVICE_NAME).deregisterDevice(SAMPLE_TOKEN)
-        user.getPush(SERVICE_NAME).deregisterDevice(SAMPLE_TOKEN)
+        user.getPush(SERVICE_NAME).deregisterDevice()
+        user.getPush(SERVICE_NAME).deregisterDevice()
     }
 
     @Test
     fun deregisterDevice_throwsBecauseOfUnknownService() {
         assertFailsWithErrorCode(ErrorCode.SERVICE_NOT_FOUND) {
-            user.getPush("asdf").deregisterDevice(SAMPLE_TOKEN)
+            user.getPush("asdf").deregisterDevice()
         }
     }
 
@@ -136,14 +136,14 @@ class PushTest {
     fun deregisterDevice_throwsBecauseOfLoggedOutUser() {
         user.logOut()
         assertFailsWithErrorCode(ErrorCode.SERVICE_UNKNOWN) {
-            user.getPush(SERVICE_NAME).deregisterDevice(SAMPLE_TOKEN)
+            user.getPush(SERVICE_NAME).deregisterDevice()
         }
     }
 
     @Test
     fun deregisterDeviceAsync() {
         looperThread.runBlocking {
-            user.getPush(SERVICE_NAME).deregisterDeviceAsync(SAMPLE_TOKEN) {
+            user.getPush(SERVICE_NAME).deregisterDeviceAsync() {
                 looperThread.testComplete()
             }
         }
@@ -152,14 +152,14 @@ class PushTest {
     @Test
     fun deregisterDeviceAsync_throwsBecauseOfWrongThread() {
         assertFailsWith(IllegalStateException::class) {
-            user.getPush(SERVICE_NAME).deregisterDeviceAsync(SAMPLE_TOKEN) { /* do nothing */ }
+            user.getPush(SERVICE_NAME).deregisterDeviceAsync() { /* do nothing */ }
         }
     }
 
     @Test
     fun deregisterDeviceAsync_throwsBecauseOfUnknownService() {
         looperThread.runBlocking {
-            user.getPush("asdf").deregisterDeviceAsync(SAMPLE_TOKEN) {
+            user.getPush("asdf").deregisterDeviceAsync() {
                 assertEquals(ErrorCode.SERVICE_NOT_FOUND, it.error.errorCode)
                 looperThread.testComplete()
             }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsPush.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsPush.cpp
@@ -84,17 +84,14 @@ Java_io_realm_internal_objectstore_OsPush_nativeDeregisterDevice(JNIEnv *env,
                                                                jlong j_push_client_ptr,
                                                                jlong j_user_ptr,
                                                                jstring j_service_name,
-                                                               jstring j_registration_token,
                                                                jobject j_callback) {
     try {
         auto push_client = reinterpret_cast<PushClient*>(j_push_client_ptr);
         auto user = *reinterpret_cast<std::shared_ptr<SyncUser>*>(j_user_ptr);
 
         JStringAccessor service_name(env, j_service_name);
-        JStringAccessor registration_token(env, j_registration_token);
 
-        push_client->deregister_device(registration_token,
-                                       user,
+        push_client->deregister_device(user,
                                        JavaNetworkTransport::create_void_callback(env, j_callback));
     }
     CATCH_STD()

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsAppCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsAppCredentials.java
@@ -15,7 +15,11 @@
  */
 package io.realm.internal.objectstore;
 
+import org.bson.Document;
+
 import io.realm.internal.NativeObject;
+import io.realm.internal.jni.JniBsonProtocol;
+import io.realm.mongodb.AppConfiguration;
 
 /**
  * Class wrapping ObjectStores {@code realm::app::AppCredentials}.
@@ -24,28 +28,34 @@ public class OsAppCredentials implements NativeObject {
 
     private static final int TYPE_ANONYMOUS = 1;
     private static final int TYPE_API_KEY = 2;
-    private static final int TYPE_APPLE = 3;
-    private static final int TYPE_CUSTOM_FUNCTION = 4;
-    private static final int TYPE_EMAIL_PASSWORD = 5;
-    private static final int TYPE_FACEBOOK = 6;
-    private static final int TYPE_GOOGLE = 7;
-    private static final int TYPE_JWT = 8;
+    private static final int TYPE_SERVER_API_KEY = 3;
+    private static final int TYPE_APPLE = 4;
+    private static final int TYPE_CUSTOM_FUNCTION = 5;
+    private static final int TYPE_EMAIL_PASSWORD = 6;
+    private static final int TYPE_FACEBOOK = 7;
+    private static final int TYPE_GOOGLE = 8;
+    private static final int TYPE_JWT = 9;
     private static final long finalizerPtr = nativeGetFinalizerMethodPtr();
 
     public static OsAppCredentials anonymous() {
         return new OsAppCredentials(nativeCreate(TYPE_ANONYMOUS));
     }
 
-    public static OsAppCredentials apiKey(String key) {
+    public static OsAppCredentials userApiKey(String key) {
         return new OsAppCredentials(nativeCreate(TYPE_API_KEY, key));
+    }
+
+    public static OsAppCredentials serverApiKey(String key) {
+        return new OsAppCredentials(nativeCreate(TYPE_SERVER_API_KEY, key));
     }
 
     public static OsAppCredentials apple(String idToken) {
         return new OsAppCredentials(nativeCreate(TYPE_APPLE, idToken));
     }
 
-    public static OsAppCredentials customFunction(String functionName, Object... args) {
-        return new OsAppCredentials(nativeCreate(TYPE_CUSTOM_FUNCTION, functionName, args));
+    public static OsAppCredentials customFunction(Document args) {
+        String encodedArgs = JniBsonProtocol.encode(args, AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY);
+        return new OsAppCredentials(nativeCreate(TYPE_CUSTOM_FUNCTION, encodedArgs));
     }
 
     public static OsAppCredentials emailPassword(String email, String password) {

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsAppCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsAppCredentials.java
@@ -40,60 +40,50 @@ public class OsAppCredentials implements NativeObject {
     private static final long finalizerPtr = nativeGetFinalizerMethodPtr();
 
     public static OsAppCredentials anonymous() {
-        return new OsAppCredentials(nativeCreate(TYPE_ANONYMOUS), Credentials.IdentityProvider.ANONYMOUS);
+        return new OsAppCredentials(nativeCreate(TYPE_ANONYMOUS));
     }
 
     public static OsAppCredentials apiKey(String key) {
-        return new OsAppCredentials(nativeCreate(TYPE_API_KEY, key), Credentials.IdentityProvider.API_KEY);
+        return new OsAppCredentials(nativeCreate(TYPE_API_KEY, key));
     }
 
     public static OsAppCredentials serverApiKey(String key) {
-        return new OsAppCredentials(nativeCreate(TYPE_SERVER_API_KEY, key), Credentials.IdentityProvider.SERVER_API_KEY);
+        return new OsAppCredentials(nativeCreate(TYPE_SERVER_API_KEY, key));
     }
 
     public static OsAppCredentials apple(String idToken) {
-        return new OsAppCredentials(nativeCreate(TYPE_APPLE, idToken), Credentials.IdentityProvider.APPLE);
+        return new OsAppCredentials(nativeCreate(TYPE_APPLE, idToken));
     }
 
     public static OsAppCredentials customFunction(Document args) {
         String encodedArgs = JniBsonProtocol.encode(args, AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY);
-        return new OsAppCredentials(nativeCreate(TYPE_CUSTOM_FUNCTION, encodedArgs), Credentials.IdentityProvider.CUSTOM_FUNCTION);
+        return new OsAppCredentials(nativeCreate(TYPE_CUSTOM_FUNCTION, encodedArgs));
     }
 
     public static OsAppCredentials emailPassword(String email, String password) {
-        return new OsAppCredentials(nativeCreate(TYPE_EMAIL_PASSWORD, email, password), Credentials.IdentityProvider.EMAIL_PASSWORD);
+        return new OsAppCredentials(nativeCreate(TYPE_EMAIL_PASSWORD, email, password));
     }
 
     public static OsAppCredentials facebook(String accessToken) {
-        return new OsAppCredentials(nativeCreate(TYPE_FACEBOOK, accessToken), Credentials.IdentityProvider.FACEBOOK);
+        return new OsAppCredentials(nativeCreate(TYPE_FACEBOOK, accessToken));
     }
 
     public static OsAppCredentials google(String whatToCallThisToken) {
-        return new OsAppCredentials(nativeCreate(TYPE_GOOGLE, whatToCallThisToken), Credentials.IdentityProvider.GOOGLE);
+        return new OsAppCredentials(nativeCreate(TYPE_GOOGLE, whatToCallThisToken));
     }
 
     public static OsAppCredentials jwt(String jwtToken) {
-        return new OsAppCredentials(nativeCreate(TYPE_JWT, jwtToken), Credentials.IdentityProvider.JWT);
+        return new OsAppCredentials(nativeCreate(TYPE_JWT, jwtToken));
     }
 
     private final long nativePtr;
-    private final Credentials.IdentityProvider identityProvider;
 
-    private OsAppCredentials(long nativePtr, Credentials.IdentityProvider identityProvider) {
+    private OsAppCredentials(long nativePtr) {
         this.nativePtr = nativePtr;
-        this.identityProvider = identityProvider;
     }
 
-    public Credentials.IdentityProvider getProvider() {
-        String nativeProvider = nativeGetProvider(nativePtr);
-        String id = identityProvider.getId();
-
-        // Sanity check - ensure nothing changed in the OS
-        if (nativeProvider.equals(id)) {
-            return identityProvider;
-        } else {
-            throw new AssertionError("The provider from the Object Store differs from the one in Realm.");
-        }
+    public String getProvider() {
+        return nativeGetProvider(nativePtr);
     }
 
     public String asJson() {

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsPush.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsPush.java
@@ -54,14 +54,14 @@ public class OsPush implements NativeObject {
         ResultHandler.handleResult(null, error);
     }
 
-    public void deregisterDevice(String registrationToken) {
+    public void deregisterDevice() {
         AtomicReference<AppException> error = new AtomicReference<>(null);
-        nativeDeregisterDevice(nativePtr, osSyncUser.getNativePtr(), serviceName, registrationToken, new OsJNIVoidResultCallback(error));
+        nativeDeregisterDevice(nativePtr, osSyncUser.getNativePtr(), serviceName, new OsJNIVoidResultCallback(error));
         ResultHandler.handleResult(null, error);
     }
 
     private static native long nativeCreate(long nativeAppPtr, String serviceName);
     private static native long nativeGetFinalizerMethodPtr();
     private static native void nativeRegisterDevice(long nativePtr, long nativeUserPtr, String serviceName, String registrationToken, OsJNIVoidResultCallback callback);
-    private static native void nativeDeregisterDevice(long nativePtr, long nativeUserPtr, String serviceName, String registrationToken, OsJNIVoidResultCallback callback);
+    private static native void nativeDeregisterDevice(long nativePtr, long nativeUserPtr, String serviceName, OsJNIVoidResultCallback callback);
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
@@ -16,6 +16,8 @@
 
 package io.realm.mongodb;
 
+import org.bson.Document;
+
 import io.realm.annotations.Beta;
 import io.realm.internal.Util;
 import io.realm.internal.objectstore.OsAppCredentials;
@@ -48,6 +50,7 @@ import io.realm.mongodb.auth.EmailPasswordAuth;
  * }
  * }
  * </pre>
+ *
  * @see <a href="https://docs.mongodb.com/stitch/authentication/providers/">Authentication Providers</a>
  */
 @Beta
@@ -71,7 +74,7 @@ public class Credentials {
     }
 
     /**
-     * Creates credentials representing a login using an API key.
+     * Creates credentials representing a login using a user API key.
      * <p>
      * This provider must be enabled on MongoDB Realm to work.
      *
@@ -80,8 +83,22 @@ public class Credentials {
      * {@link App#loginAsync(Credentials, App.Callback)}.
      */
     public static Credentials apiKey(String key) {
-        Util.checkEmpty(key, "id");
-        return new Credentials(OsAppCredentials.apiKey(key));
+        Util.checkEmpty(key, "key");
+        return new Credentials(OsAppCredentials.userApiKey(key));
+    }
+
+    /**
+     * Creates credentials representing a login using a server API key.
+     * <p>
+     * This provider must be enabled on MongoDB Realm to work.
+     *
+     * @param key the API key to use for login.
+     * @return a set of credentials that can be used to log into MongoDB Realm using
+     * {@link App#loginAsync(Credentials, App.Callback)}.
+     */
+    public static Credentials serverApiKey(String key) {
+        Util.checkEmpty(key, "key");
+        return new Credentials(OsAppCredentials.serverApiKey(key));
     }
 
     /**
@@ -99,23 +116,25 @@ public class Credentials {
     }
 
     /**
-     * FIXME
+     * Creates credentials representing a remote function previously added to MongoDB Realm. The
+     * input parameters
      * <p>
      * This provider must be enabled on MongoDB Realm to work.
      *
+     * @param arguments {@link Document} containing the values passed to the remote function. The
+     *                  keys must match the names given to the remote function parameters.
      * @return a set of credentials that can be used to log into MongoDB Realm using
      * {@link App#loginAsync(Credentials, App.Callback)}.
      */
-    public static Credentials customFunction(String functionName, Object... arguments) {
-        // FIXME: How to check arguments?
-        Util.checkEmpty(functionName, "functionName");
-        return new Credentials(OsAppCredentials.customFunction(functionName, arguments));
+    public static Credentials customFunction(Document arguments) {
+        Util.checkNull(arguments, "arguments");
+        return new Credentials(OsAppCredentials.customFunction(arguments));
     }
 
     /**
      * Creates credentials representing a login using email and password.
      *
-     * @param email email of the user logging in.
+     * @param email    email of the user logging in.
      * @param password password of the user logging in.
      * @return a set of credentials that can be used to log into MongoDB Realm using
      * {@link App#loginAsync(Credentials, App.Callback)}.
@@ -127,7 +146,7 @@ public class Credentials {
     }
 
     /**
-     * Creates credentials representing a login using an Facebook access token.
+     * Creates credentials representing a login using a Facebook access token.
      * <p>
      * This provider must be enabled on MongoDB Realm to work.
      *
@@ -141,7 +160,7 @@ public class Credentials {
     }
 
     /**
-     * Creates credentials representing a login using an Google access token.
+     * Creates credentials representing a login using a Google access token.
      * <p>
      * This provider must be enabled on MongoDB Realm to work.
      *
@@ -155,7 +174,7 @@ public class Credentials {
     }
 
     /**
-     * Creates credentials representing a login using an JWT Token. This token is normally generated
+     * Creates credentials representing a login using a JWT Token. This token is normally generated
      * after a custom OAuth2 login flow.
      * <p>
      * This provider must be enabled on MongoDB Realm to work.
@@ -200,9 +219,10 @@ public class Credentials {
      */
     public enum IdentityProvider {
         ANONYMOUS("anon-user"),
-        API_KEY(""), // FIXME
+        API_KEY("api-key"),
+        SERVER_API_KEY("api-key"),
         APPLE("oauth2-apple"),
-        CUSTOM_FUNCTION(""), // FIXME
+        CUSTOM_FUNCTION("custom-function"),
         EMAIL_PASSWORD("local-userpass"),
         FACEBOOK("oauth2-facebook"),
         GOOGLE("oauth2-google"),

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
@@ -84,7 +84,7 @@ public class Credentials {
      */
     public static Credentials apiKey(String key) {
         Util.checkEmpty(key, "key");
-        return new Credentials(OsAppCredentials.userApiKey(key));
+        return new Credentials(OsAppCredentials.apiKey(key));
     }
 
     /**
@@ -116,13 +116,13 @@ public class Credentials {
     }
 
     /**
-     * Creates credentials representing a remote function previously added to MongoDB Realm. The
-     * input parameters
+     * Creates credentials representing a remote function from MongoDB Realm using a
+     * {@link Document} which will be parsed as an argument to the remote function, so the keys must
+     * match the format and names the function expects.
      * <p>
      * This provider must be enabled on MongoDB Realm to work.
      *
-     * @param arguments {@link Document} containing the values passed to the remote function. The
-     *                  keys must match the names given to the remote function parameters.
+     * @param arguments document containing the function arguments.
      * @return a set of credentials that can be used to log into MongoDB Realm using
      * {@link App#loginAsync(Credentials, App.Callback)}.
      */
@@ -189,12 +189,12 @@ public class Credentials {
     }
 
     /**
-     * Returns the id for the provider used to authenticate with.
+     * Returns the identity provider used to authenticate with.
      *
-     * @return the id identifying the chosen authentication provider.
+     * @return the provider identifying the chosen credentials.
      */
     public IdentityProvider getIdentityProvider() {
-        return IdentityProvider.fromId(osCredentials.getProvider());
+        return osCredentials.getProvider();
     }
 
     /**
@@ -220,7 +220,7 @@ public class Credentials {
     public enum IdentityProvider {
         ANONYMOUS("anon-user"),
         API_KEY("api-key"),
-        SERVER_API_KEY("api-key"),
+        SERVER_API_KEY("api-key"),      // same value as API_KEY as per OS specifications
         APPLE("oauth2-apple"),
         CUSTOM_FUNCTION("custom-function"),
         EMAIL_PASSWORD("local-userpass"),

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/push/Push.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/push/Push.java
@@ -69,29 +69,25 @@ public abstract class Push {
     /**
      * Deregisters the FCM registration token bound to the currently logged in user's
      * device on MongoDB Realm.
-     *
-     * @param registrationToken the registration token to deregister.
      */
-    public void deregisterDevice(String registrationToken) {
-        osPush.deregisterDevice(registrationToken);
+    public void deregisterDevice() {
+        osPush.deregisterDevice();
     }
 
     /**
      * Deregisters the FCM registration token bound to the currently logged in user's
      * device on MongoDB Realm.
      *
-     * @param registrationToken The registration token to register.
-     * @param callback          The callback used when the device has been registered or the call
-     *                          failed - it will always happen on the same thread as this method was
-     *                          called on.
+     * @param callback The callback used when the device has been registered or the call
+     *                 failed - it will always happen on the same thread as this method was
+     *                 called on.
      */
-    public RealmAsyncTask deregisterDeviceAsync(String registrationToken,
-                                                App.Callback<Void> callback) {
+    public RealmAsyncTask deregisterDeviceAsync(App.Callback<Void> callback) {
         Util.checkLooperThread("Asynchronous deregistering a device is only possible from looper threads.");
         return new Request<Void>(App.NETWORK_POOL_EXECUTOR, callback) {
             @Override
             public Void run() throws AppException {
-                osPush.deregisterDevice(registrationToken);
+                osPush.deregisterDevice();
                 return null;
             }
         }.start();

--- a/tools/sync_test_server/app_config/auth_providers/custom-function.json
+++ b/tools/sync_test_server/app_config/auth_providers/custom-function.json
@@ -3,7 +3,7 @@
     "name": "custom-function",
     "type": "custom-function",
     "config": {
-        "authFunctionName": "authFunc"
+        "authFunctionName": "testAuthFunc"
     },
     "disabled": false
 }

--- a/tools/sync_test_server/app_config/functions/testAuthFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/testAuthFunc/config.json
@@ -1,0 +1,5 @@
+{
+    "id": "5edea20f0f99fe616bf40ae8",
+    "name": "testAuthFunc",
+    "private": false
+}

--- a/tools/sync_test_server/app_config/functions/testAuthFunc/source.js
+++ b/tools/sync_test_server/app_config/functions/testAuthFunc/source.js
@@ -1,0 +1,7 @@
+exports = ({mail, id}) => {
+    if (mail != "myfakemail@mongodb.com" || id != 666) {
+        return 0;
+    } else {
+        return "works";
+    }
+}

--- a/tools/sync_test_server/app_config/functions/void/config.json
+++ b/tools/sync_test_server/app_config/functions/void/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae8",
+    "id": "5edea20f0f99fe616bf40ae9",
     "name": "void",
     "private": false
 }


### PR DESCRIPTION
Closes:
https://github.com/realm/realm-java/issues/6908

Added:
- custom function credentials
- server API key (just another flavour for the standard user API key - which was already implemented, but it's treated differently in the OS)
- modified custom function credentials so that they are generated using a Bson document instead of an array of objects - needed to map the function arguments correctly
- removed token from deregistering push notifications - this will be rendered moot once v10 is updated with the latest OS v10.