### PR TITLE
Add migration test for embedded objects

### DIFF
--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -56,6 +56,8 @@ import io.realm.entities.PrimaryKeyAsString;
 import io.realm.entities.StringOnly;
 import io.realm.entities.StringOnlyRequired;
 import io.realm.entities.Thread;
+import io.realm.entities.embedded.EmbeddedSimpleChild;
+import io.realm.entities.embedded.EmbeddedSimpleParent;
 import io.realm.entities.migration.MigrationClassRenamed;
 import io.realm.entities.migration.MigrationCore6PKStringIndexedByDefault;
 import io.realm.entities.migration.MigrationFieldRenameAndAdd;
@@ -1486,6 +1488,42 @@ public class RealmMigrationTests {
         assertTrue(schema.hasPrimaryKey());
         assertFalse(schema.hasIndex(ObjectIdPrimaryKey.PROPERTY_OBJECT_ID));
         realm.close();
+    }
+
+    @Test
+    public void migrate_embeddedObject(){
+        // Create schema v0
+        RealmConfiguration originalConfig = configFactory.createConfigurationBuilder()
+                .schema(StringOnly.class)
+                .build();
+
+        Realm.getInstance(originalConfig).close();
+
+        RealmMigration migration = new RealmMigration() {
+            @Override
+            public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+                RealmSchema schema = realm.getSchema();
+                RealmObjectSchema embeddedSimpleChildSchema = schema
+                        .create(EmbeddedSimpleChild.NAME)
+                        .addField("childId", String.class, FieldAttribute.REQUIRED);
+
+                schema.create(EmbeddedSimpleParent.NAME)
+                        .addField("_id", String.class, FieldAttribute.PRIMARY_KEY, FieldAttribute.REQUIRED)
+                        .addRealmObjectField(EmbeddedSimpleParent.CHILD, embeddedSimpleChildSchema);
+
+                embeddedSimpleChildSchema.setEmbedded(true);
+            }
+        };
+
+        // Create schema v1
+        RealmConfiguration realmConfig = configFactory
+                .createConfigurationBuilder()
+                .schemaVersion(1)
+                .schema(StringOnly.class, EmbeddedSimpleParent.class, EmbeddedSimpleChild.class)
+                .migration(migration)
+                .build();
+
+        realm = Realm.getInstance(realmConfig);
     }
 
     // TODO Add unit tests for default nullability

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/entities/embedded/EmbeddedSimpleParent.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/entities/embedded/EmbeddedSimpleParent.kt
@@ -21,5 +21,10 @@ import java.util.*
 
 // Top-level object describing a simple embedded objects structure consisting of only an object reference.
 open class EmbeddedSimpleParent(@PrimaryKey var _id: String = UUID.randomUUID().toString()) : RealmObject() {
+    companion object {
+        const val NAME = "EmbeddedSimpleParent"
+        const val CHILD = "child"
+    }
+
     var child: EmbeddedSimpleChild? = null
 }


### PR DESCRIPTION
Adds a test to validate that it is possible to perform a schema migration that involves embedded objects.