### PR TITLE
Include ignored custom user data tests

### DIFF
--- a/dependencies.list
+++ b/dependencies.list
@@ -5,7 +5,7 @@ REALM_SYNC_SHA256=824192a67e7ded59d33707265f78c8d5546b1fef473e9ee5ecff8a5bc9f850
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2020-08-24
+MONGODB_REALM_SERVER=2020-08-27
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=4.0.0

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/UserTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/UserTests.kt
@@ -440,8 +440,6 @@ class UserTests {
     }
 
     @Test
-    @Ignore("Cannot automate custom user data cluster setup yet due to missing CLI support " +
-            "https://github.com/realm/realm-java/issues/6942")
     fun customData_initiallyEmpty() {
         val user = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
         // Newly registered users do not have any custom data with current test server setup
@@ -449,8 +447,6 @@ class UserTests {
     }
 
     @Test
-    @Ignore("Cannot automate custom user data cluster setup yet due to missing CLI support " +
-            "https://github.com/realm/realm-java/issues/6942")
     fun customData_refresh() {
         val user = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
         // Newly registered users do not have any custom data with current test server setup
@@ -464,8 +460,6 @@ class UserTests {
     }
 
     @Test
-    @Ignore("Cannot automate custom user data cluster setup yet due to missing CLI support " +
-            "https://github.com/realm/realm-java/issues/6942")
     fun customData_refreshAsync() = looperThread.runBlocking {
         val user = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
         // Newly registered users do not have any custom data with current test server setup
@@ -482,8 +476,6 @@ class UserTests {
     }
 
     @Test
-    @Ignore("Cannot automate custom user data cluster setup yet due to missing CLI support " +
-            "https://github.com/realm/realm-java/issues/6942")
     fun customData_refreshByLogout() {
         val password = "123456"
         val user = app.registerUserAndLogin(TestHelper.getRandomEmail(), password)
@@ -499,8 +491,6 @@ class UserTests {
     }
 
     @Test
-    @Ignore("Cannot automate custom user data cluster setup yet due to missing CLI support " +
-            "https://github.com/realm/realm-java/issues/6942")
     fun customData_refreshAsyncThrowsOnNonLooper() {
         val password = "123456"
         val user = app.registerUserAndLogin(TestHelper.getRandomEmail(), password)

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -195,14 +195,12 @@ class SyncedRealmTests {
 
     @Test
     fun nullPartition() {
-        val config = configFactory.createSyncConfigurationBuilder(createNewUser(), BsonNull()).build()
+        val config = configFactory.createSyncConfigurationBuilder(createNewUser(), BsonNull())
+                .modules(DefaultSyncSchema())
+                .build()
         assertTrue(config.path.endsWith("null.realm"))
         Realm.getInstance(config).use { realm ->
-            // FIXME: This currently fails because the server does not yet support the Null partition
-            //  Remove the catch once it is supported, after which uploading changes should work.
-            assertFailsWithErrorCode(ErrorCode.ILLEGAL_REALM_PATH) {
-                realm.syncSession.uploadAllLocalChanges() // Ensures that we can actually connect
-            }
+            realm.syncSession.uploadAllLocalChanges() // Ensures that we can actually connect
         }
     }
 

--- a/tools/sync_test_server/app_config/auth_providers/anon-user.json
+++ b/tools/sync_test_server/app_config/auth_providers/anon-user.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae9",
+    "id": "5f47673420f7388c73e8691d",
     "name": "anon-user",
     "type": "anon-user",
     "disabled": false

--- a/tools/sync_test_server/app_config/auth_providers/api-key.json
+++ b/tools/sync_test_server/app_config/auth_providers/api-key.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40aea",
+    "id": "5f47673420f7388c73e8691e",
     "name": "api-key",
     "type": "api-key",
     "disabled": false

--- a/tools/sync_test_server/app_config/auth_providers/custom-function.json
+++ b/tools/sync_test_server/app_config/auth_providers/custom-function.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40aeb",
+    "id": "5f47673420f7388c73e8691f",
     "name": "custom-function",
     "type": "custom-function",
     "config": {

--- a/tools/sync_test_server/app_config/auth_providers/local-userpass.json
+++ b/tools/sync_test_server/app_config/auth_providers/local-userpass.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40aec",
+    "id": "5f47673420f7388c73e86920",
     "name": "local-userpass",
     "type": "local-userpass",
     "config": {

--- a/tools/sync_test_server/app_config/functions/authFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/authFunc/config.json
@@ -1,6 +1,6 @@
 {
-    "id": "5edea20f0f99fe616bf40ae0",
+    "can_evaluate": {},
+    "id": "5f47673420f7388c73e86913",
     "name": "authFunc",
-    "private": false,
-    "can_evaluate": {}
+    "private": false
 }

--- a/tools/sync_test_server/app_config/functions/authorizedOnly/config.json
+++ b/tools/sync_test_server/app_config/functions/authorizedOnly/config.json
@@ -1,12 +1,12 @@
 {
-    "id": "5edea20f0f99fe616bf40ae1",
-    "name": "authorizedOnly",
-    "private": false,
     "can_evaluate": {
         "%%user.data.email": {
             "%in": [
                 "authorizeduser@example.org"
             ]
         }
-    }
+    },
+    "id": "5f47673420f7388c73e86914",
+    "name": "authorizedOnly",
+    "private": false
 }

--- a/tools/sync_test_server/app_config/functions/confirmFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/confirmFunc/config.json
@@ -1,6 +1,6 @@
 {
-    "id": "5edea20f0f99fe616bf40ae2",
+    "can_evaluate": {},
+    "id": "5f47673420f7388c73e86915",
     "name": "confirmFunc",
-    "private": false,
-    "can_evaluate": {}
+    "private": false
 }

--- a/tools/sync_test_server/app_config/functions/error/config.json
+++ b/tools/sync_test_server/app_config/functions/error/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae3",
+    "id": "5f47673420f7388c73e86916",
     "name": "error",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/firstArg/config.json
+++ b/tools/sync_test_server/app_config/functions/firstArg/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae4",
+    "id": "5f47673420f7388c73e86917",
     "name": "firstArg",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/null/config.json
+++ b/tools/sync_test_server/app_config/functions/null/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae5",
+    "id": "5f47673420f7388c73e86918",
     "name": "null",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/resetFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/resetFunc/config.json
@@ -1,6 +1,6 @@
 {
-    "id": "5edea20f0f99fe616bf40ae6",
+    "can_evaluate": {},
+    "id": "5f47673420f7388c73e86919",
     "name": "resetFunc",
-    "private": false,
-    "can_evaluate": {}
+    "private": false
 }

--- a/tools/sync_test_server/app_config/functions/sum/config.json
+++ b/tools/sync_test_server/app_config/functions/sum/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae7",
+    "id": "5f47673420f7388c73e8691a",
     "name": "sum",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/testAuthFunc/config.json
+++ b/tools/sync_test_server/app_config/functions/testAuthFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae8",
+    "id": "5f47673420f7388c73e8691b",
     "name": "testAuthFunc",
     "private": false
 }

--- a/tools/sync_test_server/app_config/functions/void/config.json
+++ b/tools/sync_test_server/app_config/functions/void/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40ae9",
+    "id": "5f47673420f7388c73e8691c",
     "name": "void",
     "private": false
 }

--- a/tools/sync_test_server/app_config/graphql/config.json
+++ b/tools/sync_test_server/app_config/graphql/config.json
@@ -1,0 +1,3 @@
+{
+    "use_natural_pluralization": false
+}

--- a/tools/sync_test_server/app_config/services/BackingDB/config.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea20f0f99fe616bf40adc",
+    "id": "5f47673420f7388c73e8690d",
     "name": "BackingDB",
     "type": "mongodb",
     "config": {
@@ -9,7 +9,6 @@
             "partition": {
                 "key": "realm_id",
                 "type": "string",
-                "required": false,
                 "permissions": {
                     "read": true,
                     "write": true

--- a/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncDog.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncDog.json
@@ -1,7 +1,7 @@
 {
-    "id": "5edea20f0f99fe616bf40add",
-    "database": "test_data",
     "collection": "SyncDog",
+    "database": "test_data",
+    "id": "5f47673420f7388c73e8690e",
     "roles": [
         {
             "name": "default",

--- a/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncPerson.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.SyncPerson.json
@@ -1,10 +1,10 @@
 {
-    "id": "5edea20f0f99fe616bf40ade",
-    "database": "test_data",
     "collection": "SyncPerson",
+    "database": "test_data",
+    "id": "5f47673420f7388c73e8690f",
     "relationships": {
         "dogs": {
-            "ref": "#/stitch/BackingDB/test_data/SyncDog",
+            "ref": "#/relationship/BackingDB/test_data/SyncDog",
             "source_key": "dogs",
             "foreign_key": "_id",
             "is_list": true

--- a/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.custom_user_data.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.custom_user_data.json
@@ -1,7 +1,7 @@
 {
-    "id": "5ede0729eab8deea4edf057c",
-    "database": "test_data",
     "collection": "custom_user_data",
+    "database": "test_data",
+    "id": "5f47673420f7388c73e86910",
     "roles": [
         {
             "name": "default",

--- a/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.mongo_data.json
+++ b/tools/sync_test_server/app_config/services/BackingDB/rules/test_data.mongo_data.json
@@ -1,7 +1,7 @@
 {
-    "id": "5edea20f0f99fe616bf40adf",
-    "database": "test_data",
     "collection": "mongo_data",
+    "database": "test_data",
+    "id": "5f47673420f7388c73e86911",
     "roles": [
         {
             "name": "default",

--- a/tools/sync_test_server/app_config/services/gcm/config.json
+++ b/tools/sync_test_server/app_config/services/gcm/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5edea2480f99fe616bf40b6a",
+    "id": "5f47673420f7388c73e86912",
     "name": "gcm",
     "type": "gcm",
     "config": {

--- a/tools/sync_test_server/app_config/stitch.json
+++ b/tools/sync_test_server/app_config/stitch.json
@@ -1,13 +1,13 @@
 {
-    "app_id": "realm-sdk-integration-tests-nldpe",
-    "config_version": 20180301,
+    "app_id": "realm-sdk-integration-tests-werwa",
+    "config_version": 20200603,
     "name": "realm-sdk-integration-tests",
     "location": "US-VA",
     "deployment_model": "GLOBAL",
     "security": {},
     "custom_user_data_config": {
         "enabled": true,
-        "mongo_service_id": "5ede0729eab8deea4edf0579",
+        "mongo_service_name": "BackingDB",
         "database_name": "test_data",
         "collection_name": "custom_user_data",
         "user_id_field": "userid"


### PR DESCRIPTION
Server image now supports importing apps with custom user data cluster configuration. 

Also fixed expected results for tests for #7022 with new server image. 

Closes #6942