### PR TITLE
Dictionary - fix crash when calling a dictionary setter with unmanaged objects (also for Mixed)

### DIFF
--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/RealmProxyClassGenerator.kt
@@ -607,12 +607,13 @@ class RealmProxyClassGenerator(private val processingEnvironment: ProcessingEnvi
                         beginControlFlow("if (entryValue == null)")
                             emitStatement("osMap.put(entryKey, null)")
                         nextControlFlow("else")
-                            emitStatement("osMap.putMixed(entryKey, entryValue.getNativePtr())")
+                            emitStatement("osMap.putMixed(entryKey, ProxyUtils.copyToRealmIfNeeded(proxyState, entryValue).getNativePtr())")
                         endControlFlow()
                     } else if (forRealmModel) {
                         beginControlFlow("if (entryValue == null)")
                             emitStatement("osMap.put(entryKey, null)")
                         nextControlFlow("else")
+                            emitStatement("proxyState.checkValidObject(entryValue)")
                             emitStatement("osMap.putRow(entryKey, ((RealmObjectProxy) entryValue).realmGet\$proxyState().getRow\$realm().getObjectKey())")
                         endControlFlow()
                     } else {

--- a/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_AllTypesRealmProxy.java
+++ b/realm/realm-annotations-processor/src/test/resources/io/realm/some_test_AllTypesRealmProxy.java
@@ -1494,6 +1494,7 @@ public class some_test_AllTypesRealmProxy extends some.test.AllTypes
             if (entryValue == null) {
                 osMap.put(entryKey, null);
             } else {
+                proxyState.checkValidObject(entryValue);
                 osMap.putRow(entryKey, ((RealmObjectProxy) entryValue).realmGet$proxyState().getRow$realm().getObjectKey());
             }
         }
