### PR TITLE
Support for queries on primitive lists

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -728,6 +728,32 @@ public class RealmQueryTests extends QueryTests {
         assertEquals(0, resultList.size());
     }
 
+    @Test
+    public void equalTo_primitiveList_string() {
+        int numberOfObjects = 4;
+        int numberOfBlocks = 5;
+
+        realm.beginTransaction();
+        for (int i = 0; i < numberOfObjects; i++) {
+            for (int j = 0; j < numberOfBlocks; j++) {
+                AllTypes obj = realm.createObject(AllTypes.class);
+                obj.getColumnStringList().add("realm" + j);
+                obj.getColumnBinaryList();
+                obj.getColumnBooleanList();
+                obj.getColumnLongList();
+                obj.getColumnDoubleList();
+                obj.getColumnFloatList();
+                obj.getColumnDateList();
+                obj.getColumnDecimal128List();
+                obj.getColumnObjectIdList();
+            }
+        }
+        realm.commitTransaction();
+
+        RealmResults<AllTypes> all = realm.where(AllTypes.class).equalTo("columnStringList", "realm0").findAll();
+        assertEquals(numberOfObjects, all.size());
+    }
+
     private void doTestForInString(String targetField) {
         populateNoPrimaryKeyNullTypesRows();
         RealmResults<NoPrimaryKeyNullTypes> resultList = realm.where(NoPrimaryKeyNullTypes.class).in(targetField, new String[]{"test data 14"}).findAll();

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -1168,6 +1168,8 @@ static void TableQuery_StringPredicate(JNIEnv* env, jlong nativeQueryPtr, jlongA
             }
             switch (predicate) {
                 case StringEqual:{
+                    // FIXME Alternative to try out querying objects by predicate on primitive lists with updated query syntax
+                    // Q(nativeQueryPtr)->and_query(Q(nativeQueryPtr)->get_table()->column<Lst<String>>(ColKey(col_key_arr[0])) == value2);
                     Q(nativeQueryPtr)->equal(ColKey(col_key_arr[0]), value2, is_case_sensitive);
                     break;
                 }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -329,7 +329,7 @@ public class RealmQuery<E> {
     }
 
     private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable String value, Case casing) {
-        FieldDescriptor fd = schema.getFieldDescriptors(fieldName, RealmFieldType.STRING);
+        FieldDescriptor fd = schema.getFieldDescriptors(fieldName, RealmFieldType.STRING, RealmFieldType.STRING_LIST);
         this.query.equalTo(fd.getColumnKeys(), fd.getNativeTablePointers(), value, casing);
         return this;
     }


### PR DESCRIPTION
This is the initial experiments with enabling queries on primitive lists (#5361)

The currently used syntax for expressions does not seem to work, so tried out some alternatives. Ended up filing https://github.com/realm/realm-core/issues/3804 for a fix. 