### PR TITLE
Automate 10.x releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -299,24 +299,23 @@ def runBuild(abiFilter, instrumentationTestTarget) {
 
 def runRelease() {
   stage('Publish Release') {
-    withCredentials([[ $class: 'StringBinding', credentialsId: 'slack-webhook-java-ci-channel', variable: 'SLACK_URL_CI']]) {
-      withCredentials([[$class: 'StringBinding', credentialsId: 'slack-webhook-releases-channel', variable: 'SLACK_URL_RELEASE']]) {
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'bintray', passwordVariable: 'BINTRAY_KEY', usernameVariable: 'BINTRAY_USER']]) {
-          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'DOCS_S3_ACCESS_KEY', credentialsId: 'mongodb-realm-docs-s3', secretKeyVariable: 'DOCS_S3_SECRET_ACCESS']]) {
-            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'REALM_S3_ACCESS_KEY', credentialsId: 'realm-s3', secretKeyVariable: 'REALM_S3_SECRET_ACCESS']]) {
-              sh '''
-                set +x  
-                tools/publish_release.sh "$BINTRAY_USER" "$BINTRAY_KEY" \
-                "$REALM_S3_ACCESS_KEY" "$REALM_S3_SECRET_KEY" \
-                "$DOCS_S3_ACCESS_KEY" "$DOCS_S3_SECRET_KEY" \
-                "$SLACK_URL_RELEASE" \
-                "SLACK_URL_CI"
-              '''
-            }
-          }
-        }
-      }
+    withCredentials([
+      [$class: 'StringBinding', credentialsId: 'slack-webhook-java-ci-channel', variable: 'SLACK_URL_CI'],
+      [$class: 'StringBinding', credentialsId: 'slack-webhook-releases-channel', variable: 'SLACK_URL_RELEASE'],
+      [$class: 'UsernamePasswordMultiBinding', credentialsId: 'bintray', passwordVariable: 'BINTRAY_KEY', usernameVariable: 'BINTRAY_USER'],
+      [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'DOCS_S3_ACCESS_KEY', credentialsId: 'mongodb-realm-docs-s3', secretKeyVariable: 'DOCS_S3_SECRET_ACCESS'],
+      [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'REALM_S3_ACCESS_KEY', credentialsId: 'realm-s3', secretKeyVariable: 'REALM_S3_SECRET_ACCESS']
+    ]) {
+      sh '''
+        set +x  
+        tools/publish_release.sh "$BINTRAY_USER" "$BINTRAY_KEY" \
+        "$REALM_S3_ACCESS_KEY" "$REALM_S3_SECRET_KEY" \
+        "$DOCS_S3_ACCESS_KEY" "$DOCS_S3_SECRET_KEY" \
+        "$SLACK_URL_RELEASE" \
+        "SLACK_URL_CI"
+      '''
     }
