### PR TITLE
Submit metrics to S3 through Realm App

### DIFF
--- a/realm-transformer/src/main/java/io/realm/transformer/RealmAnalytics.java
+++ b/realm-transformer/src/main/java/io/realm/transformer/RealmAnalytics.java
@@ -68,6 +68,7 @@ public class RealmAnalytics {
             + "      \"Anonymized MAC Address\": \"%USER_ID%\",\n"
             + "      \"Anonymized Bundle ID\": \"%APP_ID%\",\n"
             + "      \"Binding\": \"java\",\n"
+            + "      \"Target\": \"%TARGET%\",\n"
             + "      \"Language\": \"%LANGUAGE%\",\n"
             + "      \"Sync Version\": %SYNC_VERSION%,\n"
             + "      \"Realm Version\": \"%REALM_VERSION%\",\n"
@@ -86,13 +87,15 @@ public class RealmAnalytics {
     private boolean usesSync;
     private String targetSdk;
     private String minSdk;
+    private boolean app;
 
-    public RealmAnalytics(Set<String> packages, boolean usesKotlin, boolean usesSync, String targetSdk, String minSdk) {
+    public RealmAnalytics(Set<String> packages, boolean usesKotlin, boolean usesSync, String targetSdk, String minSdk, boolean app) {
         this.packages = packages;
         this.usesKotlin = usesKotlin;
         this.usesSync = usesSync;
         this.targetSdk = targetSdk;
         this.minSdk = minSdk;
+        this.app = app;
     }
 
     private void send() {
@@ -137,6 +140,7 @@ public class RealmAnalytics {
                 .replaceAll("%TOKEN%", TOKEN)
                 .replaceAll("%USER_ID%", ComputerIdentifierGenerator.get())
                 .replaceAll("%APP_ID%", getAnonymousAppId())
+                .replaceAll("%TARGET%", app ? "app" : "library")
                 .replaceAll("%LANGUAGE%", usesKotlin ? "kotlin" : "java")
                 .replaceAll("%SYNC_VERSION%", usesSync ? "\"" + Version.SYNC_VERSION + "\"": "null")
                 .replaceAll("%REALM_VERSION%", Version.VERSION)

--- a/realm-transformer/src/main/java/io/realm/transformer/RealmAnalytics.java
+++ b/realm-transformer/src/main/java/io/realm/transformer/RealmAnalytics.java
@@ -53,8 +53,10 @@ public class RealmAnalytics {
     private static RealmAnalytics instance;
     private static final int READ_TIMEOUT = 2000;
     private static final int CONNECT_TIMEOUT = 4000;
-    private static final String ADDRESS_PREFIX = "https://api.mixpanel.com/track/?data=";
-    private static final String ADDRESS_SUFFIX = "&ip=1";
+    // FIXME Settle on actual URL:
+    //  - Need to hide app name, as it is updated on subsequent imports
+    private static final String ADDRESS_PREFIX = "http://localhost:9090/api/client/v2.0/app/realm-sdk-integration-tests-uzzps/service/metric_webhook/incoming_webhook/metric?data=";
+    private static final String ADDRESS_SUFFIX = "";
     private static final String TOKEN = "ce0fac19508f6c8f20066d345d360fd0";
     private static final String EVENT_NAME = "Run";
     private static final String JSON_TEMPLATE

--- a/tools/sync_test_server/app_config/auth_providers/anon-user.json
+++ b/tools/sync_test_server/app_config/auth_providers/anon-user.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae9",
+    "id": "5f31334b9c73feb9bbb2862e",
     "name": "anon-user",
     "type": "anon-user",
     "disabled": false

--- a/tools/sync_test_server/app_config/auth_providers/api-key.json
+++ b/tools/sync_test_server/app_config/auth_providers/api-key.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40aea",
+    "id": "5f31334b9c73feb9bbb2862f",
     "name": "api-key",
     "type": "api-key",
     "disabled": false

--- a/tools/sync_test_server/app_config/auth_providers/custom-function.json
+++ b/tools/sync_test_server/app_config/auth_providers/custom-function.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40aeb",
+    "id": "5f31334b9c73feb9bbb28630",
     "name": "custom-function",
     "type": "custom-function",
     "config": {

--- a/tools/sync_test_server/app_config/auth_providers/local-userpass.json
+++ b/tools/sync_test_server/app_config/auth_providers/local-userpass.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40aec",
+    "id": "5f31334b9c73feb9bbb28631",
     "name": "local-userpass",
     "type": "local-userpass",
     "config": {

--- a/tools/sync_test_server/app_config/functions/authFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/authFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae0",
+    "id": "5f31334b9c73feb9bbb28624",
     "name": "authFunc",
     "private": false,
     "can_evaluate": {}

--- a/tools/sync_test_server/app_config/functions/authorizedOnly/config.json
+++ b/tools/sync_test_server/app_config/functions/authorizedOnly/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae1",
+    "id": "5f31334b9c73feb9bbb28625",
     "name": "authorizedOnly",
     "private": false,
     "can_evaluate": {

--- a/tools/sync_test_server/app_config/functions/confirmFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/confirmFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae2",
+    "id": "5f31334b9c73feb9bbb28626",
     "name": "confirmFunc",
     "private": false,
     "can_evaluate": {}

--- a/tools/sync_test_server/app_config/functions/error/config.json
+++ b/tools/sync_test_server/app_config/functions/error/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae3",
+    "id": "5f31334b9c73feb9bbb28627",
     "name": "error",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/firstArg/config.json
+++ b/tools/sync_test_server/app_config/functions/firstArg/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae4",
+    "id": "5f31334b9c73feb9bbb28628",
     "name": "firstArg",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/null/config.json
+++ b/tools/sync_test_server/app_config/functions/null/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae5",
+    "id": "5f31334b9c73feb9bbb28629",
     "name": "null",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/resetFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/resetFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae6",
+    "id": "5f31334b9c73feb9bbb2862a",
     "name": "resetFunc",
     "private": false,
     "can_evaluate": {}

--- a/tools/sync_test_server/app_config/functions/sum/config.json
+++ b/tools/sync_test_server/app_config/functions/sum/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae7",
+    "id": "5f31334b9c73feb9bbb2862b",
     "name": "sum",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/testAuthFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/testAuthFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae8",
+    "id": "5f31334b9c73feb9bbb2862c",
     "name": "testAuthFunc",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/void/config.json
+++ b/tools/sync_test_server/app_config/functions/void/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae9",
+    "id": "5f31334b9c73feb9bbb2862d",
     "name": "void",
     "private": false
 }

--- a/tools/sync_test_server/app_config/services/metric_s3_upload/config.json
+++ b/tools/sync_test_server/app_config/services/metric_s3_upload/config.json
@@ -1,0 +1,12 @@
+{
+    "id": "5f31340d9c73feb9bbb286e5",
+    "name": "metric_s3_upload",
+    "type": "aws",
+    "config": {
+        "accessKeyId": "AKIA4M2GNKG42J2H2NEU"
+    },
+    "secret_config": {
+        "secretAccessKey": "s3_access_key"
+    },
+    "version": 1
+}

--- a/tools/sync_test_server/app_config/services/metric_s3_upload/rules/metric_s3_upload.json
+++ b/tools/sync_test_server/app_config/services/metric_s3_upload/rules/metric_s3_upload.json
@@ -1,0 +1,7 @@
+{
+    "id": "5f3134229c73feb9bbb286f9",
+    "name": "metric_s3_upload",
+    "actions": [
+        "s3:PutObject"
+    ]
+}

--- a/tools/sync_test_server/app_config/services/metric_webhook/config.json
+++ b/tools/sync_test_server/app_config/services/metric_webhook/config.json
@@ -1,0 +1,7 @@
+{
+    "id": "5f3134519c73feb9bbb2870b",
+    "name": "metric_webhook",
+    "type": "http",
+    "config": {},
+    "version": 1
+}

--- a/tools/sync_test_server/app_config/services/metric_webhook/incoming_webhooks/metric/config.json
+++ b/tools/sync_test_server/app_config/services/metric_webhook/incoming_webhooks/metric/config.json
@@ -1,0 +1,14 @@
+{
+    "id": "5f3134979c73feb9bbb28720",
+    "name": "metric",
+    "run_as_authed_user": false,
+    "run_as_user_id": "",
+    "run_as_user_id_script_source": "",
+    "options": {
+        "httpMethod": "GET",
+        "validationMethod": "NO_VALIDATION"
+    },
+    "respond_result": true,
+    "fetch_custom_user_data": false,
+    "create_user_on_auth": false
+}

--- a/tools/sync_test_server/app_config/services/metric_webhook/incoming_webhooks/metric/source.js
+++ b/tools/sync_test_server/app_config/services/metric_webhook/incoming_webhooks/metric/source.js
@@ -1,0 +1,40 @@
+// This function is the webhook's request handler.
+exports = async function(payload, response) {
+    let timestamp = new Date().toISOString()
+    console.log( "time: ", timestamp)
+
+    // Get data from query 
+    let query = payload["query"]
+
+    console.log( "data: ", data)
+    
+    // Decode data
+    let buffer = new Buffer(query["data"], "base64")
+    let data = buffer.toString('ascii')
+    let event = JSON.parse(data)
+
+    // Extract required fields
+    let binding = event["properties"]["Binding"]
+    let token = event["properties"]["token"]
+    
+    console.log("timestamp: ", timestamp)
+    console.log("binding: ", binding)
+    
+    // Submit to S3
+    // FIXME How to provision these
+    let serviceName = "metric_s3_upload"
+    let bucketName = "rorbech";
+    let bucketRegion = "eu-central-1"
+    
+    const s3 = context.services.get(serviceName).s3(bucketRegion);
+    ;
+    const result = await s3.PutObject({
+      "Bucket": bucketName,
+      "Key": binding + '-' + timestamp + '-' + token,
+      "Body": data
+    })
+
+    console.log(EJSON.stringify(result))
+
+    return "";
+};

--- a/tools/sync_test_server/app_config/stitch.json
+++ b/tools/sync_test_server/app_config/stitch.json
@@ -1,6 +1,6 @@
 {
-    "app_id": "realm-sdk-integration-tests-nldpe",
-    "config_version": 20180301,
+    "app_id": "realm-sdk-integration-tests-uydyj",
+    "config_version": 20200603,
     "name": "realm-sdk-integration-tests",
     "location": "US-VA",
     "deployment_model": "GLOBAL",

--- a/tools/sync_test_server/setup_mongodb_realm.sh
+++ b/tools/sync_test_server/setup_mongodb_realm.sh
@@ -67,6 +67,15 @@ stitch-cli secrets add \
                   --base-url=http://localhost:9090 \
                   --config-path=/tmp/stitch-config
 
+#    - c) GCM (Firebase Cloud Messaging): Requires a server key - add your key here to test actual push notifications.
+# FIXME How to provision those secrets
+stitch-cli secrets add \
+                  --name="s3_access_key" \
+                  --value=<AWS-IAM-ACCESS-KEY> \
+                  --app-id="realm-sdk-integration-tests-$APP_ID_SUFFIX" \
+                  --base-url=http://localhost:9090 \
+                  --config-path=/tmp/stitch-config
+
 # 4. Now we can correctly import the Stitch app
 stitch-cli import \
                   --config-path=/tmp/stitch-config \


### PR DESCRIPTION
This is an initial attempt to submit metrics to S3/Segment through a Realm App. The Realm App exposes a webhook that decodes the URL-encoded metric data and pushes it to S3 through a 3-party service. 

NOTE: This is only intended as POC and the actual server configuration should not be merged. 
 
The POC uses the local integration server and a private S3 bucket. Thus to test this out you need to adjusts:
- `accessKeyId` in `tools/sync_test_server/app_config/services/metric_s3_upload/config.json``
- `AWS-IAM-ACCESS-KEY` in `tools/sync_test_server/setup_mongodb_realm.sh`
- `ADDRESS_PREFIX` in `realm-transformer/src/main/java/io/realm/transformer/RealmAnalytics.java`
- _Bucket information_ in `tools/sync_test_server/app_config/services/metric_webhook/incoming_webhooks/metric/source.js`

Unresolved questions:
- [ ] Webhook security requirements/mechanisms
- [ ] Provisioning: How to get URL, app-name, IAM-key/secret into app

TODOs:
- [ ] Javascript review from javascript developers
- [ ] Logging
- [ ] File format review. Currently just posts the same load as to mix panel

Current uploads looks like ex. : `java-2020-08-10T12:10:09.257Z-ce0fac19508f6c8f20066d345d360fd0`
```
{
   "event": "Run",
   "properties": {
      "token": "ce0fac19508f6c8f20066d345d360fd0",
      "distinct_id": "bd78f4535d26d47d7cc7345f5e19dfea7d1f2f392e05a3c60a24b990164915b6",
      "Anonymized MAC Address": "bd78f4535d26d47d7cc7345f5e19dfea7d1f2f392e05a3c60a24b990164915b6",
      "Anonymized Bundle ID": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
      "Binding": "java",
      "Language": "java",
      "Sync Version": null,
      "Realm Version": "10.0.0-BETA.6-SNAPSHOT",
      "Host OS Type": "Mac OS X",
      "Host OS Version": "10.15.6",
      "Target OS Type": "android",
      "Target OS Version": "29",
      "Target OS Minimum Version": "16"
   }
}