### PR TITLE
Correctly propagate error messages to users for App Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 10.4.1 (YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixes
+* [RealmApp] Client Reset errors now correctly forward the server error message. (Issue [#7363](https://github.com/realm/realm-java/issues/7363), since 10.0.0)
+* [RealmApp] All `AppException`s now correctly report the error message through `RuntimeException.getMessage()` instead of only through `AppException.getErrorMessage()`. 
+
+### Compatibility
+* File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 or above is required to open Realms created by this version.
+
+### Internal
+* None.
+
+
 ## 10.4.0 (2021-03-26)
 
 All releases from 10.4.0 and forward are now found on `mavenCentral()` instead of `jcenter()`. 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SessionTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SessionTests.kt
@@ -134,6 +134,10 @@ class SessionTests {
                     assertEquals(filePathFromError, filePathFromConfig)
                     assertFalse(error.backupFile.exists())
                     assertTrue(error.originalFile.exists())
+                    // Note, this error message is just the one created by ObjectStore for testing
+                    // The server will send a different message. This just ensures that we don't
+                    // accidentially modify or remove the message.
+                    assertEquals("Simulate Client Reset", error.message)
                     looperThread.testComplete()
                 }
                 .build()
@@ -442,7 +446,7 @@ class SessionTests {
             RealmLog.setLevel(LogLevel.WARN)
             val testLogger = TestLogger()
             RealmLog.add(testLogger)
-            session.notifySessionError("unknown", 3, "Unknown Error")
+            session.notifySessionError("unknown", 3, "Unknown Error", "")
             RealmLog.remove(testLogger)
             // TODO See comment above
             RealmLog.setLevel(level)

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppException.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppException.java
@@ -106,6 +106,7 @@ public class AppException extends RuntimeException {
 
     public AppException(ErrorCode errorCode, String nativeErrorType, int nativeErrorCode,
                         @Nullable String errorMessage, @Nullable Throwable exception) {
+        super(errorMessage);
         this.error = errorCode;
         this.nativeErrorType = nativeErrorType;
         this.nativeErrorIntValue = nativeErrorCode;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -228,30 +228,19 @@ public abstract class Sync {
 
     /**
      * All errors from native Sync is reported to this method. From the path we can determine which
-     * session to contact. If {@code path == null} all sessions are effected.
+     * session to contact.
      */
     @SuppressWarnings("unused")
-    private synchronized void notifyErrorHandler(String nativeErrorCategory, int nativeErrorCode, String errorMessage, @Nullable String path) {
-        if (Util.isEmptyString(path)) {
-            // notify all sessions
-            for (SyncSession syncSession : sessions.values()) {
-                try {
-                    syncSession.notifySessionError(nativeErrorCategory, nativeErrorCode, errorMessage);
-                } catch (Exception exception) {
-                    RealmLog.error(exception);
-                }
+    private synchronized void notifyErrorHandler(String nativeErrorCategory, int nativeErrorCode, String errorMessage, String clientResetPathInfo, String path) {
+        SyncSession syncSession = sessions.get(path);
+        if (syncSession != null) {
+            try {
+                syncSession.notifySessionError(nativeErrorCategory, nativeErrorCode, errorMessage, clientResetPathInfo);
+            } catch (Exception exception) {
+                RealmLog.error(exception);
             }
         } else {
-            SyncSession syncSession = sessions.get(path);
-            if (syncSession != null) {
-                try {
-                    syncSession.notifySessionError(nativeErrorCategory, nativeErrorCode, errorMessage);
-                } catch (Exception exception) {
-                    RealmLog.error(exception);
-                }
-            } else {
-                RealmLog.warn("Cannot find the SyncSession corresponding to the path: " + path);
-            }
+            RealmLog.warn("Cannot find the SyncSession corresponding to the path: " + path);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/7363

Turned out we had two bugs around exception handling

1) Exception messages in `AppException` was not correctly stored in the (standard) message property of `RuntimeException`

2) We didn't correctly pass on Client Reset error messages to users in the `AppException.errorMessage` field. 