### PR TITLE
Fix flaky test: executeTransactionAwait

### DIFF
--- a/realm/kotlin-extensions/src/androidTest/kotlin/io/realm/CoroutineTests.kt
+++ b/realm/kotlin-extensions/src/androidTest/kotlin/io/realm/CoroutineTests.kt
@@ -1,6 +1,5 @@
 package io.realm
 
-import android.util.Log
 import io.realm.entities.AllTypes
 import io.realm.entities.Dog
 import io.realm.entities.SimpleClass

--- a/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmExtensions.kt
+++ b/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmExtensions.kt
@@ -103,12 +103,14 @@ inline fun <reified T : RealmModel> Realm.createEmbeddedObject(parentObject: Rea
  * your transaction is cooperative, you have to check for the value of [CoroutineScope.isActive] while running the transaction:
  *
  * ```
- * // insert 100 objects
- * realmInstance.executeTransactionAwait { transactionRealm ->
- *   for (i in 1..100) {
- *     // all good if active, otherwise do nothing
- *     if (isActive) {
- *       transactionRealm.insert(MyObject(i))
+ * coroutineScope.launch {
+ *   // insert 100 objects
+ *   realmInstance.executeTransactionAwait { transactionRealm ->
+ *     for (i in 1..100) {
+ *       // all good if active, otherwise do nothing
+ *       if (isActive) {
+ *         transactionRealm.insert(MyObject(i))
+ *       }
  *     }
  *   }
  * }

--- a/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmExtensions.kt
+++ b/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmExtensions.kt
@@ -105,7 +105,7 @@ inline fun <reified T : RealmModel> Realm.createEmbeddedObject(parentObject: Rea
  * ```
  * coroutineScope.launch {
  *   // insert 100 objects
- *   realmInstance.executeTransactionAwait { transactionRealm ->
+ *   realm.executeTransactionAwait { transactionRealm ->
  *     for (i in 1..100) {
  *       // all good if active, otherwise do nothing
  *       if (isActive) {


### PR DESCRIPTION
Fixes https://github.com/realm/realm-java/issues/7136

- Made `executeTransactionAwait` cooperative (although it won't cancel the transaction itself)
- Fixed bogus test so that it blocks until the coroutine job is cancelled with `cancelAndJoin`
- Added tests with heavy transactions that explore cooperation for cancellation
- Added and fixed some documentation