@@ -2036,7 +2037,7 @@ public class some_test_AllTypesRealmProxy extends some.test.AllTypes
             if (entryValue == null) {
                 osMap.put(entryKey, null);
             } else {
-                osMap.putMixed(entryKey, entryValue.getNativePtr());
+                osMap.putMixed(entryKey, ProxyUtils.copyToRealmIfNeeded(proxyState, entryValue).getNativePtr());
             }
         }
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -4136,13 +4136,13 @@ public class RealmQueryTests extends QueryTests {
 
     private void fillDictionaryTests(){
         realm.executeTransaction(transactionRealm -> {
-            DictionaryAllTypes allTypes1 = realm.createObject(DictionaryAllTypes.class);
+            DictionaryAllTypes allTypes1 = realm.createObject(DictionaryAllTypes.class, "PK1");
             allTypes1.getColumnStringDictionary().put("hello world1", "Test1");
 
-            DictionaryAllTypes allTypes2 = realm.createObject(DictionaryAllTypes.class);
+            DictionaryAllTypes allTypes2 = realm.createObject(DictionaryAllTypes.class, "PK2");
             allTypes2.getColumnStringDictionary().put("hello world1", "Test2");
 
-            DictionaryAllTypes allTypes3 = realm.createObject(DictionaryAllTypes.class);
+            DictionaryAllTypes allTypes3 = realm.createObject(DictionaryAllTypes.class, "PK3");
             allTypes3.getColumnStringDictionary().put("hello world2", "Test2");
         });
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -68,6 +68,7 @@ import io.realm.rule.RunTestInLooperThread;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -4152,8 +4153,14 @@ public class RealmQueryTests extends QueryTests {
         fillDictionaryTests();
         RealmResults<DictionaryAllTypes> results = realm.where(DictionaryAllTypes.class).containsKey(DictionaryAllTypes.FIELD_STRING_DICTIONARY, "hello world1").findAll();
         assertEquals(2, results.size());
-        assertEquals("Test1", results.get(0).getColumnStringDictionary().get("hello world1"));
-        assertEquals("Test2", results.get(1).getColumnStringDictionary().get("hello world2"));
+
+        // We can't assert on values since we don't know the order in which the results are delivered, so better to assert that the keys are contained in the results
+        DictionaryAllTypes results0 = results.get(0);
+        assertNotNull(results0);
+        assertTrue(results0.getColumnStringDictionary().containsKey("hello world1"));
+        DictionaryAllTypes results1 = results.get(1);
+        assertNotNull(results1);
+        assertTrue(results1.getColumnStringDictionary().containsKey("hello world1"));
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmQueryTests.java
@@ -4153,7 +4153,7 @@ public class RealmQueryTests extends QueryTests {
         RealmResults<DictionaryAllTypes> results = realm.where(DictionaryAllTypes.class).containsKey(DictionaryAllTypes.FIELD_STRING_DICTIONARY, "hello world1").findAll();
         assertEquals(2, results.size());
         assertEquals("Test1", results.get(0).getColumnStringDictionary().get("hello world1"));
-        assertEquals("Test2", results.get(1).getColumnStringDictionary().get("hello world1"));
+        assertEquals("Test2", results.get(1).getColumnStringDictionary().get("hello world2"));
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/DictionaryTester.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/DictionaryTester.kt
@@ -42,7 +42,7 @@ interface DictionaryTester : GenericTester {
     fun copyToRealm()
     fun copyToRealmOrUpdate()
     fun copyFromRealm()
-    fun fieldAccessors()
+    fun fieldAccessors(otherConfig: RealmConfiguration? = null)
     fun addMapChangeListener()
     fun addRealmChangeListener()
     fun hasListeners()

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
@@ -717,172 +717,172 @@ enum class ChangeListenerOperation {
  */
 fun managedFactory(): List<DictionaryTester> {
     val primitiveTesters = listOf<DictionaryTester>(
-//            ManagedDictionaryTester(
-//                    testerClass = "Long",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnLongDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnLongDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredLongDictionary,
-//                    initializedDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toLong(), KEY_BYE to VALUE_NUMERIC_BYE.toLong(), KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toLong(), KEY_BYE to VALUE_NUMERIC_HELLO.toLong(), KEY_NULL to null)),
-//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toLong(),
-//                    populatedGetter = PopulatedDictionaryClass::populatedLongDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myLongDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Int",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnIntegerDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnIntegerDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredIntegerDictionary,
-//                    initializedDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO, KEY_BYE to VALUE_NUMERIC_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE, KEY_BYE to VALUE_NUMERIC_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedIntDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myIntDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Short",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnShortDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnShortDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredShortDictionary,
-//                    initializedDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toShort(), KEY_BYE to VALUE_NUMERIC_BYE.toShort(), KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toShort(), KEY_BYE to VALUE_NUMERIC_HELLO.toShort(), KEY_NULL to null)),
-//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toShort(),
-//                    populatedGetter = PopulatedDictionaryClass::populatedShortDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myShortDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Byte",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnByteDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnByteDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredByteDictionary,
-//                    initializedDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toByte(), KEY_BYE to VALUE_NUMERIC_BYE.toByte(), KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toByte(), KEY_BYE to VALUE_NUMERIC_HELLO.toByte(), KEY_NULL to null)),
-//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toByte(),
-//                    populatedGetter = PopulatedDictionaryClass::populatedByteDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myByteDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Float",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnFloatDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnFloatDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredFloatDictionary,
-//                    initializedDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toFloat(), KEY_BYE to VALUE_NUMERIC_BYE.toFloat(), KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toFloat(), KEY_BYE to VALUE_NUMERIC_HELLO.toFloat(), KEY_NULL to null)),
-//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toFloat(),
-//                    populatedGetter = PopulatedDictionaryClass::populatedFloatDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myFloatDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Double",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnDoubleDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnDoubleDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDoubleDictionary,
-//                    initializedDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toDouble(), KEY_BYE to VALUE_NUMERIC_BYE.toDouble(), KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toDouble(), KEY_BYE to VALUE_NUMERIC_HELLO.toDouble(), KEY_NULL to null)),
-//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toDouble(),
-//                    populatedGetter = PopulatedDictionaryClass::populatedDoubleDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDoubleDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "String",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
-//                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_HELLO, KEY_BYE to VALUE_STRING_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_BYE, KEY_BYE to VALUE_STRING_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_STRING_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "String-NonLatin",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
-//                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_NULL_NON_LATIN to null)),
-//                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_NULL_NON_LATIN to null)),
-//                    notPresentValue = VALUE_STRING_NON_LATIN_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Boolean",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnBooleanDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnBooleanDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBooleanDictionary,
-//                    initializedDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_HELLO, KEY_BYE to VALUE_BOOLEAN_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_BYE, KEY_BYE to VALUE_BOOLEAN_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_BOOLEAN_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedBooleanDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBooleanDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Date",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnDateDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnDateDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDateDictionary,
-//                    initializedDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_HELLO, KEY_BYE to VALUE_DATE_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_BYE, KEY_BYE to VALUE_DATE_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_DATE_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedDateDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDateDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "Decimal128",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnDecimal128Dictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnDecimal128Dictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDecimal128Dictionary,
-//                    initializedDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_HELLO, KEY_BYE to VALUE_DECIMAL128_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_BYE, KEY_BYE to VALUE_DECIMAL128_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_DECIMAL128_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedDecimal128Dictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDecimal128Dictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "ByteArray",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnBinaryDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnBinaryDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBinaryDictionary,
-//                    initializedDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_HELLO, KEY_BYE to VALUE_BINARY_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_BYE, KEY_BYE to VALUE_BINARY_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_BINARY_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedBinaryDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBinaryDictionary,
-//                    typeAsserter = BinaryAsserter()
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "ObjectId",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnObjectIdDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnObjectIdDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredObjectIdDictionary,
-//                    initializedDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_HELLO, KEY_BYE to VALUE_OBJECT_ID_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_BYE, KEY_BYE to VALUE_OBJECT_ID_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_OBJECT_ID_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedObjectIdDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myObjectIdDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "UUID",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnUUIDDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnUUIDDictionary,
-//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredUUIDDictionary,
-//                    initializedDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_HELLO, KEY_BYE to VALUE_UUID_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_BYE, KEY_BYE to VALUE_UUID_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_UUID_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedUUIDDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myUUIDDictionary
-//            ),
-//            ManagedDictionaryTester(
-//                    testerClass = "DogPrimaryKey",
-//                    dictionaryGetter = DictionaryAllTypes::getColumnRealmDictionary,
-//                    dictionarySetter = DictionaryAllTypes::setColumnRealmDictionary,
-//                    initializedDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_HELLO, KEY_BYE to VALUE_LINK_BYE, KEY_NULL to null)),
-//                    alternativeDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_BYE, KEY_BYE to VALUE_LINK_HELLO, KEY_NULL to null)),
-//                    notPresentValue = VALUE_LINK_NOT_PRESENT,
-//                    populatedGetter = PopulatedDictionaryClass::populatedRealmModelDictionary,
-//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myRealmModelDictionary,
-//                    typeAsserter = RealmModelAsserter()
-//            )
+            ManagedDictionaryTester(
+                    testerClass = "Long",
+                    dictionaryGetter = DictionaryAllTypes::getColumnLongDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnLongDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredLongDictionary,
+                    initializedDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toLong(), KEY_BYE to VALUE_NUMERIC_BYE.toLong(), KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toLong(), KEY_BYE to VALUE_NUMERIC_HELLO.toLong(), KEY_NULL to null)),
+                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toLong(),
+                    populatedGetter = PopulatedDictionaryClass::populatedLongDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myLongDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Int",
+                    dictionaryGetter = DictionaryAllTypes::getColumnIntegerDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnIntegerDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredIntegerDictionary,
+                    initializedDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO, KEY_BYE to VALUE_NUMERIC_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE, KEY_BYE to VALUE_NUMERIC_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedIntDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myIntDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Short",
+                    dictionaryGetter = DictionaryAllTypes::getColumnShortDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnShortDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredShortDictionary,
+                    initializedDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toShort(), KEY_BYE to VALUE_NUMERIC_BYE.toShort(), KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toShort(), KEY_BYE to VALUE_NUMERIC_HELLO.toShort(), KEY_NULL to null)),
+                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toShort(),
+                    populatedGetter = PopulatedDictionaryClass::populatedShortDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myShortDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Byte",
+                    dictionaryGetter = DictionaryAllTypes::getColumnByteDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnByteDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredByteDictionary,
+                    initializedDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toByte(), KEY_BYE to VALUE_NUMERIC_BYE.toByte(), KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toByte(), KEY_BYE to VALUE_NUMERIC_HELLO.toByte(), KEY_NULL to null)),
+                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toByte(),
+                    populatedGetter = PopulatedDictionaryClass::populatedByteDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myByteDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Float",
+                    dictionaryGetter = DictionaryAllTypes::getColumnFloatDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnFloatDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredFloatDictionary,
+                    initializedDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toFloat(), KEY_BYE to VALUE_NUMERIC_BYE.toFloat(), KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toFloat(), KEY_BYE to VALUE_NUMERIC_HELLO.toFloat(), KEY_NULL to null)),
+                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toFloat(),
+                    populatedGetter = PopulatedDictionaryClass::populatedFloatDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myFloatDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Double",
+                    dictionaryGetter = DictionaryAllTypes::getColumnDoubleDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnDoubleDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDoubleDictionary,
+                    initializedDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toDouble(), KEY_BYE to VALUE_NUMERIC_BYE.toDouble(), KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toDouble(), KEY_BYE to VALUE_NUMERIC_HELLO.toDouble(), KEY_NULL to null)),
+                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toDouble(),
+                    populatedGetter = PopulatedDictionaryClass::populatedDoubleDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDoubleDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "String",
+                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
+                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_HELLO, KEY_BYE to VALUE_STRING_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_BYE, KEY_BYE to VALUE_STRING_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_STRING_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "String-NonLatin",
+                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
+                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_NULL_NON_LATIN to null)),
+                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_NULL_NON_LATIN to null)),
+                    notPresentValue = VALUE_STRING_NON_LATIN_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Boolean",
+                    dictionaryGetter = DictionaryAllTypes::getColumnBooleanDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnBooleanDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBooleanDictionary,
+                    initializedDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_HELLO, KEY_BYE to VALUE_BOOLEAN_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_BYE, KEY_BYE to VALUE_BOOLEAN_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_BOOLEAN_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedBooleanDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBooleanDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Date",
+                    dictionaryGetter = DictionaryAllTypes::getColumnDateDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnDateDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDateDictionary,
+                    initializedDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_HELLO, KEY_BYE to VALUE_DATE_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_BYE, KEY_BYE to VALUE_DATE_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_DATE_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedDateDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDateDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "Decimal128",
+                    dictionaryGetter = DictionaryAllTypes::getColumnDecimal128Dictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnDecimal128Dictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDecimal128Dictionary,
+                    initializedDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_HELLO, KEY_BYE to VALUE_DECIMAL128_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_BYE, KEY_BYE to VALUE_DECIMAL128_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_DECIMAL128_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedDecimal128Dictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDecimal128Dictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "ByteArray",
+                    dictionaryGetter = DictionaryAllTypes::getColumnBinaryDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnBinaryDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBinaryDictionary,
+                    initializedDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_HELLO, KEY_BYE to VALUE_BINARY_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_BYE, KEY_BYE to VALUE_BINARY_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_BINARY_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedBinaryDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBinaryDictionary,
+                    typeAsserter = BinaryAsserter()
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "ObjectId",
+                    dictionaryGetter = DictionaryAllTypes::getColumnObjectIdDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnObjectIdDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredObjectIdDictionary,
+                    initializedDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_HELLO, KEY_BYE to VALUE_OBJECT_ID_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_BYE, KEY_BYE to VALUE_OBJECT_ID_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_OBJECT_ID_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedObjectIdDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myObjectIdDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "UUID",
+                    dictionaryGetter = DictionaryAllTypes::getColumnUUIDDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnUUIDDictionary,
+                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredUUIDDictionary,
+                    initializedDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_HELLO, KEY_BYE to VALUE_UUID_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_BYE, KEY_BYE to VALUE_UUID_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_UUID_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedUUIDDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myUUIDDictionary
+            ),
+            ManagedDictionaryTester(
+                    testerClass = "DogPrimaryKey",
+                    dictionaryGetter = DictionaryAllTypes::getColumnRealmDictionary,
+                    dictionarySetter = DictionaryAllTypes::setColumnRealmDictionary,
+                    initializedDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_HELLO, KEY_BYE to VALUE_LINK_BYE, KEY_NULL to null)),
+                    alternativeDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_BYE, KEY_BYE to VALUE_LINK_HELLO, KEY_NULL to null)),
+                    notPresentValue = VALUE_LINK_NOT_PRESENT,
+                    populatedGetter = PopulatedDictionaryClass::populatedRealmModelDictionary,
+                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myRealmModelDictionary,
+                    typeAsserter = RealmModelAsserter()
+            )
     )
 
     // Create Mixed testers now
