### PR TITLE
Add missing tests for json import on objectid and decimal128

### DIFF
--- a/realm/realm-library/src/androidTest/assets/list_alltypes_primarykey.json
+++ b/realm/realm-library/src/androidTest/assets/list_alltypes_primarykey.json
@@ -20,7 +20,9 @@
                 "id" : 3,
                 "name" : "Dog3"
             }
-        ]
+        ],
+        "columnDecimal128" : -42,
+        "columnObjectId": "789ABCDEF0123456789ABCDE"
     },
     {
         "columnString" : "Bar",
@@ -43,6 +45,8 @@
                 "id" : 6,
                 "name" : "Dog6"
             }
-        ]
+        ],
+        "columnDecimal128" : -43,
+        "columnObjectId": "789ABCDEF0123456789ABCDA"
     }
 ]

--- a/realm/realm-library/src/androidTest/assets/nulltypes.json
+++ b/realm/realm-library/src/androidTest/assets/nulltypes.json
@@ -21,7 +21,11 @@
     "fieldDoubleNull":null,
     "fieldDateNotNull": 0,
     "fieldDateNull": null,
-    "fieldObjectNull": null
+    "fieldObjectNull": null,
+    "fieldDecimal128Null": null,
+    "fieldDecimal128NotNull": -42,
+    "fieldObjectIdNull": null,
+    "fieldObjectIdNotNull": "789ABCDEF0123456789ABCDE"
   },
   {
     "id": 2,
@@ -67,7 +71,15 @@
       "fieldDoubleNull":0,
       "fieldDateNotNull": 0,
       "fieldDateNull": 0,
-      "fieldObjectNull": null
-    }
+      "fieldObjectNull": null,
+      "fieldDecimal128Null": 0,
+      "fieldDecimal128NotNull": 0,
+      "fieldObjectIdNull": "789ABCDEF0123456789ABCDE",
+      "fieldObjectIdNotNull": "789ABCDEF0123456789ABCDE"
+    },
+    "fieldDecimal128Null": 0,
+    "fieldDecimal128NotNull": 0,
+    "fieldObjectIdNull": "789ABCDEF0123456789ABCDE",
+    "fieldObjectIdNotNull": "789ABCDEF0123456789ABCDE"
   }
 ]

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmJsonTests.java
@@ -27,7 +27,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -112,6 +111,8 @@ public class RealmJsonTests {
         assertEquals(true, obj.isColumnBoolean());
         assertArrayEquals(new byte[]{1, 2, 3}, obj.getColumnBinary());
         assertEquals(new Date(2000), obj.getColumnDate());
+        assertEquals(new ObjectId("789ABCDEF0123456789ABCDA"), obj.getColumnObjectId());
+        assertEquals(new Decimal128(-43), obj.getColumnDecimal128());
         assertEquals("Dog4", obj.getColumnRealmObject().getName());
         assertEquals(2, obj.getColumnRealmList().size());
         assertEquals("Dog5", obj.getColumnRealmList().get(0).getName());
@@ -151,6 +152,12 @@ public class RealmJsonTests {
         assertEquals(new Date(0), nullTypes1.getFieldDateNotNull());
         // 11 RealmObject
         assertNull(nullTypes1.getFieldObjectNull());
+        // 12 ObjectId
+        assertNull(nullTypes1.getFieldObjectIdNull());
+        assertEquals(new ObjectId("789ABCDEF0123456789ABCDE"), nullTypes1.getFieldObjectIdNotNull());
+        // 13 Decimal128
+        assertNull(nullTypes1.getFieldDecimal128Null());
+        assertEquals(new Decimal128(-42), nullTypes1.getFieldDecimal128NotNull());
     }
 
     // Checks the imported object from nulltyps.json[1].
@@ -187,6 +194,12 @@ public class RealmJsonTests {
         assertEquals(new Date(0), nullTypes2.getFieldDateNotNull());
         // 11 RealmObject
         assertTrue(nullTypes2.getFieldObjectNull() != null);
+        // 12 ObjectId
+        assertTrue(nullTypes2.getFieldObjectIdNull() != null);
+        assertEquals(new ObjectId("789ABCDEF0123456789ABCDE"), nullTypes2.getFieldObjectIdNotNull());
+        // 13 Decimal128
+        assertTrue(nullTypes2.getFieldDecimal128Null() != null);
+        assertEquals(new Decimal128(0), nullTypes2.getFieldDecimal128NotNull());
     }
 
     @Test
@@ -205,12 +218,18 @@ public class RealmJsonTests {
     @Test
     public void createObjectFromJson_allSimpleObjectAllTypes() throws JSONException {
         JSONObject json = new JSONObject();
+
+        ObjectId objectId = new ObjectId(new Date(20));
+        Decimal128 decimal128 = new Decimal128(300);
+
         json.put("columnString", "String");
         json.put("columnLong", 1L);
         json.put("columnFloat", 1.23F);
         json.put("columnDouble", 1.23D);
         json.put("columnBoolean", true);
         json.put("columnBinary", new String(Base64.encode(new byte[] {1,2,3}, Base64.DEFAULT), UTF_8));
+        json.put("columnObjectId", objectId);
+        json.put("columnDecimal128", decimal128);
 
         realm.beginTransaction();
         realm.createObjectFromJson(AllTypes.class, json);
@@ -224,6 +243,8 @@ public class RealmJsonTests {
         assertEquals(1.23D, obj.getColumnDouble(), 0D);
         assertEquals(true, obj.isColumnBoolean());
         assertArrayEquals(new byte[]{1, 2, 3}, obj.getColumnBinary());
+        assertEquals(objectId, obj.getColumnObjectId());
+        assertEquals(decimal128, obj.getColumnDecimal128());
     }
 
     @Test
@@ -516,6 +537,8 @@ public class RealmJsonTests {
         assertEquals(DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE, managedObj.getFieldDouble(), 0d);
         assertEquals(DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE, managedObj.isFieldBoolean());
         assertEquals(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE, managedObj.getFieldDate());
+        assertEquals(DefaultValueOfField.FIELD_OBJECT_ID_DEFAULT_VALUE, managedObj.getFieldObjectId());
+        assertEquals(DefaultValueOfField.FIELD_DECIMAL128_DEFAULT_VALUE, managedObj.getFieldDecimal128());
         assertArrayEquals(DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE, managedObj.getFieldBinary());
         assertArrayEquals(DefaultValueOfField.FIELD_BYTE_LIST_DEFAULT_VALUE.toArray(), managedObj.getFieldByteList().toArray());
         assertArrayEquals(DefaultValueOfField.FIELD_SHORT_LIST_DEFAULT_VALUE.toArray(), managedObj.getFieldShortList().toArray());
@@ -525,6 +548,8 @@ public class RealmJsonTests {
         assertArrayEquals(DefaultValueOfField.FIELD_BINARY_LIST_DEFAULT_VALUE.toArray(), managedObj.getFieldBinaryList().toArray());
         assertArrayEquals(DefaultValueOfField.FIELD_STRING_LIST_DEFAULT_VALUE.toArray(), managedObj.getFieldStringList().toArray());
         assertArrayEquals(DefaultValueOfField.FIELD_DATE_LIST_DEFAULT_VALUE.toArray(), managedObj.getFieldDateList().toArray());
+        assertArrayEquals(DefaultValueOfField.FIELD_OBJECT_ID_LIST_DEFAULT_VALUE.toArray(), managedObj.getFieldObjectIdList().toArray());
+        assertArrayEquals(DefaultValueOfField.FIELD_DECIMAL128_LIST_DEFAULT_VALUE.toArray(), managedObj.getFieldDecimal128List().toArray());
         assertEquals(RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE, managedObj.getFieldObject().getFieldInt());
         assertEquals(1, managedObj.getFieldList().size());
         assertEquals(RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE, managedObj.getFieldList().first().getFieldInt());
@@ -549,6 +574,8 @@ public class RealmJsonTests {
         final double fieldDoubleValue = DefaultValueOfField.FIELD_DOUBLE_DEFAULT_VALUE + 1;
         final boolean fieldBooleanValue = !DefaultValueOfField.FIELD_BOOLEAN_DEFAULT_VALUE;
         final Date fieldDateValue = new Date(DefaultValueOfField.FIELD_DATE_DEFAULT_VALUE.getTime() + 1);
+        final ObjectId fieldObjectIdValue = new ObjectId(new Date(20));
+        final Decimal128 fieldDecimal128Value = new Decimal128(20);
         final byte[] fieldBinaryValue = {(byte) (DefaultValueOfField.FIELD_BINARY_DEFAULT_VALUE[0] - 1)};
         final int fieldObjectIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 1;
         final int fieldListIntValue = RandomPrimaryKey.FIELD_INT_DEFAULT_VALUE + 2;
@@ -566,6 +593,8 @@ public class RealmJsonTests {
         json.put(DefaultValueOfField.FIELD_DOUBLE, fieldDoubleValue);
         json.put(DefaultValueOfField.FIELD_BOOLEAN, fieldBooleanValue);
         json.put(DefaultValueOfField.FIELD_DATE, getISO8601Date(fieldDateValue));
+        json.put(DefaultValueOfField.FIELD_OBJECT_ID, fieldObjectIdValue);
+        json.put(DefaultValueOfField.FIELD_DECIMAL128, fieldDecimal128Value);
         json.put(DefaultValueOfField.FIELD_BINARY, Base64.encodeToString(fieldBinaryValue, Base64.DEFAULT));
         // Value for 'fieldObject'
         final JSONObject fieldObjectJson = new JSONObject();
@@ -602,6 +631,8 @@ public class RealmJsonTests {
         assertEquals(fieldFloatValue, managedObj.getFieldFloat(), 0f);
         assertEquals(fieldDoubleValue, managedObj.getFieldDouble(), 0d);
         assertEquals(fieldBooleanValue, managedObj.isFieldBoolean());
+        assertEquals(fieldObjectIdValue, managedObj.getFieldObjectId());
+        assertEquals(fieldDecimal128Value, managedObj.getFieldDecimal128());
         assertEquals(fieldDateValue, managedObj.getFieldDate());
         assertTrue(Arrays.equals(fieldBinaryValue, managedObj.getFieldBinary()));
         assertEquals(fieldObjectJson.getString(RandomPrimaryKey.FIELD_RANDOM_PRIMARY_KEY),
@@ -1101,6 +1132,10 @@ public class RealmJsonTests {
 
         AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
         Date date = new Date(0);
+
+        ObjectId objectId = new ObjectId(new Date(20));
+        Decimal128 decimal128 = new Decimal128(300);
+
         obj.setColumnLong(1); // ID
         obj.setColumnBinary(new byte[]{1});
         obj.setColumnBoolean(true);
@@ -1108,6 +1143,8 @@ public class RealmJsonTests {
         obj.setColumnDouble(1);
         obj.setColumnFloat(1);
         obj.setColumnString("1");
+        obj.setColumnObjectId(objectId);
+        obj.setColumnDecimal128(decimal128);
 
         realm.beginTransaction();
         realm.copyToRealm(obj);
@@ -1127,6 +1164,8 @@ public class RealmJsonTests {
         assertEquals(1D, obj.getColumnDouble(), 0D);
         assertEquals(true, obj.isColumnBoolean());
         assertEquals(date, obj.getColumnDate());
+        assertEquals(objectId, obj.getColumnObjectId());
+        assertEquals(decimal128, obj.getColumnDecimal128());
         assertArrayEquals(new byte[]{1}, obj.getColumnBinary());
         assertNull(obj.getColumnRealmObject());
         assertEquals(0, obj.getColumnRealmList().size());
@@ -1248,6 +1287,10 @@ public class RealmJsonTests {
     public void createOrUpdateObjectFromJson_objectNullValues() throws IOException {
         AllTypesPrimaryKey obj = new AllTypesPrimaryKey();
         Date date = new Date(0);
+
+        ObjectId objectId = new ObjectId(new Date(20));
+        Decimal128 decimal128 = new Decimal128(300);
+
         obj.setColumnLong(1); // ID
         obj.setColumnBinary(new byte[]{1});
         obj.setColumnBoolean(true);
@@ -1255,6 +1298,8 @@ public class RealmJsonTests {
         obj.setColumnDouble(1);
         obj.setColumnFloat(1);
         obj.setColumnString("1");
+        obj.setColumnObjectId(objectId);
+        obj.setColumnDecimal128(decimal128);
 
         realm.beginTransaction();
         realm.copyToRealm(obj);
@@ -1273,6 +1318,8 @@ public class RealmJsonTests {
         assertEquals(1D, obj.getColumnDouble(), 0D);
         assertEquals(true, obj.isColumnBoolean());
         assertEquals(date, obj.getColumnDate());
+        assertEquals(objectId, obj.getColumnObjectId());
+        assertEquals(decimal128, obj.getColumnDecimal128());
         assertArrayEquals(new byte[]{1}, obj.getColumnBinary());
         assertNull(obj.getColumnRealmObject());
         assertEquals(0, obj.getColumnRealmList().size());
@@ -2016,6 +2063,14 @@ public class RealmJsonTests {
                 new String[] {new String(Base64.encode(new byte[] {1, 2, 3}, Base64.DEFAULT), UTF_8),
                         null, new String(Base64.encode(new byte[] {4, 5, 6}, Base64.DEFAULT), UTF_8)},
                 new byte[][] {new byte[]{1, 2, 3}, null, new byte[]{4, 5, 6}});
+
+        testPrimitiveListWithValues(PrimitiveListTypes.FIELD_OBJECT_ID_LIST,
+                new String[] {"789ABCDEF0123456789ABCDA", null, "789ABCDEF0123456789ABCDB"},
+                new ObjectId[] {new ObjectId("789ABCDEF0123456789ABCDA"), null, new ObjectId("789ABCDEF0123456789ABCDB")});
+
+        testPrimitiveListWithValues(PrimitiveListTypes.FIELD_DECIMAL128_LIST,
+                new Integer[] {0, null, 1},
+                new Decimal128[] {new Decimal128(0), null, new Decimal128(1)});
     }
 
     // Null list will be saved as empty list since We don't support nullable RealmList
@@ -2030,6 +2085,8 @@ public class RealmJsonTests {
         testPrimitiveListWithValues(PrimitiveListTypes.FIELD_INT_LIST, null, new Integer[0]);
         testPrimitiveListWithValues(PrimitiveListTypes.FIELD_LONG_LIST, null, new Long[0]);
         testPrimitiveListWithValues(PrimitiveListTypes.FIELD_DATE_LIST, null, new Date[0]);
+        testPrimitiveListWithValues(PrimitiveListTypes.FIELD_OBJECT_ID_LIST, null, new ObjectId[0]);
+        testPrimitiveListWithValues(PrimitiveListTypes.FIELD_DECIMAL128_LIST, null, new Decimal128[0]);
         testPrimitiveListWithValues(PrimitiveListTypes.FIELD_BYTE_LIST, null, new byte[0][]);
     }
 
@@ -2089,6 +2146,8 @@ public class RealmJsonTests {
         testRequiredPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_REQUIRED_LONG_LIST);
         testRequiredPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_REQUIRED_DATE_LIST);
         testRequiredPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_REQUIRED_BYTE_LIST);
+        testRequiredPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_REQUIRED_OBJECT_ID_LIST);
+        testRequiredPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_REQUIRED_DECIMAL128_LIST);
     }
 
     @Test
@@ -2103,5 +2162,7 @@ public class RealmJsonTests {
         testOptionalPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_LONG_LIST);
         testOptionalPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_DATE_LIST);
         testOptionalPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_BYTE_LIST);
+        testOptionalPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_OBJECT_ID_LIST);
+        testOptionalPrimitiveListWithNullValue(PrimitiveListTypes.FIELD_DECIMAL128_LIST);
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/DefaultValueOfField.java
@@ -16,6 +16,9 @@
 
 package io.realm.entities;
 
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
 import java.util.Date;
 import java.util.UUID;
 
@@ -23,6 +26,7 @@ import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
 import io.realm.annotations.PrimaryKey;
+
 
 public class DefaultValueOfField extends RealmObject {
 
@@ -39,6 +43,8 @@ public class DefaultValueOfField extends RealmObject {
     public static final String FIELD_DOUBLE = "fieldDouble";
     public static final String FIELD_BOOLEAN = "fieldBoolean";
     public static final String FIELD_DATE = "fieldDate";
+    public static final String FIELD_OBJECT_ID = "fieldObjectId";
+    public static final String FIELD_DECIMAL128 = "fieldDecimal128";
     public static final String FIELD_BINARY = "fieldBinary";
     public static final String FIELD_OBJECT = "fieldObject";
     public static final String FIELD_LIST = "fieldList";
@@ -56,6 +62,8 @@ public class DefaultValueOfField extends RealmObject {
     public static final boolean FIELD_BOOLEAN_DEFAULT_VALUE = true;
     public static final Date FIELD_DATE_DEFAULT_VALUE = new Date(1473691826000L /*2016/9/12 23:56:26 JST*/);
     public static final byte[] FIELD_BINARY_DEFAULT_VALUE = new byte[] {123, -100, 0, 2};
+    public static final ObjectId FIELD_OBJECT_ID_DEFAULT_VALUE = new ObjectId(new Date(10));
+    public static final Decimal128 FIELD_DECIMAL128_DEFAULT_VALUE = new Decimal128(10);
     public static final RandomPrimaryKey FIELD_OBJECT_DEFAULT_VALUE;
     public static final RealmList<RandomPrimaryKey> FIELD_LIST_DEFAULT_VALUE;
     public static final RealmList<String> FIELD_STRING_LIST_DEFAULT_VALUE;
@@ -68,6 +76,8 @@ public class DefaultValueOfField extends RealmObject {
     public static final RealmList<Double> FIELD_DOUBLE_LIST_DEFAULT_VALUE;
     public static final RealmList<Float> FIELD_FLOAT_LIST_DEFAULT_VALUE;
     public static final RealmList<Date> FIELD_DATE_LIST_DEFAULT_VALUE;
+    public static final RealmList<ObjectId> FIELD_OBJECT_ID_LIST_DEFAULT_VALUE;
+    public static final RealmList<Decimal128> FIELD_DECIMAL128_LIST_DEFAULT_VALUE;
 
     static {
         FIELD_OBJECT_DEFAULT_VALUE = new RandomPrimaryKey();
@@ -84,16 +94,20 @@ public class DefaultValueOfField extends RealmObject {
         FIELD_DOUBLE_LIST_DEFAULT_VALUE = new RealmList<>(1D);
         FIELD_FLOAT_LIST_DEFAULT_VALUE = new RealmList<>(1F);
         FIELD_DATE_LIST_DEFAULT_VALUE = new RealmList<>(new Date(1));
+        FIELD_OBJECT_ID_LIST_DEFAULT_VALUE = new RealmList<>(new ObjectId(new Date(10)));
+        FIELD_DECIMAL128_LIST_DEFAULT_VALUE = new RealmList<>(new Decimal128(10));
     }
 
     public static String lastRandomStringValue;
 
-    @Ignore private String fieldIgnored = FIELD_IGNORED_DEFAULT_VALUE;
+    @Ignore
+    private String fieldIgnored = FIELD_IGNORED_DEFAULT_VALUE;
     private String fieldString = FIELD_STRING_DEFAULT_VALUE;
     private String fieldRandomString = lastRandomStringValue = UUID.randomUUID().toString();
     private short fieldShort = FIELD_SHORT_DEFAULT_VALUE;
     private int fieldInt = FIELD_INT_DEFAULT_VALUE;
-    @PrimaryKey private long fieldLongPrimaryKey = FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE;
+    @PrimaryKey
+    private long fieldLongPrimaryKey = FIELD_LONG_PRIMARY_KEY_DEFAULT_VALUE;
     private long fieldLong = FIELD_LONG_DEFAULT_VALUE;
     private byte fieldByte = FIELD_BYTE_DEFAULT_VALUE;
     private float fieldFloat = FIELD_FLOAT_DEFAULT_VALUE;
@@ -102,8 +116,10 @@ public class DefaultValueOfField extends RealmObject {
     private Date fieldDate = FIELD_DATE_DEFAULT_VALUE;
     private byte[] fieldBinary = FIELD_BINARY_DEFAULT_VALUE;
     private RandomPrimaryKey fieldObject = FIELD_OBJECT_DEFAULT_VALUE;
-    private RealmList<RandomPrimaryKey> fieldList = FIELD_LIST_DEFAULT_VALUE;
+    private ObjectId fieldObjectId = FIELD_OBJECT_ID_DEFAULT_VALUE;
+    private Decimal128 fieldDecimal128 = FIELD_DECIMAL128_DEFAULT_VALUE;
 
+    private RealmList<RandomPrimaryKey> fieldList = FIELD_LIST_DEFAULT_VALUE;
     private RealmList<String> fieldStringList = FIELD_STRING_LIST_DEFAULT_VALUE;
     private RealmList<byte[]> fieldBinaryList = FIELD_BINARY_LIST_DEFAULT_VALUE;
     private RealmList<Boolean> fieldBooleanList = FIELD_BOOLEAN_LIST_DEFAULT_VALUE;
@@ -114,6 +130,8 @@ public class DefaultValueOfField extends RealmObject {
     private RealmList<Double> fieldDoubleList = FIELD_DOUBLE_LIST_DEFAULT_VALUE;
     private RealmList<Float> fieldFloatList = FIELD_FLOAT_LIST_DEFAULT_VALUE;
     private RealmList<Date> fieldDateList = FIELD_DATE_LIST_DEFAULT_VALUE;
+    private RealmList<ObjectId> fieldObjectIdList = FIELD_OBJECT_ID_LIST_DEFAULT_VALUE;
+    private RealmList<Decimal128> fieldDecimal128List = FIELD_DECIMAL128_LIST_DEFAULT_VALUE;
 
     public DefaultValueOfField() {
     }
@@ -234,6 +252,22 @@ public class DefaultValueOfField extends RealmObject {
         this.fieldObject = fieldObject;
     }
 
+    public ObjectId getFieldObjectId() {
+        return fieldObjectId;
+    }
+
+    public void setFieldObjectId(ObjectId fieldObjectId) {
+        this.fieldObjectId = fieldObjectId;
+    }
+
+    public Decimal128 getFieldDecimal128() {
+        return fieldDecimal128;
+    }
+
+    public void setFieldDecimal128(Decimal128 fieldDecimal128) {
+        this.fieldDecimal128 = fieldDecimal128;
+    }
+
     public RealmList<RandomPrimaryKey> getFieldList() {
         return fieldList;
     }
@@ -320,5 +354,21 @@ public class DefaultValueOfField extends RealmObject {
 
     public void setFieldDateList(RealmList<Date> fieldDateList) {
         this.fieldDateList = fieldDateList;
+    }
+
+    public RealmList<ObjectId> getFieldObjectIdList() {
+        return fieldObjectIdList;
+    }
+
+    public void setFieldObjectIdList(RealmList<ObjectId> fieldObjectIdList) {
+        this.fieldObjectIdList = fieldObjectIdList;
+    }
+
+    public RealmList<Decimal128> getFieldDecimal128List() {
+        return fieldDecimal128List;
+    }
+
+    public void setFieldDecimal128List(RealmList<Decimal128> fieldDecimal128List) {
+        this.fieldDecimal128List = fieldDecimal128List;
     }
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/PrimitiveListTypes.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/PrimitiveListTypes.java
@@ -19,12 +19,12 @@ package io.realm.entities;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
-import java.text.DecimalFormat;
 import java.util.Date;
 
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.Required;
+
 
 public class PrimitiveListTypes extends RealmObject {
     public static final String FIELD_STRING_LIST = "stringList";

--- a/realm/realm-library/src/main/cpp/java_object_accessor.hpp
+++ b/realm/realm-library/src/main/cpp/java_object_accessor.hpp
@@ -562,7 +562,7 @@ inline Timestamp JavaContext::unbox(JavaValue const& v, CreatePolicy, ObjKey) co
 template <>
 inline Decimal128 JavaContext::unbox(JavaValue const& v, CreatePolicy, ObjKey) const
 {
-    return v.has_value() ? v.get_decimal128() : Decimal128();
+    return v.has_value() ? v.get_decimal128() : Decimal128(realm::null());
 }
 
 template <>

--- a/realm/realm-library/src/main/java/io/realm/ProxyUtils.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyUtils.java
@@ -20,6 +20,8 @@ import android.os.Build;
 import android.util.JsonReader;
 import android.util.JsonToken;
 
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -27,6 +29,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Locale;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -112,6 +115,43 @@ class ProxyUtils {
                     osList.addDate(JsonUtils.stringToDate((String) timestamp));
                 } else {
                     osList.addDate(new Date(jsonArray.getLong(i)));
+                }
+            }
+        } else if (realmList.clazz == ObjectId.class) {
+            for (int i = 0; i < arraySize; i++) {
+                if (jsonArray.isNull(i)) {
+                    osList.addNull();
+                    continue;
+                }
+
+                Object id = jsonArray.get(i);
+                if (id instanceof String) {
+                    osList.addObjectId(new ObjectId((String) id));
+                } else {
+                    osList.addObjectId((ObjectId) id);
+                }
+            }
+        } else if (realmList.clazz == Decimal128.class) {
+            for (int i = 0; i < arraySize; i++) {
+                if (jsonArray.isNull(i)) {
+                    osList.addNull();
+                    continue;
+                }
+
+                Object decimal = jsonArray.get(i);
+
+                if (decimal instanceof org.bson.types.Decimal128) {
+                    osList.addDecimal128((org.bson.types.Decimal128) decimal);
+                } else if (decimal instanceof String) {
+                    osList.addDecimal128(org.bson.types.Decimal128.parse((String) decimal));
+                } else if (decimal instanceof Integer) {
+                    osList.addDecimal128(new org.bson.types.Decimal128((Integer) (decimal)));
+                } else if (decimal instanceof Long) {
+                    osList.addDecimal128(new org.bson.types.Decimal128((Long) (decimal)));
+                } else if (decimal instanceof Double) {
+                    osList.addDecimal128(new org.bson.types.Decimal128(new java.math.BigDecimal((Double) (decimal))));
+                } else {
+                    osList.addDecimal128((Decimal128) decimal);
                 }
             }
         } else if (realmList.clazz == Long.class || realmList.clazz == Integer.class ||
@@ -240,6 +280,24 @@ class ProxyUtils {
                     realmList.add((byte)jsonReader.nextLong());
                 }
             }
+        } else if (elementClass == ObjectId.class) {
+            while (jsonReader.hasNext()) {
+                if (jsonReader.peek() == JsonToken.NULL) {
+                    jsonReader.skipValue();
+                    realmList.add(null);
+                } else {
+                    realmList.add(new ObjectId(jsonReader.nextString()));
+                }
+            }
+        } else if (elementClass == Decimal128.class) {
+            while (jsonReader.hasNext()) {
+                if (jsonReader.peek() == JsonToken.NULL) {
+                    jsonReader.skipValue();
+                    realmList.add(null);
+                } else {
+                    realmList.add(org.bson.types.Decimal128.parse(jsonReader.nextString()));
+                }
+            }
         } else {
             throwWrongElementType(elementClass);
         }
@@ -253,5 +311,4 @@ class ProxyUtils {
         throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Element type '%s' is not handled.",
                 clazz));
     }
-
 }

--- a/realm/realm-library/src/main/java/io/realm/ProxyUtils.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyUtils.java
@@ -29,7 +29,6 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Locale;
-import java.util.UUID;
 
 import javax.annotation.Nullable;
 

--- a/realm/realm-library/src/main/java/io/realm/internal/objectstore/OsObjectBuilder.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/objectstore/OsObjectBuilder.java
@@ -312,7 +312,7 @@ public class OsObjectBuilder implements Closeable {
     private <T> void addListItem(long builderPtr, long columnKey, @Nullable List<T> list, ItemCallback<T> itemCallback) {
         if (list != null) {
             long listPtr = nativeStartList(list.size());
-            boolean isNullable = table.isColumnNullable(columnKey);
+            boolean isNullable = (columnKey == 0) || table.isColumnNullable(columnKey);
             for (int i = 0; i < list.size(); i++) {
                 T item = list.get(i);
                 if (item == null) {

--- a/realm/realm-library/src/main/java/io/realm/internal/objectstore/OsObjectBuilder.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/objectstore/OsObjectBuilder.java
@@ -312,9 +312,13 @@ public class OsObjectBuilder implements Closeable {
     private <T> void addListItem(long builderPtr, long columnKey, @Nullable List<T> list, ItemCallback<T> itemCallback) {
         if (list != null) {
             long listPtr = nativeStartList(list.size());
+            boolean isNullable = table.isColumnNullable(columnKey);
             for (int i = 0; i < list.size(); i++) {
                 T item = list.get(i);
                 if (item == null) {
+                    if (!isNullable) {
+                        throw new IllegalArgumentException("This 'RealmList' is not nullable. A non-null value is expected.");
+                    }
                     nativeAddNullListItem(listPtr);
                 } else {
                     itemCallback.handleItem(listPtr, item);

--- a/realm/realm-library/src/testUtils/java/io/realm/entities/AllTypesPrimaryKey.java
+++ b/realm/realm-library/src/testUtils/java/io/realm/entities/AllTypesPrimaryKey.java
@@ -16,11 +16,15 @@
 
 package io.realm.entities;
 
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
 import java.util.Date;
 
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
+
 
 public class AllTypesPrimaryKey extends RealmObject {
     private String columnString;
@@ -34,6 +38,8 @@ public class AllTypesPrimaryKey extends RealmObject {
     private DogPrimaryKey columnRealmObject;
     private RealmList<DogPrimaryKey> columnRealmList;
     private Boolean columnBoxedBoolean;
+    private ObjectId columnObjectId;
+    private Decimal128 columnDecimal128;
 
     private RealmList<String> columnStringList;
     private RealmList<byte[]> columnBinaryList;
@@ -42,6 +48,8 @@ public class AllTypesPrimaryKey extends RealmObject {
     private RealmList<Double> columnDoubleList;
     private RealmList<Float> columnFloatList;
     private RealmList<Date> columnDateList;
+    private RealmList<ObjectId> columnObjectIdList;
+    private RealmList<Decimal128> columnDecimal128List;
 
     public String getColumnString() {
         return columnString;
@@ -123,6 +131,22 @@ public class AllTypesPrimaryKey extends RealmObject {
         this.columnBoxedBoolean = columnBoxedBoolean;
     }
 
+    public ObjectId getColumnObjectId() {
+        return columnObjectId;
+    }
+
+    public void setColumnObjectId(ObjectId columnObjectId) {
+        this.columnObjectId = columnObjectId;
+    }
+
+    public Decimal128 getColumnDecimal128() {
+        return columnDecimal128;
+    }
+
+    public void setColumnDecimal128(Decimal128 columnDecimal128) {
+        this.columnDecimal128 = columnDecimal128;
+    }
+
     public RealmList<String> getColumnStringList() {
         return columnStringList;
     }
@@ -177,5 +201,21 @@ public class AllTypesPrimaryKey extends RealmObject {
 
     public void setColumnDateList(RealmList<Date> columnDateList) {
         this.columnDateList = columnDateList;
+    }
+
+    public RealmList<ObjectId> getColumnObjectIdList() {
+        return columnObjectIdList;
+    }
+
+    public void setColumnObjectIdList(RealmList<ObjectId> columnObjectIdList) {
+        this.columnObjectIdList = columnObjectIdList;
+    }
+
+    public RealmList<Decimal128> getColumnDecimal128List() {
+        return columnDecimal128List;
+    }
+
+    public void setColumnDecimal128List(RealmList<Decimal128> columnDecimal128List) {
+        this.columnDecimal128List = columnDecimal128List;
     }
 }


### PR DESCRIPTION
Add missing tests for JSON import on ObjectId and Decimal128
Fixes importing null items on non-null lists
Fixes adding null decimal128 in a list get transformed in a Decimal128(0)