### PR TITLE
Improve release steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,10 @@ try {
           } else {
             echo "Building release: '${gitTag}'"
             setBuildName("Tag ${gitTag}")
+            sh """
+              set +x  
+              sh tools/publish_release.sh verify
+            """
             publishBuild = true
           }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -213,24 +213,6 @@ task javadoc(type:GradleBuild) {
     configure copyProperties
 }
 
-task createLatestJavadocRedirectFile(type: Copy) {
-    description = 'Redirects from /java/latest/ to correct version'
-    from 'realm/templates'
-    into "$buildDir/outputs/doc_redirects/java_latest"
-    include 'redirect.html.template'
-    rename { file -> 'index.html' }
-    expand(title: "Realm Java ${currentVersion}", url: "../${currentVersion}/index.html")
-}
-
-task createLatestKotlindocRedirectFile(type: Copy) {
-    description = 'Redirects from /kotlin/latest/ to correct version'
-    from 'realm/templates'
-    into "$buildDir/outputs/doc_redirects/kotlin_latest"
-    include 'redirect.html.template'
-    rename { file -> 'index.html' }
-    expand(title: "Kotlin Extensions ${currentVersion}", url: "../${currentVersion}/index.html")
-}
-
 task createKotlinRootRedirectFile(type: Copy) {
     description = 'Redirects from /kotlin/<version>/ to /kotlin/<version>/kotlin-extensions, which is the real root folder'
     from 'realm/templates'
@@ -244,34 +226,32 @@ task uploadJavadoc {
     group = 'Release'
     description = 'Upload Java and Kotlin docs to S3'
     dependsOn javadoc
-    dependsOn createLatestJavadocRedirectFile
-    dependsOn createLatestKotlindocRedirectFile
     dependsOn createKotlinRootRedirectFile
 
     doLast {
         def awsAccessKey = getPropertyValueOrThrow("SDK_DOCS_AWS_ACCESS_KEY")
         def awsSecretKey = getPropertyValueOrThrow("SDK_DOCS_AWS_SECRET_KEY")
 
-        // Upload the versioned folder of the docs
-        exec {
-            commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/realm-library/build/docs/javadoc/', "s3://realm-sdks/realm-sdks/java/${currentVersion}/"
-        }
-        exec {
-            commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/kotlin-extensions/build/docs/', "s3://realm-sdks/realm-sdks/kotlin/${currentVersion}/"
-        }
+        // Upload two copies, to 'latest' and a versioned folder for posterity.
+        // Symlinks would have been safer and faster, but this is not supported by S3.
+        [ "${currentVersion}", "latest"].forEach { version ->
+            exec {
+                commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/realm-library/build/docs/javadoc/', "s3://realm-sdks/realm-sdks/java/${version}/"
+            }
+            // The stylesheet is being uploaded with the wrong Content-Type header, which causes the stylesheet to not be applied in some browsers.
+            // So we need to modify the stylesheet after it has been uploaded.
+            exec {
+                commandLine 's3cmd', 'modify', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "--debug", '--add-header=Content-Type: text/css', "s3://realm-sdks/realm-sdks/java/${version}/stylesheet.css"
+            }
+            exec {
+                commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/kotlin-extensions/build/docs/', "s3://realm-sdks/realm-sdks/kotlin/${version}/"
+            }
 
-        // Upload automatic redirect for Kotlin extensions, since the directory structure created
-        // by Dokka only have a style.css in the root dir.
-        exec {
-            commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/kotlin_root/index.html", "s3://realm-sdks/realm-sdks/kotlin/${currentVersion}/index.html"
-        }
-
-        // Upload redirects to /latest end point so it points to the just uploaded version
-        exec {
-            commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/java_latest/index.html", "s3://realm-sdks/realm-sdks/java/latest/index.html"
-        }
-        exec {
-            commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/kotlin_latest/index.html", "s3://realm-sdks/realm-sdks/kotlin/latest/index.html"
+            // Upload automatic redirect for Kotlin extensions, since the directory structure created
+            // by Dokka only have a style.css in the root dir.
+            exec {
+                commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/kotlin_root/index.html", "s3://realm-sdks/realm-sdks/kotlin/${version}/index.html"
+            }
         }
     }
 }

--- a/tools/publish_release.sh
+++ b/tools/publish_release.sh
@@ -21,10 +21,11 @@ set -e
 usage() {
 cat <<EOF
 Usage: $0 <bintray_user> <bintray_key> <realm_s3_access_key> <realm_s3_secret_key> <docs_s3_access_key> <docs_s3_secret_key> <slack-webhook-releases-url> <slack-webhook-java-ci-url>
+Usage: $0 verify
 EOF
 }
 
-if [ "$#" -ne 8 ]; then
+if [ "$#" -ne 8 ] && [ "$1" != "verify" ]; then
   usage
   exit 1
 fi
@@ -169,8 +170,11 @@ notify_slack_channels() {
 check_env
 verify_release_preconditions
 verify_changelog
-create_javadoc
-upload_to_bintray
-upload_debug_symbols
-upload_javadoc
-notify_slack_channels
+
+if [ "$1" != "verify" ]; then
+  create_javadoc
+  upload_to_bintray
+  upload_debug_symbols
+  upload_javadoc
+  notify_slack_channels
+fi


### PR DESCRIPTION
Closes #7264 

This PR fixes two issues with the current release process.

1) The Javadoc stylesheet was uploaded with the wrong Content-type, `plain/text` instead of `text/css`. This caused it to not be applied to our Javadoc

2) We had a redirect from `/latest/index.html` to `/<version>/index.html`, but that doesn't work for links further down the tree. The ideal solution would have been to use symlinks, but this is not supported by S3, so instead we are uploading the docs twice, once to `latest` and once to a versioned folder.