@@ -914,21 +914,7 @@ fun managedFactory(): List<DictionaryTester> {
             )
     )
 
-//    return primitiveTesters.plus(mixedTesters)
-    return primitiveTesters.plus(
-        ManagedDictionaryTester(
-            testerClass = "Mixed",
-            mixedType = MixedType.OBJECT,
-            dictionaryGetter = DictionaryAllTypes::getColumnMixedDictionary,
-            dictionarySetter = DictionaryAllTypes::setColumnMixedDictionary,
-            initializedDictionary = RealmDictionary<Mixed>().init(getMixedKeyValuePairs(MixedType.OBJECT)),
-            alternativeDictionary = RealmDictionary<Mixed>().init(getMixedKeyValuePairs(MixedType.OBJECT, true)),
-            notPresentValue = VALUE_MIXED_NOT_PRESENT,
-            populatedGetter = PopulatedDictionaryClass::populatedMixedDictionary,
-            primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myMixedDictionary,
-            typeAsserter = MixedAsserter()
-        )
-    )
+    return primitiveTesters.plus(mixedTesters)
 }
 
 /**

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
@@ -25,6 +25,7 @@ import io.realm.kotlin.where
 import io.realm.rule.BlockingLooperThread
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
+import java.lang.reflect.InvocationTargetException
 import java.util.*
 import kotlin.reflect.KFunction1
 import kotlin.reflect.KFunction2
@@ -486,7 +487,7 @@ class ManagedDictionaryTester<T : Any>(
         }
     }
 
-    override fun fieldAccessors() {
+    override fun fieldAccessors(otherConfig: RealmConfiguration?) {
         realm.executeTransaction { transactionRealm ->
             val container = transactionRealm.createObject<PopulatedDictionaryClass>()
             val dictionary = populatedGetter.get(container)
@@ -494,6 +495,15 @@ class ManagedDictionaryTester<T : Any>(
             assertTrue(dictionary.isManaged)
             assertFalse(dictionary.isEmpty())
         }
+
+        assertNotNull(otherConfig)
+        typeAsserter.assertAccessorSetter(
+            realm,
+            dictionaryGetter,
+            dictionarySetter,
+            initializedDictionary,
+            otherConfig
+        )
     }
 
     override fun addMapChangeListener() {
@@ -707,172 +717,172 @@ enum class ChangeListenerOperation {
  */
 fun managedFactory(): List<DictionaryTester> {
     val primitiveTesters = listOf<DictionaryTester>(
-            ManagedDictionaryTester(
-                    testerClass = "Long",
-                    dictionaryGetter = DictionaryAllTypes::getColumnLongDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnLongDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredLongDictionary,
-                    initializedDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toLong(), KEY_BYE to VALUE_NUMERIC_BYE.toLong(), KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toLong(), KEY_BYE to VALUE_NUMERIC_HELLO.toLong(), KEY_NULL to null)),
-                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toLong(),
-                    populatedGetter = PopulatedDictionaryClass::populatedLongDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myLongDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Int",
-                    dictionaryGetter = DictionaryAllTypes::getColumnIntegerDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnIntegerDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredIntegerDictionary,
-                    initializedDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO, KEY_BYE to VALUE_NUMERIC_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE, KEY_BYE to VALUE_NUMERIC_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedIntDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myIntDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Short",
-                    dictionaryGetter = DictionaryAllTypes::getColumnShortDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnShortDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredShortDictionary,
-                    initializedDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toShort(), KEY_BYE to VALUE_NUMERIC_BYE.toShort(), KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toShort(), KEY_BYE to VALUE_NUMERIC_HELLO.toShort(), KEY_NULL to null)),
-                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toShort(),
-                    populatedGetter = PopulatedDictionaryClass::populatedShortDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myShortDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Byte",
-                    dictionaryGetter = DictionaryAllTypes::getColumnByteDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnByteDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredByteDictionary,
-                    initializedDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toByte(), KEY_BYE to VALUE_NUMERIC_BYE.toByte(), KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toByte(), KEY_BYE to VALUE_NUMERIC_HELLO.toByte(), KEY_NULL to null)),
-                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toByte(),
-                    populatedGetter = PopulatedDictionaryClass::populatedByteDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myByteDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Float",
-                    dictionaryGetter = DictionaryAllTypes::getColumnFloatDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnFloatDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredFloatDictionary,
-                    initializedDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toFloat(), KEY_BYE to VALUE_NUMERIC_BYE.toFloat(), KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toFloat(), KEY_BYE to VALUE_NUMERIC_HELLO.toFloat(), KEY_NULL to null)),
-                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toFloat(),
-                    populatedGetter = PopulatedDictionaryClass::populatedFloatDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myFloatDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Double",
-                    dictionaryGetter = DictionaryAllTypes::getColumnDoubleDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnDoubleDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDoubleDictionary,
-                    initializedDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toDouble(), KEY_BYE to VALUE_NUMERIC_BYE.toDouble(), KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toDouble(), KEY_BYE to VALUE_NUMERIC_HELLO.toDouble(), KEY_NULL to null)),
-                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toDouble(),
-                    populatedGetter = PopulatedDictionaryClass::populatedDoubleDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDoubleDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "String",
-                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
-                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_HELLO, KEY_BYE to VALUE_STRING_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_BYE, KEY_BYE to VALUE_STRING_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_STRING_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "String-NonLatin",
-                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
-                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_NULL_NON_LATIN to null)),
-                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_NULL_NON_LATIN to null)),
-                    notPresentValue = VALUE_STRING_NON_LATIN_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Boolean",
-                    dictionaryGetter = DictionaryAllTypes::getColumnBooleanDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnBooleanDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBooleanDictionary,
-                    initializedDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_HELLO, KEY_BYE to VALUE_BOOLEAN_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_BYE, KEY_BYE to VALUE_BOOLEAN_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_BOOLEAN_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedBooleanDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBooleanDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Date",
-                    dictionaryGetter = DictionaryAllTypes::getColumnDateDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnDateDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDateDictionary,
-                    initializedDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_HELLO, KEY_BYE to VALUE_DATE_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_BYE, KEY_BYE to VALUE_DATE_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_DATE_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedDateDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDateDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "Decimal128",
-                    dictionaryGetter = DictionaryAllTypes::getColumnDecimal128Dictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnDecimal128Dictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDecimal128Dictionary,
-                    initializedDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_HELLO, KEY_BYE to VALUE_DECIMAL128_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_BYE, KEY_BYE to VALUE_DECIMAL128_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_DECIMAL128_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedDecimal128Dictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDecimal128Dictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "ByteArray",
-                    dictionaryGetter = DictionaryAllTypes::getColumnBinaryDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnBinaryDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBinaryDictionary,
-                    initializedDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_HELLO, KEY_BYE to VALUE_BINARY_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_BYE, KEY_BYE to VALUE_BINARY_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_BINARY_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedBinaryDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBinaryDictionary,
-                    typeAsserter = BinaryAsserter()
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "ObjectId",
-                    dictionaryGetter = DictionaryAllTypes::getColumnObjectIdDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnObjectIdDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredObjectIdDictionary,
-                    initializedDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_HELLO, KEY_BYE to VALUE_OBJECT_ID_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_BYE, KEY_BYE to VALUE_OBJECT_ID_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_OBJECT_ID_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedObjectIdDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myObjectIdDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "UUID",
-                    dictionaryGetter = DictionaryAllTypes::getColumnUUIDDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnUUIDDictionary,
-                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredUUIDDictionary,
-                    initializedDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_HELLO, KEY_BYE to VALUE_UUID_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_BYE, KEY_BYE to VALUE_UUID_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_UUID_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedUUIDDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myUUIDDictionary
-            ),
-            ManagedDictionaryTester(
-                    testerClass = "DogPrimaryKey",
-                    dictionaryGetter = DictionaryAllTypes::getColumnRealmDictionary,
-                    dictionarySetter = DictionaryAllTypes::setColumnRealmDictionary,
-                    initializedDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_HELLO, KEY_BYE to VALUE_LINK_BYE, KEY_NULL to null)),
-                    alternativeDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_BYE, KEY_BYE to VALUE_LINK_HELLO, KEY_NULL to null)),
-                    notPresentValue = VALUE_LINK_NOT_PRESENT,
-                    populatedGetter = PopulatedDictionaryClass::populatedRealmModelDictionary,
-                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myRealmModelDictionary,
-                    typeAsserter = RealmModelAsserter()
-            )
+//            ManagedDictionaryTester(
+//                    testerClass = "Long",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnLongDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnLongDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredLongDictionary,
+//                    initializedDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toLong(), KEY_BYE to VALUE_NUMERIC_BYE.toLong(), KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Long>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toLong(), KEY_BYE to VALUE_NUMERIC_HELLO.toLong(), KEY_NULL to null)),
+//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toLong(),
+//                    populatedGetter = PopulatedDictionaryClass::populatedLongDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myLongDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Int",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnIntegerDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnIntegerDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredIntegerDictionary,
+//                    initializedDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO, KEY_BYE to VALUE_NUMERIC_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Int>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE, KEY_BYE to VALUE_NUMERIC_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedIntDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myIntDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Short",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnShortDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnShortDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredShortDictionary,
+//                    initializedDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toShort(), KEY_BYE to VALUE_NUMERIC_BYE.toShort(), KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Short>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toShort(), KEY_BYE to VALUE_NUMERIC_HELLO.toShort(), KEY_NULL to null)),
+//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toShort(),
+//                    populatedGetter = PopulatedDictionaryClass::populatedShortDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myShortDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Byte",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnByteDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnByteDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredByteDictionary,
+//                    initializedDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toByte(), KEY_BYE to VALUE_NUMERIC_BYE.toByte(), KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Byte>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toByte(), KEY_BYE to VALUE_NUMERIC_HELLO.toByte(), KEY_NULL to null)),
+//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toByte(),
+//                    populatedGetter = PopulatedDictionaryClass::populatedByteDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myByteDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Float",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnFloatDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnFloatDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredFloatDictionary,
+//                    initializedDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toFloat(), KEY_BYE to VALUE_NUMERIC_BYE.toFloat(), KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Float>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toFloat(), KEY_BYE to VALUE_NUMERIC_HELLO.toFloat(), KEY_NULL to null)),
+//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toFloat(),
+//                    populatedGetter = PopulatedDictionaryClass::populatedFloatDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myFloatDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Double",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnDoubleDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnDoubleDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDoubleDictionary,
+//                    initializedDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_HELLO.toDouble(), KEY_BYE to VALUE_NUMERIC_BYE.toDouble(), KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Double>().init(listOf(KEY_HELLO to VALUE_NUMERIC_BYE.toDouble(), KEY_BYE to VALUE_NUMERIC_HELLO.toDouble(), KEY_NULL to null)),
+//                    notPresentValue = VALUE_NUMERIC_NOT_PRESENT.toDouble(),
+//                    populatedGetter = PopulatedDictionaryClass::populatedDoubleDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDoubleDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "String",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
+//                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_HELLO, KEY_BYE to VALUE_STRING_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO to VALUE_STRING_BYE, KEY_BYE to VALUE_STRING_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_STRING_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "String-NonLatin",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnStringDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnStringDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredStringDictionary,
+//                    initializedDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_NULL_NON_LATIN to null)),
+//                    alternativeDictionary = RealmDictionary<String>().init(listOf(KEY_HELLO_NON_LATIN to VALUE_STRING_NON_LATIN_BYE, KEY_BYE_NON_LATIN to VALUE_STRING_NON_LATIN_HELLO, KEY_NULL_NON_LATIN to null)),
+//                    notPresentValue = VALUE_STRING_NON_LATIN_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedStringDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myStringDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Boolean",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnBooleanDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnBooleanDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBooleanDictionary,
+//                    initializedDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_HELLO, KEY_BYE to VALUE_BOOLEAN_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Boolean>().init(listOf(KEY_HELLO to VALUE_BOOLEAN_BYE, KEY_BYE to VALUE_BOOLEAN_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_BOOLEAN_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedBooleanDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBooleanDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Date",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnDateDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnDateDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDateDictionary,
+//                    initializedDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_HELLO, KEY_BYE to VALUE_DATE_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Date>().init(listOf(KEY_HELLO to VALUE_DATE_BYE, KEY_BYE to VALUE_DATE_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_DATE_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedDateDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDateDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "Decimal128",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnDecimal128Dictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnDecimal128Dictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredDecimal128Dictionary,
+//                    initializedDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_HELLO, KEY_BYE to VALUE_DECIMAL128_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<Decimal128>().init(listOf(KEY_HELLO to VALUE_DECIMAL128_BYE, KEY_BYE to VALUE_DECIMAL128_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_DECIMAL128_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedDecimal128Dictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myDecimal128Dictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "ByteArray",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnBinaryDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnBinaryDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredBinaryDictionary,
+//                    initializedDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_HELLO, KEY_BYE to VALUE_BINARY_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<ByteArray>().init(listOf(KEY_HELLO to VALUE_BINARY_BYE, KEY_BYE to VALUE_BINARY_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_BINARY_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedBinaryDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myBinaryDictionary,
+//                    typeAsserter = BinaryAsserter()
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "ObjectId",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnObjectIdDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnObjectIdDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredObjectIdDictionary,
+//                    initializedDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_HELLO, KEY_BYE to VALUE_OBJECT_ID_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<ObjectId>().init(listOf(KEY_HELLO to VALUE_OBJECT_ID_BYE, KEY_BYE to VALUE_OBJECT_ID_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_OBJECT_ID_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedObjectIdDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myObjectIdDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "UUID",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnUUIDDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnUUIDDictionary,
+//                    requiredDictionaryGetter = DictionaryAllTypes::getColumnRequiredUUIDDictionary,
+//                    initializedDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_HELLO, KEY_BYE to VALUE_UUID_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<UUID>().init(listOf(KEY_HELLO to VALUE_UUID_BYE, KEY_BYE to VALUE_UUID_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_UUID_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedUUIDDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myUUIDDictionary
+//            ),
+//            ManagedDictionaryTester(
+//                    testerClass = "DogPrimaryKey",
+//                    dictionaryGetter = DictionaryAllTypes::getColumnRealmDictionary,
+//                    dictionarySetter = DictionaryAllTypes::setColumnRealmDictionary,
+//                    initializedDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_HELLO, KEY_BYE to VALUE_LINK_BYE, KEY_NULL to null)),
+//                    alternativeDictionary = RealmDictionary<DogPrimaryKey>().init(listOf(KEY_HELLO to VALUE_LINK_BYE, KEY_BYE to VALUE_LINK_HELLO, KEY_NULL to null)),
+//                    notPresentValue = VALUE_LINK_NOT_PRESENT,
+//                    populatedGetter = PopulatedDictionaryClass::populatedRealmModelDictionary,
+//                    primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myRealmModelDictionary,
+//                    typeAsserter = RealmModelAsserter()
+//            )
     )
 
     // Create Mixed testers now
