### PR TITLE
Throw descriptive exception when collecting flow on closed Realm

### DIFF
--- a/realm/kotlin-extensions/src/androidTest/kotlin/io/realm/CoroutineTests.kt
+++ b/realm/kotlin-extensions/src/androidTest/kotlin/io/realm/CoroutineTests.kt
@@ -194,14 +194,17 @@ class CoroutineTests {
                     .findAllAsync()
                     .toFlow()
             realmInstance.close()
-            // FIXME Collecting after close throw. Emit a more descriptive error
-            //  java.lang.IllegalStateException: 'awaitClose { yourCallbackOrListener.cancel() }' should be used in the end of callbackFlow block.
-//            assertFailsWith<> {
-                findAllAsync.collect()
-//            }
+
+            // There will never be emited any changes, but at least ensure that we are not
+            // triggering coroutines internal
+            // java.lang.IllegalStateException: 'awaitClose { yourCallbackOrListener.cancel() }' should be used in the end of callbackFlow block.
+            assertFailsWith<TimeoutCancellationException> {
+                withTimeout(10) {
+                    findAllAsync.collect()
+                }
+            }
             countDownLatch.countDown()
         }
-
         TestHelper.awaitOrFail(countDownLatch)
     }
 

--- a/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmResultsExtensions.kt
+++ b/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmResultsExtensions.kt
@@ -75,6 +75,9 @@ fun <T : RealmModel> RealmResults<T>.toFlow(): Flow<RealmResults<T>> {
 
         // Do nothing if the results are invalid
         if (!results.isValid) {
+            // Prevent callbackFlow's internal asserting
+            // java.lang.IllegalStateException: 'awaitClose { yourCallbackOrListener.cancel() }' should be used in the end of callbackFlow block.
+            awaitClose {}
             return@callbackFlow
         }
 


### PR DESCRIPTION
Seems like there is an internal assertion that `callbackFlows` must call `awaitClose` to collect listeners. We should probably yield a more descriptive exception in that case. 

Currently just adding a test that reproduces the situation. 
 
Relates to #7176 