### PR TITLE
Revisit MongoCollection tests for findOneAndModify operations

### DIFF
--- a/dependencies.list
+++ b/dependencies.list
@@ -5,7 +5,7 @@ REALM_SYNC_SHA256=824192a67e7ded59d33707265f78c8d5546b1fef473e9ee5ecff8a5bc9f850
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER_VERSION=2020-06-29
+MONGODB_REALM_SERVER_VERSION=2020-08-17
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=3.6.1

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/MongoClientTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/MongoClientTest.kt
@@ -18,8 +18,6 @@ package io.realm.mongodb
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.*
-import io.realm.log.LogLevel
-import io.realm.log.RealmLog
 import io.realm.mongodb.mongo.MongoClient
 import io.realm.mongodb.mongo.MongoCollection
 import io.realm.mongodb.mongo.MongoNamespace
@@ -53,8 +51,6 @@ class MongoClientTest {
         app = TestApp()
         user = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
         client = user.getMongoClient(SERVICE_NAME)
-
-        RealmLog.setLevel(LogLevel.DEBUG)
     }
 
     @After

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/MongoClientTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/MongoClientTest.kt
@@ -18,6 +18,8 @@ package io.realm.mongodb
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.*
+import io.realm.log.LogLevel
+import io.realm.log.RealmLog
 import io.realm.mongodb.mongo.MongoClient
 import io.realm.mongodb.mongo.MongoCollection
 import io.realm.mongodb.mongo.MongoNamespace
@@ -32,7 +34,6 @@ import org.bson.codecs.configuration.CodecRegistries
 import org.bson.types.ObjectId
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.*
@@ -52,6 +53,8 @@ class MongoClientTest {
         app = TestApp()
         user = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
         client = user.getMongoClient(SERVICE_NAME)
+
+        RealmLog.setLevel(LogLevel.DEBUG)
     }
 
     @After
@@ -713,35 +716,42 @@ class MongoClientTest {
         }
     }
 
-    // FIXME: projections and sorts aren't currently working due to a bug in Stitch: https://jira.mongodb.org/browse/REALMC-5787
     @Test
-    @Ignore("Projections and sorts don't work")
     fun findOneAndUpdate_withProjectionAndSort() {
         with(getCollectionInternal()) {
-            val sampleUpdate = Document("\$set", Document("hello", "hellothere")).apply {
-                this["\$inc"] = Document("num", 1)
-            }
-            sampleUpdate.remove("\$set")        // FIXME
-            val sampleProject = Document("hello", 1)
-            sampleProject["_id"] = 0
+            insertMany(listOf(
+                    Document(mapOf(Pair("team", "Fearful Mallards"), Pair("score", 25000))),
+                    Document(mapOf(Pair("team", "Tactful Mooses"), Pair("score", 23500))),
+                    Document(mapOf(Pair("team", "Aquatic Ponies"), Pair("score", 19250))),
+                    Document(mapOf(Pair("team", "Cuddly Zebras"), Pair("score", 15235))),
+                    Document(mapOf(Pair("team", "Garrulous Bears"), Pair("score", 18000)))
+            )).get()
 
-            var options = FindOneAndModifyOptions()
-                    .projection(sampleProject)
-                    .sort(Document("num", 1))
-            assertEquals(Document("hello", "world1"),
-                    findOneAndUpdate(Document(), sampleUpdate, options)
-                            .get()!!
-                            .withoutId())
-            assertEquals(3, count().get())
+            assertEquals(5, count().get())
+            assertNotNull(findOne(Document("team", "Cuddly Zebras")))
 
-            options = FindOneAndModifyOptions()
-                    .projection(sampleProject)
-                    .sort(Document("num", -1))
-            assertEquals(Document("hello", "world3"),
-                    findOneAndUpdate(Document(), sampleUpdate, options)
-                            .get()!!
-                            .withoutId())
-            assertEquals(3, count().get())
+            // Project: team, hide _id; Sort: score ascending
+            val project = Document(mapOf(Pair("_id", 0), Pair("team", 1), Pair("score", 1)))
+            val sort = Document("score", 1)
+
+            // This results in the update of Cuddly Zebras
+            val updatedDocument = findOneAndUpdate(
+                    Document("score", Document("\$lt", 22250)),
+                    Document("\$inc", Document("score", 1)),
+                    FindOneAndModifyOptions()
+                            .projection(project)
+                            .sort(sort)
+            ).get()
+
+            assertEquals(5, count().get())
+            assertEquals(
+                    Document(mapOf(Pair("team", "Cuddly Zebras"), Pair("score", 15235))),
+                    updatedDocument
+            )
+            assertEquals(
+                    Document(mapOf(Pair("team", "Cuddly Zebras"), Pair("score", 15235 + 1))),
+                    findOne(Document("team", "Cuddly Zebras")).get().withoutId()
+            )
         }
     }
 
