### PR TITLE
Disable building FFI

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -43,6 +43,7 @@ android {
 
                 arguments "-DREALM_JAVA_BUILD_CORE_FROM_SOURCE=${project.hasProperty('buildCore') && project.getProperty('buildCore').toBoolean()}"
                 arguments "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${!project.hasProperty('enableLTO') || project.getProperty('enableLTO').toBoolean()}"
+                targets "realm-jni"
             }
         }
 

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -64,7 +64,9 @@ if(NDK_LCACHE)
     set(CMAKE_CXX_CREATE_SHARED_LIBRARY "${NDK_LCACHE} ${CMAKE_CXX_CREATE_SHARED_LIBRARY}")
 endif()
 
-# Set flag REALM_ENABLE_SYNC
+# Set option flags for Core.
+# See https://github.com/realm/realm-core/blob/master/CMakeLists.txt#L174 for the full list.
+set(REALM_ENABLE_FFI OFF)
 if (REALM_FLAVOR STREQUAL base)
     set(REALM_ENABLE_SYNC OFF)
 else()

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -66,7 +66,6 @@ endif()
 
 # Set option flags for Core.
 # See https://github.com/realm/realm-core/blob/master/CMakeLists.txt#L174 for the full list.
-set(REALM_ENABLE_FFI OFF)
 if (REALM_FLAVOR STREQUAL base)
     set(REALM_ENABLE_SYNC OFF)
 else()

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsObjectStore.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsObjectStore.cpp
@@ -39,45 +39,21 @@ JNIEXPORT void JNICALL Java_io_realm_internal_OsObjectStore_nativeSetPrimaryKeyF
 {
     try {
         auto& shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        JStringAccessor class_name_accessor(env, j_class_name);
-        JStringAccessor pk_field_name_accessor(env, j_pk_field_name);
+        JStringAccessor class_name(env, j_class_name);
+        JStringAccessor primary_key_field_name(env, j_pk_field_name);
 
-        auto table = ObjectStore::table_for_object_type(shared_realm->read_group(), class_name_accessor);
-        if (!table) {
+        auto& group = shared_realm->read_group();
+        if (!group.has_table(class_name)) {
+            std::string name_str = class_name;
+            if (name_str.find(TABLE_PREFIX) == 0) {
+                name_str = name_str.substr(TABLE_PREFIX.length());
+            }
             THROW_JAVA_EXCEPTION(env, JavaExceptionDef::IllegalArgument,
-                                 format("Class '%1' doesn't exist.", StringData(class_name_accessor)));
+                                 util::format("The class '%1' doesn't exist in this Realm.", name_str));
         }
+        TableRef table = group.get_table(class_name);
         shared_realm->verify_in_write();
-
-        if (j_pk_field_name) {
-            // Not removal, check the column.
-            ColKey pk_column_col = table->get_column_key(pk_field_name_accessor);
-            if (!table->valid_column(pk_column_col)) {
-
-                THROW_JAVA_EXCEPTION(env, JavaExceptionDef::IllegalArgument,
-                                     format("Field '%1' doesn't exist in Class '%2'.",
-                                            StringData(pk_field_name_accessor), StringData(class_name_accessor)));
-            }
-
-            // Check valid column type
-            auto field_type = table->get_column_type(pk_column_col);
-            if (field_type != type_Int && field_type != type_String && field_type != type_ObjectId) {
-                THROW_JAVA_EXCEPTION(
-                    env, JavaExceptionDef::IllegalArgument,
-                    format("Field '%1' is not a valid primary key type.", StringData(pk_field_name_accessor)));
-            }
-
-            // Check duplicated values. The pk field must have been indexed before set as a PK.
-             if (!table->contains_unique_values(pk_column_col)) {
-                THROW_JAVA_EXCEPTION(env, JavaExceptionDef::IllegalArgument,
-                                     format("Field '%1' cannot be set as primary key since there are duplicated "
-                                            "values for field '%1' in Class '%2'.",
-                                            StringData(pk_field_name_accessor), StringData(class_name_accessor)));
-            }
-        }
-        shared_realm->verify_in_write();
-        ObjectStore::set_primary_key_for_object(shared_realm->read_group(), class_name_accessor,
-                                                pk_field_name_accessor);
+        table->set_primary_key_column(table->get_column_key(primary_key_field_name));
     }
     CATCH_STD()
 }
@@ -88,9 +64,11 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_OsObjectStore_nativeGetPrimaryK
 {
     try {
         auto& shared_realm = *(reinterpret_cast<SharedRealm*>(shared_realm_ptr));
-        JStringAccessor class_name_accessor(env, j_class_name);
-        StringData pk_field_name = ObjectStore::get_primary_key_for_object(shared_realm->read_group(), class_name_accessor);
-        return pk_field_name.size() == 0 ? nullptr : to_jstring(env, pk_field_name);
+        JStringAccessor class_name(env, j_class_name);
+        TableRef table = shared_realm->read_group().get_table(class_name);
+        auto col = table->get_primary_key_column();
+        std::string primary_key_field_name = (col) ? table->get_column_name(col) : "";
+        return primary_key_field_name.size() == 0 ? nullptr : to_jstring(env, primary_key_field_name);
     }
     CATCH_STD()
     return nullptr;

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -122,6 +122,10 @@ void ConvertException(JNIEnv* env, const char* file, int line)
         ss << e.what() << " in " << file << " line " << line;
         ThrowException(env, IllegalState, ss.str());
     }
+    catch(DuplicatePrimaryKeyValueException& e) {
+        ss << e.what() << " in " << file << " line " << line;
+        ThrowException(env, IllegalArgument, ss.str());
+    }
     catch (realm::LogicError e) {
         ExceptionKind kind;
         if (e.kind() == LogicError::string_too_big || e.kind() == LogicError::binary_too_big ||

--- a/realm/realm-library/src/main/java/io/realm/internal/OsObjectStore.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsObjectStore.java
@@ -19,6 +19,7 @@ package io.realm.internal;
 import javax.annotation.Nullable;
 
 import io.realm.RealmConfiguration;
+import io.realm.internal.Util;
 
 /**
  * Java wrapper for methods in object_store.hpp.
@@ -40,10 +41,12 @@ public class OsObjectStore {
      */
     public static void setPrimaryKeyForObject(OsSharedRealm sharedRealm, String className,
                                               @Nullable String primaryKeyFieldName) {
+        className = Util.getTablePrefix() + className;
         nativeSetPrimaryKeyForObject(sharedRealm.getNativePtr(), className, primaryKeyFieldName);
     }
 
     public static @Nullable String getPrimaryKeyForObject(OsSharedRealm sharedRealm, String className) {
+        className = Util.getTablePrefix() + className;
         return nativeGetPrimaryKeyForObject(sharedRealm.getNativePtr(), className);
     }
 


### PR DESCRIPTION
- Only build relevant targets in Core, i.e. don't build FFI
- Update to latest master branch commit and fix related issues. Most noticeably, some helper methods were removed. These helper methods where designed to make it easier to work with the primary key table found in Core 5, but this was removed in Core 6. But it also meant that some extra checks are now missing. I added them to Java as a temporary solution.