### PR TITLE
Flaky build - extensions:publishObjectServerPublicationPublicationToMavenLocal

### DIFF
--- a/realm/kotlin-extensions/build.gradle
+++ b/realm/kotlin-extensions/build.gradle
@@ -196,7 +196,9 @@ publishing {
             groupId 'io.realm'
             artifactId 'realm-android-kotlin-extensions'
             version project.version
-            artifact file("${rootDir}/kotlin-extensions/build/outputs/aar/realm-kotlin-extensions-base-release.aar")
+            artifact (file("${rootDir}/kotlin-extensions/build/outputs/aar/realm-kotlin-extensions-base-release.aar")) {
+                builtBy assemble
+            }
             artifact sourcesJar
             artifact javadocJar
 
@@ -207,7 +209,9 @@ publishing {
             groupId 'io.realm'
             artifactId 'realm-android-kotlin-extensions-object-server'
             version project.version
-            artifact file("${rootDir}/kotlin-extensions/build/outputs/aar/realm-kotlin-extensions-objectServer-release.aar")
+            artifact (file("${rootDir}/kotlin-extensions/build/outputs/aar/realm-kotlin-extensions-objectServer-release.aar")) {
+                builtBy assemble
+            }
             artifact sourcesJar
             artifact javadocJar
 


### PR DESCRIPTION
Fixes #7107

The `assemble` task has to be run explicitly before `publishObjectServerPublicationPublicationToMavenLocal`. For some reason writing `publishToMavenLocal.dependsOn assemble` is not enough anymore, so we needed to ensure this precendece by adding `builtBy` to `basePublication` and `objectServerPublication`.