@@ -838,28 +848,46 @@ class MongoClientTest {
         }
     }
 
-    // FIXME: projections and sorts aren't currently working due to a bug in Stitch: https://jira.mongodb.org/browse/REALMC-5787
     @Test
-    @Ignore("Projections and sorts don't work")
     fun findOneAndReplace_withProjectionAndSort() {
         with(getCollectionInternal()) {
-            val sampleProject = Document("hello", 1)
-            sampleProject["_id"] = 0
+            insertMany(listOf(
+                    Document(mapOf(Pair("team", "Fearful Mallards"), Pair("score", 25000))),
+                    Document(mapOf(Pair("team", "Tactful Mooses"), Pair("score", 23500))),
+                    Document(mapOf(Pair("team", "Aquatic Ponies"), Pair("score", 19250))),
+                    Document(mapOf(Pair("team", "Cuddly Zebras"), Pair("score", 15235))),
+                    Document(mapOf(Pair("team", "Garrulous Bears"), Pair("score", 18000)))
+            )).get()
 
-            val sampleUpdate = Document("hello", "world0")
-            sampleUpdate["num"] = 0
+            assertEquals(5, count().get())
+            assertNotNull(findOne(Document("team", "Cuddly Zebras")))
 
-            var options = FindOneAndModifyOptions().projection(sampleProject).sort(Document("num", 1))
-            val result = findOneAndReplace(Document(), sampleUpdate, options).get()
-            assertEquals(Document("hello", "world4"), result!!.withoutId())
-            assertEquals(3, count().get())
+            // Project: team, hide _id; Sort: score ascending
+            val project = Document(mapOf(Pair("_id", 0), Pair("team", 1)))
+            val sort = Document("score", 1)
 
-            options = FindOneAndModifyOptions()
-                    .projection(sampleProject)
-                    .sort(Document("num", -1))
-            assertEquals(Document("hello", "world6"),
-                    findOneAndReplace(Document(), sampleUpdate, options).get()!!.withoutId())
-            assertEquals(3, count().get())
+            // This results in the replacement of Cuddly Zebras
+            val replacedDocument = findOneAndReplace(
+                    Document("score", Document("\$lt", 22250)),
+                    Document(mapOf(Pair("team", "Therapeutic Hamsters"), Pair("score", 22250))),
+                    FindOneAndModifyOptions()
+                            .projection(project)
+                            .sort(sort)
+            ).get()
+
+            assertEquals(5, count().get())
+            assertEquals(Document("team", "Cuddly Zebras"), replacedDocument)
+            assertNull(findOne(Document("team", "Cuddly Zebras")).get())
+            assertNotNull(findOne(Document("team", "Therapeutic Hamsters")).get())
+
+            // Check returnNewDocument
+            val newDocument = findOneAndReplace(
+                    Document("score", 22250),
+                    Document(mapOf(Pair("team", "New Therapeutic Hamsters"), Pair("score", 30000))),
+                    FindOneAndModifyOptions().returnNewDocument(true)
+            ).get()
+
+            assertEquals(Document(mapOf(Pair("team", "New Therapeutic Hamsters"), Pair("score", 30000))), newDocument.withoutId())
         }
     }
 
