### PR TITLE
Add rules for bson type references

### DIFF
--- a/examples/mongoDbRealmExample/build.gradle
+++ b/examples/mongoDbRealmExample/build.gradle
@@ -44,6 +44,7 @@ android {
         debug {
             buildConfigField "String", "MONGODB_REALM_URL", "\"${mongodbRealmUrl}\""
             buildConfigField "String", "MONGODB_REALM_APP_ID", "\"${appId}\""
+            minifyEnabled true
         }
         release {
             buildConfigField "String", "MONGODB_REALM_URL", "\"${mongodbRealmUrl}\""

--- a/realm/realm-library/proguard-rules-consumer-common.pro
+++ b/realm/realm-library/proguard-rules-consumer-common.pro
@@ -20,3 +20,7 @@
 }
 
 -dontnote rx.Observable
+
+# Referenced on JNI
+-keep class org.bson.types.Decimal128
+-keep class org.bson.types.ObjectId

--- a/realm/realm-library/proguard-rules-consumer-common.pro
+++ b/realm/realm-library/proguard-rules-consumer-common.pro
@@ -21,6 +21,6 @@
 
 -dontnote rx.Observable
 
-# Referenced on JNI
+# Referenced from JNI
 -keep class org.bson.types.Decimal128
 -keep class org.bson.types.ObjectId

--- a/realm/realm-library/proguard-rules-consumer-objectServer.pro
+++ b/realm/realm-library/proguard-rules-consumer-objectServer.pro
@@ -8,3 +8,23 @@
 
 # See https://github.com/square/okhttp/issues/3922
 -dontwarn okhttp3.internal.platform.*
+
+# Referenced from JNI
+-keep class io.realm.internal.objectstore.OsJavaNetworkTransport$Response {
+    int getHttpResponseCode();
+    int getCustomResponseCode();
+    java.lang.String[] getJNIFriendlyHeaders();
+    java.lang.String getBody();
+}
+
+-keep class io.realm.internal.objectstore.OsJavaNetworkTransport$Request {
+    <init>(...);
+}
+
+-keep class io.realm.internal.OsSharedRealm$SchemaChangedCallback {
+    void onSchemaChanged();
+}
+
+-keep class io.realm.internal.objectstore.OsApp {
+    io.realm.internal.objectstore.OsJavaNetworkTransport getNetworkTransport();
+}

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OsJNIVoidResultCallback.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/jni/OsJNIVoidResultCallback.java
@@ -18,6 +18,9 @@ package io.realm.internal.jni;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.realm.internal.Keep;
+
+@Keep
 public class OsJNIVoidResultCallback extends OsJNIResultCallback {
 
     public OsJNIVoidResultCallback(AtomicReference error) {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppException.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppException.java
@@ -19,6 +19,7 @@ package io.realm.mongodb;
 import javax.annotation.Nullable;
 
 import io.realm.annotations.Beta;
+import io.realm.internal.Keep;
 import io.realm.internal.Util;
 import io.realm.mongodb.sync.SyncSession;
 
@@ -33,6 +34,7 @@ import io.realm.mongodb.sync.SyncSession;
  * @see ErrorCode for a list of possible errors.
  */
 @Beta
+@Keep
 public class AppException extends RuntimeException {
 
     // The Java representation of the error.

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/ErrorCode.java
@@ -20,6 +20,7 @@ package io.realm.mongodb;
 import java.util.Locale;
 
 import io.realm.annotations.Beta;
+import io.realm.internal.Keep;
 import io.realm.internal.objectstore.OsJavaNetworkTransport;
 import io.realm.log.RealmLog;
 import io.realm.mongodb.sync.SyncConfiguration;
@@ -28,6 +29,7 @@ import io.realm.mongodb.sync.SyncConfiguration;
  * This class enumerate all potential errors related to using the Object Server or synchronizing data.
  */
 @Beta
+@Keep
 public enum ErrorCode {
 
     // See Client::Error in https://github.com/realm/realm-sync/blob/master/src/realm/sync/client.hpp#L1230


### PR DESCRIPTION
This PR protects ObjectId and Decimal128 BSON types in proguard.