### PR TITLE
Backport fix to refreshing connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 6.1.1(YYYY-MM-DD)
+
+### Enhancements 
+* None.
+
+### Fixed
+* [ObjectServer] Calling `SyncManager.refreshConnections()` did not correctly refresh connections in all cases, which could delay reconnects up to 5 minutes. (Issue [#7003](https://github.com/realm/realm-java/issues/7003))
+
+### Compatibility
+* Realm Object Server: 3.23.1 or later.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* APIs are backwards compatible with all previous release of realm-java in the 6.x.y series.
+
+### Internal
+* None.
+
+
 ## 6.1.0(2020-01-17)
 
 ### Enhancements

--- a/realm/realm-library/src/main/java/io/realm/internal/async/RealmAsyncTaskImpl.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/async/RealmAsyncTaskImpl.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import io.realm.RealmAsyncTask;
 
 
-public final class RealmAsyncTaskImpl implements RealmAsyncTask {
+public class RealmAsyncTaskImpl implements RealmAsyncTask {
     private final Future<?> pendingTask;
     private final ThreadPoolExecutor service;
     private volatile boolean isCancelled = false;

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -535,6 +535,9 @@ public class SyncManager {
 
     private static synchronized void notifyNetworkIsBack() {
         try {
+            for (SyncSession session : sessions.values()) {
+                session.refreshConnection();
+            }
             nativeReconnect();
         } catch (Exception exception) {
             RealmLog.error(exception);

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -44,6 +44,7 @@ import io.realm.internal.SyncObjectServerFacade;
 import io.realm.internal.Util;
 import io.realm.internal.android.AndroidCapabilities;
 import io.realm.internal.async.RealmAsyncTaskImpl;
+import io.realm.internal.async.ResetableRealmAsyncTask;
 import io.realm.internal.network.AuthenticateResponse;
 import io.realm.internal.network.RealmObjectServer;
 import io.realm.internal.network.ExponentialBackoffTask;
@@ -81,9 +82,9 @@ public class SyncSession {
 
     private final SyncConfiguration configuration;
     private final ErrorHandler errorHandler;
-    private RealmAsyncTask networkRequest;
+    private ResetableRealmAsyncTask networkRequest; //
     private RealmAsyncTask refreshTokenTask;
-    private RealmAsyncTask refreshTokenNetworkRequest;
+    private ResetableRealmAsyncTask refreshTokenNetworkRequest;
     private AtomicBoolean onGoingAccessTokenQuery = new AtomicBoolean(false);
     private volatile boolean isClosed = false;
     private final AtomicReference<WaitForSessionWrapper> waitingForServerChanges = new AtomicReference<>(null);
@@ -436,7 +437,7 @@ public class SyncSession {
         }
     }
 
-    void close() {
+    synchronized void close() {
         isClosed = true;
         if (networkRequest != null) {
             networkRequest.cancel();
@@ -741,7 +742,7 @@ public class SyncSession {
     }
 
     // Return the access token for the Realm this Session is connected to.
-    String getAccessToken(final RealmObjectServer authServer, String refreshToken) {
+    synchronized String getAccessToken(final RealmObjectServer authServer, String refreshToken) {
         // check first if there's a valid access_token we can return immediately
         if (getUser().isRealmAuthenticated(configuration)) {
             Token accessToken = getUser().getAccessToken(configuration);
@@ -773,15 +774,16 @@ public class SyncSession {
     }
 
     // Authenticate by getting access tokens for the specific Realm
-    private void authenticateRealm(final RealmObjectServer authServer) {
+    synchronized void authenticateRealm(final RealmObjectServer authServer) {
         if (networkRequest != null) {
             networkRequest.cancel();
         }
         clearScheduledAccessTokenRefresh();
 
         onGoingAccessTokenQuery.set(true);
+        final String taskName = "Session[" + configuration.getPath() + "][AuthenticateRealm]";
         // Authenticate in a background thread. This allows incremental backoff and retries in a safe manner.
-        Future<?> task = SyncManager.NETWORK_POOL_EXECUTOR.submit(new ExponentialBackoffTask<AuthenticateResponse>() {
+        networkRequest = new ResetableRealmAsyncTask(new ExponentialBackoffTask<AuthenticateResponse>() {
             @Override
             protected AuthenticateResponse execute() {
                 if (!isClosed && !Thread.currentThread().isInterrupted()) {
@@ -808,6 +810,7 @@ public class SyncSession {
                         onGoingAccessTokenQuery.set(false);
                     }
                 }
+                networkRequest = null;
             }
 
             @Override
@@ -823,12 +826,17 @@ public class SyncSession {
                         && !(response.getError().getException() instanceof InterruptedIOException)) {
                     errorHandler.onError(SyncSession.this, response.getError());
                 }
+                networkRequest = null;
             }
-        });
-        networkRequest = new RealmAsyncTaskImpl(task, SyncManager.NETWORK_POOL_EXECUTOR);
+
+            @Override
+            protected String getName() {
+                return taskName;
+            }
+        }, SyncManager.NETWORK_POOL_EXECUTOR);
     }
 
-    private void scheduleRefreshAccessToken(final RealmObjectServer authServer, long expireDateInMs) {
+    private synchronized void scheduleRefreshAccessToken(final RealmObjectServer authServer, long expireDateInMs) {
         onGoingAccessTokenQuery.set(true);
         // calculate the delay time before which we should refresh the access_token,
         // we adjust to 10 second to proactively refresh the access_token before the session
@@ -836,7 +844,7 @@ public class SyncSession {
         long refreshAfter =  expireDateInMs - System.currentTimeMillis() - REFRESH_MARGIN_DELAY;
         if (refreshAfter < 0) {
             // Token already expired
-            RealmLog.debug("Expires time already reached for the access token, refresh as soon as possible");
+            RealmLog.debug("Session[%s]: Expires time already reached for the access token, refresh as soon as possible", configuration.getPath());
             // we avoid refreshing directly to avoid an edge case where the client clock is ahead
             // of the server, causing all access_token received from the server to be always
             // expired, we will flood the server with refresh token requests then, so adding
@@ -844,7 +852,7 @@ public class SyncSession {
             refreshAfter = REFRESH_MARGIN_DELAY;
         }
 
-        RealmLog.debug("Scheduling an access_token refresh in " + (refreshAfter) + " milliseconds");
+        RealmLog.debug("Session[%s]: Schedule refresh of access token in %s sec.", configuration.getPath(), TimeUnit.SECONDS.convert(refreshAfter, TimeUnit.MILLISECONDS));
 
         if (refreshTokenTask != null) {
             refreshTokenTask.cancel();
@@ -862,11 +870,11 @@ public class SyncSession {
     }
 
     // Authenticate by getting access tokens for the specific Realm
-    private void refreshAccessToken(final RealmObjectServer authServer) {
+    private synchronized void refreshAccessToken(final RealmObjectServer authServer) {
         // Authenticate in a background thread. This allows incremental backoff and retries in a safe manner.
         clearScheduledAccessTokenRefresh();
-
-        Future<?> task = SyncManager.NETWORK_POOL_EXECUTOR.submit(new ExponentialBackoffTask<AuthenticateResponse>() {
+        final String taskName = "Session[" + configuration.getPath() + "][RefreshAccessToken]";
+        refreshTokenNetworkRequest = new ResetableRealmAsyncTask(new ExponentialBackoffTask<AuthenticateResponse>() {
             @Override
             protected AuthenticateResponse execute() {
                 if (!isClosed && !Thread.currentThread().isInterrupted()) {
@@ -879,7 +887,7 @@ public class SyncSession {
             protected void onSuccess(AuthenticateResponse response) {
                 synchronized (SyncSession.this) {
                     if (!isClosed && !Thread.currentThread().isInterrupted() && !refreshTokenNetworkRequest.isCancelled()) {
-                        RealmLog.debug("Access Token refreshed successfully, Sync URL: " + configuration.getServerUrl());
+                        RealmLog.debug("Session[%s]: Access Token refreshed successfully.", configuration.getPath());
 
                         SyncWorker syncWorker = response.getSyncWorker();
                         if (syncWorker != null) {
@@ -894,6 +902,7 @@ public class SyncSession {
                             scheduleRefreshAccessToken(authServer, response.getAccessToken().expiresMs());
                         }
                     }
+                    refreshTokenNetworkRequest = null;
                 }
             }
 
@@ -901,19 +910,35 @@ public class SyncSession {
             protected void onError(AuthenticateResponse response) {
                 if (!isClosed && !Thread.currentThread().isInterrupted()) {
                     onGoingAccessTokenQuery.set(false);
-                    RealmLog.error("Unrecoverable error, while refreshing the access Token (" + response.getError().toString() + ") reschedule will not happen");
+                    RealmLog.debug("Session[%s]: Unrecoverable error, while refreshing the access Token. Reschedule will not happen. %s", configuration.getPath(), response.getError());
                 }
+                refreshTokenNetworkRequest = null;
             }
-        });
-        refreshTokenNetworkRequest = new RealmAsyncTaskImpl(task, SyncManager.NETWORK_POOL_EXECUTOR);
+
+            @Override
+            protected String getName() {
+                return taskName;
+            }
+        }, SyncManager.NETWORK_POOL_EXECUTOR);
     }
 
-    void clearScheduledAccessTokenRefresh() {
+    synchronized void refreshConnection() {
+        if (networkRequest != null) {
+            networkRequest.resetTask();
+        }
+        if (refreshTokenNetworkRequest != null) {
+            refreshTokenNetworkRequest.resetTask();
+        }
+    }
+
+    synchronized void clearScheduledAccessTokenRefresh() {
         if (refreshTokenTask != null) {
             refreshTokenTask.cancel();
+            refreshTokenTask = null;
         }
         if (refreshTokenNetworkRequest != null) {
             refreshTokenNetworkRequest.cancel();
+            refreshTokenNetworkRequest = null;
         }
         onGoingAccessTokenQuery.set(false);
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -357,6 +357,7 @@ public class SyncUser {
             final Token refreshTokenToBeRevoked = refreshToken;
 
             ThreadPoolExecutor networkPoolExecutor = SyncManager.NETWORK_POOL_EXECUTOR;
+            String taskName = "LogOutUser[" + identity + "]";
             networkPoolExecutor.submit(new ExponentialBackoffTask<LogoutResponse>(3) {
 
                 @Override
@@ -372,6 +373,11 @@ public class SyncUser {
                 @Override
                 protected void onError(LogoutResponse response) {
                     RealmLog.error("Failed to log user out.\n" + response.getError().toString());
+                }
+
+                @Override
+                protected String getName() {
+                    return taskName;
                 }
             });
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/async/ResetableRealmAsyncTask.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/async/ResetableRealmAsyncTask.java
@@ -1,0 +1,31 @@
+package io.realm.internal.async;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import io.realm.internal.network.ExponentialBackoffTask;
+
+/**
+ * Wrapper class for tasks that can internally retry operations until they succeed.
+ *
+ * Using this class will automatically add the task to the ThreadPoolExecutor.
+ */
+public class ResetableRealmAsyncTask extends RealmAsyncTaskImpl {
+
+    private final ExponentialBackoffTask<?> task;
+
+    public ResetableRealmAsyncTask(ExponentialBackoffTask<?> pendingTask, ThreadPoolExecutor service) {
+        super(service.submit(pendingTask) , service);
+        this.task = pendingTask;
+    }
+
+    /**
+     * If this task is currently waiting to retry. Calling this method will reset it and make it
+     * retry again immediately.
+     */
+    public void resetTask() {
+        task.resetDelay();
+    }
+}

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/SyncedRealmIntegrationTests.java
@@ -554,4 +554,29 @@ public class SyncedRealmIntegrationTests extends StandardIntegrationTest {
             }
         });
     }
+
+    // Smoke test to check that `refreshConnections` doesn't crash.
+    // Testing that it actually works is not feasible in a unit test.
+    @Test
+    @RunTestInLooperThread
+    public void refreshConnections() {
+        RealmLog.setLevel(LogLevel.DEBUG);
+        SyncManager.refreshConnections(); // No Realms
+
+        // A single active Realm
+        String username = UUID.randomUUID().toString();
+        String password = "password";
+        SyncUser user = SyncUser.logIn(SyncCredentials.usernamePassword(username, password, true), Constants.AUTH_URL);
+        final SyncConfiguration config = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
+                .fullSynchronization()
+                .schema(StringOnly.class)
+                .build();
+        Realm realm = Realm.getInstance(config);
+        SyncManager.refreshConnections();
+
+        // A single logged out Realm
+        realm.close();
+        SyncManager.refreshConnections();
+        looperThread.testComplete();
+    }
 }


### PR DESCRIPTION
Backport https://github.com/realm/realm-java/pull/7019 to the 6.x releases, due to customers hitting this and upgrading right now is not an option.

CI might be a problem. Looking into it.