### PR TITLE
Add support for copyOrUpdate dictionary of objects

### DIFF
--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
@@ -47,7 +47,7 @@ class ManagedDictionaryTester<T : Any>(
         private val alternativeDictionary: RealmDictionary<T>,
         private val populatedGetter: KProperty1<PopulatedDictionaryClass, RealmDictionary<T>>,
         private val typeAsserter: TypeAsserter<T> = TypeAsserter(),
-        private val primaryKeyDictionaryGetter: KProperty1<PrimaryKeyDictionaryContainer, RealmDictionary<T>>
+        private val primaryKeyDictionaryProperty: KProperty1<PrimaryKeyDictionaryContainer, RealmDictionary<T>>
 ) : DictionaryTester {
 
     private lateinit var config: RealmConfiguration
@@ -369,7 +369,7 @@ class ManagedDictionaryTester<T : Any>(
     override fun copyToRealmOrUpdate() {
         // Instantiate container and set dictionary on container
         val manualInstance = PrimaryKeyDictionaryContainer().apply {
-            primaryKeyDictionaryGetter.get(this).putAll(initializedDictionary)
+            primaryKeyDictionaryProperty.get(this).putAll(initializedDictionary)
         }
 
         // Copy to Realm
@@ -381,14 +381,19 @@ class ManagedDictionaryTester<T : Any>(
         // Get dictionary from container from Realm
         val primaryKeyDictionaryContainer = realm.where<PrimaryKeyDictionaryContainer>().findFirst()
         assertNotNull(primaryKeyDictionaryContainer)
-        val dictionary = dictionaryGetter.call(primaryKeyDictionaryContainer)
+        val dictionary = primaryKeyDictionaryProperty.get(primaryKeyDictionaryContainer)
         assertFalse(dictionary.isEmpty())
         initializedDictionary.forEach { key, value ->
             typeAsserter.assertEqualsHelper(realm, value, dictionary[key])
         }
 
-        primaryKeyDictionaryGetter.get(manualInstance).clear()
-        // Copy to Realm (updating)
+        if (testerClass == "String-NonLatin" || testerClass == "Mixed-NonLatin") {
+            primaryKeyDictionaryProperty.get(manualInstance)[NEW_KEY_NON_LATIN] = alternativeDictionary[KEY_BYE_NON_LATIN]
+        } else {
+            primaryKeyDictionaryProperty.get(manualInstance)[NEW_KEY] = alternativeDictionary[KEY_BYE]
+        }
+
+        // Copy to Realm with non managed updated model
         realm.executeTransaction {
             val allTypesObject = realm.copyToRealmOrUpdate(manualInstance)
             assertNotNull(allTypesObject)
@@ -396,8 +401,13 @@ class ManagedDictionaryTester<T : Any>(
 
         val updatedContainer = realm.where<PrimaryKeyDictionaryContainer>().findFirst()
         assertNotNull(updatedContainer)
-        val updatedDictinary = dictionaryGetter.call(primaryKeyDictionaryContainer)
-        assertTrue(dictionaryGetter.call(updatedDictinary).isEmpty())
+        val updatedDictinary = primaryKeyDictionaryProperty.get(primaryKeyDictionaryContainer)
+        assertEquals(initializedDictionary.size + 1, updatedDictinary.size)
+        if (testerClass == "String-NonLatin" || testerClass == "Mixed-NonLatin") {
+            typeAsserter.assertEqualsHelper(realm, alternativeDictionary[KEY_BYE_NON_LATIN], updatedDictinary[NEW_KEY_NON_LATIN])
+        } else {
+            typeAsserter.assertEqualsHelper(realm, alternativeDictionary[KEY_BYE], updatedDictinary[NEW_KEY])
+        }
     }
 
     override fun copyFromRealm() {
@@ -635,7 +645,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toLong(), KEY_BYE to VALUE_NUMERIC_BYE.toLong(), KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toLong(), KEY_BYE to VALUE_NUMERIC_HELLO.toLong(), KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedLongDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myLongDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myLongDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Int",
@@ -645,7 +655,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO, KEY_BYE to VALUE_NUMERIC_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE, KEY_BYE to VALUE_NUMERIC_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedIntDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myIntDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myIntDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Short",
@@ -655,7 +665,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toShort(), KEY_BYE to VALUE_NUMERIC_BYE.toShort(), KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toShort(), KEY_BYE to VALUE_NUMERIC_HELLO.toShort(), KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedShortDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myShortDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myShortDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Byte",
@@ -665,7 +675,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toByte(), KEY_BYE to VALUE_NUMERIC_BYE.toByte(), KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toByte(), KEY_BYE to VALUE_NUMERIC_HELLO.toByte(), KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedByteDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myByteDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myByteDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Float",
@@ -675,7 +685,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toFloat(), KEY_BYE to VALUE_NUMERIC_BYE.toFloat(), KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toFloat(), KEY_BYE to VALUE_NUMERIC_HELLO.toFloat(), KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedFloatDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myFloatDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myFloatDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Double",
@@ -685,7 +695,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toDouble(), KEY_BYE to VALUE_NUMERIC_BYE.toDouble(), KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toDouble(), KEY_BYE to VALUE_NUMERIC_HELLO.toDouble(), KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedDoubleDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myDoubleDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDoubleDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "String",
@@ -695,7 +705,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_HELLO, KEY_BYE to VALUE_STRING_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_BYE, KEY_BYE to VALUE_STRING_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myStringDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "String-NonLatin",
@@ -705,7 +715,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_NULL_NON_LATIN to null)),
                     alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_NULL_NON_LATIN to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myStringDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Boolean",
@@ -715,7 +725,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_HELLO, KEY_BYE to VALUE_BOOLEAN_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_BYE, KEY_BYE to VALUE_BOOLEAN_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedBooleanDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myBooleanDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBooleanDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Date",
@@ -725,7 +735,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_HELLO, KEY_BYE to VALUE_DATE_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_BYE, KEY_BYE to VALUE_DATE_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedDateDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myDateDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDateDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "Decimal128",
@@ -735,7 +745,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_HELLO, KEY_BYE to VALUE_DECIMAL128_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_BYE, KEY_BYE to VALUE_DECIMAL128_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedDecimal128Dictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myDecimal128Dictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDecimal128Dictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "ByteArray",
@@ -745,7 +755,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_HELLO, KEY_BYE to VALUE_BINARY_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_BYE, KEY_BYE to VALUE_BINARY_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedBinaryDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myBinaryDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBinaryDictionary,
                     typeAsserter = BinaryAsserter()
             ),
             ManagedDictionaryTester(
@@ -756,7 +766,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_HELLO, KEY_BYE to VALUE_OBJECT_ID_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_BYE, KEY_BYE to VALUE_OBJECT_ID_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedObjectIdDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myObjectIdDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myObjectIdDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "UUID",
@@ -766,7 +776,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_HELLO, KEY_BYE to VALUE_UUID_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_BYE, KEY_BYE to VALUE_UUID_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedUUIDDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myUUIDDictionary
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myUUIDDictionary
             ),
             ManagedDictionaryTester(
                     testerClass = "DogPrimaryKey",
@@ -775,7 +785,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_HELLO, KEY_BYE to VALUE_LINK_BYE, KEY_NULL to null)),
                     alternativeDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_BYE, KEY_BYE to VALUE_LINK_HELLO, KEY_NULL to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedRealmModelDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myRealmModelDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myRealmModelDictionary,
                     typeAsserter = RealmModelAsserter()
             )
     )
