### PR TITLE
Fix toFlow extension

### DIFF
--- a/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmResultsExtensions.kt
+++ b/realm/kotlin-extensions/src/main/kotlin/io/realm/kotlin/RealmResultsExtensions.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.isActive
 
 /**
  * Returns a [Flow] that monitors changes to this RealmResults. It will emit the current
@@ -81,7 +82,9 @@ fun <T : RealmModel> RealmResults<T>.toFlow(): Flow<RealmResults<T>> {
         // Get instance to ensure the Realm is open for as long as we are listening
         val flowRealm = Realm.getInstance(config)
         val listener = RealmChangeListener<RealmResults<T>> { listenerResults ->
-            offer(listenerResults.freeze())
+            if (isActive) {
+                offer(listenerResults.freeze())
+            }
         }
 
         results.addChangeListener(listener)


### PR DESCRIPTION
It seems there is a concurrency issue between the `RealmChangeListener` and the `awaitClose` which lead to the crash below, especially on low device. Checking the scope `isActive` solved the issue, inspired from `executeTransactionAwait` (#7209)

![image](https://user-images.githubusercontent.com/45555889/99551657-692bca00-29bc-11eb-935d-7f379253ccaa.png)
