### PR TITLE
Fallback to dynamic realm models on classes without an schema

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -628,6 +628,9 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                 case UUID:
                     value = UUID.fromString(strValue);
                     break;
+                case MIXED:
+                    value = Mixed.valueOf(strValue);
+                    break;
                 default:
                     throw new IllegalArgumentException(String.format(Locale.US,
                             "Field %s is not a String field, " +
@@ -677,6 +680,8 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             setObjectId(fieldName, (ObjectId) value);
         } else if (valueClass == UUID.class) {
             setUUID(fieldName, (UUID) value);
+        } else if (valueClass == Mixed.class) {
+            setMixed(fieldName, (Mixed) value);
         } else {
             throw new IllegalArgumentException("Value is of an type not supported: " + value.getClass());
         }

--- a/realm/realm-library/src/main/java/io/realm/MixedOperator.java
+++ b/realm/realm-library/src/main/java/io/realm/MixedOperator.java
@@ -22,12 +22,12 @@ import org.bson.types.ObjectId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.realm.exceptions.RealmException;
 import io.realm.internal.OsSharedRealm;
 import io.realm.internal.RealmObjectProxy;
 import io.realm.internal.Table;
@@ -60,11 +60,15 @@ public abstract class MixedOperator {
             case UUID:
                 return new UUIDMixedOperator(nativeMixed);
             case OBJECT:
-                if (realm instanceof DynamicRealm) {
-                    return new DynamicRealmModelMixedOperator(realm, nativeMixed);
-                } else {
-                    return new RealmModelOperator(realm, nativeMixed);
+                if (realm instanceof Realm) {
+                    try {
+                        Class<RealmModel> clazz = nativeMixed.getModelClass(realm.sharedRealm, realm.configuration.getSchemaMediator());
+                        return new RealmModelOperator(realm, nativeMixed, clazz);
+                    } catch (RealmException ignore) {
+                        // Fall through to DynamicRealmModelOperator
+                    }
                 }
+                return new DynamicRealmModelMixedOperator(realm, nativeMixed);
             case NULL:
                 return new NullMixedOperator(nativeMixed);
             default:
@@ -347,18 +351,6 @@ final class NullMixedOperator extends PrimitiveMixedOperator {
 }
 
 class RealmModelOperator extends MixedOperator {
-    private static <T extends RealmModel> Class<T> getModelClass(BaseRealm realm, NativeMixed nativeMixed) {
-        OsSharedRealm sharedRealm = realm
-                .getSharedRealm();
-
-        String className = Table.getClassNameForTable(nativeMixed.getRealmModelTableName(sharedRealm));
-
-        return realm
-                .getConfiguration()
-                .getSchemaMediator()
-                .getClazz(className);
-    }
-
     private static <T extends RealmModel> T getRealmModel(BaseRealm realm, Class<T> clazz, NativeMixed nativeMixed) {
         return realm
                 .get(clazz, nativeMixed.getRealmModelRowKey(), false, Collections.emptyList());
@@ -372,12 +364,10 @@ class RealmModelOperator extends MixedOperator {
         this.clazz = realmModel.getClass();
     }
 
-    <T extends RealmModel> RealmModelOperator(BaseRealm realm, NativeMixed nativeMixed) {
+    <T extends RealmModel> RealmModelOperator(BaseRealm realm, NativeMixed nativeMixed, Class<T> clazz) {
         super(nativeMixed);
 
-        Class<T> clazz = getModelClass(realm, nativeMixed);
         this.clazz = clazz;
-
         this.value = getRealmModel(realm, clazz, nativeMixed);
     }
 
@@ -422,8 +412,7 @@ final class DynamicRealmModelMixedOperator extends RealmModelOperator {
 
         String className = Table.getClassNameForTable(nativeMixed.getRealmModelTableName(sharedRealm));
 
-        return realm
-                .get((Class<T>) DynamicRealmObject.class, className, nativeMixed.getRealmModelRowKey());
+        return realm.get((Class<T>) DynamicRealmObject.class, className, nativeMixed.getRealmModelRowKey());
     }
 
     DynamicRealmModelMixedOperator(BaseRealm realm, NativeMixed nativeMixed) {

--- a/realm/realm-library/src/main/java/io/realm/internal/core/NativeMixed.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/core/NativeMixed.java
@@ -23,11 +23,14 @@ import java.util.Date;
 import java.util.UUID;
 
 import io.realm.MixedType;
+import io.realm.RealmModel;
 import io.realm.internal.NativeContext;
 import io.realm.internal.NativeObject;
 import io.realm.internal.OsSharedRealm;
 import io.realm.internal.RealmObjectProxy;
+import io.realm.internal.RealmProxyMediator;
 import io.realm.internal.Row;
+import io.realm.internal.Table;
 
 
 public class NativeMixed implements NativeObject {
@@ -84,7 +87,7 @@ public class NativeMixed implements NativeObject {
         this(createMixedLink(model));
     }
 
-    private static long createMixedLink(RealmObjectProxy model){
+    private static long createMixedLink(RealmObjectProxy model) {
         Row row$realm = model.realmGet$proxyState().getRow$realm();
 
         long targetTablePtr = row$realm.getTable().getNativePtr();
@@ -150,6 +153,11 @@ public class NativeMixed implements NativeObject {
 
     public UUID asUUID() {
         return UUID.fromString(nativeMixedAsUUID(nativePtr));
+    }
+
+    public <T extends RealmModel> Class<T> getModelClass(OsSharedRealm osSharedRealm, RealmProxyMediator mediator) {
+        String className = Table.getClassNameForTable(nativeGetRealmModelTableName(nativePtr, osSharedRealm.getNativePtr()));
+        return mediator.getClazz(className);
     }
 
     public String getRealmModelTableName(OsSharedRealm osSharedRealm) {


### PR DESCRIPTION
Given a Mixed which inner value referenced is an object whose schema isn't backed by an`InmutableObjectSchema`, if we retrieve its inner value it would throw a RealmException.

This PR allows falling back to a `DynamicRealmObject` in such cases.

Example:
```
ObjectWithMixed objectWithMixed = realm.where(ObjectWithMixed.class).findFirst();

// the mixed content object schema is missing in the realm
assertEquals(DynamicRealmObject.class, objectWithMixed.mixed.getValueClass());
```