### PR TITLE
Fix wrong logic in annotation processor for generating ObjectId PKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 * Fixed crash when adding classes containing an `ObjectId` as primary key to the schema (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0).
+* Fixed crash when creating proxy classes containing an `ObjectId` as primary key (Issue [#7197](https://github.com/realm/realm-java/issues/7197), since v10.0.0).
 
 ### Compatibility
 * File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 * None.
 
 ### Fixes
-* Fixed crash when adding classes containing an `ObjectId` as primary key to the schema (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0).
-* Fixed crash when creating proxy classes containing an `ObjectId` as primary key (Issue [#7197](https://github.com/realm/realm-java/issues/7197), since v10.0.0).
+* Fixed crash when adding classes containing an `ObjectId` as primary key to the schema. (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0)
+* Fixed crash when creating proxy classes containing an `ObjectId` as primary key. (Issue [#7197](https://github.com/realm/realm-java/issues/7197), since v10.0.0)
 
 ### Compatibility
 * File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -2098,7 +2098,6 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                     var pkType = "Long"
                     var jsonAccessorMethodSuffix = "Long"
                     var findFirstCast = ""
-                    var constructor = ""
                     if (Utils.isString(metadata.primaryKey)) {
                         pkType = "String"
                         jsonAccessorMethodSuffix=  "String"
@@ -2106,10 +2105,9 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                         pkType = "ObjectId"
                         findFirstCast = "(org.bson.types.ObjectId)"
                         jsonAccessorMethodSuffix = ""
-                        constructor = "org.bson.types.ObjectId"
                     }
                     val nullableMetadata = if (Utils.isObjectId(metadata.primaryKey)) {
-                        "objKey = table.findFirst%s(pkColumnKey, new %s((String)json.get%s(\"%s\")))".format(pkType, constructor, jsonAccessorMethodSuffix, metadata.primaryKey!!.simpleName)
+                        "objKey = table.findFirst%s(pkColumnKey, new org.bson.types.ObjectId((String)json.get%s(\"%s\")))".format(pkType, jsonAccessorMethodSuffix, metadata.primaryKey!!.simpleName)
                     } else {
                         "objKey = table.findFirst%s(pkColumnKey, %sjson.get%s(\"%s\"))".format(pkType, findFirstCast, jsonAccessorMethodSuffix, metadata.primaryKey!!.simpleName)
                     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonAbsentPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonAbsentPrimaryKeyTests.java
@@ -36,6 +36,7 @@ import io.realm.entities.PrimaryKeyAsBoxedByte;
 import io.realm.entities.PrimaryKeyAsBoxedInteger;
 import io.realm.entities.PrimaryKeyAsBoxedLong;
 import io.realm.entities.PrimaryKeyAsBoxedShort;
+import io.realm.entities.PrimaryKeyAsObjectId;
 import io.realm.entities.PrimaryKeyAsString;
 import io.realm.rule.TestRealmConfigurationFactory;
 
@@ -68,11 +69,12 @@ public class RealmJsonAbsentPrimaryKeyTests {
     @Parameterized.Parameters
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {PrimaryKeyAsBoxedByte.class,    "{ \"name\":\"HaHaHaHaHaHaHaHaH\" }"},
-            {PrimaryKeyAsBoxedShort.class,   "{ \"name\":\"KeyValueTestIsFun\" }"},
-            {PrimaryKeyAsBoxedInteger.class, "{ \"name\":\"FunValueTestIsKey\" }"},
-            {PrimaryKeyAsBoxedLong.class,    "{ \"name\":\"NameAsBoxedLong-!\" }"},
-            {PrimaryKeyAsString.class,       "{ \"id\":2429214 }"}
+                {PrimaryKeyAsBoxedByte.class, "{ \"name\":\"HaHaHaHaHaHaHaHaH\" }"},
+                {PrimaryKeyAsBoxedShort.class, "{ \"name\":\"KeyValueTestIsFun\" }"},
+                {PrimaryKeyAsBoxedInteger.class, "{ \"name\":\"FunValueTestIsKey\" }"},
+                {PrimaryKeyAsBoxedLong.class, "{ \"name\":\"NameAsBoxedLong-!\" }"},
+                {PrimaryKeyAsString.class, "{ \"id\":2429214 }"},
+                {PrimaryKeyAsObjectId.class, "{ \"name\":\"789ABCDEF0123456789ABCDE\" }"}
         });
     }
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonNullPrimaryKeyTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonNullPrimaryKeyTests.java
@@ -31,11 +31,13 @@ import io.realm.entities.PrimaryKeyAsBoxedByte;
 import io.realm.entities.PrimaryKeyAsBoxedInteger;
 import io.realm.entities.PrimaryKeyAsBoxedLong;
 import io.realm.entities.PrimaryKeyAsBoxedShort;
+import io.realm.entities.PrimaryKeyAsObjectId;
 import io.realm.entities.PrimaryKeyAsString;
 import io.realm.objectid.NullPrimaryKey;
 import io.realm.rule.TestRealmConfigurationFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 public class RealmJsonNullPrimaryKeyTests {
@@ -61,11 +63,12 @@ public class RealmJsonNullPrimaryKeyTests {
     @Parameterized.Parameters
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {PrimaryKeyAsBoxedByte.class,    "OhThisIsNullKey?!", "{ \"id\":null, \"name\":\"OhThisIsNullKey?!\" }"},
-            {PrimaryKeyAsBoxedShort.class,   "YouBetItIsNullKey", "{ \"id\":null, \"name\":\"YouBetItIsNullKey\" }"},
-            {PrimaryKeyAsBoxedInteger.class, "Gosh Didnt KnowIt", "{ \"id\":null, \"name\":\"Gosh Didnt KnowIt\" }"},
-            {PrimaryKeyAsBoxedLong.class,    "?YOUNOWKNOWRIGHT?", "{ \"id\":null, \"name\":\"?YOUNOWKNOWRIGHT?\" }"},
-            {PrimaryKeyAsString.class,       "4299121",           "{ \"name\":null, \"id\":4299121  }"},
+                {PrimaryKeyAsBoxedByte.class, "OhThisIsNullKey?!", "{ \"id\":null, \"name\":\"OhThisIsNullKey?!\" }"},
+                {PrimaryKeyAsBoxedShort.class, "YouBetItIsNullKey", "{ \"id\":null, \"name\":\"YouBetItIsNullKey\" }"},
+                {PrimaryKeyAsBoxedInteger.class, "Gosh Didnt KnowIt", "{ \"id\":null, \"name\":\"Gosh Didnt KnowIt\" }"},
+                {PrimaryKeyAsBoxedLong.class, "?YOUNOWKNOWRIGHT?", "{ \"id\":null, \"name\":\"?YOUNOWKNOWRIGHT?\" }"},
+                {PrimaryKeyAsString.class, "4299121", "{ \"name\":null, \"id\":4299121  }"},
+                {PrimaryKeyAsObjectId.class, "Samsquanch", "{ \"id\":null, \"name\":\"Samsquanch\" }"},
         });
     }
 
@@ -91,14 +94,13 @@ public class RealmJsonNullPrimaryKeyTests {
             RealmResults<PrimaryKeyAsString> results = realm.where(PrimaryKeyAsString.class).findAll();
             assertEquals(1, results.size());
             assertEquals(Long.valueOf(secondaryFieldValue).longValue(), results.first().getId());
-            assertEquals(null, results.first().getName());
-
-        // PrimaryKeyAsNumber
+            assertNull(results.first().getName());
         } else {
+            // Other types
             RealmResults results = realm.where(clazz).findAll();
             assertEquals(1, results.size());
-            assertEquals(null, ((NullPrimaryKey)results.first()).getId());
-            assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());
+            assertNull(((NullPrimaryKey) results.first()).getId());
+            assertEquals(secondaryFieldValue, ((NullPrimaryKey) results.first()).getName());
         }
     }
 
@@ -115,13 +117,12 @@ public class RealmJsonNullPrimaryKeyTests {
             assertEquals(1, results.size());
             assertEquals(Long.valueOf(secondaryFieldValue).longValue(), results.first().getId());
             assertEquals(null, results.first().getName());
-
-        // PrimaryKeyAsNumber
         } else {
+            // Other types
             RealmResults results = realm.where(clazz).findAll();
             assertEquals(1, results.size());
-            assertEquals(null, ((NullPrimaryKey)results.first()).getId());
-            assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());
+            assertEquals(null, ((NullPrimaryKey) results.first()).getId());
+            assertEquals(secondaryFieldValue, ((NullPrimaryKey) results.first()).getName());
         }
     }
 