@@ -924,32 +952,35 @@ class MongoClientTest {
         }
     }
 
-    // FIXME: projections and sorts aren't currently working due to a bug in Stitch: https://jira.mongodb.org/browse/REALMC-5787
     @Test
-    @Ignore("find_one_and_delete function is wrongly implemented in OS and projections and sorts don't work")
     fun findOneAndDelete_withProjectionAndSort() {
         with(getCollectionInternal()) {
-            val doc2 = Document("hello", "world2").apply { this["num"] = 2 }
-            val doc3 = Document("hello", "world3").apply { this["num"] = 3 }
+            insertMany(listOf(
+                    Document(mapOf(Pair("team", "Fearful Mallards"), Pair("score", 25000))),
+                    Document(mapOf(Pair("team", "Tactful Mooses"), Pair("score", 23500))),
+                    Document(mapOf(Pair("team", "Aquatic Ponies"), Pair("score", 19250))),
+                    Document(mapOf(Pair("team", "Cuddly Zebras"), Pair("score", 15235))),
+                    Document(mapOf(Pair("team", "Garrulous Bears"), Pair("score", 18000)))
+            )).get()
 
-            insertMany(listOf(doc2, doc3)).get()
+            assertEquals(5, count().get())
+            assertNotNull(findOne(Document("team", "Cuddly Zebras")))
 
-            // Return "hello", hide "_id"
-            val sampleProject = Document("hello", 1).apply { this["_id"] = 0 }
+            // Project: team, hide _id; Sort: score ascending
+            val project = Document(mapOf(Pair("_id", 0), Pair("team", 1)))
+            val sort = Document("score", 1)
 
-            var options = FindOneAndModifyOptions()
-                    .projection(sampleProject)
-                    .sort(Document("num", -1))
-            assertEquals(Document("hello", "world3"),
-                    findOneAndDelete(Document(), options).get()!!.withoutId())
-            assertEquals(2, count().get())
+            // This results in the deletion of Cuddly Zebras
+            val deletedDocument = findOneAndDelete(
+                    Document("score", Document("\$lt", 22250)),
+                    FindOneAndModifyOptions()
+                            .projection(project)
+                            .sort(sort)
+            ).get()
 
-            options = FindOneAndModifyOptions()
-                    .projection(sampleProject)
-                    .sort(Document("num", 1))
-            assertEquals(Document("hello", "world1"),
-                    findOneAndDelete(Document(), options).get()!!.withoutId())
-            assertEquals(1, count().get())
+            assertEquals(4, count().get())
+            assertEquals(Document("team", "Cuddly Zebras"), deletedDocument.withoutId())
+            assertNull(findOne(Document("team", "Cuddly Zebras")).get())
         }
     }
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoCollection.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoCollection.cpp
@@ -74,7 +74,7 @@ static std::function<jobject(JNIEnv*, RemoteMongoCollection::RemoteUpdateResult)
     Bson modified_count(result.modified_count);
     Bson upserted_value;
     if (result.upserted_id) {
-        upserted_value = new Bson(result.upserted_id.value());
+        upserted_value = Bson(result.upserted_id.value());
     }
     // FIXME: maybe not the most efficient way. Suggestions?
     std::vector<Bson> bson_vector = { matched_count, modified_count, upserted_value };

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
@@ -20,7 +20,6 @@ import io.realm.util.assertFailsWithErrorCode
 import io.realm.util.assertFailsWithMessage
 import org.bson.BsonInt32
 import org.bson.BsonInt64
-import org.bson.BsonObjectId
 import org.bson.BsonString
 import org.bson.types.ObjectId
 import org.hamcrest.CoreMatchers
@@ -28,7 +27,6 @@ import org.junit.*
 import org.junit.Assert.*
 import org.junit.runner.RunWith
 import java.io.Closeable
-import java.lang.IllegalStateException
 import java.lang.Thread
 import java.util.*
 import java.util.concurrent.CountDownLatch
