### PR TITLE
Dictionary - move implementation of Freezable interface to RealmCollection

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/CollectionTests.java
@@ -52,7 +52,7 @@ public abstract class CollectionTests {
     // Enumerates all methods from the RealmCollection interface that depend on Realm API's.
     protected enum RealmCollectionMethod {
         WHERE, MIN, MAX, SUM, AVERAGE, MIN_DATE, MAX_DATE, DELETE_ALL_FROM_REALM, IS_VALID,
-        IS_MANAGED, IS_FROZEN
+        IS_MANAGED, IS_FROZEN, FREEZE
     }
 
     // Enumerates all methods from the Collection interface

--- a/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/ManagedRealmCollectionTests.java
@@ -606,6 +606,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
                         case IS_VALID:
                         case IS_MANAGED:
                         case IS_FROZEN:
+                        case FREEZE:
                             continue;
 
                         default:
@@ -639,6 +640,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
                     case IS_VALID:
                     case IS_MANAGED:
                     case IS_FROZEN:
+                    case FREEZE:
                         continue;
 
                     default:
@@ -828,6 +830,7 @@ public class ManagedRealmCollectionTests extends CollectionTests {
 
                         // These methods are threadsafe pr. design
                         case IS_FROZEN:
+                        case FREEZE:
                             return true;
                     }
                     return false;

--- a/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/OrderedRealmCollectionIteratorTests.java
@@ -773,6 +773,7 @@ public class OrderedRealmCollectionIteratorTests extends CollectionTests {
                 case IS_VALID:
                 case IS_MANAGED:
                 case IS_FROZEN:
+                case FREEZE:
                     realm.cancelTransaction();
                     continue;
 

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmListTests.java
@@ -782,9 +782,10 @@ public class RealmListTests extends CollectionTests {
                     case MIN_DATE: results.minDate(CyclicType.FIELD_DATE); break;
                     case MAX_DATE: results.maxDate(CyclicType.FIELD_DATE); break;
                     case DELETE_ALL_FROM_REALM: results.deleteAllFromRealm(); break;
-                    case IS_VALID:              // Does not throw.
-                    case IS_MANAGED:            // Does not throw.
-                    case IS_FROZEN: continue;   // Does not throw
+                    case IS_VALID: continue; // Does not throw.
+                    case IS_MANAGED: continue; // Does not throw.
+                    case IS_FROZEN: continue; // Does not throw
+                    case FREEZE: results.freeze(); break;
                 }
                 fail(method + " should have thrown an Exception.");
             } catch (IllegalStateException ignored) {

--- a/realm/realm-library/src/androidTest/java/io/realm/UnManagedRealmCollectionTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/UnManagedRealmCollectionTests.java
@@ -97,6 +97,7 @@ public class UnManagedRealmCollectionTests extends CollectionTests {
                     case MIN_DATE: collection.minDate(AllJavaTypes.FIELD_DATE); break;
                     case MAX_DATE: collection.maxDate(AllJavaTypes.FIELD_DATE); break;
                     case DELETE_ALL_FROM_REALM: collection.deleteAllFromRealm(); break;
+                    case FREEZE: collection.freeze(); break;
 
                     // Supported methods.
                     case IS_VALID: assertTrue(collection.isValid()); continue;

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionSnapshot.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionSnapshot.java
@@ -49,7 +49,7 @@ import io.realm.internal.UncheckedRow;
  * }
  * </pre>
  */
-public class OrderedRealmCollectionSnapshot<E> extends OrderedRealmCollectionImpl<E> implements Freezable<OrderedRealmCollection<E>> {
+public class OrderedRealmCollectionSnapshot<E> extends OrderedRealmCollectionImpl<E> {
 
     private int size = -1;
 

--- a/realm/realm-library/src/main/java/io/realm/RealmCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCollection.java
@@ -22,6 +22,7 @@ import java.util.Date;
 
 import javax.annotation.Nullable;
 
+import io.realm.internal.Freezable;
 import io.realm.internal.ManageableObject;
 
 
@@ -35,7 +36,7 @@ import io.realm.internal.ManageableObject;
  *
  * @param <E> type of {@link RealmObject} stored in the collection.
  */
-public interface RealmCollection<E> extends Collection<E>, ManageableObject {
+public interface RealmCollection<E> extends Collection<E>, ManageableObject, Freezable<RealmCollection<E>> {
 
     /**
      * Returns a {@link RealmQuery}, which can be used to query for specific objects from this collection.

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -62,7 +62,7 @@ import io.realm.rx.CollectionChange;
  * @param <E> the class of objects in list.
  */
 
-public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollection<E>, Freezable<RealmList<E>> {
+public class RealmList<E> extends AbstractList<E> implements OrderedRealmCollection<E> {
 
     private static final String ONLY_IN_MANAGED_MODE_MESSAGE = "This method is only available in managed mode.";
     static final String ALLOWED_ONLY_FOR_REALM_MODEL_ELEMENT_MESSAGE = "This feature is available only when the element type is implementing RealmModel.";

--- a/realm/realm-library/src/main/java/io/realm/RealmMap.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmMap.java
@@ -428,7 +428,7 @@ abstract class RealmMap<K, V> implements Map<K, V>, ManageableObject, Freezable<
 
         @Override
         public RealmMap<K, V> freeze() {
-            throw new UnsupportedOperationException("This method is only available in managed RealmMaps.");
+            throw new UnsupportedOperationException("Unmanaged RealmMaps cannot be frozen.");
         }
 
         // ------------------------------------------

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -68,7 +68,7 @@ import io.realm.rx.CollectionChange;
  * @see RealmQuery#findAll()
  * @see Realm#executeTransaction(Realm.Transaction)
  */
-public class RealmResults<E> extends OrderedRealmCollectionImpl<E> implements Freezable<RealmResults<E>> {
+public class RealmResults<E> extends OrderedRealmCollectionImpl<E> {
 
     // Called from Realm Proxy classes
     @SuppressLint("unused")


### PR DESCRIPTION
- Moved implementation of `Freezable` interface to `RealmCollection`.
- Restored previously removed test cases that used `RealmCollectionMethod.FREEZE`.