### PR TITLE
Show error messages for UTF decoding issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 7.0.6 (yyyy-mm-dd)
+
+### Enhancements
+* Better exception messaging for UTF encoding errors. ([Issue #7093](https://github.com/realm/realm-java/pull/7093))
+
+### Fixes
+* None.
+
+### Compatibility
+* None.
+
+### Internal
+* None.
+
+
 ## 7.0.5 (2020-09-09)
 
 ### Enhancements

--- a/realm/realm-library/src/androidTest/java/io/realm/UTFStrings.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/UTFStrings.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.realm;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import io.realm.entities.StringOnly;
+import io.realm.rule.TestRealmConfigurationFactory;
+
+@RunWith(AndroidJUnit4.class)
+public class UTFStrings {
+    @Rule
+    public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private Realm realm;
+
+    @Before
+    public void setUp() {
+        RealmConfiguration config = configFactory.createConfiguration();
+        realm = Realm.getInstance(config);
+    }
+
+    @After
+    public void tearDown() {
+        if (realm != null) {
+            realm.close();
+        }
+    }
+
+    @Test
+    public void valid_utf() {
+        realm.beginTransaction();
+
+        StringOnly validString = new StringOnly();
+        validString.setChars("\uD800\uDC00");
+        realm.copyToRealm(validString);
+
+        realm.commitTransaction();
+    }
+
+    @Test
+    public void invalid_first_half() {
+        realm.beginTransaction();
+
+        // Test invalid first surrogate
+        StringOnly invalidFirstSurrogate = new StringOnly();
+        invalidFirstSurrogate.setChars("\uDC00\uD800");
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Illegal Argument: Failure when converting to UTF-8: Invalid first half of surrogate pair; error_code = 5;  0xdc00 0xd800");
+
+        realm.copyToRealm(invalidFirstSurrogate);
+        realm.commitTransaction();
+    }
+
+    @Test
+    public void invalid_second_half() {
+        realm.beginTransaction();
+
+        // Test invalid second surrogate
+        StringOnly invalidSecondSurrogate = new StringOnly();
+        invalidSecondSurrogate.setChars("\uD800\uD800");
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Illegal Argument: Failure when converting to UTF-8: Invalid second half of surrogate pair; error_code = 7;  0xd800 0xd800");
+
+        realm.copyToRealm(invalidSecondSurrogate);
+
+        realm.commitTransaction();
+    }
+
+    @Test
+    public void incomplete_surrogate() {
+        realm.beginTransaction();
+
+        // Test incomplete surrogate
+        StringOnly incompleteSurrogate = new StringOnly();
+        incompleteSurrogate.setChars("\u0000\uD800");
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Illegal Argument: Failure when converting to UTF-8: Incomplete surrogate pair; error_code = 6;  0x0000 0xd800");
+
+        realm.copyToRealm(incompleteSurrogate);
+
+        realm.commitTransaction();
+    }
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/UTFStrings.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/UTFStrings.java
@@ -15,7 +15,7 @@
  */
 package io.realm;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Before;

--- a/realm/realm-library/src/androidTest/java/io/realm/UTFStringsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/UTFStringsTests.java
@@ -28,7 +28,7 @@ import io.realm.entities.StringOnly;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 @RunWith(AndroidJUnit4.class)
-public class UTFStrings {
+public class UTFStringsTests {
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
     @Rule

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -362,11 +362,29 @@ static string string_to_hex(const string& message, StringData& str, const char* 
     return ret.str();
 }
 
+static string error_code_to_message(size_t error_code){
+    switch (error_code){
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+            return "Not enough output buffer space";
+        case 5:
+            return "Invalid first half of surrogate pair";
+        case 6:
+            return "Incomplete surrogate pair";
+        case 7:
+            return "Invalid second half of surrogate pair";
+        default:
+            return "Unknown";
+    }
+}
+
 static string string_to_hex(const string& message, const jchar* str, size_t size, size_t error_code)
 {
     ostringstream ret;
 
-    ret << message << "; ";
+    ret << message << ": " << error_code_to_message(error_code) << "; ";
     ret << "error_code = " << error_code << "; ";
     for (size_t i = 0; i < size; ++i) {
         ret << " 0x" << std::hex << std::setfill('0') << std::setw(4) << (int) str[i];

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -362,7 +362,7 @@ static string string_to_hex(const string& message, StringData& str, const char* 
     return ret.str();
 }
 
-static string error_code_to_message(size_t error_code){
+static string str_to_hex_error_code_to_message(size_t error_code){
     switch (error_code){
         case 1:
         case 2:
@@ -384,7 +384,7 @@ static string string_to_hex(const string& message, const jchar* str, size_t size
 {
     ostringstream ret;
 
-    ret << message << ": " << error_code_to_message(error_code) << "; ";
+    ret << message << ": " << str_to_hex_error_code_to_message(error_code) << "; ";
     ret << "error_code = " << error_code << "; ";
     for (size_t i = 0; i < size; ++i) {
         ret << " 0x" << std::hex << std::setfill('0') << std::setw(4) << (int) str[i];


### PR DESCRIPTION
Show a more descriptive message for UTF encoding exceptions

This PR rebases the changes from #7091 into releases.

Error descriptions are extracted from the comments in [utf8.hpp : to_utf8()](https://github.com/realm/realm-java/blob/0e1464114782f88165309bd0d73d13a8fde72ab7/realm/realm-library/src/main/cpp/utf8.hpp#L260)

closes #7081