@@ -103,7 +101,7 @@ class SyncSessionTests {
                 // TODO We generate new partition value for each test to avoid overlaps in data. We
                 //  could make test booting with a cleaner state by somehow flushing data between
                 //  tests.
-                .createSyncConfigurationBuilder(user, BsonObjectId(ObjectId()))
+                .createSyncConfigurationBuilder(user, BsonString(UUID.randomUUID().toString()))
                 .modules(DefaultSyncSchema())
                 .build()
     }
@@ -132,40 +130,57 @@ class SyncSessionTests {
     }
 
     @Test
-    fun partitionValue_int32() {
+    fun partitionValue_int32_failsWhenServerConfiguredWithStringPartition() {
         val int = 123536462
         val syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, BsonInt32(int))
                 .modules(DefaultSyncSchema())
                 .build()
-        Realm.getInstance(syncConfiguration).use { realm ->
-            realm.executeTransaction {
-                realm.createObject(SyncDog::class.java, ObjectId())
+
+        looperThread.runBlocking {
+            Realm.getInstance(syncConfiguration).use { realm ->
+                realm.executeTransaction {
+                    realm.createObject(SyncDog::class.java, ObjectId())
+                }
+
+                assertFailsWith<AppException> {
+                    // This throws as the server has NOT been configured to have int partitions!
+                    realm.syncSession.uploadAllLocalChanges()
+                }.also {
+                    looperThread.testComplete()
+                }
             }
-            realm.syncSession.uploadAllLocalChanges()
         }
     }
 
     @Test
-    fun partitionValue_int64() {
+    fun partitionValue_int64_failsWhenServerConfiguredWithStringPartition() {
         val long = 1243513244L
         val syncConfiguration = configFactory
                 .createSyncConfigurationBuilder(user, BsonInt64(long))
                 .modules(DefaultSyncSchema())
                 .build()
-        Realm.getInstance(syncConfiguration).use { realm ->
-            realm.executeTransaction {
-                realm.createObject(SyncDog::class.java, ObjectId())
+
+        looperThread.runBlocking {
+            Realm.getInstance(syncConfiguration).use { realm ->
+                realm.executeTransaction {
+                    realm.createObject(SyncDog::class.java, ObjectId())
+                }
+
+                assertFailsWith<AppException> {
+                    // This throws as the server has NOT been configured to have long partitions!
+                    realm.syncSession.uploadAllLocalChanges()
+                }.also {
+                    looperThread.testComplete()
+                }
             }
-            realm.syncSession.uploadAllLocalChanges()
         }
     }
 
     @Test
     fun partitionValue_objectId() {
-        val objectId = ObjectId("5ecf72df02aa3c32ab6b4ce0")
         val syncConfiguration = configFactory
-                .createSyncConfigurationBuilder(user, BsonObjectId(objectId))
+                .createSyncConfigurationBuilder(user, BsonString(UUID.randomUUID().toString()))
                 .modules(DefaultSyncSchema())
                 .build()
         Realm.getInstance(syncConfiguration).use { realm ->
@@ -228,8 +243,8 @@ class SyncSessionTests {
     fun getState_loggedOut() {
         Realm.getInstance(syncConfiguration).use { realm ->
             val session = realm.syncSession
-            user.logOut();
-            assertEquals(SyncSession.State.INACTIVE, session.state);
+            user.logOut()
+            assertEquals(SyncSession.State.INACTIVE, session.state)
         }
     }
 
@@ -237,7 +252,7 @@ class SyncSessionTests {
     fun session_throwOnLogoutUser() {
         user.logOut()
         assertFailsWith<IllegalStateException> {
-            Realm.getInstance(syncConfiguration).use { realm -> }
+            Realm.getInstance(syncConfiguration).use { }
         }
     }
 
@@ -296,7 +311,7 @@ class SyncSessionTests {
         // New user and different partition value
         val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
         val config2 = configFactory
-                .createSyncConfigurationBuilder(user2, BsonObjectId(ObjectId()))
+                .createSyncConfigurationBuilder(user2, BsonString(UUID.randomUUID().toString()))
                 .modules(DefaultSyncSchema())
                 .build()
 
@@ -320,7 +335,7 @@ class SyncSessionTests {
         // New user and different partition value
         val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
         val config2 = configFactory
-                .createSyncConfigurationBuilder(user2, BsonObjectId(ObjectId()))
+                .createSyncConfigurationBuilder(user2, BsonString(UUID.randomUUID().toString()))
                 .modules(DefaultSyncSchema())
                 .build()
 
@@ -392,7 +407,7 @@ class SyncSessionTests {
         Realm.getInstance(syncConfiguration).use { realm1 ->
             // New partitionValue to differentiate sync session
             val syncConfiguration2 = configFactory
-                    .createSyncConfigurationBuilder(user, BsonObjectId(ObjectId()))
+                    .createSyncConfigurationBuilder(user, BsonString(UUID.randomUUID().toString()))
                     .modules(DefaultSyncSchema())
                     .build()
 
@@ -561,7 +576,7 @@ class SyncSessionTests {
     @Ignore("Does not terminate")
     fun downloadChangesWhenRealmOutOfScope() {
         val uniqueName = UUID.randomUUID().toString()
-        var credentials = app.emailPasswordAuth.registerUser(uniqueName, "password")
+        app.emailPasswordAuth.registerUser(uniqueName, "password")
         val config1 = configFactory
                 .createSyncConfigurationBuilder(user)
                 .modules(SyncStringOnlyModule())
@@ -670,11 +685,9 @@ class SyncSessionTests {
                     fail("Listener should have been removed")
                 }
             }
-            var listener2 = object : ConnectionListener {
-                override fun onChange(oldState: ConnectionState, newState: ConnectionState) {
-                    if (newState == ConnectionState.DISCONNECTED) {
-                        looperThread.testComplete()
-                    }
+            val listener2 = ConnectionListener { oldState, newState ->
+                if (newState == ConnectionState.DISCONNECTED) {
+                    looperThread.testComplete()
                 }
             }
             session.addConnectionChangeListener(listener1)

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -12,12 +12,12 @@
 
 # Verify that Github username and tokens are available as environment vars
 if [[ -z "${GITHUB_DOCKER_USER}" ]]; then
-  echo "Could not find \$GITHUB_DOCKER_USER as an environment variabel"
+  echo "Could not find \$GITHUB_DOCKER_USER as an environment variable"
   exit 1
 fi
 
 if [[ -z "${GITHUB_DOCKER_TOKEN}" ]]; then
-  echo "Could not find \$GITHUB_DOCKER_TOKEN as an environment variabel. This is used to download Docker Registry packages."
+  echo "Could not find \$GITHUB_DOCKER_TOKEN as an environment variable. This is used to download Docker Registry packages."
   exit 1
 fi
 
@@ -43,4 +43,3 @@ docker run --rm -i -t -d --network container:$ID -v$TMP_DIR:/tmp --name mongodb-
 docker cp "$DOCKERFILE_DIR"/app_config mongodb-realm:/tmp/app_config
 docker cp "$DOCKERFILE_DIR"/setup_mongodb_realm.sh mongodb-realm:/tmp/
 docker exec -it mongodb-realm sh /tmp/setup_mongodb_realm.sh
-


### PR DESCRIPTION
- Bumped server to the version that includes a fix for projections and sort - https://github.com/10gen/baas/pull/3022
- Rewrote tests for `findAndModify` methods with examples based on the online documentation.
- Fixed bug in JNI that returned a boolean as the upserted value instead of an objectId.
- Replaced `BsonObjectId` used as partition value in `EncryptedSynchronizedRealmTests` and `SyncSessionTests` and added "ignore" to `setEncryptionKey_shouldCrashIfKeyNotProvided` until https://github.com/realm/realm-java/issues/7028 is fixed.