### PR TITLE
Keep constructors for Decimal128 and ObjectId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 10.0.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixes
+* Crash with `Assertion failed: m_method_id != nullptr with (method_name, signature) =  ["<init>", "(Ljava/lang/String;)V"]` when `Minify` is enabled.
+
+### Compatibility
+* None.
+
+### Internal
+* None.
+
+
 ## 10.0.0 (2020-10-15)
 
 NOTE: This is a unified release note covering all v10.0.0-BETA.X v10.0.0-RC.X releases.

--- a/realm/realm-library/proguard-rules-consumer-common.pro
+++ b/realm/realm-library/proguard-rules-consumer-common.pro
@@ -22,5 +22,9 @@
 -dontnote rx.Observable
 
 # Referenced from JNI
--keep class org.bson.types.Decimal128
--keep class org.bson.types.ObjectId
+-keep class org.bson.types.Decimal128 {
+    public static org.bson.types.Decimal128 fromIEEE754BIDEncoding(...);
+}
+-keep class org.bson.types.ObjectId {
+    <init>(...);
+}


### PR DESCRIPTION
This PR fixes the crashes in JNI when trying to instantiate ObjectIds' or Decimal128s' with Proguard enabled.