### PR TITLE
Add support for the Null partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The old Realm Cloud legacy APIs have undergone significant refactoring. The new 
 
 ### Enhancements
 * [RealmApp] Support for using `null` as a partition value.
-* [RealmApp] Improve errors exception messages from `SyncSession.downloadAllServerChanges()` an `SyncSession.uploadAllLocalChanges()`.
+* [RealmApp] Improve errors exception messages from `SyncSession.downloadAllServerChanges()` and `SyncSession.uploadAllLocalChanges()`.
 
 ### Fixed
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The old Realm Cloud legacy APIs have undergone significant refactoring. The new 
 
 ### Enhancements
 * [RealmApp] Support for using `null` as a partition value.
+* [RealmApp] Improve errors exception messages from `SyncSession.downloadAllServerChanges()` an `SyncSession.uploadAllLocalChanges()`.
 
 ### Fixed
 * None.
@@ -19,7 +20,7 @@ The old Realm Cloud legacy APIs have undergone significant refactoring. The new 
 * Realm Studio 10.0.0 and above is required to open Realms created by this version.
 
 ### Internal
-* None.
+* Updated to Object Store commit: 39e20006761e77014ceb19a2bd8f43018cc96f5a.
 
 
 ## 10.0.0-BETA.6 (2020-08-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 10.0.0-BETA.7 (YYYY-MM-DD)
+
+We no longer support Realm Cloud (legacy), but instead the new MongoDB Realm Cloud. MongoDB Realm is a serverless platform that enables developers to quickly build applications without having to set up server infrastructure. MongoDB Realm is built on top of MongoDB Atlas, automatically integrating the connection to your database.
+
+The old Realm Cloud legacy APIs have undergone significant refactoring. The new APIs are all located in the `io.realm.mongodb` package with `io.realm.mongodb.App` as the entry point.
+
+### Breaking Changes
+*  None.
+
+### Enhancements
+* [RealmApp] Support for using `null` as a partition value.
+
+### Fixed
+* None.
+
+### Compatibility
+* File format: Generates Realms with format v11 (Reads and upgrades all previous formats from Realm Java 2.0 and later).
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 and above is required to open Realms created by this version.
+
+### Internal
+* None.
+
+
 ## 10.0.0-BETA.6 (2020-08-17)
 
 We no longer support Realm Cloud (legacy), but instead the new MongoDB Realm Cloud. MongoDB Realm is a serverless platform that enables developers to quickly build applications without having to set up server infrastructure. MongoDB Realm is built on top of MongoDB Atlas, automatically integrating the connection to your database.

--- a/dependencies.list
+++ b/dependencies.list
@@ -5,7 +5,7 @@ REALM_SYNC_SHA256=824192a67e7ded59d33707265f78c8d5546b1fef473e9ee5ecff8a5bc9f850
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER_VERSION=2020-08-17
+MONGODB_REALM_SERVER_VERSION=2020-08-24
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=3.6.1

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
@@ -324,6 +324,26 @@ class SyncConfigurationTests {
     }
 
     @Test