+  }
 }
 
 def forwardAdbPorts() {

--- a/build.gradle
+++ b/build.gradle
@@ -372,8 +372,8 @@ task uploadDistributionPackage {
     group = 'Release'
     description = 'Upload the distribution package to S3'
     dependsOn distributionJniUnstrippedPackage
-    def s3AccessKey = "${getPropertyValueOrThrow('REALM_S3_ACCESS_KEY')}"
-    def s3SecretKey = "${getPropertyValueOrThrow('REALM_S3_SECRET_KEY')}"
+    def s3AccessKey = "${ -> getPropertyValueOrThrow('REALM_S3_ACCESS_KEY')}"
+    def s3SecretKey = "${ -> getPropertyValueOrThrow('REALM_S3_SECRET_KEY')}"
     doLast {
         exec {
             workingDir "${buildDir}/outputs/distribution/"
@@ -385,8 +385,8 @@ task uploadDistributionPackage {
 task uploadUpdateVersion(type: Exec) {
     group = 'Release'
     description = 'Update the file on S3 containing the latest version'
-    def s3AccessKey = "${getPropertyValueOrThrow('REALM_S3_ACCESS_KEY')}"
-    def s3SecretKey = "${getPropertyValueOrThrow('REALM_S3_SECRET_KEY')}"
+    def s3AccessKey = "${ -> getPropertyValueOrThrow('REALM_S3_ACCESS_KEY')}"
+    def s3SecretKey = "${ -> getPropertyValueOrThrow('REALM_S3_SECRET_KEY')}"
     commandLine 's3cmd', "--access_key=${s3AccessKey}", "--secret_key=${s3SecretKey}", 'put', "${rootDir}/version.txt", 's3://static.realm.io/update/java'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -372,8 +372,8 @@ task uploadDistributionPackage {
     group = 'Release'
     description = 'Upload the distribution package to S3'
     dependsOn distributionJniUnstrippedPackage
-    def s3AccessKey = getPropertyValueOrThrow("REALM_S3_ACCESS_KEY")
-    def s3SecretKey = getPropertyValueOrThrow("REALM_S3_SECRET_KEY")
+    def s3AccessKey = "${getPropertyValueOrThrow('REALM_S3_ACCESS_KEY')}"
+    def s3SecretKey = "${getPropertyValueOrThrow('REALM_S3_SECRET_KEY')}"
     doLast {
         exec {
             workingDir "${buildDir}/outputs/distribution/"
@@ -385,8 +385,8 @@ task uploadDistributionPackage {
 task uploadUpdateVersion(type: Exec) {
     group = 'Release'
     description = 'Update the file on S3 containing the latest version'
-    def s3AccessKey = getPropertyValueOrThrow("REALM_S3_ACCESS_KEY")
-    def s3SecretKey = getPropertyValueOrThrow("REALM_S3_SECRET_KEY")
+    def s3AccessKey = "${getPropertyValueOrThrow('REALM_S3_ACCESS_KEY')}"
+    def s3SecretKey = "${getPropertyValueOrThrow('REALM_S3_SECRET_KEY')}"
     commandLine 's3cmd', "--access_key=${s3AccessKey}", "--secret_key=${s3SecretKey}", 'put', "${rootDir}/version.txt", 's3://static.realm.io/update/java'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,21 @@ apply plugin: 'ch.netzwerg.release'
 
 def currentVersion = file("${projectDir}/version.txt").text.trim()
 
+// Find property in either System environment or Gradle properties.
+// If set in both places, Gradle properties win.
+def getPropertyValueOrThrow(String propertyName) {
+    def value = System.getenv(propertyName)
+    if (project.hasProperty(propertyName)) {
+        value = project.getProperty(propertyName)
+    }
+    if (value == null || value.trim().isEmpty()) {
+        throw new GradleException("Could not find '$propertyName'. " +
+                "Most be provided as either environment variable or " +
+                "a Gradle property.")
+    }
+    return value
+}
+
 // Shared configuration that copies relevant properties from the root level and parse them on to
 // child projects.
 def copyProperties = {
@@ -195,21 +210,6 @@ task javadoc(type:GradleBuild) {
     configure copyProperties
 }
 
-// Find property in either System environment or Gradle properties.
-// If set in both places, Gradle properties win.
-def getPropertyValueOrThrow(String propertyName) {
-    def value = System.getenv(propertyName)
-    if (project.hasProperty(propertyName)) {
-        value = project.getProperty(propertyName)
-    }
-    if (value == null || value.trim().isEmpty()) {
-        throw new GradleException("Could not find '$propertyName'. " +
-                "Most be provided as either environment variable or " +
-                "a Gradle property.")
-    }
-    return value
-}
-
 task createLatestJavadocRedirectFile(type: Copy) {
     description = 'Redirects from /java/latest/ to correct version'
     from 'realm/templates'
@@ -372,10 +372,12 @@ task uploadDistributionPackage {
     group = 'Release'
     description = 'Upload the distribution package to S3'
     dependsOn distributionJniUnstrippedPackage
+    def s3AccessKey = getPropertyValueOrThrow("REALM_S3_ACCESS_KEY")
+    def s3SecretKey = getPropertyValueOrThrow("REALM_S3_SECRET_KEY")
     doLast {
         exec {
             workingDir "${buildDir}/outputs/distribution/"
-            commandLine 's3cmd', 'put', "realm-java-jni-libs-unstripped-${currentVersion}.zip", 's3://static.realm.io/downloads/java/'
+            commandLine 's3cmd', "--access_key=${s3AccessKey}", "--secret_key=${s3SecretKey}", 'put', "realm-java-jni-libs-unstripped-${currentVersion}.zip", 's3://static.realm.io/downloads/java/'
         }
     }
 }
@@ -383,7 +385,9 @@ task uploadDistributionPackage {
 task uploadUpdateVersion(type: Exec) {
     group = 'Release'
     description = 'Update the file on S3 containing the latest version'
-    commandLine 's3cmd', 'put', "${rootDir}/version.txt", 's3://static.realm.io/update/java'
+    def s3AccessKey = getPropertyValueOrThrow("REALM_S3_ACCESS_KEY")
+    def s3SecretKey = getPropertyValueOrThrow("REALM_S3_SECRET_KEY")
+    commandLine 's3cmd', "--access_key=${s3AccessKey}", "--secret_key=${s3SecretKey}", 'put', "${rootDir}/version.txt", 's3://static.realm.io/update/java'
 }
 
 task distribute {

--- a/build.gradle
+++ b/build.gradle
@@ -287,35 +287,6 @@ task assemble {
     dependsOn assembleExamples
 }
 
-task distributionPackage(type:Zip) {
-    description = 'Generate the distribution package'
-    dependsOn assembleRealm
-    dependsOn javadoc
-
-    group = 'Artifact'
-    archiveName = "realm-java-${currentVersion}.zip"
-    destinationDir = file("${buildDir}/outputs/distribution")
-
-    from('changelog.txt')
-    from('LICENSE')
-    from('version.txt')
-    from('realm.properties')
-    from('realm/realm-library/build/libs') {
-        include 'realm-android-${currentVersion}-javadoc.jar'
-        into 'docs'
-    }
-    from('realm/realm-library/build/docs') {
-        include '**/*'
-        into 'docs'
-    }
-    from('examples') {
-        exclude 'local.properties'
-        exclude '**/.gradle'
-        exclude '**/build'
-        into 'examples'
-    }
-}
-
 task distributionJniUnstrippedPackage(type:Zip) {
     description = 'Generate native libs package with debug symbols'
     dependsOn assembleRealm
@@ -400,13 +371,8 @@ task manualClean {
 task uploadDistributionPackage {
     group = 'Release'
     description = 'Upload the distribution package to S3'
-    dependsOn distributionPackage
     dependsOn distributionJniUnstrippedPackage
     doLast {
-        exec {
-            workingDir "${buildDir}/outputs/distribution/"
-            commandLine 's3cmd', 'put', "realm-java-${currentVersion}.zip", 's3://static.realm.io/downloads/java/'
-        }
         exec {
             workingDir "${buildDir}/outputs/distribution/"
             commandLine 's3cmd', 'put', "realm-java-jni-libs-unstripped-${currentVersion}.zip", 's3://static.realm.io/downloads/java/'
@@ -414,34 +380,16 @@ task uploadDistributionPackage {
     }
 }
 
-task createEmptyFile(type: Exec) {
-    group = 'Release'
-    description = 'Create an empty file that will serve as a link on S3'
-    dependsOn uploadDistributionPackage
-    commandLine 'touch', 'latest'
-}
-
-['java', 'android'].each() { link ->
-    task "upload${link.capitalize()}LatestLink"(type: Exec) {
-        group = 'Release'
-        description = "Update the link to the latest version for ${link.capitalize()}"
-        dependsOn createEmptyFile
-        commandLine 's3cmd', 'put', 'latest', "--add-header=x-amz-website-redirect-location:/downloads/java/realm-java-${currentVersion}.zip", "s3://static.realm.io/downloads/${link}/latest"
-    }
-}
-
 task uploadUpdateVersion(type: Exec) {
     group = 'Release'
     description = 'Update the file on S3 containing the latest version'
-    ['java', 'android'].each() { link ->
-        dependsOn "upload${link.capitalize()}LatestLink"
-    }
     commandLine 's3cmd', 'put', "${rootDir}/version.txt", 's3://static.realm.io/update/java'
 }
 
 task distribute {
     group = 'Release'
     description = 'Distribute release artifacts to S3'
+    dependsOn uploadDistributionPackage
     dependsOn uploadUpdateVersion
 }
 
@@ -478,6 +426,53 @@ task bintrayTransformer(type: GradleBuild) {
     tasks = ['bintrayUpload']
 }
 
+import groovy.json.JsonSlurper
+def checkPackageIsReady(String packageName, String version) {
+    // See https://bintray.com/docs/api/#_get_version
+    def userName = project.findProperty('bintrayUser') ?: 'noUser'
+    def accessKey = project.findProperty('bintrayKey') ?: 'noKey'
+    def result = new ByteArrayOutputStream()
+    exec {
+        commandLine 'curl',
+                '-X',
+                'GET',
+                '-u',
+                "${userName}:${accessKey}",
+                "https://api.bintray.com/packages/realm/maven/$packageName/versions/$version"
+        standardOutput = result
+    }
+    def parser = new JsonSlurper()
+    def commandlineResponse = result.toString()
+    def json = parser.parseText(commandlineResponse)
+    if (json["published"] != false) {
+        throw new GradleException("$packageName was not ready to be published: $commandlineResponse")
+    }
+}
+
+int publishPackage(String packageName, String version) {
+    // See https://bintray.com/docs/api/#_publish_discard_uploaded_content
+    def userName = project.findProperty('bintrayUser') ?: 'noUser'
+    def accessKey = project.findProperty('bintrayKey') ?: 'noKey'
+    def result = new ByteArrayOutputStream()
+    exec {
+        commandLine 'curl',
+                '-X',
+                'POST',
+                '-u',
+                "${userName}:${accessKey}",
+                "https://api.bintray.com/content/realm/maven/$packageName/$version/publish"
+        standardOutput = result
+    }
+    def parser = new JsonSlurper()
+    def commandlineResponse = result.toString()
+    println "$commandlineResponse"
+    def json = parser.parseText(commandlineResponse)
+    if (!json.keySet().contains('files')) {
+        throw new GradleException("$packageName was not correctly published: $commandlineResponse")
+    }
+    return json['files']
+}
+
 task bintrayUpload {
     description = 'Publish all the Realm artifacts to Bintray'
     group = 'Publishing'
@@ -485,6 +480,40 @@ task bintrayUpload {
     dependsOn bintrayAnnotations
     dependsOn bintrayGradlePlugin
     dependsOn bintrayTransformer
+
+    doLast {
+        // All the packages we want to release
+        def packages = [ "realm-annotations",
+                         "realm-transformer",
+                         "realm-annotations-processor",
+                         "realm-android-library",
+                         "realm-android-library-object-server",
+                         "realm-android-kotlin-extensions",
+                         "realm-android-kotlin-extensions-object-server",
+                         "realm-gradle-plugin" ]
+
+        // Number of files we expect to have been released. If this
+        // does not happen, an error is thrown and manual intervention
+        // is needed.
+        def expectedFilesReleasedCount = 24
+
+        // Check that all packages are available on BinTray before publishing them
+        // This makes it possible to quickly release them using the Web UI if
+        // anything goes wrong.
+        packages.each {pckg ->
+            checkPackageIsReady(pckg, currentVersion);
+        }
+
+        // Once we verified all packages are ready, we release them while keeping
+        // track of the number of released files.
+        def releasedFilesCount = 0
+        packages.each {pckg ->
+            releasedFilesCount += publishPackage(pckg, currentVersion);
+        }
+        if (releasedFilesCount != expectedFilesReleasedCount) {
+            throw new GradleException("Something went wrong when releasing on BinTray. Number of files did not match the expected: $releasedFilesCount vs. $expectedFilesReleasedCount")
+        }
+    }
 }
 
 task ojoRealm(type: GradleBuild) {

--- a/tools/publish_release.sh
+++ b/tools/publish_release.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+# Script that make sure release build is correctly published in the appropriate channels.
+#
+# The following steps are executed:
+#
+# 1. Check that version in version.txt matches git tag which indicate a release.
+# 2. Check that the changelog has a correct set date.
+# 3. Build Javadoc
+# 4. Upload all artifacts to Bintray without releasing them.
+# 5. Verify that all artifacts have been uploaded, then release all of them at once.
+# 6. Upload native debug symobols and update latest version number on S3.
+# 7. Upload Javadoc to MongoDB Realm S3 bucket.
+# 8. Notify #realm-releases and #realm-java-team-ci about the new release.
+
+IFS=$'\n\t'
+
+######################################
+# Input Validation
+######################################
+
+usage() {
+cat <<EOF
+Usage: $0 <slack-webhook-releases-url> <slack-webhook-java-ci-url>
+EOF
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ] ; then
+    usage
+    exit 1
+fi
+
+######################################
+# Define Release steps
+######################################
+
+HERE="$(pwd)"
+REALM_JAVA_PATH="$(pwd)/.."
+RELEASE_VERSION=""
+SLACK_WEBHOOK_RELEASES_URL="$1"
+SLACK_WEBHOOK_JAVA_CI_URL="$2"
+
+check_env() {
+    echo "Checking environment..."
+
+    # Try to find s3cmd
+    path_to_s3cmd=$(which s3cmd)
+    if [[ ! -x "$path_to_s3cmd" ]] ; then
+        echo "Cannot find executable file 's3cmd'. Aborting."
+        abort_release()
+        exit -1
+    fi
+
+    # Try to find git
+    path_to_git=$(which git)
+    if [[ ! -x "$path_to_git" ]] ; then
+        echo "Cannot find executable file 'git'. Aborting."
+        abort_release()
+        exit -1
+    fi
+
+    # Try to find pcregrep
+    path_to_pcregrep=$(which pcregrep)
+    if [[ ! -x "$path_to_pcregrep" ]] ; then
+        echo "Cannot find executable file 'pcregrep'. Aborting."
+        abort_release()
+        exit -1
+    fi
+
+    echo "Environment is OK."
+}
+
+verify_release_preconditions() {
+	echo "Checking release branch..."
+	gitTag=`git describe --tags | tr -d '[:space:]'`
+	version=`cat $HERE/../version.txt | tr -d '[:space:]'`
+
+	if [[ "v$version" == "$gitTag" ]]; then
+		RELEASE_VERSION=$version
+	    echo "Git tag and version.txt matches: $version. Continue releasing."
+	else
+	    echo "Version in version.txt was '$version' while the branch was tagged with '$gitTag'. Aborting release."
+      abort_release()
+	    exit -1
+	fi
+}
+
+verify_changelog() {
+	echo "Checking CHANGELOG.md..."
+	query="grep -c '^## $RELEASE_VERSION ([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])' $HERE/../CHANGELOG.md"
+
+	if [[ `eval $query` -ne 1 ]]; then
+		echo "Changelog does not appear to be correct. First line should match the version being released and the date should be set. Aborting."
+    abort_release()
+		exit -1
+	else 
+		echo "CHANGELOG date and version is correctly set."
+	fi
+}
+
+create_javadoc() {
+	echo "Creating JavaDoc..."
+	cd $REALM_JAVA_PATH
+	./gradlew javadoc
+	cd $HERE
+}
+
+create_native_debug_symbols_package() {
+	echo "Creating zip file with native debug symbols.."
+	cd $REALM_JAVA_PATH
+	./gradlew distributionPackage
+	cd $HERE
+}
+
+upload_to_bintray() {
+	echo "Releasing on Bintray..."
+	cd $REALM_JAVA_PATH
+	./gradlew bintrayUpload
+	cd $HERE
+}
+
+upload_debug_symbols() {
+	echo "Uploading native debug symbols..."
+	cd $REALM_JAVA_PATH
+	./gradlew distribute
+	cd $HERE
+}
+
+upload_javadoc() {
+	echo "Uploading docs..."
+	cd $REALM_JAVA_PATH
+	./gradlew uploadJavadoc
+	cd $HERE
+}
+
+notify_slack_channels() {
+	echo "Notifying Slack channels..."
+
+	# Read first . Link is the value with ".",")","(" and space removed.
+	tag=`grep '$RELEASE_VERSION' $REALM_JAVA_PATH/CHANGELOG.md | cut -c 4- | sed 's/[.)(]//g' | sed 's/ /-/g'`
+	if [ -z "$tag" ]; then
+      echo "\$tag did not resolve correctly. Aborting."
+      abort_release()
+	fi
+ 	current_branch=`git rev-parse --abbrev-ref HEAD`
+	if [ -z "$current_branch" ]; then
+      echo "Could not find current branch. Aborting."
+      abort_release()
+	fi
+
+	link_to_changelog="https://github.com/realm/realm-java/blob/$current_branch/CHANGELOG.md#$tag"
+	payload="{ \"username\": \"Realm CI\", \"icon_emoji\": \":realm_new:\", \"text\": \"<$link_to_changelog|*Realm Java $RELEASE_VERSION has been released*>\\nSee the Release Notes for more details.\" }"
+
+  echo "Pinging #realm-releases"
+	curl -X POST --data-urlencode "payload=${payload}" ${SLACK_WEBHOOK_RELEASES_URL} 
+  echo "Pinging #realm-java-team-ci"
+	curl -X POST --data-urlencode "payload=${payload}" ${SLACK_WEBHOOK_JAVA_CI_URL} 
+}
+
+abort_release() {
+  # Reporting failures to #realm-java-team-ci is done from Jenkins
+  exit 1
+}
+
+######################################
+# Run Release steps
+######################################\
+
+check_env
+verify_release_preconditions
+verify_changelog
+create_javadoc
+upload_to_bintray
+upload_debug_symbols
+upload_javadoc
+notify_slack_channels


### PR DESCRIPTION
This adds support for fully automating 10.x releases by using tags.

After this is merged the only thing needed to publish a release is to tag a commit and then build the branch. I don't believe CI runs automatically when just pushing a tag, so I suspect this must be triggered manually (needs to be tested).

I tested as many parts of this script as I could but the entire thing hasn't run yet on CI so I suspect there are still some bugs around making it run correctly on CI with credentials.

Once reviewed I plan to use this to release BETA.7 as validation.