### PR TITLE
Update master to latest core master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Realm Studio 10.0.0 or above is required to open Realms created by this version.
 
 ### Internal
-* Updated to Realm Core commit: b72b5d6897fac5c1029c2a56a87096877fdca766.
+* Updated to Realm Core commit: df57de0101b5b817f8f4158cf45e11985cd640c2.
 * Updated to NDK 22.0.7026061.
 
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -986,7 +986,8 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeSetEmbedded(JNIEnv
 {
     try {
         TableRef table = TableRef(TBL_REF(j_table_ptr));
-        return to_jbool(table->set_embedded(to_bool(j_embedded)));
+        table->set_embedded(to_bool(j_embedded));
+        return true;
     }
     CATCH_STD()
     return false;


### PR DESCRIPTION
Updated to latest core master and fixed breaking change in `set_embedded`: where the old version would return `false` the new one throws, so we can assume that if we catch an exception we should then return `false` and `true` if nothing happened.