+    fun nullPartitionValue() {
+        val user: User = createTestUser(app)
+
+        val configs = listOf<SyncConfiguration>(
+            SyncConfiguration.defaultConfig(user, null as String?),
+            SyncConfiguration.defaultConfig(user, null as Int?),
+            SyncConfiguration.defaultConfig(user, null as Long?),
+            SyncConfiguration.defaultConfig(user, null as ObjectId?),
+            SyncConfiguration.Builder(user, null as String?).build(),
+            SyncConfiguration.Builder(user, null as Int?).build(),
+            SyncConfiguration.Builder(user, null as Long?).build(),
+            SyncConfiguration.Builder(user, null as ObjectId?).build()
+        )
+
+        configs.forEach { config ->
+            assertTrue(config.path.endsWith("/null.realm"))
+        }
+    }
+
+    @Test
     fun loggedOutUsersThrows() {
         val user: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
         user.logOut()

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -26,11 +26,9 @@ import io.realm.kotlin.syncSession
 import io.realm.kotlin.where
 import io.realm.log.LogLevel
 import io.realm.log.RealmLog
-import io.realm.mongodb.App
-import io.realm.mongodb.Credentials
+import io.realm.mongodb.*
 import io.realm.mongodb.SyncTestUtils.Companion.createTestUser
-import io.realm.mongodb.User
-import io.realm.mongodb.close
+import io.realm.util.assertFailsWithErrorCode
 import org.bson.BsonNull
 import org.junit.*
 import org.junit.runner.RunWith
@@ -200,7 +198,11 @@ class SyncedRealmTests {
         val config = configFactory.createSyncConfigurationBuilder(createNewUser(), BsonNull()).build()
         assertTrue(config.path.endsWith("null.realm"))
         Realm.getInstance(config).use { realm ->
-            realm.syncSession.uploadAllLocalChanges() // Ensures that we can actually connect
+            // FIXME: This currently fails because the server does not yet support the Null partition
+            //  Remove the catch once it is supported, after which uploading changes should work.
+            assertFailsWithErrorCode(ErrorCode.ILLEGAL_REALM_PATH) {
+                realm.syncSession.uploadAllLocalChanges() // Ensures that we can actually connect
+            }
         }
     }
 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -31,6 +31,7 @@ import io.realm.mongodb.Credentials
 import io.realm.mongodb.SyncTestUtils.Companion.createTestUser
 import io.realm.mongodb.User
 import io.realm.mongodb.close
+import org.bson.BsonNull
 import org.junit.*
 import org.junit.runner.RunWith
 import java.io.File
@@ -191,6 +192,15 @@ class SyncedRealmTests {
             assertNotNull(realm.syncSession)
             assertEquals(SyncSession.State.ACTIVE, realm.syncSession.state)
             assertEquals(user, realm.syncSession.user)
+        }
+    }
+
+    @Test
+    fun nullPartition() {
+        val config = configFactory.createSyncConfigurationBuilder(createNewUser(), BsonNull()).build()
+        assertTrue(config.path.endsWith("null.realm"))
+        Realm.getInstance(config).use { realm ->
+            realm.syncSession.uploadAllLocalChanges() // Ensures that we can actually connect
         }
     }
 

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
@@ -164,18 +164,20 @@ JNIEXPORT jboolean JNICALL Java_io_realm_mongodb_sync_SyncSession_nativeWaitForU
         if (session) {
             static JavaClass java_sync_session_class(env, "io/realm/mongodb/sync/SyncSession");
             static JavaMethod java_notify_result_method(env, java_sync_session_class, "notifyAllChangesSent",
-                                                        "(ILjava/lang/Long;Ljava/lang/String;)V");
+                                                        "(ILjava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V");
 
             session->wait_for_upload_completion([session_ref = JavaGlobalRefByCopy(env, session_object), callback_id] (std::error_code error) {
                 JNIEnv* env = JniUtils::get_env(true);
+                JavaLocalRef<jstring> java_error_category;
                 JavaLocalRef<jobject> java_error_code;
                 JavaLocalRef<jstring> java_error_message;
                 if (error != std::error_code{}) {
+                    java_error_category = JavaLocalRef<jstring>(env, env->NewStringUTF(error.category().name()));
                     java_error_code = JavaLocalRef<jobject>(env, JavaClassGlobalDef::new_long(env, error.value()));
                     java_error_message = JavaLocalRef<jstring>(env, env->NewStringUTF(error.message().c_str()));
                 }
                 env->CallVoidMethod(session_ref.get(), java_notify_result_method,
-                                    callback_id, java_error_code.get(), java_error_message.get());
+                                    callback_id, java_error_category.get(), java_error_code.get(), java_error_message.get());
             });
             return JNI_TRUE;
         }

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
@@ -131,19 +131,20 @@ JNIEXPORT jboolean JNICALL Java_io_realm_mongodb_sync_SyncSession_nativeWaitForD
         if (session) {
             static JavaClass java_sync_session_class(env, "io/realm/mongodb/sync/SyncSession");
             static JavaMethod java_notify_result_method(env, java_sync_session_class, "notifyAllChangesSent",
-                                                        "(ILjava/lang/Long;Ljava/lang/String;)V");
+                                                        "(ILjava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V");
 
             session->wait_for_download_completion([session_ref = JavaGlobalRefByCopy(env, session_object), callback_id](std::error_code error) {
                 JNIEnv* env = JniUtils::get_env(true);
+                JavaLocalRef<jstring> java_error_category;
                 JavaLocalRef<jobject> java_error_code;
                 JavaLocalRef<jstring> java_error_message;
                 if (error != std::error_code{}) {
-                    java_error_code =
-                        JavaLocalRef<jobject>(env, JavaClassGlobalDef::new_long(env, error.value()));
+                    java_error_category = JavaLocalRef<jstring>(env, env->NewStringUTF(error.category().name()));
+                    java_error_code = JavaLocalRef<jobject>(env, JavaClassGlobalDef::new_long(env, error.value()));
                     java_error_message = JavaLocalRef<jstring>(env, env->NewStringUTF(error.message().c_str()));
                 }
                 env->CallVoidMethod(session_ref.get(), java_notify_result_method,
-                                    callback_id, java_error_code.get(), java_error_message.get());
+                                    callback_id, java_error_category.get(), java_error_code.get(), java_error_message.get());
             });
             return to_jbool(JNI_TRUE);
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -98,6 +98,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
                 case OBJECT_ID:
                 case INT32:
                 case INT64:
