### PR TITLE
Fix file upgrade bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 * APIs are backwards compatible with all previous release of realm-java in the 7.x.y series.
 
 ### Internal
-* Upgraded to Realm Sync 5.0.6.
-* Upgraded to Realm Core 6.0.7.
+* Upgraded to Realm Sync 5.0.7.
+* Upgraded to Realm Core 6.0.8.
 
 
 ## 7.0.0(2020-05-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes
 * Upgrading older Realm files with String indexes was very slow. (Issue [#6875](https://github.com/realm/realm-java/issues/6875), since 7.0.0)
 * Aborting upgrading a Realm file could result in the file getting corrupted. (Isse [#6866](https://github.com/realm/realm-java/issues/6866), since 7.0.0)
+* Automatic indexes on primary keys are now correctly stripped when upgrading the file as they are no longer needed. (Since 7.0.0)
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 7.0.1(YYYY-MN-DD)
+
+### Enhancements
+* None.
+
+### Fixes
+* Upgrading older Realm files with String indexes was very slow. (Issue [#6875](https://github.com/realm/realm-java/issues/6875), since 7.0.0)
+* Aborting upgrading a Realm file could result in the file getting corrupted. (Isse [#6866](https://github.com/realm/realm-java/issues/6866), since 7.0.0)
+
+### Compatibility
+* Realm Object Server: 3.23.1 or later.
+* File format: Generates Realms with format v10 (Reads and upgrades all previous formats from Realm Java 2.0 and later).
+* APIs are backwards compatible with all previous release of realm-java in the 7.x.y series.
+
+### Internal
+* Upgraded to Realm Sync 5.0.6.
+* Upgraded to Realm Core 6.0.7.
+
+
 ## 7.0.0(2020-05-16)
 
 NOTE: This version bumps the Realm file format to version 10. Files created with previous versions of Realm will be automatically upgraded. It is not possible to downgrade to version 9 or earlier. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Upgrading older Realm files with String indexes was very slow. (Issue [#6875](https://github.com/realm/realm-java/issues/6875), since 7.0.0)
 * Aborting upgrading a Realm file could result in the file getting corrupted. (Isse [#6866](https://github.com/realm/realm-java/issues/6866), since 7.0.0)
 * Automatic indexes on primary keys are now correctly stripped when upgrading the file as they are no longer needed. (Since 7.0.0)
+* "NoSuchTable" was thrown after comitting a transaction. (Issue [#6947](https://github.com/realm/realm-java/issues/6947))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Upgrading older Realm files with String indexes was very slow. (Issue [#6875](https://github.com/realm/realm-java/issues/6875), since 7.0.0)
 * Aborting upgrading a Realm file could result in the file getting corrupted. (Isse [#6866](https://github.com/realm/realm-java/issues/6866), since 7.0.0)
 * Automatic indexes on primary keys are now correctly stripped when upgrading the file as they are no longer needed. (Since 7.0.0)
-* "NoSuchTable" was thrown after comitting a transaction. (Issue [#6947](https://github.com/realm/realm-java/issues/6947))
+* `NoSuchTable` was thrown after comitting a transaction. (Issue [#6947](https://github.com/realm/realm-java/issues/6947))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,7 +1,7 @@
 # Realm Sync release used by Realm Java (This includes Realm Core)
 # https://github.com/realm/realm-sync/releases
-REALM_SYNC_VERSION=5.0.3
-REALM_SYNC_SHA256=bccf1fb89e32950a78dca4e93074f6479e0d016320897ab8bd1135d8568a18d3
+REALM_SYNC_VERSION=5.0.6
+REALM_SYNC_SHA256=420a4a3b8beb72d3dce2f0d422d118d85502c15f092b16000a36ef579a9bfd74
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,7 +1,7 @@
 # Realm Sync release used by Realm Java (This includes Realm Core)
 # https://github.com/realm/realm-sync/releases
-REALM_SYNC_VERSION=5.0.6
-REALM_SYNC_SHA256=420a4a3b8beb72d3dce2f0d422d118d85502c15f092b16000a36ef579a9bfd74
+REALM_SYNC_VERSION=5.0.7
+REALM_SYNC_SHA256=239049c777e4275fe094c73ae6dfa8736ae5ca9aa821c8d58b6d5eb3d84415e0
 
 # Object Server Release used by Integration tests. Installed using NPM.
 # Use `npm view realm-object-server versions` to get a list of available versions.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -1444,7 +1444,8 @@ public class RealmMigrationTests {
                 .schema(MigrationCore6PKStringIndexedByDefault.class)
                 .build());
         assertFalse(realm.isEmpty());
-        assertTrue(realm.getSchema().get("MigrationCore6PKStringIndexedByDefault").hasIndex("name"));
+        // Upgrading to Core 6 will strip all indexes on primary keys as they are no longer needed.
+        assertFalse(realm.getSchema().get("MigrationCore6PKStringIndexedByDefault").hasIndex("name"));
         MigrationCore6PKStringIndexedByDefault first = realm.where(MigrationCore6PKStringIndexedByDefault.class).findFirst();
         assertNotNull(first);
         assertEquals("Foo", first.name);


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/6875
Closes https://github.com/realm/realm-java/issues/6866

Upgrade Core which contains some fixes for both files being corrupted during a file upgrade and slow upgrade times on Android if the file contained String indexes.