### PR TITLE
Fixes concurrent modification exception in ColumnIndices class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 ### Fixes
 * Fixes concurrent modification exceptions in the schema when refreshing a Realm (Issue [#6876](https://github.com/realm/realm-java/issues/6876))
 
-### Fixes
-* None.
-
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.
 * File format: Generates Realms with format v11 (Reads and upgrades all previous formats from Realm Java 2.0 and later).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 7.0.6 (yyyy-mm-dd)
+
+### Enhancements
+* None.
+
+### Fixes
+* Fixes concurrent modification exceptions when refreshing a Realm (Issue [#6876](https://github.com/realm/realm-java/issues/6876))
+
+### Compatibility
+* None.
+
+### Internal
+* None.
+
+
 ## 7.0.5 (2020-09-09)
 
 ### Enhancements

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nonnull;
 
@@ -49,7 +50,7 @@ import io.realm.exceptions.RealmException;
 public final class ColumnIndices {
     // Class to ColumnInfo map
     private final Map<Class<? extends RealmModel>, ColumnInfo> classToColumnInfoMap =
-            new HashMap<Class<? extends RealmModel>, ColumnInfo>();
+            new ConcurrentHashMap<Class<? extends RealmModel>, ColumnInfo>();
     // Class name to ColumnInfo map. All the elements in this map should be existing in classToColumnInfoMap.
     private final Map<String, ColumnInfo> simpleClassNameToColumnInfoMap =
             new HashMap<String, ColumnInfo>();


### PR DESCRIPTION
ColumnIndices was not thread-safe and could throw concurrent modification exceptions if the app tried, at the same time, to refresh a schema and to get info about a model.

closes #6876 