### PR TITLE
Fix NullPointerException in toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes
 * In some cases a frozen Realm of the wrong version could be returned.
 * Upgrading files with string primary keys would result in a file where it was not possible to find the objects by primary key. ([Core issue #3893](https://github.com/realm/realm-core/pull/3893), since 7.0.0)
+* NullPointerException when calling `toString` on RealmObjects with a binary field containing `null`. (Issue [#7084](https://github.com/realm/realm-java/issues/7084), since 7.0.0)
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -1630,7 +1630,11 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                             emitStatement("stringBuilder.append(%s().get())", metadata.getInternalGetter(fieldName))
                         }
                         Utils.isByteArray(field) -> {
-                            emitStatement("stringBuilder.append(\"binary(\" + %s().length + \")\")", metadata.getInternalGetter(fieldName))
+                            if (metadata.isNullable(field)) {
+                                emitStatement("stringBuilder.append((%1\$s() == null) ? \"null\" : \"binary(\" + %1\$s().length + \")\")", metadata.getInternalGetter(fieldName))
+                            } else {
+                                emitStatement("stringBuilder.append(\"binary(\" + %1\$s().length + \")\")", metadata.getInternalGetter(fieldName))
+                            }
                         }
                         else -> {
                             if (metadata.isNullable(field)) {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NullTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_NullTypesRealmProxy.java
@@ -3960,7 +3960,7 @@ public class some_test_NullTypesRealmProxy extends some.test.NullTypes
         stringBuilder.append("}");
         stringBuilder.append(",");
         stringBuilder.append("{fieldBytesNull:");
-        stringBuilder.append("binary(" + realmGet$fieldBytesNull().length + ")");
+        stringBuilder.append((realmGet$fieldBytesNull() == null) ? "null" : "binary(" + realmGet$fieldBytesNull().length + ")");
         stringBuilder.append("}");
         stringBuilder.append(",");
         stringBuilder.append("{fieldByteNotNull:");

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmObjectTests.java
@@ -478,6 +478,17 @@ public class RealmObjectTests {
         assertEquals(expected, cm.toString());
     }
 
+    // Test for https://github.com/realm/realm-java/issues/7084
+    @Test
+    public void toString_nullBinary() {
+        realm.beginTransaction();
+        AllJavaTypes obj = realm.createObject(AllJavaTypes.class, 1);
+        obj.setFieldBinary(null);
+        realm.commitTransaction();
+        String desc = obj.toString();
+        assertTrue(desc.contains("fieldBinary:null"));
+    }
+
     @Test
     public void hashCode_cyclicObject() {
         realm.beginTransaction();


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/7084

Fixes a bug when calling `toString()` on a RealmObject with a `byte[]` field that contained the value `null`.