### PR TITLE
Automate uploading docs to MongoDB Realm website

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,7 +239,7 @@ task createKotlinRootRedirectFile(type: Copy) {
 
 task uploadJavadoc {
     group = 'Release'
-    description = 'Upload the distribution package to S3'
+    description = 'Upload Java and Kotlin docs to S3'
     dependsOn javadoc
     dependsOn createLatestJavadocRedirectFile
     dependsOn createLatestKotlindocRedirectFile

--- a/build.gradle
+++ b/build.gradle
@@ -195,21 +195,53 @@ task javadoc(type:GradleBuild) {
     configure copyProperties
 }
 
-task javadocPackage(type: Zip) {
-    description = 'Generate a Zip file with all SDK docs'
+// Find property in either System environment or Gradle properties.
+// If set in both places, Gradle properties win.
+def getPropertyValueOrThrow(String propertyName) {
+    def value = System.getenv(propertyName)
+    if (project.hasProperty(propertyName)) {
+        value = project.getProperty(propertyName)
+    }
+    if (value == null || value.trim().isEmpty()) {
+        throw new GradleException("Could not find '$propertyName'. " +
+                "Most be provided as either environment variable or " +
+                "a Gradle property.")
+    }
+    return value
+}
+
+task uploadJavadoc {
+    group = 'Release'
+    description = 'Upload the distribution package to S3'
     dependsOn javadoc
 
-    group = 'Artifact'
-    archiveName = "realm-java-${currentVersion}-docs.zip"
-    destinationDir = file("${buildDir}/outputs/docs")
+    doLast {
+        def awsAccessKey = getPropertyValueOrThrow("SDK_DOCS_AWS_ACCESS_KEY")
+        def awsSecretKey = getPropertyValueOrThrow("SDK_DOCS_AWS_SECRET_KEY")
 
-    from('realm/realm-library/build/docs/javadoc') {
-        include '**/*'
-        into 'javadoc'
-    }
-    from('realm/kotlin-extensions/build/docs') {
-        include '**/*'
-        into 'kotlindocs'
+        // Upload the versioned folder of the docs
+        exec {
+            commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/realm-library/build/docs/javadoc/', "s3://realm-sdks/realm-sdks/java/${currentVersion}/"
+        }
+        exec {
+            commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/kotlin-extensions/build/docs/', "s3://realm-sdks/realm-sdks/kotlin/${currentVersion}/"
+        }
+
+        // /latest should always contain a copy of the latest docs.
+        // We delete the /latest folder first to avoid risk having old subsections around,
+        // then copy all content from the versioned folder
+        exec {
+            commandLine 's3cmd', 'del', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 's3://realm-sdks/realm-sdks/java/latest'
+        }
+        exec {
+            commandLine 's3cmd', 'cp', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "s3://realm-sdks/realm-sdks/java/${currentVersion}/", "s3://realm-sdks/realm-sdks/java/latest/"
+        }
+        exec {
+            commandLine 's3cmd', 'del', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 's3://realm-sdks/realm-sdks/kotlin/latest'
+        }
+        exec {
+            commandLine 's3cmd', 'cp', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "s3://realm-sdks/realm-sdks/kotlin/${currentVersion}/", "s3://realm-sdks/realm-sdks/kotlin/latest/"
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -210,10 +210,40 @@ def getPropertyValueOrThrow(String propertyName) {
     return value
 }
 
+task createLatestJavadocRedirectFile(type: Copy) {
+    description = 'Redirects from /java/latest/ to correct version'
+    from 'realm/templates'
+    into "$buildDir/outputs/doc_redirects/java_latest"
+    include 'redirect.html.template'
+    rename { file -> 'index.html' }
+    expand(title: "Realm Java ${currentVersion}", url: "../${currentVersion}/index.html")
+}
+
+task createLatestKotlindocRedirectFile(type: Copy) {
+    description = 'Redirects from /kotlin/latest/ to correct version'
+    from 'realm/templates'
+    into "$buildDir/outputs/doc_redirects/kotlin_latest"
+    include 'redirect.html.template'
+    rename { file -> 'index.html' }
+    expand(title: "Kotlin Extensions ${currentVersion}", url: "../${currentVersion}/index.html")
+}
+
+task createKotlinRootRedirectFile(type: Copy) {
+    description = 'Redirects from /kotlin/<version>/ to /kotlin/<version>/kotlin-extensions, which is the real root folder'
+    from 'realm/templates'
+    into "$buildDir/outputs/doc_redirects/kotlin_root"
+    include 'redirect.html.template'
+    rename { file -> 'index.html' }
+    expand(title: "Kotlin Extensions ${currentVersion}", url: "./kotlin-extensions/index.html")
+}
+
 task uploadJavadoc {
     group = 'Release'
     description = 'Upload the distribution package to S3'
     dependsOn javadoc
+    dependsOn createLatestJavadocRedirectFile
+    dependsOn createLatestKotlindocRedirectFile
+    dependsOn createKotlinRootRedirectFile
 
     doLast {
         def awsAccessKey = getPropertyValueOrThrow("SDK_DOCS_AWS_ACCESS_KEY")
@@ -227,20 +257,18 @@ task uploadJavadoc {
             commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/kotlin-extensions/build/docs/', "s3://realm-sdks/realm-sdks/kotlin/${currentVersion}/"
         }
 
-        // /latest should always contain a copy of the latest docs.
-        // We delete the /latest folder first to avoid risk having old subsections around,
-        // then copy all content from the versioned folder
+        // Upload automatic redirect for Kotlin extensions, since the directory structure created
+        // by Dokka only have a style.css in the root dir.
         exec {
-            commandLine 's3cmd', 'del', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 's3://realm-sdks/realm-sdks/java/latest'
+            commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/kotlin_root/index.html", "s3://realm-sdks/realm-sdks/kotlin/${currentVersion}/index.html"
+        }
+
+        // Upload redirects to /latest end point so it points to the just uploaded version
+        exec {
+            commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/java_latest/index.html", "s3://realm-sdks/realm-sdks/java/latest/index.html"
         }
         exec {
-            commandLine 's3cmd', 'cp', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "s3://realm-sdks/realm-sdks/java/${currentVersion}/", "s3://realm-sdks/realm-sdks/java/latest/"
-        }
-        exec {
-            commandLine 's3cmd', 'del', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 's3://realm-sdks/realm-sdks/kotlin/latest'
-        }
-        exec {
-            commandLine 's3cmd', 'cp', '-r', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "s3://realm-sdks/realm-sdks/kotlin/${currentVersion}/", "s3://realm-sdks/realm-sdks/kotlin/latest/"
+            commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/kotlin_latest/index.html", "s3://realm-sdks/realm-sdks/kotlin/latest/index.html"
         }
     }
 }

--- a/realm/templates/README.md
+++ b/realm/templates/README.md
@@ -1,0 +1,4 @@
+This folder contains template files used when releasing Realm Java
+
+**redirect.html.template**	
+Template file that can be used to redirect people to other parts of the documentation. 

--- a/realm/templates/redirect.html.template
+++ b/realm/templates/redirect.html.template
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML>
+<meta charset="UTF-8">
+<meta http-equiv="refresh" content="0; url=${url}">
+<script>
+  window.location.href = "${url}"
+</script>
+<title>${title}</title>
+If you are not redirected automatically, follow the <a href="${url}">link to the documentation.</a>


### PR DESCRIPTION
One step closer to having a fully automated release...

It works by:

1) Uploading new docs to a version folder
2) Update the redirect found in `/java/latest` and `kotlin/latest`

Note, there is a also a redirect for the Kotlin docs since Dokka output a slightly annoying format where there only exist a `style.css` in the root and you have to go to a subfolder for the index.html.

### TODO
- [x] Avoid copying the same docs twice and use redirects instead.