### PR TITLE
Update SyncSessionTests schema to avoid UPLOAD errors

### DIFF
--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/DefaultSyncSchema.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/DefaultSyncSchema.kt
@@ -22,6 +22,6 @@ const val defaultPartitionValue = "default"
 /**
  * The set of classes initially supported by MongoDB Realm.
  */
-@RealmModule(classes = [SyncDog::class, SyncPerson::class, SyncSupportedTypes::class])
+@RealmModule(classes = [SyncDog::class, SyncPerson::class, SyncAllTypes::class])
 class DefaultSyncSchema {
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncAllTypes.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncAllTypes.kt
@@ -51,9 +51,6 @@ open class SyncAllTypes : RealmObject() {
         const val FIELD_DOUBLE_LIST = "columnDoubleList"
         const val FIELD_FLOAT_LIST = "columnFloatList"
         const val FIELD_DATE_LIST = "columnDateList"
-        val INVALID_TYPES_FIELDS_FOR_DISTINCT = arrayOf(FIELD_REALMOBJECT, FIELD_REALMLIST, FIELD_DOUBLE, FIELD_FLOAT,
-                FIELD_STRING_LIST, FIELD_BINARY_LIST, FIELD_BOOLEAN_LIST, FIELD_LONG_LIST,
-                FIELD_DOUBLE_LIST, FIELD_FLOAT_LIST, FIELD_DATE_LIST)
     }
 
     @PrimaryKey
@@ -63,7 +60,10 @@ open class SyncAllTypes : RealmObject() {
     @Required
     var columnString = ""
     var columnLong: Long = 0
-    var columnFloat = 0f
+
+    // FIXME Float ruins initial upload of scheme, works if added to schema later
+//    var columnFloat = 0f
+
     var columnDouble = 0.0
     var isColumnBoolean = false
 
@@ -80,16 +80,29 @@ open class SyncAllTypes : RealmObject() {
     var columnObjectId = ObjectId(TestHelper.randomObjectIdHexString())
     val columnRealmInteger = MutableRealmInteger.ofNull()
     var columnRealmObject: SyncDog? = null
+
     var columnRealmList: RealmList<SyncDog>? = null
+    @Required
     var columnStringList: RealmList<String>? = null
+    @Required
     var columnBinaryList: RealmList<ByteArray>? = null
+    @Required
     var columnBooleanList: RealmList<Boolean>? = null
+    @Required
     var columnLongList: RealmList<Long>? = null
+    @Required
     var columnDoubleList: RealmList<Double>? = null
-    var columnFloatList: RealmList<Float>? = null
+
+    // FIXME Float ruins initial upload of scheme, works if added to schema later
+//    @Required
+//    var columnFloatList: RealmList<Float>? = null
+
+    @Required
     var columnDateList: RealmList<Date>? = null
+    @Required
     var columnDecimal128List: RealmList<Decimal128>? = null
 
+    @Required
     var columnObjectIdList: RealmList<ObjectId>? = null
 
     fun setColumnMutableRealmInteger(value: Int) {

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncAllTypesWithFloat.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncAllTypesWithFloat.kt
@@ -28,7 +28,9 @@ import org.bson.types.ObjectId
 import java.math.BigDecimal
 import java.util.*
 
-open class SyncSupportedTypes : RealmObject() {
+// TODO This class is only for tracking failure when uploading SyncAllTypes including float field.
+//  Once supported this class can be deleted and we can include the float field in SyncAllTypes
+open class SyncAllTypesWithFloat : RealmObject() {
 
     companion object {
         const val CLASS_NAME = "AllTypes"
@@ -51,9 +53,6 @@ open class SyncSupportedTypes : RealmObject() {
         const val FIELD_DOUBLE_LIST = "columnDoubleList"
         const val FIELD_FLOAT_LIST = "columnFloatList"
         const val FIELD_DATE_LIST = "columnDateList"
-        val INVALID_TYPES_FIELDS_FOR_DISTINCT = arrayOf(FIELD_REALMOBJECT, FIELD_REALMLIST, FIELD_DOUBLE, FIELD_FLOAT,
-                FIELD_STRING_LIST, FIELD_BINARY_LIST, FIELD_BOOLEAN_LIST, FIELD_LONG_LIST,
-                FIELD_DOUBLE_LIST, FIELD_FLOAT_LIST, FIELD_DATE_LIST)
     }
 
     @PrimaryKey
@@ -63,7 +62,10 @@ open class SyncSupportedTypes : RealmObject() {
     @Required
     var columnString = ""
     var columnLong: Long = 0
+
     var columnFloat = 0f
+
+    var columnDouble = 0.0
     var isColumnBoolean = false
 
     @Required
@@ -79,21 +81,29 @@ open class SyncSupportedTypes : RealmObject() {
     var columnObjectId = ObjectId(TestHelper.randomObjectIdHexString())
     val columnRealmInteger = MutableRealmInteger.ofNull()
     var columnRealmObject: SyncDog? = null
+
     var columnRealmList: RealmList<SyncDog>? = null
+    @Required
+    var columnStringList: RealmList<String>? = null
+    @Required
+    var columnBinaryList: RealmList<ByteArray>? = null
+    @Required
+    var columnBooleanList: RealmList<Boolean>? = null
+    @Required
+    var columnLongList: RealmList<Long>? = null
+    @Required
+    var columnDoubleList: RealmList<Double>? = null
 
-    // FIXME These are the fields needed to be removed from SyncAllTypes for sync to work when
-    //  updating the partitionValue
-//    var columnDouble = 0.0
-//    var columnStringList: RealmList<String>? = null
-//    var columnBinaryList: RealmList<ByteArray>? = null
-//    var columnBooleanList: RealmList<Boolean>? = null
-//    var columnLongList: RealmList<Long>? = null
-//    var columnDoubleList: RealmList<Double>? = null
-//    var columnFloatList: RealmList<Float> = RealmList()
-//    var columnDateList: RealmList<Date>? = null
-//    var columnDecimal128List: RealmList<Decimal128>? = null
+    @Required
+    var columnFloatList: RealmList<Float>? = null
 
-//    var columnObjectIdList: RealmList<ObjectId>? = null
+    @Required
+    var columnDateList: RealmList<Date>? = null
+    @Required
+    var columnDecimal128List: RealmList<Decimal128>? = null
+
+    @Required
+    var columnObjectIdList: RealmList<ObjectId>? = null
 
     fun setColumnMutableRealmInteger(value: Int) {
         columnRealmInteger.set(value.toLong())

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/transport/OkHttpNetworkTransportTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/transport/OkHttpNetworkTransportTests.kt
@@ -127,21 +127,15 @@ class OkHttpNetworkTransportTests {
                     Pair("Accept", "application/json")
             )
 
-            val t = Thread(Runnable {
-                val response: OsJavaNetworkTransport.Response = transport.sendRequest(method.nativeKey,
-                        url,
-                        5000,
-                        headers,
-                        body)
-                assertEquals(0, response.httpResponseCode)
-                assertEquals(OsJavaNetworkTransport.ERROR_IO, response.customResponseCode)
-                assertTrue(response.body.contains("interrupted"))
-            })
-            t.start()
-            // There is a very small chance that the network request already completed when getting
-            // to here, which would cause the test to fail. Ignore this possibility for now.
-            t.interrupt()
-            t.join()
+            Thread.currentThread().interrupt()
+            val response: OsJavaNetworkTransport.Response = transport.sendRequest(method.nativeKey,
+                    url,
+                    5000,
+                    headers,
+                    body)
+            assertEquals(0, response.httpResponseCode)
+            assertEquals(OsJavaNetworkTransport.ERROR_IO, response.customResponseCode)
+            assertTrue(response.body.contains("interrupted"))
         }
     }
 

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
@@ -15,6 +15,7 @@ import io.realm.mongodb.*
 import io.realm.mongodb.sync.*
 import io.realm.rule.BlockingLooperThread
 import io.realm.util.ResourceContainer
+import io.realm.util.assertFailsWithErrorCode
 import io.realm.util.assertFailsWithMessage
 import org.bson.BsonInt32
 import org.bson.BsonInt64
@@ -231,7 +232,7 @@ class SyncSessionTests {
     fun uploadDownloadAllChanges() {
         Realm.getInstance(syncConfiguration).use { realm ->
             realm.executeTransaction {
-                realm.createObject(SyncSupportedTypes::class.java, ObjectId())
+                realm.createObject(SyncAllTypes::class.java, ObjectId())
             }
             realm.syncSession.uploadAllLocalChanges()
         }
@@ -246,15 +247,35 @@ class SyncSessionTests {
         Realm.getInstance(config2).use { realm ->
             realm.syncSession.downloadAllServerChanges()
             realm.refresh()
-            assertEquals(1, realm.where(SyncSupportedTypes::class.java).count())
+            assertEquals(1, realm.where(SyncAllTypes::class.java).count())
+        }
+    }
+
+    // TODO This test is only for tracking failure when uploading SyncAllTypes including float field.
+    //  Once this test fails (meaning that the full schema can be uploaded) the test can be removed
+    //  and we can include the float field in SyncAllTypes
+    @Test
+    fun uploadDownloadAllChangesWithFloatFails() {
+        val config = configFactory
+                .createSyncConfigurationBuilder(user, syncConfiguration.partitionValue)
+                .testSchema(SyncAllTypesWithFloat::class.java, SyncDog::class.java, SyncPerson::class.java)
+                .build()
+
+        Realm.getInstance(config).use { realm ->
+            realm.executeTransaction {
+                realm.createObject(SyncAllTypesWithFloat::class.java, ObjectId())
+            }
+            assertFailsWithErrorCode(ErrorCode.UNKNOWN) {
+                realm.syncSession.uploadAllLocalChanges()
+            }
         }
     }
 
     @Test
-    fun differentPartitionValue_supportedTypes() {
+    fun differentPartitionValue_allTypes() {
         Realm.getInstance(syncConfiguration).use { realm ->
             realm.executeTransaction {
-                realm.createObject(SyncSupportedTypes::class.java, ObjectId())
+                realm.createObject(SyncAllTypes::class.java, ObjectId())
             }
             realm.syncSession.uploadAllLocalChanges()
         }
@@ -268,7 +289,7 @@ class SyncSessionTests {
 
         Realm.getInstance(config2).use { realm ->
             realm.executeTransaction {
-                realm.createObject(SyncSupportedTypes::class.java, ObjectId())
+                realm.createObject(SyncAllTypes::class.java, ObjectId())
             }
             realm.syncSession.uploadAllLocalChanges()
         }
@@ -278,7 +299,7 @@ class SyncSessionTests {
     fun differentPartitionValue_noCrosstalk() {
         Realm.getInstance(syncConfiguration).use { realm ->
             realm.executeTransaction {
-                realm.createObject(SyncSupportedTypes::class.java, ObjectId())
+                realm.createObject(SyncAllTypes::class.java, ObjectId())
             }
             realm.syncSession.uploadAllLocalChanges()
         }
@@ -293,95 +314,60 @@ class SyncSessionTests {
         Realm.getInstance(config2).use { realm ->
             realm.syncSession.downloadAllServerChanges()
             // We should not have any data here
-            assertEquals(0, realm.where(SyncSupportedTypes::class.java).count())
-        }
-    }
-
-    @Test
-    // FIXME Investigate further
-    @Ignore("Bad changeset for session with different partitionValue")
-    fun differentPartitionValue_allTypes() {
-        val config = configFactory
-                .createSyncConfigurationBuilder(user)
-                .modules(SyncAllTypesSchema())
-                .build()
-        Realm.getInstance(config).use { realm ->
-            realm.executeTransaction {
-                realm.createObject(SyncAllTypes::class.java, ObjectId())
-            }
-            realm.syncSession.uploadAllLocalChanges()
-        }
-
-        // New user and different partition value
-        val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
-        val config2 = configFactory
-                .createSyncConfigurationBuilder(user2, BsonObjectId(ObjectId()))
-                .modules(SyncAllTypesSchema())
-                .build()
-
-        Realm.getInstance(config2).use { realm ->
-            realm.executeTransaction {
-                realm.createObject(SyncAllTypes::class.java, ObjectId())
-            }
-            realm.syncSession.uploadAllLocalChanges()
+            assertEquals(0, realm.where(SyncAllTypes::class.java).count())
         }
     }
 
     @Test
     fun interruptWaits() {
-        // FIXME Convert to BackgroundLooperThread? Is it doable with all the interruptions
-        val t = Thread(Runnable {
-            Realm.getInstance(syncConfiguration).use { userRealm ->
-                userRealm.executeTransaction {
-                    userRealm.createObject(SyncSupportedTypes::class.java, ObjectId())
-                }
-                val userSession = userRealm.syncSession
-                try {
-                    // 1. Start download (which will be interrupted)
-                    Thread.currentThread().interrupt()
-                    userSession.downloadAllServerChanges()
-                    fail()
-                } catch (ignored: InterruptedException) {
-                    assertFalse(Thread.currentThread().isInterrupted)
-                }
-                try {
-                    // 2. Upload all changes
-                    userSession.uploadAllLocalChanges()
-                } catch (e: InterruptedException) {
-                    fail("Upload interrupted")
-                }
+        Realm.getInstance(syncConfiguration).use { userRealm ->
+            userRealm.executeTransaction {
+                userRealm.createObject(SyncAllTypes::class.java, ObjectId())
             }
-
-            // New user but same Realm as configuration has the same partition value
-            val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
-            val config2 = configFactory
-                    .createSyncConfigurationBuilder(user2, syncConfiguration.partitionValue)
-                    .modules(DefaultSyncSchema())
-                    .build()
-
-            Realm.getInstance(config2).use { adminRealm ->
-                val adminSession: SyncSession = adminRealm.syncSession
-                try {
-                    // 3. Start upload (which will be interrupted)
-                    Thread.currentThread().interrupt()
-                    adminSession.uploadAllLocalChanges()
-                    fail()
-                } catch (ignored: InterruptedException) {
-                    assertFalse(Thread.currentThread().isInterrupted) // clear interrupted flag
-                }
-                try {
-                    // 4. Download all changes
-                    adminSession.downloadAllServerChanges()
-                } catch (e: InterruptedException) {
-                    fail("Download interrupted")
-                }
-                adminRealm.refresh()
-
-                assertEquals(1, adminRealm.where(SyncSupportedTypes::class.java).count())
+            val userSession = userRealm.syncSession
+            try {
+                // 1. Start download (which will be interrupted)
+                Thread.currentThread().interrupt()
+                userSession.downloadAllServerChanges()
+                fail()
+            } catch (ignored: InterruptedException) {
+                assertFalse(Thread.currentThread().isInterrupted)
             }
-        })
-        t.start()
-        t.join()
+            try {
+                // 2. Upload all changes
+                userSession.uploadAllLocalChanges()
+            } catch (e: InterruptedException) {
+                fail("Upload interrupted")
+            }
+        }
+
+        // New user but same Realm as configuration has the same partition value
+        val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
+        val config2 = configFactory
+                .createSyncConfigurationBuilder(user2, syncConfiguration.partitionValue)
+                .modules(DefaultSyncSchema())
+                .build()
+
+        Realm.getInstance(config2).use { adminRealm ->
+            val adminSession: SyncSession = adminRealm.syncSession
+            try {
+                // 3. Start upload (which will be interrupted)
+                Thread.currentThread().interrupt()
+                adminSession.uploadAllLocalChanges()
+                fail()
+            } catch (ignored: InterruptedException) {
+                assertFalse(Thread.currentThread().isInterrupted) // clear interrupted flag
+            }
+            try {
+                // 4. Download all changes
+                adminSession.downloadAllServerChanges()
+            } catch (e: InterruptedException) {
+                fail("Download interrupted")
+            }
+            adminRealm.refresh()
+
+            assertEquals(1, adminRealm.where(SyncAllTypes::class.java).count())
+        }
     }
 
     // check that logging out a SyncUser used by different Realm will


### PR DESCRIPTION
Updates to SynsSessionTests including:
- Avoid crashing test app when `interruptedWaits` fails
- Eliminate `float` from `SyncAllTypes`-schema as it generate change sets that are rejected by the current sync implementation
- Add test case to track the failing `float` support 