+                case NULL:
                     encodedPartitionValue = JniBsonProtocol.encode(partitionValue, AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY);
                     break;
                 default:

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -184,6 +184,7 @@ public abstract class Sync {
             case OBJECT_ID:
             case INT32:
             case INT64:
+            case NULL:
                 encodedPartitionValue = JniBsonProtocol.encode(partitionValue, AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY);
                 break;
             default:

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
@@ -20,6 +20,7 @@ import android.content.Context;
 
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
+import org.bson.BsonNull;
 import org.bson.BsonObjectId;
 import org.bson.BsonString;
 import org.bson.BsonValue;
@@ -197,7 +198,7 @@ public class SyncConfiguration extends RealmConfiguration {
      * @return the default configuration for the given user and partition value.
      */
     @Beta
-    public static SyncConfiguration defaultConfig(User user, String partitionValue) {
+    public static SyncConfiguration defaultConfig(User user, @Nullable String partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
 
@@ -209,7 +210,7 @@ public class SyncConfiguration extends RealmConfiguration {
      * @return the default configuration for the given user and partition value.
      */
     @Beta
-    public static SyncConfiguration defaultConfig(User user, long partitionValue) {
+    public static SyncConfiguration defaultConfig(User user, @Nullable Long partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
 
@@ -221,7 +222,7 @@ public class SyncConfiguration extends RealmConfiguration {
      * @return the default configuration for the given user and partition value.
      */
     @Beta
-    public static SyncConfiguration defaultConfig(User user, int partitionValue) {
+    public static SyncConfiguration defaultConfig(User user, @Nullable Integer partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
 
@@ -233,7 +234,7 @@ public class SyncConfiguration extends RealmConfiguration {
      * @return the default configuration for the given user and partition value.
      */
     @Beta
-    public static SyncConfiguration defaultConfig(User user, ObjectId partitionValue) {
+    public static SyncConfiguration defaultConfig(User user, @Nullable ObjectId partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
 
@@ -471,8 +472,8 @@ public class SyncConfiguration extends RealmConfiguration {
          * @param user The user that will be used for accessing the Realm App.
          * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
          */
-        public Builder(User user, String partitionValue) {
-            this(user, new BsonString(partitionValue));
+        public Builder(User user, @Nullable String partitionValue) {
+            this(user, (partitionValue == null? new BsonNull() : new BsonString(partitionValue)));
         }
 
         /**
@@ -482,8 +483,8 @@ public class SyncConfiguration extends RealmConfiguration {
          * @param user The user that will be used for accessing the Realm App.
          * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
          */
-        public Builder(User user, ObjectId partitionValue) {
-            this(user, new BsonObjectId(partitionValue));
+        public Builder(User user, @Nullable ObjectId partitionValue) {
+            this(user, (partitionValue == null? new BsonNull() : new BsonObjectId(partitionValue)));
         }
 
         /**
@@ -493,8 +494,8 @@ public class SyncConfiguration extends RealmConfiguration {
          * @param user The user that will be used for accessing the Realm App.
          * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
          */
-        public Builder(User user, int partitionValue) {
-            this(user, new BsonInt32(partitionValue));
+        public Builder(User user, @Nullable Integer partitionValue) {
+            this(user, (partitionValue == null? new BsonNull() : new BsonInt32(partitionValue)));
         }
 
         /**
@@ -504,8 +505,8 @@ public class SyncConfiguration extends RealmConfiguration {
          * @param user The user that will be used for accessing the Realm App.
          * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
          */
-        public Builder(User user, long partitionValue) {
-            this(user, new BsonInt64(partitionValue));
+        public Builder(User user, @Nullable Long partitionValue) {
+            this(user, (partitionValue == null? new BsonNull() : new BsonInt64(partitionValue)));
         }
 
         /**

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
@@ -417,7 +417,7 @@ public class SyncSession {
     // If the native listener was successfully registered, Object Store guarantees that this method will be called at
     // least once, even if the session is closed.
     @SuppressWarnings("unused")
-    private void notifyAllChangesSent(int callbackId, Long errorcode, String errorMessage) {
+    private void notifyAllChangesSent(int callbackId, String errorCategory, Long errorCode, String errorMessage) {
         WaitForSessionWrapper wrapper = waitingForServerChanges.get();
         if (wrapper != null) {
             // Only react to callback if the callback is "active"
@@ -427,7 +427,7 @@ public class SyncSession {
             // 3. Call `uploadAllLocalChanges()` ( callback = 2)
             // 4. Sync notifies session that callback:1 is done. It should be ignored.
             if (waitCounter.get() == callbackId) {
-                wrapper.handleResult(errorcode, errorMessage);
+                wrapper.handleResult(errorCategory, errorCode, errorMessage);
             }
         }
     }
@@ -695,6 +695,7 @@ public class SyncSession {
 
         private final CountDownLatch waiter = new CountDownLatch(1);
         private volatile boolean resultReceived = false;
+        private String errorCategory;
         private Long errorCode = null;
         private String errorMessage;
 
@@ -715,7 +716,8 @@ public class SyncSession {
          * @param errorCode error code if an error occurred, {@code null} if changes were successfully downloaded.
          * @param errorMessage error message (if any).
          */
-        public void handleResult(Long errorCode, String errorMessage) {
+        public void handleResult(String errorCategory, Long errorCode, String errorMessage) {
+            this.errorCategory = errorCategory;
             this.errorCode = errorCode;
             this.errorMessage = errorMessage;
             this.resultReceived = true;
@@ -732,8 +734,16 @@ public class SyncSession {
          */
         public void throwExceptionIfNeeded() {
             if (resultReceived && errorCode != null) {
-                throw new AppException(ErrorCode.UNKNOWN,
-                        String.format(Locale.US, "Internal error (%d): %s", errorCode, errorMessage));
+                // Core report errors with int64, so we need to check some extra checks
+                // to make sure the value is within a range of known errors we can map to,
+                // which are all inside Integer range
+                long longErrorCode = errorCode;
+                ErrorCode mappedError = ErrorCode.fromNativeError(errorCategory, (int) longErrorCode);
+                if (longErrorCode >= Integer.MIN_VALUE && longErrorCode <= Integer.MAX_VALUE && mappedError != ErrorCode.UNKNOWN) {
+                    throw new AppException(mappedError, errorMessage);
+                } else {
+                    throw new AppException(mappedError, String.format(Locale.US, "Internal error (%d): %s", errorCode, errorMessage));
+                }
             }
         }
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
@@ -734,7 +734,7 @@ public class SyncSession {
          */
         public void throwExceptionIfNeeded() {
             if (resultReceived && errorCode != null) {
-                // Core report errors with int64, so we need to check some extra checks
+                // Core report errors with int64, so we need to add some extra checks
                 // to make sure the value is within a range of known errors we can map to,
                 // which are all inside Integer range
                 long longErrorCode = errorCode;

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
@@ -293,7 +293,7 @@ class SyncSessionTests {
             realm.executeTransaction {
                 realm.createObject(SyncAllTypesWithFloat::class.java, ObjectId())
             }
-            assertFailsWithErrorCode(ErrorCode.UNKNOWN) {
+            assertFailsWithErrorCode(ErrorCode.INVALID_SCHEMA_CHANGE) {
                 realm.syncSession.uploadAllLocalChanges()
             }
         }

--- a/tools/sync_test_server/app_config/services/BackingDB/config.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/config.json
@@ -9,6 +9,7 @@
             "partition": {
                 "key": "realm_id",
                 "type": "string",
+                "required": false,
                 "permissions": {
                     "read": true,
                     "write": true


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/7022

Adds support for defining Null partition values. Note the unit test currently captures the server not supporting it, but we will reverse that as soon as it does.

### TODO
- [x] Wait for https://github.com/realm/realm-object-store/pull/1070 to be merged and use it
- [x] Add unit tests for all constructors checking they all point to the same Realm.
- [x] Changelog