### PR TITLE
Add argument substitution on raw query predicates

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -3988,40 +3988,38 @@ public class RealmQueryTests extends QueryTests {
         assertTrue(results.isEmpty());
     }
 
-    @Ignore("Re-Enable when support for Mixed as been added.")
     @Test
     public void rawPredicate_argumentSubstitution() {
         populateTestRealm();
         RealmQuery<AllTypes> query = realm.where(AllTypes.class);
-        query.rawPredicate("columnString = '$1' " +
-                "AND columnBoolean = $2 " +
-                "AND columnFloat = $3 " +
-                "AND columnInteger = $4", new Object[] {"test data 0", true, 1.2345f, 0});
+        query.rawPredicate("columnString = $0 " +
+                "AND columnBoolean = $1 " +
+                "AND columnFloat = $2 " +
+                "AND columnLong = $3", "test data 0", true, 1.2345f, 0);
         RealmResults<AllTypes> results = query.findAll();
         assertEquals(1, results.size());
     }
 
-    @Ignore("Re-Enable when support for Mixed as been added.")
     @Test
     public void rawPredicate_invalidFormatOptions() {
         RealmQuery<AllTypes> query = realm.where(AllTypes.class);
         try {
             // Argument type not valid
-            query.rawPredicate("columnString = '$1'", new Object[] { 42 });
+            query.rawPredicate("columnString = $0", 42);
             fail();
         } catch (IllegalArgumentException ignore) {
         }
 
         try {
             // Missing number of arguments
-            query.rawPredicate("columnString = '$1' AND columnString  = '$2'", new Object[] { "foo" });
+            query.rawPredicate("columnString = $0 AND columnString  = $1", "foo");
             RealmLog.error(query.getDescription());
         } catch (IllegalArgumentException ignore) {
         }
 
         try {
             // Wrong syntax for argument substitution
-            query.rawPredicate("columnString = '%1'", new Object[] {"foo" });
+            query.rawPredicate("columnString = %0", "foo");
             fail();
         } catch (IllegalArgumentException ignore) {
         }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_TableQuery.cpp
@@ -2376,6 +2376,16 @@ JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeAddUUIDArgument
     CATCH_STD()
 }
 
