### PR TITLE
Ensure flow emissions are cooperative after the job has been cancelled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Fixes
 * Fixed crash when adding classes containing an `ObjectId` as primary key to the schema. (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0)
 * Fixed crash when creating proxy classes containing an `ObjectId` as primary key. (Issue [#7197](https://github.com/realm/realm-java/issues/7197), since v10.0.0)
-* Fixed crash present on slow devices in which calls to `toFlow` could crash if the Flow job is cancelled and object updates are emitted after that happens. (Issue [7211](https://github.com/realm/realm-java/issues/7211), since v10.0.1)
+* Fixed crash where calls to `toFlow` could crash if the Flow job is canceled and object updates are emitted after that happens. (Issue [7211](https://github.com/realm/realm-java/issues/7211), since v10.0.1)
 
 ### Compatibility
 * File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 * Fixed crash when adding classes containing an `ObjectId` as primary key to the schema. (Issue [#7189](https://github.com/realm/realm-java/issues/7189), since v10.0.0)
 * Fixed crash when creating proxy classes containing an `ObjectId` as primary key. (Issue [#7197](https://github.com/realm/realm-java/issues/7197), since v10.0.0)
+* Fixed crash present on slow devices in which calls to `toFlow` could crash if the Flow job is cancelled and object updates are emitted after that happens. (Issue [7211](https://github.com/realm/realm-java/issues/7211), since v10.0.1)
 
 ### Compatibility
 * File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-library/src/main/java/io/realm/internal/coroutines/InternalFlowFactory.kt
+++ b/realm/realm-library/src/main/java/io/realm/internal/coroutines/InternalFlowFactory.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.isActive
 
 /**
  * Internal factory implementation used to conceal Kotlin implementation details from the public
@@ -43,10 +44,12 @@ class InternalFlowFactory(
         return callbackFlow {
             val flowRealm = Realm.getInstance(realm.configuration)
             val listener = RealmChangeListener<Realm> { listenerRealm ->
-                if (returnFrozenObjects) {
-                    offer(realm.freeze())
-                } else {
-                    offer(listenerRealm)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(realm.freeze())
+                    } else {
+                        offer(listenerRealm)
+                    }
                 }
             }
 
@@ -74,10 +77,12 @@ class InternalFlowFactory(
         return callbackFlow {
             val flowRealm = DynamicRealm.getInstance(dynamicRealm.configuration)
             val listener = RealmChangeListener<DynamicRealm> { listenerRealm ->
-                if (returnFrozenObjects) {
-                    offer(dynamicRealm.freeze())
-                } else {
-                    offer(listenerRealm)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(dynamicRealm.freeze())
+                    } else {
+                        offer(listenerRealm)
+                    }
                 }
             }
 
@@ -116,10 +121,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = Realm.getInstance(config)
             val listener = RealmChangeListener<RealmResults<T>> { listenerResults ->
-                if (returnFrozenObjects) {
-                    offer(listenerResults.freeze())
-                } else {
-                    offer(listenerResults)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(listenerResults.freeze())
+                    } else {
+                        offer(listenerResults)
+                    }
                 }
             }
 
@@ -164,10 +171,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = Realm.getInstance(config)
             val listener = OrderedRealmCollectionChangeListener<RealmResults<T>> { listenerResults, changeSet ->
-                if (returnFrozenObjects) {
-                    offer(CollectionChange(listenerResults.freeze(), changeSet))
-                } else {
-                    offer(CollectionChange(listenerResults, changeSet))
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(CollectionChange(listenerResults.freeze(), changeSet))
+                    } else {
+                        offer(CollectionChange(listenerResults, changeSet))
+                    }
                 }
             }
 
@@ -212,10 +221,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = DynamicRealm.getInstance(config)
             val listener = RealmChangeListener<RealmResults<T>> { listenerResults ->
-                if (returnFrozenObjects) {
-                    offer(listenerResults.freeze())
-                } else {
-                    offer(listenerResults)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(listenerResults.freeze())
+                    } else {
+                        offer(listenerResults)
+                    }
                 }
             }
 
@@ -260,10 +271,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = DynamicRealm.getInstance(config)
             val listener = OrderedRealmCollectionChangeListener<RealmResults<T>> { listenerResults, changeSet ->
-                if (returnFrozenObjects) {
-                    offer(CollectionChange(listenerResults.freeze(), changeSet))
-                } else {
-                    offer(CollectionChange(listenerResults, changeSet))
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(CollectionChange(listenerResults.freeze(), changeSet))
+                    } else {
+                        offer(CollectionChange(listenerResults, changeSet))
+                    }
                 }
             }
 
@@ -306,10 +319,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = Realm.getInstance(config)
             val listener = RealmChangeListener<RealmList<T>> { listenerResults ->
-                if (returnFrozenObjects) {
-                    offer(listenerResults.freeze())
-                } else {
-                    offer(listenerResults)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(listenerResults.freeze())
+                    } else {
+                        offer(listenerResults)
+                    }
                 }
             }
 
@@ -354,10 +369,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = Realm.getInstance(config)
             val listener = OrderedRealmCollectionChangeListener<RealmList<T>> { listenerList, changeSet ->
-                if (returnFrozenObjects) {
-                    offer(CollectionChange(listenerList.freeze(), changeSet))
-                } else {
-                    offer(CollectionChange(listenerList, changeSet))
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(CollectionChange(listenerList.freeze(), changeSet))
+                    } else {
+                        offer(CollectionChange(listenerList, changeSet))
+                    }
                 }
             }
 
@@ -399,10 +416,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = DynamicRealm.getInstance(config)
             val listener = RealmChangeListener<RealmList<T>> { listenerResults ->
-                if (returnFrozenObjects) {
-                    offer(listenerResults.freeze())
-                } else {
-                    offer(listenerResults)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(listenerResults.freeze())
+                    } else {
+                        offer(listenerResults)
+                    }
                 }
             }
 
@@ -447,10 +466,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = DynamicRealm.getInstance(config)
             val listener = OrderedRealmCollectionChangeListener<RealmList<T>> { listenerList, changeSet ->
-                if (returnFrozenObjects) {
-                    offer(CollectionChange(listenerList.freeze(), changeSet))
-                } else {
-                    offer(CollectionChange(listenerList, changeSet))
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(CollectionChange(listenerList.freeze(), changeSet))
+                    } else {
+                        offer(CollectionChange(listenerList, changeSet))
+                    }
                 }
             }
 
@@ -493,10 +514,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = Realm.getInstance(config)
             val listener = RealmChangeListener<T> { listenerObj ->
-                if (returnFrozenObjects) {
-                    offer(RealmObject.freeze(listenerObj) as T)
-                } else {
-                    offer(listenerObj)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(RealmObject.freeze(listenerObj) as T)
+                    } else {
+                        offer(listenerObj)
+                    }
                 }
             }
 
@@ -541,10 +564,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = Realm.getInstance(config)
             val listener = RealmObjectChangeListener<T> { listenerObject, changeSet ->
-                if (returnFrozenObjects) {
-                    offer(ObjectChange(RealmObject.freeze(listenerObject), changeSet))
-                } else {
-                    offer(ObjectChange(listenerObject, changeSet))
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(ObjectChange(RealmObject.freeze(listenerObject), changeSet))
+                    } else {
+                        offer(ObjectChange(listenerObject, changeSet))
+                    }
                 }
             }
 
@@ -590,10 +615,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = DynamicRealm.getInstance(config)
             val listener = RealmChangeListener<DynamicRealmObject> { listenerObj ->
-                if (returnFrozenObjects) {
-                    offer(listenerObj.freeze())
-                } else {
-                    offer(listenerObj)
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(listenerObj.freeze())
+                    } else {
+                        offer(listenerObj)
+                    }
                 }
             }
 
@@ -638,10 +665,12 @@ class InternalFlowFactory(
             // Get instance to ensure the Realm is open for as long as we are listening
             val flowRealm = Realm.getInstance(config)
             val listener = RealmObjectChangeListener<DynamicRealmObject> { listenerObject, changeSet ->
-                if (returnFrozenObjects) {
-                    offer(ObjectChange(RealmObject.freeze(listenerObject), changeSet))
-                } else {
-                    offer(ObjectChange(listenerObject, changeSet))
+                if (isActive) {
+                    if (returnFrozenObjects) {
+                        offer(ObjectChange(RealmObject.freeze(listenerObject), changeSet))
+                    } else {
+                        offer(ObjectChange(listenerObject, changeSet))
+                    }
                 }
             }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/coroutines/InternalFlowFactory.kt
+++ b/realm/realm-library/src/main/java/io/realm/internal/coroutines/InternalFlowFactory.kt
@@ -526,10 +526,12 @@ class InternalFlowFactory(
             RealmObject.addChangeListener(realmObject, listener)
 
             // Emit current value
-            if (returnFrozenObjects) {
-                offer(RealmObject.freeze(realmObject))
-            } else {
-                offer(realmObject)
+            if (RealmObject.isLoaded(realmObject)) {
+                if (returnFrozenObjects) {
+                    offer(RealmObject.freeze(realmObject))
+                } else {
+                    offer(realmObject)
+                }
             }
 
             awaitClose {
@@ -576,10 +578,12 @@ class InternalFlowFactory(
             RealmObject.addChangeListener(realmObject, listener)
 
             // Emit current value
-            if (returnFrozenObjects) {
-                offer(ObjectChange(RealmObject.freeze(realmObject), null))
-            } else {
-                offer(ObjectChange(realmObject, null))
+            if (RealmObject.isLoaded(realmObject)) {
+                if (returnFrozenObjects) {
+                    offer(ObjectChange(RealmObject.freeze(realmObject), null))
+                } else {
+                    offer(ObjectChange(realmObject, null))
+                }
             }
 
             awaitClose {
@@ -627,10 +631,12 @@ class InternalFlowFactory(
             dynamicRealmObject.addChangeListener(listener)
 
             // Emit current value
-            if (returnFrozenObjects) {
-                offer(RealmObject.freeze(dynamicRealmObject))
-            } else {
-                offer(dynamicRealmObject)
+            if (RealmObject.isLoaded(dynamicRealmObject)) {
+                if (returnFrozenObjects) {
+                    offer(RealmObject.freeze(dynamicRealmObject))
+                } else {
+                    offer(dynamicRealmObject)
+                }
             }
 
             awaitClose {
@@ -677,10 +683,12 @@ class InternalFlowFactory(
             RealmObject.addChangeListener(dynamicRealmObject, listener)
 
             // Emit current value
-            if (returnFrozenObjects) {
-                offer(ObjectChange(RealmObject.freeze(dynamicRealmObject), null))
-            } else {
-                offer(ObjectChange(dynamicRealmObject, null))
+            if (RealmObject.isLoaded(dynamicRealmObject)) {
+                if (returnFrozenObjects) {
+                    offer(ObjectChange(RealmObject.freeze(dynamicRealmObject), null))
+                } else {
+                    offer(ObjectChange(dynamicRealmObject, null))
+                }
             }
 
             awaitClose {


### PR DESCRIPTION
Fixes #7211 

It is possible that a job is cancelled and the listener keeps emitting object updates. This could result in an `AbortFlowException`. To fix this we have to make the flow emissions cooperative.