@@ -139,12 +140,12 @@ public class RealmJsonNullPrimaryKeyTests {
             assertEquals(1, results.size());
             assertEquals(Long.valueOf(secondaryFieldValue).longValue(), results.first().getId());
             assertEquals(null, results.first().getName());
-        // PrimaryKeyAsNumber
         } else {
+            // Other types
             RealmResults results = realm.where(clazz).findAll();
             assertEquals(1, results.size());
-            assertEquals(null, ((NullPrimaryKey)results.first()).getId());
-            assertEquals(secondaryFieldValue, ((NullPrimaryKey)results.first()).getName());
+            assertEquals(null, ((NullPrimaryKey) results.first()).getId());
+            assertEquals(secondaryFieldValue, ((NullPrimaryKey) results.first()).getName());
         }
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
@@ -57,6 +57,7 @@ import io.realm.entities.Dog;
 import io.realm.entities.NoPrimaryKeyNullTypes;
 import io.realm.entities.NullTypes;
 import io.realm.entities.OwnerPrimaryKey;
+import io.realm.entities.PrimaryKeyAsObjectId;
 import io.realm.entities.PrimitiveListTypes;
 import io.realm.entities.RandomPrimaryKey;
 import io.realm.exceptions.RealmException;
@@ -1557,6 +1558,20 @@ public class RealmJsonTests {
         realm.commitTransaction();
 
         assertAllTypesPrimaryKeyUpdated();
+    }
+
+    @Test
+    public void createOrUpdateObjectFromJson_objectIdPK() throws JSONException {
+        String stringId = "789ABCDEF0123456789ABCDE";
+        JSONObject jsonObject = new JSONObject("{\"id\": \""+ stringId + "\", \"name\": \"bar\"}");
+        realm.executeTransaction(realmInstance -> {
+            realmInstance.createObject(PrimaryKeyAsObjectId.class, new ObjectId());
+            realmInstance.createOrUpdateObjectFromJson(PrimaryKeyAsObjectId.class, jsonObject);
+        });
+        RealmResults<PrimaryKeyAsObjectId> owners = realm.where(PrimaryKeyAsObjectId.class).findAll();
+        assertEquals(2, owners.size());
+        assertEquals(new ObjectId(stringId), owners.get(1).getId());
+        assertEquals("bar", owners.get(1).getName());
     }
 
     // Tests creating objects from Json, all nullable fields with null values or non-null values.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
