### PR TITLE
Update object store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Internal
 * Updated to Realm Sync: 10.1.0.
 * Updated to Realm Core: 10.1.0.
+* Updated to Object Store commit: fd246c54de7d1fee6bcbeb3609de75a4eccd5b70.
 
 
 ## 10.0.0 (2020-10-15)

--- a/dependencies.list
+++ b/dependencies.list
@@ -5,7 +5,7 @@ REALM_SYNC_SHA256=e0cf26042beb9909658e40fe486ac3ac8d023989f9c7a40440d00a34132e14
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2020-09-21
+MONGODB_REALM_SERVER=2020-10-03
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=4.0.0

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -3086,8 +3086,8 @@ public class RealmQueryTests extends QueryTests {
     public void findAll_indexedCaseInsensitiveFields() {
         // Catches https://github.com/realm/realm-java/issues/4788
         realm.beginTransaction();
-        realm.createObject(IndexedFields.class).indexedString = "ROVER";
-        realm.createObject(IndexedFields.class).indexedString = "Rover";
+        realm.createObject(IndexedFields.class, new ObjectId()).indexedString = "ROVER";
+        realm.createObject(IndexedFields.class, new ObjectId()).indexedString = "Rover";
         realm.commitTransaction();
 
         RealmResults<IndexedFields> results = realm.where(IndexedFields.class)

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/IndexedFields.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/IndexedFields.java
@@ -16,14 +16,21 @@
 
 package io.realm.entities;
 
+import org.bson.types.ObjectId;
+
 import io.realm.RealmObject;
 import io.realm.annotations.Index;
+import io.realm.annotations.PrimaryKey;
 
 
 public class IndexedFields extends RealmObject {
-
+    public static final String CLASS_NAME = IndexedFields.class.getSimpleName();
+    public static final String FIELD_PRIMARY_STRING = "_id";
     public static final String FIELD_INDEXED_STRING = "indexedString";
     public static final String FIELD_NON_INDEXED_STRING = "nonIndexedString";
+
+    @PrimaryKey
+    public ObjectId _id = new ObjectId();
 
     @Index
     public String indexedString;

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/AppTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/AppTests.kt
@@ -18,13 +18,12 @@ package io.realm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.admin.ServerAdmin
-import io.realm.entities.DefaultSyncSchema
+import io.realm.entities.SyncStringOnly
 import io.realm.exceptions.RealmFileException
-import io.realm.kotlin.syncSession
 import io.realm.mongodb.*
 import io.realm.mongodb.sync.SyncConfiguration
+import io.realm.mongodb.sync.testSchema
 import io.realm.rule.BlockingLooperThread
-import org.bson.BsonString
 import org.bson.codecs.StringCodec
 import org.bson.codecs.configuration.CodecRegistries
 import org.junit.*
@@ -36,7 +35,6 @@ import kotlin.test.assertFailsWith
 
 @RunWith(AndroidJUnit4::class)
 class AppTests {
-
     @get:Rule
     val configFactory = TestSyncConfigurationFactory()
 
@@ -283,7 +281,12 @@ class AppTests {
         try {
             // Create Realm in order to create the sync metadata Realm
             var user = testApp.login(Credentials.anonymous())
-            val syncConfig = SyncConfiguration.defaultConfig(user, "foo")
+
+            val syncConfig = SyncConfiguration
+                    .Builder(user, "foo")
+                    .testSchema(SyncStringOnly::class.java)
+                    .build()
+
             Realm.getInstance(syncConfig).close()
 
             // Create a configuration pointing to the metadata Realm for that app

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncStringOnly.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/entities/SyncStringOnly.kt
@@ -23,13 +23,14 @@ import org.bson.types.ObjectId
 open class SyncStringOnly : RealmObject() {
 
     companion object {
-        const val CLASS_NAME = "StringOnly"
+        const val CLASS_NAME = "SyncStringOnly"
+        const val FIELD_ID = "_id"
         const val FIELD_CHARS = "chars"
     }
 
     @PrimaryKey
     @RealmField(name = "_id")
-    var id = ObjectId()
+    var id: ObjectId = ObjectId()
 
     var chars: String? = null
 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
@@ -18,8 +18,8 @@ package io.realm.mongodb.sync
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.*
-import io.realm.entities.StringOnly
-import io.realm.entities.StringOnlyModule
+import io.realm.entities.SyncStringOnly
+import io.realm.entities.SyncStringOnlyModule
 import io.realm.kotlin.createObject
 import io.realm.kotlin.where
 import io.realm.mongodb.AppException
@@ -204,11 +204,11 @@ class SyncConfigurationTests {
     fun initialData() {
         val user: User = createTestUser(app)
         val config = configFactory.createSyncConfigurationBuilder(user)
-                .schema(StringOnly::class.java)
+                .schema(SyncStringOnly::class.java)
                 .initialData(object : Realm.Transaction {
                     override fun execute(realm: Realm) {
-                        val stringOnly: StringOnly = realm.createObject<StringOnly>()
-                        stringOnly.setChars("TEST 42")
+                        val stringOnly: SyncStringOnly = realm.createObject(ObjectId())
+                        stringOnly.chars = "TEST 42"
                     }
                 })
                 .build()
@@ -216,14 +216,14 @@ class SyncConfigurationTests {
 
         // open the first time - initialData must be triggered
         Realm.getInstance(config).use { realm ->
-            val results: RealmResults<StringOnly> = realm.where<StringOnly>().findAll()
+            val results: RealmResults<SyncStringOnly> = realm.where<SyncStringOnly>().findAll()
             assertEquals(1, results.size)
-            assertEquals("TEST 42", results.first()!!.getChars())
+            assertEquals("TEST 42", results.first()!!.chars)
         }
 
         // open the second time - initialData must not be triggered
         Realm.getInstance(config).use { realm ->
-            assertEquals(1, realm.where<StringOnly>().count())
+            assertEquals(1, realm.where<SyncStringOnly>().count())
         }
     }
 
@@ -250,10 +250,10 @@ class SyncConfigurationTests {
         val user2: User = app.registerUserAndLogin(TestHelper.getRandomEmail(), "123456")
 
         val config1: SyncConfiguration = SyncConfiguration.Builder(user1, DEFAULT_PARTITION)
-                .modules(StringOnlyModule())
+                .modules(SyncStringOnlyModule())
                 .build()
         val config2: SyncConfiguration = SyncConfiguration.Builder(user2, DEFAULT_PARTITION)
-                .modules(StringOnlyModule())
+                .modules(SyncStringOnlyModule())
                 .build()
 
         // Verify that two different configurations can be used for the same URL
@@ -330,8 +330,8 @@ class SyncConfigurationTests {
     @Test
     fun differentPartitionValuesAreDifferentRealms() {
         val user: User = createTestUser(app)
-        val config1 = SyncConfiguration.defaultConfig(user, "realm1")
-        val config2 = SyncConfiguration.defaultConfig(user, "realm2")
+        val config1 = SyncConfiguration.Builder(user, "realm1").modules(SyncStringOnlyModule()).build()
+        val config2 = SyncConfiguration.Builder(user, "realm2").modules(SyncStringOnlyModule()).build()
         assertNotEquals(config1.path, config2.path)
 
          assertTrue(config1.path.endsWith("${app.configuration.appId}/${user.id}/s_realm1.realm"))

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp
@@ -382,8 +382,6 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_OsObject_nativeCreateNewObjectWit
         Obj obj = do_create_row_with_object_id_primary_key(env, shared_realm_ptr, table_ref_ptr, pk_column_ndx, pk_value);
         if (bool(obj)) {
             return reinterpret_cast<jlong>(new Obj(obj));
-        } else {
-            THROW_JAVA_EXCEPTION(env, PK_CONSTRAINT_EXCEPTION_CLASS, "Invalid Object returned from 'do_create_row_with_object_id_primary_key'");
         }
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsSharedRealm.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsSharedRealm.cpp
@@ -275,7 +275,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_OsSharedRealm_nativeCreateTable(J
 }
 
 JNIEXPORT jlong JNICALL Java_io_realm_internal_OsSharedRealm_nativeCreateTableWithPrimaryKeyField(
-    JNIEnv* env, jclass, jlong shared_realm_ptr, jstring j_table_name, jstring j_field_name, jboolean is_string_type,
+    JNIEnv* env, jclass, jlong shared_realm_ptr, jstring j_table_name, jstring j_field_name, jint j_field_type,
     jboolean is_nullable)
 {
     std::string class_name_str;
@@ -285,7 +285,8 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_OsSharedRealm_nativeCreateTableWi
         JStringAccessor field_name(env, j_field_name); // throws
         auto& shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
         shared_realm->verify_in_write(); // throws
-        DataType pkType = is_string_type ? DataType::type_String : DataType::type_Int;
+
+        DataType pkType = static_cast<DataType>(j_field_type);
         TableRef table;
         auto& group = shared_realm->read_group();
 #if REALM_ENABLE_SYNC

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoClient.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoClient.cpp
@@ -25,8 +25,8 @@
 #include <realm/util/optional.hpp>
 #include <sync/app.hpp>
 #include <sync/sync_user.hpp>
-#include <sync/remote_mongo_client.hpp>
-#include <sync/remote_mongo_database.hpp>
+#include <sync/mongo_client.hpp>
+#include <sync/mongo_database.hpp>
 
 using namespace realm;
 using namespace realm::app;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoCollection.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoCollection.cpp
@@ -26,8 +26,8 @@
 
 #include <realm/util/optional.hpp>
 #include <sync/app.hpp>
-#include <sync/remote_mongo_database.hpp>
-#include <sync/remote_mongo_collection.hpp>
+#include <sync/mongo_database.hpp>
+#include <sync/mongo_collection.hpp>
 #include <jni_util/bson_util.hpp>
 
 using namespace realm;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoDatabase.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMongoDatabase.cpp
@@ -25,8 +25,8 @@
 #include <realm/util/optional.hpp>
 #include <sync/app.hpp>
 #include <sync/sync_user.hpp>
-#include <sync/remote_mongo_database.hpp>
-#include <sync/remote_mongo_collection.hpp>
+#include <sync/mongo_database.hpp>
+#include <sync/mongo_collection.hpp>
 
 using namespace realm;
 using namespace realm::app;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsWatchStream.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsWatchStream.cpp
@@ -19,7 +19,7 @@
 #include "java_class_global_def.hpp"
 #include "jni_util/bson_util.hpp"
 
-#include <sync/remote_mongo_collection.hpp>
+#include <sync/mongo_collection.hpp>
 
 using namespace realm;
 using namespace realm::app;

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_mongo_iterable_AggregateIterable.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_mongo_iterable_AggregateIterable.cpp
@@ -25,7 +25,7 @@
 #include "object-store/src/util/bson/bson.hpp"
 
 #include <realm/util/optional.hpp>
-#include <sync/remote_mongo_collection.hpp>
+#include <sync/mongo_collection.hpp>
 #include <jni_util/bson_util.hpp>
 #include <jni.h>
 

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_mongo_iterable_FindIterable.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_mongo_iterable_FindIterable.cpp
@@ -25,7 +25,7 @@
 #include "object-store/src/util/bson/bson.hpp"
 
 #include <realm/util/optional.hpp>
-#include <sync/remote_mongo_collection.hpp>
+#include <sync/mongo_collection.hpp>
 #include <jni_util/bson_util.hpp>
 
 using namespace realm;

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmSchema.java
@@ -83,12 +83,14 @@ class MutableRealmSchema extends RealmSchema {
         String internalTableName = checkAndGetTableNameFromClassName(className);
 
         RealmObjectSchema.FieldMetaData metadata = RealmObjectSchema.getSupportedSimpleFields().get(fieldType);
-        if (metadata == null || (metadata.fieldType != RealmFieldType.STRING &&
-                metadata.fieldType != RealmFieldType.INTEGER)) {
+        if ((metadata == null) || (
+                        (metadata.fieldType != RealmFieldType.STRING) &&
+                        (metadata.fieldType != RealmFieldType.INTEGER) &&
+                        (metadata.fieldType != RealmFieldType.OBJECT_ID)
+        )) {
             throw new IllegalArgumentException(String.format("Realm doesn't support primary key field type '%s'.",
                     fieldType));
         }
-        boolean isStringField = (metadata.fieldType == RealmFieldType.STRING);
 
         boolean nullable = metadata.defaultNullable;
         if (MutableRealmObjectSchema.containsAttribute(attributes, FieldAttribute.REQUIRED)) {
@@ -97,7 +99,7 @@ class MutableRealmSchema extends RealmSchema {
 
         return new MutableRealmObjectSchema(realm, this,
                 realm.getSharedRealm().createTableWithPrimaryKey(internalTableName, primaryKeyFieldName,
-                        isStringField, nullable));
+                        metadata.fieldType, nullable));
     }
 
     @Override

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -16,6 +16,9 @@
 
 package io.realm;
 
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -28,10 +31,8 @@ import javax.annotation.Nullable;
 
 import io.realm.annotations.RealmClass;
 import io.realm.annotations.Required;
-import io.realm.internal.CheckedRow;
 import io.realm.internal.ColumnInfo;
 import io.realm.internal.OsObjectStore;
-import io.realm.internal.OsResults;
 import io.realm.internal.Table;
 import io.realm.internal.fields.FieldDescriptor;
 
@@ -68,6 +69,8 @@ public abstract class RealmObjectSchema {
         m.put(Byte.class, new FieldMetaData(RealmFieldType.INTEGER, RealmFieldType.INTEGER_LIST, true));
         m.put(byte[].class, new FieldMetaData(RealmFieldType.BINARY, RealmFieldType.BINARY_LIST, true));
         m.put(Date.class, new FieldMetaData(RealmFieldType.DATE, RealmFieldType.DATE_LIST, true));
+        m.put(ObjectId.class, new FieldMetaData(RealmFieldType.OBJECT_ID, RealmFieldType.OBJECT_ID_LIST, true));
+        m.put(Decimal128.class, new FieldMetaData(RealmFieldType.DECIMAL128, RealmFieldType.DECIMAL128_LIST, true));
         SUPPORTED_SIMPLE_FIELDS = Collections.unmodifiableMap(m);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nullable;
 
 import io.realm.RealmConfiguration;
+import io.realm.RealmFieldType;
 import io.realm.internal.android.AndroidCapabilities;
 import io.realm.internal.android.AndroidRealmNotifier;
 import io.realm.internal.annotations.ObjectServer;
@@ -326,10 +327,9 @@ public final class OsSharedRealm implements Closeable, NativeObject {
      * @param isNullable          if the primary key field is nullable or not.
      * @return a newly created {@link Table} object.
      */
-    public Table createTableWithPrimaryKey(String tableName, String primaryKeyFieldName, boolean isStringType,
+    public Table createTableWithPrimaryKey(String tableName, String primaryKeyFieldName, RealmFieldType primaryKeyFieldType,
                                            boolean isNullable) {
-        return new Table(this, nativeCreateTableWithPrimaryKeyField(nativePtr, tableName, primaryKeyFieldName,
-                isStringType, isNullable));
+        return new Table(this, nativeCreateTableWithPrimaryKeyField(nativePtr, tableName, primaryKeyFieldName, primaryKeyFieldType.getNativeValue(), isNullable));
     }
 
     public void renameTable(String oldName, String newName) {
@@ -602,7 +602,7 @@ public final class OsSharedRealm implements Closeable, NativeObject {
     // If isStringType is false, the PK field will be created as an integer PK field.
     private static native long nativeCreateTableWithPrimaryKeyField(long nativeSharedRealmPtr, String tableName,
                                                                     String primaryKeyFieldName,
-                                                                    boolean isStringType, boolean isNullable);
+                                                                    int primaryKeyFieldType, boolean isNullable);
 
     private static native String[] nativeGetTablesName(long nativeSharedRealmPtr);
 

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
@@ -65,6 +65,7 @@ class SyncSessionTests {
             val user = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
             val syncConfiguration = configFactory
                     .createSyncConfigurationBuilder(user)
+                    .testSchema(SyncStringOnly::class.java)
                     .build()
             val realm = Realm.getInstance(syncConfiguration)
             looperThread.closeAfterTest(realm)
@@ -599,6 +600,7 @@ class SyncSessionTests {
 
         val configRef = AtomicReference<SyncConfiguration?>(null)
         val config: SyncConfiguration = configFactory.createSyncConfigurationBuilder(user)
+                .testSchema(SyncStringOnly::class.java)
                 // ClientResyncMode is currently hidden, but MANUAL is the default
                 // .clientResyncMode(ClientResyncMode.MANUAL)
                 // FIXME Is this critical for the test
@@ -732,6 +734,7 @@ class SyncSessionTests {
     @Test
     fun cachedInstanceShouldNotThrowIfUserTokenIsInvalid() {
         val configuration: RealmConfiguration = configFactory.createSyncConfigurationBuilder(user)
+                .testSchema(SyncStringOnly::class.java)
                 .errorHandler { session, error ->
                     RealmLog.debug("error", error)
                 }

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncedRealmIntegrationTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncedRealmIntegrationTests.kt
@@ -41,7 +41,6 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.io.File
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -73,6 +72,7 @@ class SyncedRealmIntegrationTests {
                 //  could make test booting with a cleaner state by somehow flushing data between
                 //  tests.
                 .createSyncConfigurationBuilder(user, BsonObjectId(ObjectId()))
+                .testSchema(StringOnly::class.java)
                 .modules(DefaultSyncSchema())
                 .build()
     }
@@ -213,6 +213,7 @@ class SyncedRealmIntegrationTests {
     fun waitForInitialData_resilientInCaseOfRetriesAsync() = looperThread.runBlocking {
         val config: SyncConfiguration = configurationFactory.createSyncConfigurationBuilder(user, user.id)
                 .testSessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
+                .testSchema(SyncStringOnly::class.java)
                 .waitForInitialRemoteData()
                 .build()
         val randomizer = Random()
@@ -297,7 +298,10 @@ class SyncedRealmIntegrationTests {
 
     @Test
     fun defaultRealm() {
-        val config: SyncConfiguration = SyncConfiguration.defaultConfig(user, user.id)
+        val config: SyncConfiguration = SyncConfiguration.Builder(user, user.id)
+                .testSchema(SyncStringOnly::class.java)
+                .build()
+
         Realm.getInstance(config).use { realm ->
             realm.syncSession.downloadAllServerChanges()
             realm.refresh()
@@ -319,7 +323,7 @@ class SyncedRealmIntegrationTests {
         val password = "password"
         val user: User = app.registerUserAndLogin(username, password)
         val config: SyncConfiguration = configurationFactory.createSyncConfigurationBuilder(user, Constants.USER_REALM)
-                .testSchema(StringOnly::class.java)
+                .testSchema(SyncStringOnly::class.java)
                 .build()
         val realm = Realm.getInstance(config)
         app.sync.reconnect()

--- a/realm/realm-library/src/testUtils/java/io/realm/entities/SyncByteArray.java
+++ b/realm/realm-library/src/testUtils/java/io/realm/entities/SyncByteArray.java
@@ -1,0 +1,14 @@
+package io.realm.entities;
+
+import org.bson.types.ObjectId;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+
+public class SyncByteArray extends RealmObject {
+    @PrimaryKey
+    public ObjectId _id;
+    @Required
+    public byte[] columnBinary = new byte[0];
+}


### PR DESCRIPTION
This PR fixes several issues related to the object store update:
* Renamed c++ headers
* Synced schemas require model classes not marked as embedded to have a primary key named `_id`