@@ -904,7 +914,21 @@ fun managedFactory(): List<DictionaryTester> {
             )
     )
 
-    return primitiveTesters.plus(mixedTesters)
+//    return primitiveTesters.plus(mixedTesters)
+    return primitiveTesters.plus(
+        ManagedDictionaryTester(
+            testerClass = "Mixed",
+            mixedType = MixedType.OBJECT,
+            dictionaryGetter = DictionaryAllTypes::getColumnMixedDictionary,
+            dictionarySetter = DictionaryAllTypes::setColumnMixedDictionary,
+            initializedDictionary = RealmDictionary<Mixed>().init(getMixedKeyValuePairs(MixedType.OBJECT)),
+            alternativeDictionary = RealmDictionary<Mixed>().init(getMixedKeyValuePairs(MixedType.OBJECT, true)),
+            notPresentValue = VALUE_MIXED_NOT_PRESENT,
+            populatedGetter = PopulatedDictionaryClass::populatedMixedDictionary,
+            primaryKeyDictionaryProperty = PrimaryKeyDictionaryContainer::myMixedDictionary,
+            typeAsserter = MixedAsserter()
+        )
+    )
 }
 
 /**
@@ -948,6 +972,24 @@ open class TypeAsserter<T> {
     // ByteArray, RealmModel and Mixed require different testing here
     open fun assertEqualsHelper(realm: Realm, value: T?, valueFromRealm: T?) =
             assertEquals(value, valueFromRealm)
+
+    // RealmModel requires different testing here
+    open fun assertAccessorSetter(
+        realm: Realm,
+        dictionaryGetter: KFunction1<DictionaryAllTypes, RealmDictionary<T>>,
+        dictionarySetter: KFunction2<DictionaryAllTypes, RealmDictionary<T>, Unit>,
+        initializedDictionary: RealmDictionary<T>,
+        otherConfig: RealmConfiguration
+    ) {
+        realm.executeTransaction { transactionRealm ->
+            val anotherContainer = transactionRealm.createObject<DictionaryAllTypes>("PRIMARY_KEY")
+            dictionarySetter.call(anotherContainer, initializedDictionary)
+            val dictionary = dictionaryGetter.call(anotherContainer)
+            assertNotNull(dictionary)
+            assertTrue(dictionary.isManaged)
+            assertEquals(initializedDictionary.size, dictionary.size)
+        }
+    }
 
     fun assertChangeListenerUpdates(
             testerClass: String,
@@ -1120,6 +1162,54 @@ class RealmModelAsserter : TypeAsserter<DogPrimaryKey>() {
 
         assertNotNull(modelFromRealm)
         assertEquals(modelFromRealm, valueFromRealm)
+    }
+
+    override fun assertAccessorSetter(
+        realm: Realm,
+        dictionaryGetter: KFunction1<DictionaryAllTypes, RealmDictionary<DogPrimaryKey>>,
+        dictionarySetter: KFunction2<DictionaryAllTypes, RealmDictionary<DogPrimaryKey>, Unit>,
+        initializedDictionary: RealmDictionary<DogPrimaryKey>,
+        otherConfig: RealmConfiguration
+    ) {
+        realm.executeTransaction { transactionRealm ->
+            // Setter fails when calling with a dictionary that contains unmanaged objects
+            // The throwable is an IllegalArgumentException wrapped inside an InvocationTargetException
+            // due to calling 'call' on the KFunction2
+            val anotherContainer = transactionRealm.createObject<DictionaryAllTypes>("A_PK")
+            assertFailsWith<InvocationTargetException> {
+                dictionarySetter.call(anotherContainer, initializedDictionary)
+            }.let { e ->
+                assertTrue {
+                    e.targetException is IllegalArgumentException
+                }
+            }
+        }
+
+        // Setter fails when calling with a dictionary containing managed objects from another Realm
+        var otherRealmDictionary: RealmDictionary<DogPrimaryKey>? = null
+        val otherRealm = Realm.getInstance(otherConfig)
+        otherRealm.executeTransaction { transactionRealm ->
+            val otherRealmContainer = transactionRealm.createObject<DictionaryAllTypes>("ANOTHER_PK")
+            otherRealmDictionary = dictionaryGetter.call(otherRealmContainer)
+                .apply { this.putAll(initializedDictionary) }
+        }
+
+        realm.executeTransaction { transactionRealm ->
+            val anotherContainer = transactionRealm.createObject<DictionaryAllTypes>("YET_ANOTHER_PK")
+
+            // The throwable is an IllegalArgumentException wrapped inside an InvocationTargetException
+            // due to calling 'call' on the KFunction2
+            assertFailsWith<InvocationTargetException> {
+                dictionarySetter.call(anotherContainer, otherRealmDictionary)
+            }.let { e ->
+                assertTrue {
+                    e.targetException is IllegalArgumentException
+                }
+            }
+        }
+
+        // Remember to close the other Realm!
+        otherRealm.close()
     }
 }
 

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ParameterizedDictionaryTests.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ParameterizedDictionaryTests.kt
@@ -186,7 +186,7 @@ class ParameterizedDictionaryTests(
 
     @Test
     fun fieldAccessors() {
-        tester.fieldAccessors()
+        tester.fieldAccessors(configFactory.createConfiguration("alternativeRealm"))
     }
 
     @Test

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ParameterizedDictionaryTests.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ParameterizedDictionaryTests.kt
@@ -54,8 +54,7 @@ class ParameterizedDictionaryTests(
         fun testTypes(): List<DictionaryTester> {
             return DictionaryMode.values().map { type ->
                 when (type) {
-//                    DictionaryMode.UNMANAGED -> unmanagedFactory()
-                    DictionaryMode.UNMANAGED -> listOf()
+                    DictionaryMode.UNMANAGED -> unmanagedFactory()
                     DictionaryMode.MANAGED -> managedFactory()
                 }
             }.flatten()

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/UnmanagedDictionaryTesters.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/UnmanagedDictionaryTesters.kt
@@ -210,10 +210,10 @@ class UnmanagedGenericTester<T : Any>(
         }
     }
 
-    override fun copyToRealm() = Unit                                   // Not applicable
-    override fun copyToRealmOrUpdate() = Unit                           // Not applicable
-    override fun copyFromRealm() = Unit                                 // Not applicable
-    override fun fieldAccessors() = Unit                                // Not applicable
+    override fun copyToRealm() = Unit                                       // Not applicable
+    override fun copyToRealmOrUpdate() = Unit                               // Not applicable
+    override fun copyFromRealm() = Unit                                     // Not applicable
+    override fun fieldAccessors(otherConfig: RealmConfiguration?) = Unit    // Not applicable
 
     override fun addMapChangeListener() {
         val dictionary = RealmDictionary<T>()


### PR DESCRIPTION
A guard against unmanaged objects when calling a dictionary setter has been added in the proxy code. This way we control that only managed objects can be put.

The semantics for `RealmDictionary<Mixed>` containing `RealmModel`s are different though: if a setter is called using a dictionary containing a `Mixed` instance containing an unmanaged `RealmModel`, that model will be implicitly copied to Realm since that is the default behaviour for lists and sets as well.