### PR TITLE
Add @Nullable annotation to input parameter in RealmObject.isValid(obj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 10.2.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixes
+* Added `@Nullable` annotation to input parameter in `RealmObject.isValid(item)` to avoid mismatch warnings from Kotlin code (Issue [#7216](https://github.com/realm/realm-java/issues/7216)).
+
+### Compatibility
+* File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 or above is required to open Realms created by this version.
+
+### Internal
+* Updated to Object Store commit: fc790d558ddc0e25a50d6b27dadf617532a1bf44.
+
+
 ## 10.2.0 (2020-12-02)
 
 ### Deprecated
@@ -7,7 +27,7 @@
 * None.
 
 ### Enhancements
-* [RealmApp] Added `Credentials.google(token: String, authType: GoogleAuthType)`, as MongoDB Realm now supports multiple ways of logging into Google Accounts.
+* [RealmApp] Added `Credentials.google(token: String, authType: GoogleAuthType)`, as MongoDB Realm now supports multiple ways of logging into Google Accounts.  
 
 ### Fixes
 * [RealmApp] Bug that would prevent eventual consistency during conflict resolution. Affected clients would experience data divergence and potentially consistency errors as a result if they experienced conflict resolution between cycles of Create-Erase-Create for objects with primary keys.
@@ -20,7 +40,7 @@
 
 ### Internal
 * Updated to Realm Sync: 10.1.4.
-* Updated to Object Store commit: f838a27402c5b5243280102014defd844420abba66eb93c10334507d9c0fd513..
+* Updated to Object Store commit: f838a27402c5b5243280102014defd844420abba66eb93c10334507d9c0fd513.
 
 
 ## 10.1.2 (2020-12-02)

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -20,6 +20,8 @@ import android.app.IntentService;
 
 import java.util.Collections;
 
+import javax.annotation.Nullable;
+
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.realm.annotations.RealmClass;
@@ -150,7 +152,7 @@ public abstract class RealmObject implements RealmModel, ManageableObject {
      * @param object RealmObject to check validity for.
      * @return {@code true} if the object is still accessible or an unmanaged object, {@code false} otherwise.
      */
-    public static <E extends RealmModel> boolean isValid(E object) {
+    public static <E extends RealmModel> boolean isValid(@Nullable E object) {
         if (object instanceof RealmObjectProxy) {
             RealmObjectProxy proxy = (RealmObjectProxy) object;
             Row row = proxy.realmGet$proxyState().getRow$realm();


### PR DESCRIPTION
Closes #7216

- Added @Nullable annotation to the input parameter in public static <E extends RealmModel> boolean isValid(@Nullable E object) to avoid mismatch warning from Kotlin in case the object type is nullable as the function itself accepts null values.
- Updated to latest OS.