### PR TITLE
Use canonical URLs for docs links on overview page

### DIFF
--- a/realm/realm-library/src/overview.html
+++ b/realm/realm-library/src/overview.html
@@ -7,42 +7,42 @@
     <li><b>{@link io.realm.Realm}</b><br/> The Realm database. The storage and transactional manager of your object
         persistent store. It is in charge of creating and removing instances of your RealmObjects, querying, and
         performing transactions.
-        <a href="https://docs.mongodb.com/realm/android/realms">Read more</a>.
+        <a href="https://docs.mongodb.com/realm/sdk/android/fundamentals/realms/">Read more</a>.
         <p />
     </li>
 
     <li><b>{@link io.realm.RealmConfiguration}</b><br/>
         A configuration object that is used to setup a specific Realm instance.
-        <a href="https://docs.mongodb.com/realm/android/open-a-realm">Read more</a>.
+        <a href="https://docs.mongodb.com/realm/sdk/android/examples/open-and-close-a-local-realm/">Read more</a>.
         <p />
     </li>
 
     <li><b>{@link io.realm.RealmObject}</b><br/>
         The super class of all objects (models) that are to be stored in Realm. A Java object must extend
         {@link io.realm.RealmObject} in order to be considered a <i>RealmObject</i>.
-        <a href="https://docs.mongodb.com/realm/android/objects">Read more</a>.
+        <a href="https://docs.mongodb.com/realm/sdk/android/fundamentals/object-models-and-schemas/">Read more</a>.
         <p />
     </li>
 
     <li><b>{@link io.realm.RealmList}</b><br/>
         A <a href="https://docs.oracle.com/javase/7/docs/api/java/util/List.html">List</a> that is used in
         <i>RealmObject</i>s to model one-to-many relationships with other <i>RealmObject</i>s.
-        <a href="https://docs.mongodb.com/realm/android/collections#list-collections">Read more</a>.
+        <a href="https://docs.mongodb.com/realm/sdk/android/data-types/collections/#list-collections">Read more</a>.
         <p />
     </li>
 
     <li><b>{@link io.realm.RealmQuery}</b><br/>
         An object that encapsulates a query as defined through Realms fluent query interface. Queries are executed
         using either the {@link io.realm.RealmQuery#findAll}, {@link io.realm.RealmQuery#findFirst} or their variants.
-        <a href="https://docs.mongodb.com/realm/android/query-engine">Read more</a>.
+        <a href="https://docs.mongodb.com/realm/sdk/android/fundamentals/live-queries/">Read more</a>.
         <p />
     </li>
 
     <li><b>{@link io.realm.RealmResults}</b><br/>
         The result set of an executed <i>RealmQuery</i> for a given Realm. <i>RealmResults</i> are live,
-        <a href="https://docs.mongodb.com/realm/android/collections#collections-are-live">auto-updating</a> views into the underlying
-        data, which means results never have to be re-fetched.
-        <a href="https://docs.mongodb.com/realm/android/collections#results-collections">Read more</a>.
+        <a href="https://docs.mongodb.com/realm/sdk/android/data-types/collections/#collections-are-live">auto-updating</a> 
+        views into the underlying data, which means results never have to be re-fetched.
+        <a href="https://docs.mongodb.com/realm/sdk/android/data-types/collections/#results-collections">Read more</a>.
         <p />
     </li>
 </ul>


### PR DESCRIPTION
These changes resolve a series of redirect chains that are currently in the Realm SDK docs and are negatively affecting search engine performance.

(I'm on the Documentation Platform team at MongoDB and this was identified as part of a broader SEO project that we're currently working on.)