+JNIEXPORT void JNICALL Java_io_realm_internal_TableQuery_nativeAddObjectArgument
+        (JNIEnv* env, jclass, jlong data_ptr, jlong row_ptr)
+{
+    try {
+        const JavaValue value(reinterpret_cast<Obj*>(row_ptr));
+        add_argument(data_ptr, value);
+    }
+    CATCH_STD()
+}
+
 JNIEXPORT void JNICALL
 Java_io_realm_internal_TableQuery_nativeRawPredicate(JNIEnv *env,
                                                      jobject,

--- a/realm/realm-library/src/main/cpp/java_object_accessor.hpp
+++ b/realm/realm-library/src/main/cpp/java_object_accessor.hpp
@@ -374,6 +374,7 @@ struct JavaValue {
             case JavaValueType::Mixed:
                 return reinterpret_cast<JavaValue*>(this->get_mixed())->to_mixed();
             case JavaValueType::Object:
+                return Mixed(this->get_object()->get_key());
             case JavaValueType::List:
             case JavaValueType::PropertyList:
             case JavaValueType::Dictionary:

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -2322,12 +2322,16 @@ public class RealmQuery<E> {
 
     /**
      * Create a text-based predicate using the Realm Query Language. This predicate can be combined
-     * with other raw or type safe predicates, it accepts Realm values as arguments.
+     * with other raw or type safe predicates, it accepts Realm primitives or Realm objects as arguments.
      * <p>
      * Class and property names used in the raw predicate can be either the names defined in the
      * Realm Model classes or the internal names defined using the {@link io.realm.annotations.RealmClass}
      * or {@link io.realm.annotations.RealmField} annotations.
-     * </p>
+     * <p>
+     * Arguments are defined in the string predicate as $argument_index, where $argument_index is a decimal integer that
+     * specifies the position of the argument in the argument list. The first argument is referenced by $0, the second
+     * by $1, etc.  
+     * <p>
      * See <a href="https://docs.mongodb.com/realm-sdks/js/latest/tutorial-query-language.html">these docs</a>
      * for a more detailed description of the Realm Query Language.
      * <p>
@@ -2358,8 +2362,8 @@ public class RealmQuery<E> {
      * </pre>
      *
      * @param predicate a Realm Query Language predicate.
-     * @param arguments Realm values for the predicate.
-     * @throws java.lang.IllegalArgumentException if there is an syntax error.
+     * @param arguments Realm primitives or objects for the predicate.
+     * @throws java.lang.IllegalArgumentException if there is an syntax or type error.
      */
     public RealmQuery<E> rawPredicate(String predicate, Object... arguments) {
         realm.checkIfValid();

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -2322,7 +2322,7 @@ public class RealmQuery<E> {
 
     /**
      * Create a text-based predicate using the Realm Query Language. This predicate can be combined
-     * with other raw or type safe predicates.
+     * with other raw or type safe predicates, it accepts Realm values as arguments.
      * <p>
      * Class and property names used in the raw predicate can be either the names defined in the
      * Realm Model classes or the internal names defined using the {@link io.realm.annotations.RealmClass}
@@ -2351,41 +2351,30 @@ public class RealmQuery<E> {
      *
      * // Sort, Distinct, Limit
      * query.rawPredicate("name = 'Jane' SORT(lastName) DISTINCT(city) LIMIT(5)");
+     *
+     * // Arguments
+     * query.rawPredicate("name = $0 AND age > $1", "Jane", 18);
      * }
      * </pre>
      *
-     * @param predicate A Realm Query Language predicate.
+     * @param predicate a Realm Query Language predicate.
+     * @param arguments Realm values for the predicate.
      * @throws java.lang.IllegalArgumentException if there is an syntax error.
      */
-    public RealmQuery<E> rawPredicate(String predicate) {
-        return rawPredicate(predicate, new String[0]);
-    }
-
-    // TODO: This should be the public API once support for Mixed as been added, so arguments
-    //  can be parsed to C++ using the Mixed wrapper. Change from Object[] to Object...
-    RealmQuery<E> rawPredicate(String predicate, Object[] arguments) {
+    public RealmQuery<E> rawPredicate(String predicate, Object... arguments) {
         realm.checkIfValid();
         if (Util.isEmptyString(predicate)) {
             throw new IllegalArgumentException("Non-null 'predicate' required.");
         }
 
-        String[] args = new String[arguments.length];
-        for (int i = 0; i < arguments.length; i++) {
-            if (arguments[i] == null) {
-                throw new IllegalArgumentException("Null argument provided at index: " + i);
-            }
-            args[i] = arguments[i].toString();
-        }
-
         try {
-            query.rawPredicate(predicate, realm.getSchema().getKeyPathMapping(), queryDescriptors, args);
+            query.rawPredicate(predicate, realm.getSchema().getKeyPathMapping(), queryDescriptors, arguments);
         } catch (RuntimeException e) {
             // Work-around for QueryParser not always throwing the correct type of exceptions
             throw new IllegalArgumentException(e);
         }
         return this;
     }
-
 
     /**
      * Returns the {@link Realm} instance to which this query belongs.

--- a/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
@@ -25,6 +25,8 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import io.realm.Case;
+import io.realm.RealmModel;
+import io.realm.RealmObject;
 import io.realm.internal.core.DescriptorOrdering;
 import io.realm.internal.objectstore.OsKeyPathMapping;
 import io.realm.log.RealmLog;
@@ -734,6 +736,16 @@ public class TableQuery implements NativeObject {
             } else if (argument instanceof UUID) {
                 UUID value = (UUID) argument;
                 nativeAddUUIDArgument(listPtr, value.toString());
+            } else if (argument instanceof RealmModel) {
+                RealmModel value = (RealmModel) argument;
+
+                if (!RealmObject.isValid(value) || !RealmObject.isManaged(value)) {
+                    throw new IllegalArgumentException("Argument[" + i + "] is not a valid managed object.");
+                }
+
+                RealmObjectProxy proxy = (RealmObjectProxy) value;
+                UncheckedRow row = (UncheckedRow) proxy.realmGet$proxyState().getRow$realm();
+                nativeAddObjectArgument(listPtr, row.getNativePtr());
             } else {
                 throw new IllegalArgumentException("Unsupported query argument type: " + argument.getClass().getSimpleName());
             }
@@ -968,7 +980,7 @@ public class TableQuery implements NativeObject {
 
     private static native void nativeAddUUIDArgument(long listPtr, String data);
 
-//    private static native void nativeAddObjectArgument(long listPtr, long rowPtr);
+    private static native void nativeAddObjectArgument(long listPtr, long rowPtr);
 
     private native void nativeRawPredicate(long nativeQueryPtr, String filter, long mapppingPtr, long descriptorsPointer, long argsPtr);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
@@ -496,7 +496,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery greaterThanOrEqual(long[] columnKeys, long[] tablePtrs, ObjectId value) {
-        nativeGreaterEqualObjectId(nativePtr, columnKeys, tablePtrs,  value.toString());
+        nativeGreaterEqualObjectId(nativePtr, columnKeys, tablePtrs, value.toString());
         queryValidated = false;
         return this;
     }
@@ -534,7 +534,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery greaterThanOrEqual(long[] columnKeys, long[] tablePtrs, UUID value) {
-        nativeGreaterEqualUUID(nativePtr, columnKeys, tablePtrs,  value.toString());
+        nativeGreaterEqualUUID(nativePtr, columnKeys, tablePtrs, value.toString());
         queryValidated = false;
         return this;
     }
@@ -703,12 +703,49 @@ public class TableQuery implements NativeObject {
         return nativeCount(nativePtr);
     }
 
-    public void rawPredicate(String filter, @Nullable OsKeyPathMapping mapping, DescriptorOrdering descriptors, String[] args) {
+    public void rawPredicate(String filter, @Nullable OsKeyPathMapping mapping, DescriptorOrdering descriptors, Object[] args) {
+        long listPtr = nativeCreateArgumentList();
+
+        for (int i = 0; i < args.length; i++) {
+            Object argument = args[i];
+            if (argument == null) {
+                nativeAddNullArgument(listPtr);
+            } else if (argument instanceof Boolean) {
+                nativeAddBooleanArgument(listPtr, (Boolean) argument);
+            } else if (argument instanceof Float) {
+                nativeAddFloatArgument(listPtr, (Float) argument);
+            } else if (argument instanceof Double) {
+                nativeAddDoubleArgument(listPtr, (Double) argument);
+            } else if (argument instanceof Number) {
+                Number value = (Number) argument;
+                nativeAddIntegerArgument(listPtr, value.longValue());
+            } else if (argument instanceof String) {
+                nativeAddStringArgument(listPtr, (String) argument);
+            } else if (argument instanceof byte[]) {
+                nativeAddByteArrayArgument(listPtr, (byte[]) argument);
+            } else if (argument instanceof Date) {
+                nativeAddDateArgument(listPtr, ((Date) argument).getTime());
+            } else if (argument instanceof Decimal128) {
+                Decimal128 value = (Decimal128) argument;
+                nativeAddDecimal128Argument(listPtr, value.getLow(), value.getHigh());
+            } else if (argument instanceof ObjectId) {
+                ObjectId value = (ObjectId) argument;
+                nativeAddObjectIdArgument(listPtr, value.toString());
+            } else if (argument instanceof UUID) {
+                UUID value = (UUID) argument;
+                nativeAddUUIDArgument(listPtr, value.toString());
+            } else {
+                throw new IllegalArgumentException("Unsupported query argument type: " + argument.getClass().getSimpleName());
+            }
+        }
+
         nativeRawPredicate(nativePtr,
                 filter,
-                (mapping != null) ? mapping.getNativePtr() : null,
+                (mapping != null) ? mapping.getNativePtr() : 0,
                 descriptors.getNativePtr(),
-                args);
+                listPtr);
+
+        nativeDestroyArgumentList(listPtr);
     }
 
     public long remove() {
@@ -905,7 +942,35 @@ public class TableQuery implements NativeObject {
 
     private native long nativeRemove(long nativeQueryPtr);
 
-    private native void nativeRawPredicate(long nativeQueryPtr, String filter, Long mapppingPtr, long descriptorsPointer, String[] args);
+    private static native long nativeCreateArgumentList();
+
+    private static native void nativeDestroyArgumentList(long listPtr);
+
+    private static native void nativeAddNullArgument(long listPtr);
+
+    private static native void nativeAddIntegerArgument(long listPtr, long val);
+
+    private static native void nativeAddStringArgument(long listPtr, String val);
+
+    private static native void nativeAddFloatArgument(long listPtr, float val);
+
+    private static native void nativeAddDoubleArgument(long listPtr, double val);
+
+    private static native void nativeAddBooleanArgument(long listPtr, boolean val);
+
+    private static native void nativeAddByteArrayArgument(long listPtr, byte[] val);
+
+    private static native void nativeAddDateArgument(long listPtr, long val);
+
+    private static native void nativeAddDecimal128Argument(long listPtr, long low, long high);
+
+    private static native void nativeAddObjectIdArgument(long listPtr, String data);
+
+    private static native void nativeAddUUIDArgument(long listPtr, String data);
+
+//    private static native void nativeAddObjectArgument(long listPtr, long rowPtr);
+
+    private native void nativeRawPredicate(long nativeQueryPtr, String filter, long mapppingPtr, long descriptorsPointer, long argsPtr);
 
     private static native long nativeGetFinalizerPtr();
 }


### PR DESCRIPTION
This PR adds support for argument substitution on the brand new query raw predicates.

It accepts any Realm value or Realm object as arguments.