### PR TITLE
Fix issues with building on v10

### DIFF
--- a/realm/gradle.properties
+++ b/realm/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xms512m -Xmx2048m
+org.gradle.jvmargs=-Xms1024m -Xmx4096m
 org.gradle.caching=true
 kotlin.incremental=false
 org.gradle.parallel=false


### PR DESCRIPTION
This PR does 2 things:

----

Attempt to combat `java.lang.OutOfMemoryError: Java heap space` when building our v10 branch for CI which build and test both base and objectServer variants. Not sure why we suddenly started running out of memory for the builds.

Note, no effect should be visible on this PR as this error has only been observed on the v10 branch.

----

Disable OJO uploads when doing full release builds as we can only host SNAPSHOT versions on OJO

----
