### PR TITLE
Add test for escaped JSON output from results

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmResultsTests.java
@@ -16,12 +16,14 @@
 
 package io.realm;
 
+import androidx.test.annotation.UiThreadTest;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -40,8 +42,6 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import androidx.test.annotation.UiThreadTest;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.realm.entities.AllJavaTypes;
 import io.realm.entities.AllTypes;
 import io.realm.entities.CyclicType;
@@ -2021,6 +2021,25 @@ public class RealmResultsTests extends CollectionTests {
                 "      ]\n" +
                 "   }\n" +
                 "]";
+        JSONAssert.assertEquals(expectedJSON, json, false);
+    }
+
+    @Test
+    public void asJSON_withEscaping() throws JSONException {
+        realm.beginTransaction();
+        PrimaryKeyAsLong element = realm.createObject(PrimaryKeyAsLong.class, 1);
+        String value = "\"something\"";
+        element.setName(value);
+        realm.commitTransaction();
+
+        RealmResults<PrimaryKeyAsLong> all = realm.where(PrimaryKeyAsLong.class)
+                .equalTo(PrimaryKeyAsString.FIELD_ID, element.getId())
+                .findAll();
+
+        assertEquals(1, all.size());
+
+        String json = all.asJSON();
+        final String expectedJSON = "[{\"_key\":1,\"id\":1,\"name\":\"\\\"something\\\"\"}]";
         JSONAssert.assertEquals(expectedJSON, json, false);
     }
 


### PR DESCRIPTION
This just adds a test validating that https://github.com/realm/realm-core/issues/3492 actually fixed escaping when serializing objects to JSON. 

Closes #6649