@@ -790,7 +800,7 @@ fun managedFactory(): List<DictionaryTester> {
                 initializedDictionary = RealmDictionary<Mixed>().init(getMixedKeyValuePairs(mixedType)),
                 alternativeDictionary = RealmDictionary<Mixed>().init(getMixedKeyValuePairs(mixedType, true)),
                 populatedGetter = PopulatedDictionaryClass::populatedMixedDictionary,
-                primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myMixedDictionary,
+                primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myMixedDictionary,
                 typeAsserter = MixedAsserter()
         )
     }.plus(
@@ -802,7 +812,7 @@ fun managedFactory(): List<DictionaryTester> {
                     initializedDictionary = RealmDictionary<Mixed>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_MIXED_STRING_NON_LATIN_BYE, KEY_BYE_NON_LATIN to VALUE_MIXED_STRING_NON_LATIN_HELLO, KEY_NULL_NON_LATIN to null)),
                     alternativeDictionary = RealmDictionary<Mixed>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_MIXED_STRING_NON_LATIN_HELLO, KEY_BYE_NON_LATIN to VALUE_MIXED_STRING_NON_LATIN_BYE, KEY_NULL_NON_LATIN to null)),
                     populatedGetter = PopulatedDictionaryClass::populatedMixedDictionary,
-                    primaryKeyDictionaryGetter = PrimaryKeyDictionaryContainer::myMixedDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myMixedDictionary,
                     typeAsserter = MixedAsserter()
             )
     )

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ParameterizedDictionaryTests.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ParameterizedDictionaryTests.kt
@@ -174,6 +174,11 @@ class ParameterizedDictionaryTests(
     }
 
     @Test
+    fun copyToRealmOrUpdate() {
+        tester.copyToRealmOrUpdate()
+    }
+
+    @Test
     fun copyFromRealm() {
         tester.copyFromRealm()
     }
@@ -231,6 +236,8 @@ internal const val KEY_BYE_NON_LATIN = "Keyさようなら"
 internal const val KEY_NULL_NON_LATIN = "Keyヌル"
 internal const val KEY_NOT_PRESENT_NON_LATIN = "Key現在ではない"
 
+internal const val NEW_KEY = "NEW KEY"
+internal const val NEW_KEY_NON_LATIN = "NEW KEYさようなら"
 internal const val VALUE_BOOLEAN_HELLO = true
 internal const val VALUE_BOOLEAN_BYE = false
 internal const val VALUE_BOOLEAN_NOT_PRESENT = VALUE_BOOLEAN_BYE

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsObjectBuilder.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsObjectBuilder.cpp
@@ -650,6 +650,20 @@ Java_io_realm_internal_objectstore_OsObjectBuilder_nativeAddUUIDDictionaryEntry(
 }
 
 JNIEXPORT void JNICALL
+Java_io_realm_internal_objectstore_OsObjectBuilder_nativeAddObjectDictionaryEntry(JNIEnv* env,
+                                                                                jclass,
+                                                                                jlong dictionary_ptr,
+                                                                                jstring j_key,
+                                                                                jlong j_value) {
+    try {
+        auto dictionary = reinterpret_cast<std::map<std::string, JavaValue>*>(dictionary_ptr);
+        JStringAccessor key(env, j_key);
+        dictionary->insert(std::make_pair(key, JavaValue(reinterpret_cast<Obj*>(j_value))));
+    }
+    CATCH_STD()
+}
+
+JNIEXPORT void JNICALL
 Java_io_realm_internal_objectstore_OsObjectBuilder_nativeAddMixedDictionaryEntry(JNIEnv* env,
                                                                                  jclass,
                                                                                  jlong dictionary_ptr,


### PR DESCRIPTION
This PR adds support copyOrUpdate on a dictionary of objects and using null values on objects.