### PR TITLE
Add support for addPrimaryKey with ObjectId keys on migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixes
-* [RealmMigration] Fixed crash when adding classes containing an `ObjectId` as primary key to the schema (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0).
+* Fixed crash when adding classes containing an `ObjectId` as primary key to the schema (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0).
 
 ### Compatibility
 * File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 10.0.2 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixes
+* [RealmMigration] Fixed crash when adding classes containing an `ObjectId` as primary key to the schema (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0).
+
+### Compatibility
+* File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 or above is required to open Realms created by this version.
+
+### Internal
+* None.
+
+
 ## 10.0.1 (2020-11-06)
 
 ### Breaking Changes

--- a/realm-annotations/src/main/java/io/realm/annotations/PrimaryKey.java
+++ b/realm-annotations/src/main/java/io/realm/annotations/PrimaryKey.java
@@ -31,8 +31,8 @@ import java.lang.annotation.Target;
  * Primary keys also count as having the {@link Index} annotation.
  * <p>
  * It is allowed to apply this annotation on the following primitive types: byte, short, int, and long.
- * String, Byte, Short, Integer, and Long are also allowed, and further permitted to have {@code null}
- * as a primary key value.
+ * String, Byte, Short, Integer, Long and ObjectId are also allowed, and further permitted to have
+ * {@code null} as a primary key value.
  * <p>
  * This annotation is not allowed inside Realm classes marked as {@code \@RealmClass(embedded = true)}.
  * </p>

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -17,9 +17,11 @@
 package io.realm;
 
 import android.content.Context;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.bson.types.ObjectId;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -41,6 +43,7 @@ import io.realm.entities.CatOwner;
 import io.realm.entities.Dog;
 import io.realm.entities.FieldOrder;
 import io.realm.entities.NullTypes;
+import io.realm.entities.ObjectIdPrimaryKey;
 import io.realm.entities.PrimaryKeyAsBoxedByte;
 import io.realm.entities.PrimaryKeyAsBoxedInteger;
 import io.realm.entities.PrimaryKeyAsBoxedLong;
@@ -1451,6 +1454,38 @@ public class RealmMigrationTests {
         MigrationCore6PKStringIndexedByDefault first = realm.where(MigrationCore6PKStringIndexedByDefault.class).findFirst();
         assertNotNull(first);
         assertEquals("Foo", first.name);
+    }
+
+    @Test
+    public void migrateRealm_addPrimaryKey_objectId() {
+        // Creates v0 of the Realm.
+        RealmConfiguration originalConfig = configFactory.createConfigurationBuilder()
+                .schema(StringOnly.class)
+                .build();
+        Realm.getInstance(originalConfig).close();
+
+        RealmMigration migration = new RealmMigration() {
+            @Override
+            public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+                RealmSchema schema = realm.getSchema();
+                schema.create(ObjectIdPrimaryKey.CLASS_NAME)
+                        .addField(ObjectIdPrimaryKey.PROPERTY_OBJECT_ID, ObjectId.class)
+                        .addPrimaryKey(ObjectIdPrimaryKey.PROPERTY_OBJECT_ID);
+            }
+        };
+
+        // Creates v1 of the Realm.
+        RealmConfiguration realmConfig = configFactory.createConfigurationBuilder()
+                .schemaVersion(1)
+                .schema(StringOnly.class, ObjectIdPrimaryKey.class)
+                .migration(migration)
+                .build();
+
+        realm = Realm.getInstance(realmConfig);
+        RealmObjectSchema schema = realm.getSchema().get(ObjectIdPrimaryKey.CLASS_NAME);
+        assertTrue(schema.hasPrimaryKey());
+        assertFalse(schema.hasIndex(ObjectIdPrimaryKey.PROPERTY_OBJECT_ID));
+        realm.close();
     }
 
     // TODO Add unit tests for default nullability

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/ObjectIdPrimaryKey.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/ObjectIdPrimaryKey.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import org.bson.types.ObjectId;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class ObjectIdPrimaryKey extends RealmObject {
+
+    public static final String CLASS_NAME = "ObjectIdPrimaryKey";
+    public static final String PROPERTY_OBJECT_ID = "objectId";
+
+    @PrimaryKey
+    private ObjectId objectId;
+
+    public ObjectId getObjectId() {
+        return objectId;
+    }
+
+    public void setObjectId(ObjectId objectId) {
+        this.objectId = objectId;
+    }
+}

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObjectStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObjectStore.cpp
@@ -61,7 +61,7 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsObjectStore_nativeSetPrimaryKeyF
 
             // Check valid column type
             auto field_type = table->get_column_type(pk_column_col);
-            if (field_type != type_Int && field_type != type_String) {
+            if (field_type != type_Int && field_type != type_String && field_type != type_ObjectId) {
                 THROW_JAVA_EXCEPTION(
                     env, JavaExceptionDef::IllegalArgument,
                     format("Field '%1' is not a valid primary key type.", StringData(pk_field_name_accessor)));

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -40,13 +40,18 @@ static void finalize_table(jlong ptr);
 
 inline static bool is_allowed_to_index(JNIEnv* env, DataType column_type)
 {
-    if (!(column_type == type_String || column_type == type_Int || column_type == type_Bool ||
-          column_type == type_Timestamp || column_type == type_OldDateTime)) {
-        ThrowException(env, IllegalArgument, "This field cannot be indexed - "
-                                             "Only String/byte/short/int/long/boolean/Date fields are supported.");
-        return false;
+    if (column_type == type_String
+           || column_type == type_Int
+           || column_type == type_Bool
+           || column_type == type_Timestamp
+           || column_type == type_OldDateTime
+           || column_type == type_ObjectId) {
+        return true;
     }
-    return true;
+
+    ThrowException(env, IllegalArgument, "This field cannot be indexed - "
+                                         "Only String/byte/short/int/long/boolean/Date/ObjectId fields are supported.");
+    return false;
 }
 
 // Note: Don't modify spec on a table which has a shared_spec.


### PR DESCRIPTION
Fixes #7189

We didn't support adding ObjectId primary keys in migrations. This PR addresses this issue.