### PR TITLE
Support toString DynamicRealmObject on dicts and sets fields

### DIFF
--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedDictionaryTesters.kt
@@ -449,7 +449,23 @@ class ManagedDictionaryTester<T : Any>(
 
         assertEquals(1, dynamicObject.get<RealmDictionary<T>>(dictionaryFieldName).size)
 
+        // Validate that dict is properly represented as a String
+        validateToString(dynamicObject, dynamicDictionary)
+
         dynamicRealm.close()
+    }
+
+    private fun validateToString(dynamicObject: DynamicRealmObject, dynamicDictionary: RealmDictionary<*>) {
+        val type = when (dictionaryFieldClass.simpleName) {
+            "Byte", "Short", "Integer" -> "Long"
+            else -> dictionaryFieldClass.simpleName
+        }
+
+        val expectedDictionaryString = "${dictionaryFieldName}:RealmDictionary<$type>[${dynamicDictionary.size}]"
+        assertTrue(
+            dynamicObject.toString().contains(expectedDictionaryString),
+            "DynamicRealmObject does not contain expected RealmDictionary string: $expectedDictionaryString"
+        )
     }
 
     private fun doObjectDynamicTest() {
@@ -505,6 +521,9 @@ class ManagedDictionaryTester<T : Any>(
         }
 
         assertEquals(1, dynamicObject.get<RealmDictionary<T>>(dictionaryFieldName).size)
+
+        // Validate that dict is properly represented as a String
+        validateToString(dynamicObject, dynamicDictionary)
 
         dynamicRealm.close()
     }

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedSetTester.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/ManagedSetTester.kt
@@ -387,7 +387,23 @@ class ManagedSetTester<T : Any>(
         assertSetContainsSet(listOf(notPresentValue), dynamicSet)
         assertEquals(1, dynamicObject.get<RealmSet<T>>(setFieldName).size)
 
+        // Validate that set is properly represented as a String
+        validateToString(dynamicObject, dynamicSet)
+
         dynamicRealm.close()
+    }
+
+    fun validateToString(dynamicObject: DynamicRealmObject, dynamicSet: RealmSet<*>) {
+        val type = when (setFieldClass.simpleName) {
+            "Byte", "Short", "Integer" -> "Long"
+            else -> setFieldClass.simpleName
+        }
+
+        val expectedSetString = "${setFieldName}:RealmSet<$type>[${dynamicSet.size}]"
+        assertTrue(
+            dynamicObject.toString().contains(expectedSetString),
+            "DynamicRealmObject does not contain expected RealmSet string: $expectedSetString"
+        )
     }
 
     override fun insert() {

--- a/realm/realm-library/src/androidTest/kotlin/io/realm/RealmModelManagedSetTester.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/RealmModelManagedSetTester.kt
@@ -193,6 +193,9 @@ class RealmModelManagedSetTester<T : Any>(
 
         assertEquals(1, dynamicObject.getRealmSet(setFieldName, setFieldClass).size)
 
+        // Validate that set is properly represented as a String
+        managedTester.validateToString(dynamicObject, dynamicSet)
+
         dynamicRealm.close()
     }
 
@@ -244,6 +247,9 @@ class RealmModelManagedSetTester<T : Any>(
         }
 
         assertEquals(1, dynamicObject.get<RealmSet<T>>(setFieldName).size)
+
+        // Validate that set is properly represented as a String
+        managedTester.validateToString(dynamicObject, dynamicSet)
 
         dynamicRealm.close()
     }

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -1767,10 +1767,11 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                             ? "null"
                             : proxyState.getRow$realm().getTable().getLinkTarget(columnKey).getClassName());
                     break;
-                case LIST:
+                case LIST: {
                     String targetClassName = proxyState.getRow$realm().getTable().getLinkTarget(columnKey).getClassName();
                     sb.append(String.format(Locale.US, "RealmList<%s>[%s]", targetClassName, proxyState.getRow$realm().getModelList(columnKey).size()));
                     break;
+                }
                 case INTEGER_LIST:
                     sb.append(String.format(Locale.US, "RealmList<Long>[%s]", proxyState.getRow$realm().getValueList(columnKey, type).size()));
                     break;
@@ -1804,6 +1805,82 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
                 case MIXED_LIST:
                     sb.append(String.format(Locale.US, "RealmList<RealmAny>[%s]", proxyState.getRow$realm().getValueList(columnKey, type).size()));
                     break;
+                case STRING_TO_INTEGER_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<Long>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_BOOLEAN_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<Boolean>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_STRING_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<String>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_BINARY_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<byte[]>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_DATE_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<Date>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_FLOAT_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<Float>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_DOUBLE_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<Double>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_DECIMAL128_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<Decimal128>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_OBJECT_ID_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<ObjectId>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_UUID_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<UUID>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_MIXED_MAP:
+                    sb.append(String.format(Locale.US, "RealmDictionary<RealmAny>[%s]", proxyState.getRow$realm().getValueMap(columnKey, type).size()));
+                    break;
+                case STRING_TO_LINK_MAP: {
+                    String targetClassName = proxyState.getRow$realm().getTable().getLinkTarget(columnKey).getClassName();
+                    sb.append(String.format(Locale.US, "RealmDictionary<%s>[%s]", targetClassName, proxyState.getRow$realm().getModelMap(columnKey).size()));
+                    break;
+                }
+                case INTEGER_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<Long>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case BOOLEAN_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<Boolean>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case STRING_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<String>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case BINARY_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<byte[]>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case DATE_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<Date>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case FLOAT_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<Float>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case DOUBLE_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<Double>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case DECIMAL128_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<Decimal128>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case OBJECT_ID_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<ObjectId>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case UUID_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<UUID>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case MIXED_SET:
+                    sb.append(String.format(Locale.US, "RealmSet<RealmAny>[%s]", proxyState.getRow$realm().getValueSet(columnKey, type).size()));
+                    break;
+                case LINK_SET: {
+                    String targetClassName = proxyState.getRow$realm().getTable().getLinkTarget(columnKey).getClassName();
+                    sb.append(String.format(Locale.US, "RealmSet<%s>[%s]", targetClassName, proxyState.getRow$realm().getModelSet(columnKey).size()));
+                    break;
+                }
                 default:
                     sb.append("?");
                     break;


### PR DESCRIPTION
Implement string conversion for `DynamicRealmObject` `RealmDictionary` and `RealmField` fields.

It will render the type and how many elements the field contains:

- `exampleSetField:RealmSet<String>[4]`
- `exampleDictionaryField:RealmDictionary<String>[8]` 