@@ -1564,14 +1564,14 @@ public class RealmJsonTests {
     public void createOrUpdateObjectFromJson_objectIdPK() throws JSONException {
         String stringId = "789ABCDEF0123456789ABCDE";
         JSONObject jsonObject = new JSONObject("{\"id\": \""+ stringId + "\", \"name\": \"bar\"}");
-        realm.executeTransaction(realmInstance -> {
-            realmInstance.createObject(PrimaryKeyAsObjectId.class, new ObjectId());
-            realmInstance.createOrUpdateObjectFromJson(PrimaryKeyAsObjectId.class, jsonObject);
-        });
+        realm.beginTransaction();
+        realm.createOrUpdateObjectFromJson(PrimaryKeyAsObjectId.class, jsonObject);
+        realm.commitTransaction();
+
         RealmResults<PrimaryKeyAsObjectId> owners = realm.where(PrimaryKeyAsObjectId.class).findAll();
-        assertEquals(2, owners.size());
-        assertEquals(new ObjectId(stringId), owners.get(1).getId());
-        assertEquals("bar", owners.get(1).getName());
+        assertEquals(1, owners.size());
+        assertEquals(new ObjectId(stringId), owners.get(0).getId());
+        assertEquals("bar", owners.get(0).getName());
     }
 
     // Tests creating objects from Json, all nullable fields with null values or non-null values.

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsObjectId.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimaryKeyAsObjectId.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.realm.entities;
+
+import org.bson.types.ObjectId;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
+import io.realm.objectid.NullPrimaryKey;
+
+public class PrimaryKeyAsObjectId extends RealmObject implements NullPrimaryKey<ObjectId, String> {
+
+    public static final String CLASS_NAME = "PrimaryKeyAsObjectId";
+    public static final String FIELD_PRIMARY_KEY = "name";
+    public static final String FIELD_ID = "id";
+
+    @PrimaryKey
+    private ObjectId id;
+    private String name;
+
+    public PrimaryKeyAsObjectId() {
+    }
+
+    public PrimaryKeyAsObjectId(ObjectId id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public ObjectId getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Closes #7197 

- Fixed logic in `RealmProxyClassGenerator` to instantiate an `ObjectId` instead of directly casting a string.
- Fixed tests for absent and null PK during json generation.
- Added missing test for creating objects with an `ObjectId` PK.