### PR TITLE
Fixing annotation processor to safely check for embedded classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 10.1.1 (2020-10-27)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixes
+* KAPT crash when processing a RealmObject referenced from another module (changed revealed after we started checking for embedded types). (Issue [#7213](https://github.com/realm/realm-java/issues/7213), since v10.0.0)
+
+### Compatibility
+* File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 or above is required to open Realms created by this version.
+
+### Internal
+* Updated to Realm Sync: 10.1.3.
+* Updated to Realm Core: 10.1.3.
+* Updated to Object Store commit: fc6daca61133aa9601e4cb34fbeb9ec7569e162e.
+
+
 ## 10.1.0 (2020-10-23)
 
 ### Breaking Changes

--- a/realm/realm-annotations-processor/build.gradle
+++ b/realm/realm-annotations-processor/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     implementation "io.realm:realm-annotations:${version}"
     implementation "org.mongodb:bson:${properties.getProperty('BSON_DEPENDENCY')}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation files(Jvm.current().toolsJar)
     testImplementation files('../realm-library/build/intermediates/aar_main_jar/baseRelease/classes.jar') // Java projects cannot depend on AAR files
-    testImplementation files("${System.properties['java.home']}/../lib/tools.jar") // This is needed otherwise compile-testing won't be able to find it
     testImplementation group:'junit', name:'junit', version:'4.12'
     testImplementation group:'com.google.testing.compile', name:'compile-testing', version:'0.6'
     testImplementation files(file("${System.env.ANDROID_HOME}/platforms/android-29/android.jar"))
@@ -24,6 +24,7 @@ dependencies {
 
 // for Ant filter
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.internal.jvm.Jvm
 
 task generateVersionClass(type: Copy) {
     from 'src/main/templates/Version.java'

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassCollection.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/ClassCollection.kt
@@ -40,6 +40,10 @@ class ClassCollection {
                 ?: throw IllegalArgumentException("Class $className was not found")
     }
 
+    fun getClassFromQualifiedNameOrNull(className: QualifiedClassName): ClassMetaData? {
+        return qualifiedNameClassMap[className]
+    }
+
     fun size(): Int {
         return classSet.size
     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -2421,7 +2421,6 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
         return fieldTypeMetaData?.embedded ?: type.isEmbedded()
     }
 
-
     private fun TypeMirror.isEmbedded() : Boolean {
         var isEmbedded = false
 

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -2410,11 +2410,11 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
 
     }
 
-    // Returns whether a type of a  Realm field is embedded or not.
-    // If the type class is part of this processing round then lookup the class metadata from 'classCollection'
-    // then invoke 'embedded' property, Otherwise the class might not be present within the 'classCollection' because it was
-    // processed from another module for example, then use the compiler tool api to find out if it was annotated with 'embedded'
-    // the second method could be slightly slower this is why we default to the first appraoch.
+    // Returns whether a type of a Realm field is embedded or not.
+    // For types which are part of this processing round we can look it up immediately from 
+    // the metadata in the `classCollection`. For types defined in other modules we will 
+    // have to use the slower approach of inspecting the `embedded` property of the
+    // RealmClass annotation using the compiler tool api. 
     private fun isFieldTypeEmbedded(type: TypeMirror) : Boolean  {
         val fieldType = QualifiedClassName(type)
         val fieldTypeMetaData: ClassMetaData? = classCollection.getClassFromQualifiedNameOrNull(fieldType)

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -2425,11 +2425,12 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
         if (this is Type.ClassType) {
             val declarationAttributes: com.sun.tools.javac.util.List<Attribute.Compound>? = tsym.metadata?.declarationAttributes
             if (declarationAttributes != null) {
-                for (attribute: Attribute.Compound in declarationAttributes) {
+                loop@for (attribute: Attribute.Compound in declarationAttributes) {
                     if (attribute.type.tsym.qualifiedName.toString() == "io.realm.annotations.RealmClass") {
                         for (pair: Pair<Symbol.MethodSymbol, Attribute> in attribute.values) {
                             if (pair.fst.name.toString() == "embedded") {
                                 isEmbedded = pair.snd.value as Boolean
+                                break@loop
                             }
                         }
                     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -17,9 +17,12 @@
 package io.realm.processor
 
 import com.squareup.javawriter.JavaWriter
+import com.sun.tools.javac.code.Attribute
+import com.sun.tools.javac.code.Symbol
+import com.sun.tools.javac.code.Type
+import com.sun.tools.javac.util.Pair
 import io.realm.processor.ext.beginMethod
 import io.realm.processor.ext.beginType
-import org.bson.types.ObjectId
 import java.io.BufferedWriter
 import java.io.IOException
 import java.util.*
@@ -370,8 +373,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
             // Getter - End
 
             // Setter - Start
-            val fieldType = QualifiedClassName(field.asType())
-            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
+            val isEmbedded = isFieldTypeEmbedded(field.asType())
             val linkedQualifiedClassName: QualifiedClassName = Utils.getFieldTypeQualifiedName(field)
             val linkedProxyClass: SimpleClassName = Utils.getProxyClassSimpleName(field)
             emitAnnotation("Override")
@@ -383,7 +385,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                         emitStatement("return")
                     endControlFlow()
                     beginControlFlow("if (value != null && !RealmObject.isManaged(value))")
-                        if (fieldTypeMetaData.embedded) {
+                        if (isEmbedded) {
                             emitStatement("%1\$s proxyObject = realm.createEmbeddedObject(%1\$s.class, this, \"%2\$s\")", linkedQualifiedClassName, fieldName)
                             emitStatement("%s.updateEmbeddedObject(realm, value, proxyObject, new HashMap<RealmModel, RealmObjectProxy>(), Collections.EMPTY_SET)", linkedProxyClass)
                             emitStatement("value = proxyObject")
@@ -409,7 +411,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                     emitStatement("return")
                 endControlFlow()
 
-                if (fieldTypeMetaData.embedded) {
+                if (isEmbedded) {
                     beginControlFlow("if (RealmObject.isManaged(value))")
                         emitStatement("proxyState.checkValidObject(value)")
                     endControlFlow()
@@ -895,7 +897,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
             emitEmptyLine()
         }
     }
-   
+
     @Throws(IOException::class)
     private fun setTableValues(writer: JavaWriter, fieldType: String, fieldName: String, interfaceName: SimpleClassName, getter: String, isUpdate: Boolean) {
         writer.apply {
@@ -1064,13 +1066,12 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
 
                 when {
                     Utils.isRealmModel(field) -> {
-                        val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
-
+                        val isEmbedded = isFieldTypeEmbedded(field.asType())
                         emitEmptyLine()
                         emitStatement("%s %sObj = ((%s) object).%s()", fieldType, fieldName, interfaceName, getter)
                         beginControlFlow("if (%sObj != null)", fieldName)
                             emitStatement("Long cache%1\$s = cache.get(%1\$sObj)", fieldName)
-                            if (fieldTypeMetaData.embedded) {
+                            if (isEmbedded) {
                                 beginControlFlow("if (cache%s != null)", fieldName)
                                     emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cache%s.toString())", fieldName)
                                 nextControlFlow("else")
@@ -1085,20 +1086,19 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                         endControlFlow()
                     }
                     Utils.isRealmModelList(field) -> {
-                        val genericType = Utils.getGenericTypeQualifiedName(field)!!
-                        val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(genericType)
-
+                        val genericType: TypeMirror = Utils.getGenericType(field)!!
+                        val isEmbedded = isFieldTypeEmbedded(genericType)
                         emitEmptyLine()
                         emitStatement("RealmList<%s> %sList = ((%s) object).%s()", genericType, fieldName, interfaceName, getter)
                         beginControlFlow("if (%sList != null)", fieldName)
                             emitStatement("OsList %1\$sOsList = new OsList(table.getUncheckedRow(objKey), columnInfo.%1\$sColKey)", fieldName)
                             beginControlFlow("for (%1\$s %2\$sItem : %2\$sList)", genericType, fieldName)
                                 emitStatement("Long cacheItemIndex%1\$s = cache.get(%1\$sItem)", fieldName)
-                                if (fieldTypeMetaData.embedded) {
+                                if (isEmbedded) {
                                     beginControlFlow("if (cacheItemIndex%s != null)", fieldName)
                                         emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cacheItemIndex%s.toString())", fieldName)
                                     nextControlFlow("else")
-                                        emitStatement("cacheItemIndex%1\$s = %2\$s.insert(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(genericType), fieldName)
+                                        emitStatement("cacheItemIndex%1\$s = %2\$s.insert(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(QualifiedClassName(genericType.toString())), fieldName)
                                     endControlFlow()
                                 } else {
                                     beginControlFlow("if (cacheItemIndex%s == null)", fieldName)
@@ -1180,13 +1180,13 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                         val getter = metadata.getInternalGetter(fieldName)
 
                         if (Utils.isRealmModel(field)) {
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
+                            val isEmbedded = isFieldTypeEmbedded(field.asType())
 
                             emitEmptyLine()
                             emitStatement("%s %sObj = ((%s) object).%s()", fieldType, fieldName, interfaceName, getter)
                             beginControlFlow("if (%sObj != null)", fieldName)
                                 emitStatement("Long cache%1\$s = cache.get(%1\$sObj)", fieldName)
-                                if (fieldTypeMetaData.embedded) {
+                                if (isEmbedded) {
                                     beginControlFlow("if (cache%s != null)", fieldName)
                                         emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cache%s.toString())", fieldName)
                                     nextControlFlow("else")
@@ -1200,8 +1200,8 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                 }
                             endControlFlow()
                         } else if (Utils.isRealmModelList(field)) {
-                            val genericType = Utils.getGenericTypeQualifiedName(field)!!
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(genericType)
+                            val genericType: TypeMirror = Utils.getGenericType(field)!!
+                            val isEmbedded = isFieldTypeEmbedded(genericType)
 
                             emitEmptyLine()
                             emitStatement("RealmList<%s> %sList = ((%s) object).%s()", genericType, fieldName, interfaceName, getter)
@@ -1209,11 +1209,11 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                 emitStatement("OsList %1\$sOsList = new OsList(table.getUncheckedRow(objKey), columnInfo.%1\$sColKey)", fieldName)
                                 beginControlFlow("for (%1\$s %2\$sItem : %2\$sList)", genericType, fieldName)
                                     emitStatement("Long cacheItemIndex%1\$s = cache.get(%1\$sItem)", fieldName)
-                                    if (fieldTypeMetaData.embedded) {
+                                    if (isEmbedded) {
                                         beginControlFlow("if (cacheItemIndex%s != null)", fieldName)
                                             emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cacheItemIndex%s.toString())", fieldName)
                                         nextControlFlow("else")
-                                            emitStatement("cacheItemIndex%1\$s = %2\$s.insert(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(genericType), fieldName)
+                                            emitStatement("cacheItemIndex%1\$s = %2\$s.insert(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(QualifiedClassName(genericType.toString())), fieldName)
                                         endControlFlow()
                                     } else {
                                         beginControlFlow("if (cacheItemIndex%s == null)", fieldName)
@@ -1284,13 +1284,12 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                 val getter = metadata.getInternalGetter(fieldName)
 
                 if (Utils.isRealmModel(field)) {
-                    val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
-
+                    val isEmbedded = isFieldTypeEmbedded(field.asType())
                     emitEmptyLine()
                     emitStatement("%s %sObj = ((%s) object).%s()", fieldType, fieldName, interfaceName, getter)
                     beginControlFlow("if (%sObj != null)", fieldName)
                         emitStatement("Long cache%1\$s = cache.get(%1\$sObj)", fieldName)
-                        if (fieldTypeMetaData.embedded) {
+                        if (isEmbedded) {
                             beginControlFlow("if (cache%s != null)", fieldName)
                                 emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cache%s.toString())", fieldName)
                             nextControlFlow("else")
@@ -1307,13 +1306,13 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                         emitStatement("Table.nativeNullifyLink(tableNativePtr, columnInfo.%sColKey, objKey)", fieldName)
                     endControlFlow()
                 } else if (Utils.isRealmModelList(field)) {
-                    val genericType = Utils.getGenericTypeQualifiedName(field)!!
-                    val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(genericType)
+                    val genericType: TypeMirror = Utils.getGenericType(field)!!
+                    val isEmbedded = isFieldTypeEmbedded(genericType)
 
                     emitEmptyLine()
                     emitStatement("OsList %1\$sOsList = new OsList(table.getUncheckedRow(objKey), columnInfo.%1\$sColKey)", fieldName)
                     emitStatement("RealmList<%s> %sList = ((%s) object).%s()", genericType, fieldName, interfaceName, getter)
-                    if (fieldTypeMetaData.embedded) {
+                    if (isEmbedded) {
                         emitStatement("%1\$sOsList.removeAll()", fieldName)
                         beginControlFlow("if (%sList != null)", fieldName)
                             beginControlFlow("for (%1\$s %2\$sItem : %2\$sList)", genericType, fieldName)
@@ -1321,7 +1320,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                 beginControlFlow("if (cacheItemIndex%s != null)", fieldName)
                                     emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cacheItemIndex%s.toString())", fieldName)
                                 nextControlFlow("else")
-                                    emitStatement("cacheItemIndex%1\$s = %2\$s.insertOrUpdate(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(genericType), fieldName)
+                                    emitStatement("cacheItemIndex%1\$s = %2\$s.insertOrUpdate(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(QualifiedClassName(genericType.toString())), fieldName)
                                 endControlFlow()
                             endControlFlow()
                         endControlFlow()
@@ -1422,13 +1421,12 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
 
                         when {
                             Utils.isRealmModel(field) -> {
-                                val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
-
+                                val isEmbedded = isFieldTypeEmbedded(field.asType())
                                 emitEmptyLine()
                                 emitStatement("%s %sObj = ((%s) object).%s()", fieldType, fieldName, interfaceName, getter)
                                 beginControlFlow("if (%sObj != null)", fieldName)
                                     emitStatement("Long cache%1\$s = cache.get(%1\$sObj)", fieldName)
-                                    if (fieldTypeMetaData.embedded) {
+                                    if (isEmbedded) {
                                         beginControlFlow("if (cache%s != null)", fieldName)
                                             emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cache%s.toString())", fieldName)
                                         nextControlFlow("else")
@@ -1446,9 +1444,8 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                 endControlFlow()
                             }
                             Utils.isRealmModelList(field) -> {
-                                val genericType = Utils.getGenericTypeQualifiedName(field)!!
-                                val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(genericType)
-
+                                val genericType: TypeMirror = Utils.getGenericType(field)!!
+                                val isEmbedded = isFieldTypeEmbedded(genericType)
                                 emitEmptyLine()
                                 emitStatement("OsList %1\$sOsList = new OsList(table.getUncheckedRow(objKey), columnInfo.%1\$sColKey)", fieldName)
                                 emitStatement("RealmList<%s> %sList = ((%s) object).%s()", genericType, fieldName, interfaceName, getter)
@@ -1458,11 +1455,11 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                     beginControlFlow("for (int i = 0; i < objectCount; i++)")
                                         emitStatement("%1\$s %2\$sItem = %2\$sList.get(i)", genericType, fieldName)
                                         emitStatement("Long cacheItemIndex%1\$s = cache.get(%1\$sItem)", fieldName)
-                                        if (fieldTypeMetaData.embedded) {
+                                        if (isEmbedded) {
                                             beginControlFlow("if (cacheItemIndex%s != null)", fieldName)
                                                 emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cacheItemIndex%s.toString())", fieldName)
                                             nextControlFlow("else")
-                                                emitStatement("cacheItemIndex%1\$s = %2\$s.insertOrUpdate(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(genericType), fieldName)
+                                                emitStatement("cacheItemIndex%1\$s = %2\$s.insertOrUpdate(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(QualifiedClassName(genericType.toString())), fieldName)
                                             endControlFlow()
                                         } else {
                                             beginControlFlow("if (cacheItemIndex%s == null)", fieldName)
@@ -1476,11 +1473,11 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                     beginControlFlow("if (%sList != null)", fieldName)
                                         beginControlFlow("for (%1\$s %2\$sItem : %2\$sList)", genericType, fieldName)
                                             emitStatement("Long cacheItemIndex%1\$s = cache.get(%1\$sItem)", fieldName)
-                                            if (fieldTypeMetaData.embedded) {
+                                            if (isEmbedded) {
                                                 beginControlFlow("if (cacheItemIndex%s != null)", fieldName)
                                                     emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: \" + cacheItemIndex%s.toString())", fieldName)
                                                 nextControlFlow("else")
-                                                    emitStatement("cacheItemIndex%1\$s = %2\$s.insertOrUpdate(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(genericType), fieldName)
+                                                    emitStatement("cacheItemIndex%1\$s = %2\$s.insertOrUpdate(realm, table, columnInfo.%3\$sColKey, objKey, %3\$sItem, cache)", fieldName, Utils.getProxyClassName(QualifiedClassName(genericType.toString())), fieldName)
                                                 endControlFlow()
                                             } else {
                                                 beginControlFlow("if (cacheItemIndex%s == null)", fieldName)
@@ -1520,7 +1517,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                     }
                 endControlFlow()
             endMethod()
-            emitEmptyLine()            
+            emitEmptyLine()
         }
     }
 
@@ -1576,7 +1573,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                     } else {
                         emitStatement("objKey = OsObject.createRowWithPrimaryKey(table, pkColumnKey, ((%s) object).%s())", interfaceName, primaryKeyGetter)
                     }
-    
+
                     if (throwIfPrimaryKeyDuplicate) {
                         nextControlFlow("else")
                         emitStatement("Table.throwDuplicatePrimaryKeyException(primaryKeyValue)")
@@ -1648,7 +1645,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
 
                     when {
                         Utils.isRealmModel(field) -> {
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
+                            val isEmbedded = isFieldTypeEmbedded(field.asType())
                             val fieldColKey: String = fieldColKeyVariableReference(field)
                             val linkedQualifiedClassName: QualifiedClassName = Utils.getFieldTypeQualifiedName(field)
                             val linkedProxyClass: SimpleClassName = Utils.getProxyClassSimpleName(field)
@@ -1659,7 +1656,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                             nextControlFlow("else")
                                 emitStatement("%s cache%s = (%s) cache.get(%sObj)", fieldType, fieldName, fieldType, fieldName)
 
-                                if (fieldTypeMetaData.embedded) {
+                                if (isEmbedded) {
                                     beginControlFlow("if (cache%s != null)", fieldName)
                                         emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: cache%s.toString()\")", fieldName)
                                     nextControlFlow("else")
@@ -1682,10 +1679,10 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                             emitEmptyLine()
                         }
                         Utils.isRealmModelList(field) -> {
-                            val listElementType: QualifiedClassName = Utils.getRealmListType(field)!!
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(listElementType)
+                            val listElementType: TypeMirror = Utils.getGenericType(field)!!
                             val genericType: QualifiedClassName = Utils.getGenericTypeQualifiedName(field)!!
                             val linkedProxyClass: SimpleClassName = Utils.getProxyClassSimpleName(field)
+                            val isEmbedded = isFieldTypeEmbedded(listElementType)
 
                             emitStatement("RealmList<%s> %sUnmanagedList = unmanagedSource.%s()", genericType, fieldName, getter)
                             beginControlFlow("if (%sUnmanagedList != null)", fieldName)
@@ -1696,7 +1693,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                     emitStatement("%1\$s %2\$sUnmanagedItem = %2\$sUnmanagedList.get(i)", genericType, fieldName)
                                     emitStatement("%1\$s cache%2\$s = (%1\$s) cache.get(%2\$sUnmanagedItem)", genericType, fieldName)
 
-                                    if (fieldTypeMetaData.embedded) {
+                                    if (isEmbedded) {
                                         beginControlFlow("if (cache%s != null)", fieldName)
                                             emitStatement("throw new IllegalArgumentException(\"Embedded objects can only have one parent pointing to them. This object was already copied, so another object is pointing to it: cache%s.toString()\")", fieldName)
                                         nextControlFlow("else")
@@ -1800,7 +1797,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
             emitEmptyLine()
         }
     }
-   
+
     @Throws(IOException::class)
     private fun emitUpdateMethod(writer: JavaWriter) {
         if (!metadata.hasPrimaryKey() && !metadata.embedded) {
@@ -1828,15 +1825,14 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
 
                     when {
                         Utils.isRealmModel(field) -> {
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
-
                             emitEmptyLine()
                             emitStatement("%s %sObj = realmObjectSource.%s()", fieldType, fieldName, getter)
                             beginControlFlow("if (%sObj == null)", fieldName)
                                 emitStatement("builder.addNull(%s)", fieldColKeyVariableReference(field))
                             nextControlFlow("else")
 
-                            if (fieldTypeMetaData.embedded) {
+                            val isEmbedded = isFieldTypeEmbedded(field.asType())
+                            if (isEmbedded) {
                                 // Embedded objects are created in-place as we need to know the
                                 // parent object + the property containing it.
                                 // After this we know that changing values will always be considered
@@ -1867,7 +1863,9 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                         }
                         Utils.isRealmModelList(field) -> {
                             val genericType: QualifiedClassName = Utils.getRealmListType(field)!!
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(genericType)
+                            val fieldTypeMetaData: TypeMirror = Utils.getGenericType(field)!!
+
+                            val isEmbedded = isFieldTypeEmbedded(fieldTypeMetaData)
                             val proxyClass: SimpleClassName = Utils.getProxyClassSimpleName(field)
 
                             emitEmptyLine()
@@ -1875,7 +1873,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                             beginControlFlow("if (%sUnmanagedList != null)", fieldName)
                                 emitStatement("RealmList<%s> %sManagedCopy = new RealmList<%s>()", genericType, fieldName, genericType)
 
-                                if (fieldTypeMetaData.embedded) {
+                                if (isEmbedded) {
                                     emitStatement("OsList targetList = realmObjectTarget.realmGet\$%s().getOsList()", fieldName)
                                     emitStatement("targetList.deleteAll()")
                                     beginControlFlow("for (int i = 0; i < %sUnmanagedList.size(); i++)", fieldName)
@@ -2032,9 +2030,9 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
             emitEmptyLine()
         }
     }
-   
 
-   
+
+
     @Throws(IOException::class)
     private fun emitEqualsMethod(writer: JavaWriter) {
         if (metadata.containsEquals()) {
@@ -2069,7 +2067,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
             endMethod()
         }
     }
-   
+
     @Throws(IOException::class)
     private fun emitCreateOrUpdateUsingJsonObject(writer: JavaWriter) {
         writer.apply {
@@ -2158,15 +2156,14 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                     }
                     when {
                         Utils.isRealmModel(field) -> {
-                            val fieldType = QualifiedClassName(field.asType())
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
+                            val isEmbedded = isFieldTypeEmbedded(field.asType())
                             RealmJsonTypeHelper.emitFillRealmObjectWithJsonValue(
                                     "objProxy",
                                     metadata.getInternalSetter(fieldName),
                                     fieldName,
                                     qualifiedFieldType,
                                     Utils.getProxyClassSimpleName(field),
-                                    fieldTypeMetaData.embedded,
+                                    isEmbedded,
                                     writer)
                         }
                         Utils.isRealmModelList(field) -> {
@@ -2301,7 +2298,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                 emitStatement("return obj")
             }
             endMethod()
-            emitEmptyLine()            
+            emitEmptyLine()
         }
     }
 
@@ -2410,5 +2407,39 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
             }
             return count
         }
+
+    }
+
+    // Returns whether a type of a  Realm field is embedded or not.
+    // If the type class is part of this processing round then lookup the class metadata from 'classCollection'
+    // then invoke 'embedded' property, Otherwise the class might not be present within the 'classCollection' because it was
+    // processed from another module for example, then use the compiler tool api to find out if it was annotated with 'embedded'
+    // the second method could be slightly slower this is why we default to the first appraoch.
+    private fun isFieldTypeEmbedded(type: TypeMirror) : Boolean  {
+        val fieldType = QualifiedClassName(type)
+        val fieldTypeMetaData: ClassMetaData? = classCollection.getClassFromQualifiedNameOrNull(fieldType)
+        return fieldTypeMetaData?.embedded ?: type.isEmbedded()
+    }
+
+
+    private fun TypeMirror.isEmbedded() : Boolean {
+        var isEmbedded = false
+
+        if (this is Type.ClassType) {
+            val declarationAttributes: com.sun.tools.javac.util.List<Attribute.Compound>? = tsym.metadata?.declarationAttributes
+            if (declarationAttributes != null) {
+                for (attribute: Attribute.Compound in declarationAttributes) {
+                    if (attribute.type.tsym.qualifiedName.toString() == "io.realm.annotations.RealmClass") {
+                        for (pair: Pair<Symbol.MethodSymbol, Attribute> in attribute.values) {
+                            if (pair.fst.name.toString() == "embedded") {
+                                isEmbedded = pair.snd.value as Boolean
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return isEmbedded
     }
 }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -2031,8 +2031,6 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
         }
     }
 
-
-
     @Throws(IOException::class)
     private fun emitEqualsMethod(writer: JavaWriter) {
         if (metadata.containsEquals()) {

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.kt
@@ -319,6 +319,15 @@ object Utils {
     }
 
     /**
+     * Return generic type mirror if any.
+     */
+    fun getGenericType(field: VariableElement): TypeMirror? {
+        val fieldType = field.asType()
+        val typeArguments = (fieldType as DeclaredType).typeArguments
+        return if (typeArguments.isEmpty()) null else typeArguments[0]
+    }
+
+    /**
      * Strips the package name from a fully qualified class name.
      */
     fun stripPackage(fullyQualifiedClassName: String): String {


### PR DESCRIPTION
Fixes https://github.com/realm/realm-java/issues/7213

kapt runs within modules so `classCollection` contains only processed classes from the particular module. However, the embedded class could be in another transitive module, therefore  relying on `classCollection` could throw an exception because we might be trying to lookup a class processed from another round/module.

The usage of `classCollection.getClassFromQualifiedName` is mainly introduced to know if the type we're processing is embedded or not. In this PR we introduce an alternative way to obtain this information without relying necessarily on the `classCollection`, we use alternatively the JDK compiler tools API.
