### PR TITLE
KAPT complementary fix for missed edge case in https://github.com/realm/realm-java/pull/7220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,6 @@
 * APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
 * Realm Studio 10.0.0 or above is required to open Realms created by this version.
 
-### Internal
-* Updated to Realm Sync: 10.1.3.
-* Updated to Realm Core: 10.1.3.
-* Updated to Object Store commit: fc6daca61133aa9601e4cb34fbeb9ec7569e162e.
-
-
 ## 10.1.1 (2020-10-27)
 
 ### Breaking Changes
@@ -35,11 +29,6 @@
 * File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
 * APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
 * Realm Studio 10.0.0 or above is required to open Realms created by this version.
-
-### Internal
-* Updated to Realm Sync: 10.1.3.
-* Updated to Realm Core: 10.1.3.
-* Updated to Object Store commit: fc6daca61133aa9601e4cb34fbeb9ec7569e162e.
 
 
 ## 10.1.0 (2020-10-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 10.1.2 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixes
+* Complementary fix for missed edge case in https://github.com/realm/realm-java/pull/7220 where KAPT crash if we process a RealmObject referencing a type in RealmList defined in another module. (Issue [#7213](https://github.com/realm/realm-java/issues/7213), since v10.0.0).
+
+### Compatibility
+* File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 or above is required to open Realms created by this version.
+
+### Internal
+* Updated to Realm Sync: 10.1.3.
+* Updated to Realm Core: 10.1.3.
+* Updated to Object Store commit: fc6daca61133aa9601e4cb34fbeb9ec7569e162e.
+
+
 ## 10.1.1 (2020-10-27)
 
 ### Breaking Changes

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -2165,8 +2165,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                     writer)
                         }
                         Utils.isRealmModelList(field) -> {
-                            val fieldType = QualifiedClassName((field.asType() as DeclaredType).typeArguments[0])
-                            val fieldTypeMetaData: ClassMetaData = classCollection.getClassFromQualifiedName(fieldType)
+                            val fieldType = (field.asType() as DeclaredType).typeArguments[0]
                             RealmJsonTypeHelper.emitFillRealmListWithJsonValue(
                                     "objProxy",
                                     metadata.getInternalGetter(fieldName),
@@ -2174,7 +2173,7 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                                     fieldName,
                                     (field.asType() as DeclaredType).typeArguments[0].toString(),
                                     Utils.getProxyClassSimpleName(field),
-                                    fieldTypeMetaData.embedded,
+                                    isFieldTypeEmbedded(fieldType),
                                     writer)
                         }
                         Utils.isRealmValueList(field) -> emitStatement("ProxyUtils.setRealmListWithJsonObject(objProxy.%1\$s(), json, \"%2\$s\")", metadata.getInternalGetter(fieldName), fieldName)


### PR DESCRIPTION
Fixes a missed case in https://github.com/realm/realm-java/pull/7220 covering the usage of a type (defined in another module) in a `RealmList`