### PR TITLE
Fix incorrect HTTP headers and resetPassword args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The old Realm Cloud legacy APIs have undergone significant refactoring. The new 
 * Realm Studio 10.0.0 and above is required to open Realms created by this version.
 
 ### Internal
-* Updated to Object Store commit: 17043b26a7f3db54830af47054e01ab44e0e77f0.
+* Updated to Object Store commit: 035eb07f3ef313bfb78c046be9cf6b4f065d6772.
 
 
 ## 10.0.0-BETA.7 (2020-09-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 10.0.0-BETA.8 (YYYY-MM-DD)
+
+We no longer support Realm Cloud (legacy), but instead the new MongoDB Realm Cloud. MongoDB Realm is a serverless platform that enables developers to quickly build applications without having to set up server infrastructure. MongoDB Realm is built on top of MongoDB Atlas, automatically integrating the connection to your database.
+
+The old Realm Cloud legacy APIs have undergone significant refactoring. The new APIs are all located in the `io.realm.mongodb` package with `io.realm.mongodb.App` as the entry point.
+
+### Fixed
+* [RealmApp] Logging in caused an `token contains an invalid number of segments` error. (Issue [#7117](https://github.com/realm/realm-java/issues/7117), since 10.0.0-BETA.7) 
+* [RealmApp] The order of arguments to `EmailPassword.resetPassword()` was not handled correctly, resulting in resetting the password failing. (Issue [#7116](https://github.com/realm/realm-java/issues/7116), since 10.0.0-BETA.1)
+
+### Compatibility
+* File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java 10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 and above is required to open Realms created by this version.
+
+### Internal
+* Updated to Object Store commit: 17043b26a7f3db54830af47054e01ab44e0e77f0.
+
+
 ## 10.0.0-BETA.7 (2020-09-16)
 
 We no longer support Realm Cloud (legacy), but instead the new MongoDB Realm Cloud. MongoDB Realm is a serverless platform that enables developers to quickly build applications without having to set up server infrastructure. MongoDB Realm is built on top of MongoDB Atlas, automatically integrating the connection to your database.

--- a/dependencies.list
+++ b/dependencies.list
@@ -5,7 +5,7 @@ REALM_SYNC_SHA256=da27012959fdd7e35b9b0f3274a1dd7ad391e027217527cf8897020a4c1562
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2020-08-27
+MONGODB_REALM_SERVER=2020-09-21
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=4.0.0

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/ApiKeyAuthTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/ApiKeyAuthTests.kt
@@ -462,7 +462,7 @@ class ApiKeyAuthTests {
                 }
                 fail("$method should have thrown an exception")
             } catch (error: AppException) {
-                assertEquals(ErrorCode.INVALID_SESSION, error.errorCode)
+                assertEquals(ErrorCode.SERVICE_UNKNOWN, error.errorCode)
             }
         }
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpNetworkTransport.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/OkHttpNetworkTransport.java
@@ -38,12 +38,14 @@ public class OkHttpNetworkTransport extends OsJavaNetworkTransport {
 
     private okhttp3.Request makeRequest(String method, String url, Map<String, String> headers, String body){
         okhttp3.Request.Builder builder = new okhttp3.Request.Builder().url(url);
-        // TODO Ensure that we have correct custom headers until OS handles it
-        //  first of all add all custom headers
+
+        // Ensure that we have correct custom headers until OS handles it.
+
+        // 1. First of all add all custom headers
         for (Map.Entry<String, String> entry : getCustomRequestHeaders().entrySet()) {
             builder.addHeader(entry.getKey(), entry.getValue());
         }
-        //  and then replace default authorization header with custom one if present
+        // 2. Then replace default authorization header with custom one if present
         String authorizationHeaderValue = headers.get(AppConfiguration.DEFAULT_AUTHORIZATION_HEADER_NAME);
         String authorizationHeaderName = getAuthorizationHeaderName();
         if (authorizationHeaderValue != null && !AppConfiguration.DEFAULT_AUTHORIZATION_HEADER_NAME.equals(authorizationHeaderName)) {
@@ -51,9 +53,11 @@ public class OkHttpNetworkTransport extends OsJavaNetworkTransport {
             headers.put(authorizationHeaderName, authorizationHeaderValue);
         }
 
+        // 3. Finally add all headers defined by Object Store
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             builder.addHeader(entry.getKey(), entry.getValue());
         }
+        
         switch (method) {
             case "get":
                 builder.get();
@@ -72,10 +76,6 @@ public class OkHttpNetworkTransport extends OsJavaNetworkTransport {
                 break;
             default:
                 throw new IllegalArgumentException("Unknown method type: " + method);
-        }
-
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-            builder.addHeader(entry.getKey(), entry.getValue());
         }
 
         return builder.build();

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/Credentials.java
@@ -150,17 +150,17 @@ public class Credentials {
     }
 
     /**
-     * Creates credentials representing a login using a Google access token.
+     * Creates credentials representing a login using a Google Authorization Code.
      * <p>
      * This provider must be enabled on MongoDB Realm to work.
      *
-     * @param googleToken the access token returned when logging in to Google.
+     * @param authorizationCode the authorization code returned when logging in to Google.
      * @return a set of credentials that can be used to log into MongoDB Realm using
      * {@link App#loginAsync(Credentials, App.Callback)}.
      */
-    public static Credentials google(String googleToken) {
-        Util.checkEmpty(googleToken, "googleToken");
-        return new Credentials(OsAppCredentials.google(googleToken), Provider.GOOGLE);
+    public static Credentials google(String authorizationCode) {
+        Util.checkEmpty(authorizationCode, "authorizationCode");
+        return new Credentials(OsAppCredentials.google(authorizationCode), Provider.GOOGLE);
     }
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/EmailPasswordAuth.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/auth/EmailPasswordAuth.java
@@ -285,7 +285,9 @@ public abstract class EmailPasswordAuth {
         Util.checkEmpty(tokenId, "tokenId");
         Util.checkEmpty(newPassword, "newPassword");
         AtomicReference<AppException> error = new AtomicReference<>(null);
-        call(TYPE_RESET_PASSWORD, new OsJNIVoidResultCallback(error), token, tokenId, newPassword);
+        // The order of arguments in ObjectStore is different than the order of arguments in the
+        // Java API. The Java API order came from the old Stitch API.
+        call(TYPE_RESET_PASSWORD, new OsJNIVoidResultCallback(error), newPassword, token, tokenId);
         ResultHandler.handleResult(null, error);
     }
 


### PR DESCRIPTION
Closes #7117 
Only partially closes #7116 . Even with the correct argument order we are still getting "Invalid token data", but this also happens on JS, so until proven otherwise I'm going with the assumption the problem is in either ObjectStore or on the server. I'm trying to verify if the endpoint we are hitting for resetPassword is correct in order to rule out OS, but this PR should be in a reviewable state nonetheless.