### PR TITLE
Fix notifications on Linux 5.5 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 10.5.1 (YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixes
+* Notifications now trigger correctly on Linux kernel 5.5 and above. So far this only impacted the preview emulator image for Android 12. (Issue[#7321](https://github.com/realm/realm-java/issues/7321))   
+
+### Compatibility
+* File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.x.y series.
+* Realm Studio 10.0.0 or above is required to open Realms created by this version.
+
+### Internal
+* Updated to Realm Core 10.x.x, commit xxx.
+
+
 ## 10.5.0 (2021-05-07)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * None.
 
 ### Fixes
-* Notifications now trigger correctly on Linux kernel 5.5 and above. So far this only impacted the preview emulator image for Android 12. (Issue[#7321](https://github.com/realm/realm-java/issues/7321))   
+* [RealmApp] Errors related to "uncaught exception in notifier thread: N5realm11KeyNotFoundE: No such object". This could happen in a sync'd app when a linked object was deleted by another client.
+* Notifications now trigger correctly on Linux kernel 5.5 and above. So far this only impacted the preview emulator image for Android 12. (Issue[#7321](https://github.com/realm/realm-java/issues/7321))  
+
 
 ### Compatibility
 * File format: Generates Realms with format v20. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
@@ -12,7 +14,7 @@
 * Realm Studio 10.0.0 or above is required to open Realms created by this version.
 
 ### Internal
-* Updated to Realm Core 10.x.x, commit xxx.
+* Updated to Realm Core 10.7.2, commit ae14e6be382a72a9252d4e6710c2710c1ea4e688.
 
 
 ## 10.5.0 (2021-05-07)

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -197,10 +197,11 @@ endif()
 #FIXME maybe-uninitialized is reported by table_view.cpp:272:15:
 #     'best.m_nanoseconds' was declared here
 #     -Wno-missing-field-initializers disable in object store as well.
+# FIXME See https://github.com/realm/realm-core/issues/4732
 set(WARNING_CXX_FLAGS "-Werror -Wall -Wextra -pedantic -Wmissing-declarations \
     -Wempty-body -Wparentheses -Wunknown-pragmas -Wunreachable-code \
     -Wno-missing-field-initializers -Wno-unevaluated-expression -Wno-unreachable-code \
-    -Wno-c99-extensions")
+    -Wno-c99-extensions -Wno-dtor-name")
 set(REALM_COMMON_CXX_FLAGS "${REALM_COMMON_CXX_FLAGS} -DREALM_ANDROID -DREALM_HAVE_CONFIG -DPIC -fdata-sections -pthread -frtti -fvisibility=hidden -fsigned-char -fno-stack-protector -std=c++17")
 if (REALM_ENABLE_SYNC)
     set(REALM_COMMON_CXX_FLAGS "${REALM_COMMON_CXX_FLAGS} -DREALM_ENABLE_SYNC=1")

--- a/realm/realm-library/src/testUtils/java/io/realm/services/RemoteProcessService.java
+++ b/realm/realm-library/src/testUtils/java/io/realm/services/RemoteProcessService.java
@@ -24,6 +24,7 @@ import android.os.IBinder;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
+import android.os.SystemClock;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -152,8 +153,35 @@ public class RemoteProcessService extends Service {
         }
     };
 
+    public final static Step stepCreateObjects = new Step(30) {
+
+        @Override
+        void run() {
+            thiz.testRealm = Realm.getInstance(getConfiguration());
+            thiz.testRealm.executeTransaction(new Realm.Transaction() {
+                @Override
+                public void execute(Realm realm) {
+                    realm.createObject(AllTypes.class);
+                }
+            });
+            SystemClock.sleep(1000);
+            thiz.testRealm.executeTransaction(new Realm.Transaction() {
+                @Override
+                public void execute(Realm realm) {
+                    realm.createObject(AllTypes.class);
+                }
+            });
+            thiz.testRealm.close();
+            response(null);
+            Runtime.getRuntime().exit(0);
+        }
+    };
+
     private static RealmConfiguration getConfiguration() {
-        return new RealmConfiguration.Builder().modules(new AllTypesModelModule()).build();
+        return new RealmConfiguration.Builder()
+                .allowQueriesOnUiThread(true)
+                .allowWritesOnUiThread(true)
+                .modules(new AllTypesModelModule()).build();
     }
 
 }


### PR DESCRIPTION
Closes https://github.com/realm/realm-java/issues/7321
A fix for #7321 is currently being implemented in Core, but can currently only be caught on Android 12 Emulator preview images.

This PR re-enables interprocess tests and adds a test for interprocess notifications. The fix has been verified to work manually, but since the first attempt didn't account for multiprocess notifications, I added a test for it as part of the PR. But generally, any test that expects multiple notifications would break.