### PR TITLE
Update newsreaderExample's NYTimes api version to v2

### DIFF
--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesDataLoader.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesDataLoader.java
@@ -51,7 +51,7 @@ public class NYTimesDataLoader {
         Retrofit retrofit = new Retrofit.Builder()
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .addConverterFactory(JacksonConverterFactory.create())
-                .baseUrl("http://api.nytimes.com/")
+                .baseUrl("https://api.nytimes.com/")
                 .build();
         nyTimesService = retrofit.create(NYTimesService.class);
     }

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesDataLoader.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesDataLoader.java
@@ -71,7 +71,8 @@ public class NYTimesDataLoader {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {
                     Timber.d("Success - Data received: %s", sectionKey);
-                    processAndAddData(realm, response.section, response.results);
+                    // response.section is different from sectionKey
+                    processAndAddData(realm, sectionKey, response.results);
                     networkInUse.onNext(false);
                 }, throwable -> {
                     networkInUse.onNext(false);

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesService.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesService.java
@@ -29,7 +29,7 @@ import retrofit2.http.Query;
  * Retrofit interface for the New York Times WebService
  */
 public interface NYTimesService {
-    @GET("svc/topstories/v1/{section}.json")
+    @GET("svc/topstories/v2/{section}.json")
     Observable<NYTimesResponse<List<NYTimesStory>>> topStories(
             @Path("section") String section,
             @Query(value = "api-key", encoded = true) String apiKey);

--- a/examples/newsreaderExample/src/main/res/values/strings.xml
+++ b/examples/newsreaderExample/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">NewsReader</string>
     <!-- API Keys : Note they are throttled, so consider requesting your own: http://developer.nytimes.com/apps/register -->
-    <string name="nyc_top_stories_api_key">6fd358f33363137b6b5e0b5758bd9052:18:73641711</string>
+    <string name="nyc_top_stories_api_key">YUPmyj0Q09Fm2VlCHmD9FU7rpCcI5dUD</string>
     <string name="read">READ</string>
     <string name="no_news">No news</string>
 </resources>


### PR DESCRIPTION
Updates NYTimes API version to v2. V1 is obsolete and V2 supports https protocol.
Closes #7045 