### PR TITLE
Attempt to capture bug with waitForInitialRemoteData 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 10.7.0 (YYYY-MM-DD)
+## 10.6.2 (YYYY-MM-DD)
 
 ### Enhancements
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 10.7.0 (YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixed
+* [RealmApp] Realm.getInstanceAsync does not wait for the initial remote data. (Issue [#7501](https://github.com/realm/realm-java/issues/7517))
+
+### Compatibility
+* File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
+* Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
+
+### Internal
+* None.
+
 ## 10.6.1 (2021-07-01)
 
 ### Enhancements

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -391,7 +391,7 @@ final class RealmCache {
         }
 
         // If there is no Realm file it means that we need to sync the initial remote data in the worker thread.
-        if (!configuration.realmExists()) {
+        if (configuration.isSyncConfiguration() && !configuration.realmExists()) {
             pendingRealmFileCreation.add(configuration.getPath());
         }
 

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncedRealmIntegrationTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncedRealmIntegrationTests.kt
@@ -175,9 +175,9 @@ class SyncedRealmIntegrationTests {
     fun waitForInitialRemoteData_getInstanceAsync() = looperThread.runBlocking {
         // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)
         val configOld: SyncConfiguration = configurationFactory.createSyncConfigurationBuilder(user, user.id)
-                .testSchema(SyncStringOnly::class.java)
-                .testSessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
-                .build()
+            .testSchema(SyncStringOnly::class.java)
+            .testSessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
+            .build()
         Realm.getInstance(configOld).use { realm ->
             // Create many changesets to make sure that download is "slow"
             for (i in 0..999) {
@@ -194,9 +194,9 @@ class SyncedRealmIntegrationTests {
         // Use different user to trigger different path
         val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
         val config: SyncConfiguration = configurationFactory.createSyncConfigurationBuilder(user2, user.id)
-                .testSchema(SyncStringOnly::class.java)
-                .waitForInitialRemoteData()
-                .build()
+            .testSchema(SyncStringOnly::class.java)
+            .waitForInitialRemoteData()
+            .build()
 
         assertFalse(File(config.path).exists())
         Realm.getInstanceAsync(config, object: Realm.Callback() {
@@ -210,6 +210,53 @@ class SyncedRealmIntegrationTests {
                 fail(exception.toString())
             }
         })
+    }
+
+    // Attempt to reproduce: https://github.com/realm/realm-java/issues/7517
+    @Test
+    fun waitForInitialRemoteData_getInstance_race_AsyncAndSync() = looperThread.runBlocking {
+        // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)
+        val configOld: SyncConfiguration = configurationFactory.createSyncConfigurationBuilder(user, user.id)
+            .testSchema(SyncStringOnly::class.java)
+            .testSessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
+            .build()
+        Realm.getInstance(configOld).use { realm ->
+            // Create many changesets to make sure that download is "slow"
+            for (i in 0..999) {
+                realm.executeTransaction { realm ->
+                    realm.createObject(SyncStringOnly::class.java, ObjectId()).chars = "Foo$i"
+                }
+            }
+            realm.syncSession.uploadAllLocalChanges()
+        }
+        user.logOut()
+
+        // 2. Local state should now be completely reset. Open the same sync Realm but different local name again with
+        // a new configuration which should download the uploaded changes (pray it managed to do so within the time frame).
+        // Use different user to trigger different path
+        val user2 = app.registerUserAndLogin(TestHelper.getRandomEmail(), SECRET_PASSWORD)
+        val config: SyncConfiguration = configurationFactory.createSyncConfigurationBuilder(user2, user.id)
+            .testSchema(SyncStringOnly::class.java)
+            .waitForInitialRemoteData()
+            .build()
+
+        assertFalse(File(config.path).exists())
+
+        // Validate both async and sync are properly initialized.
+        Realm.getInstanceAsync(config, object: Realm.Callback() {
+            override fun onSuccess(realm: Realm) {
+                looperThread.closeAfterTest(realm)
+                assertEquals(1000, realm.where(SyncStringOnly::class.java).count())
+                looperThread.testComplete()
+            }
+
+            override fun onError(exception: Throwable) {
+                fail(exception.toString())
+            }
+        })
+        Realm.getInstance(config).use { realm ->
+            assertEquals(1000, realm.where(SyncStringOnly::class.java).count())
+        }
     }
 
     // This tests will start and cancel getting a Realm 10 times. The Realm should be resilient towards that

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncedRealmIntegrationTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncedRealmIntegrationTests.kt
@@ -170,7 +170,8 @@ class SyncedRealmIntegrationTests {
         }
     }
 
-    // Attempt to reproduce: https://github.com/realm/realm-java/issues/7517
+    // Attempt to reproduce: https://github.com/realm/realm-java/issues/7517. getInstanceAsync did not
+    // wait for the initial remote data.
     @Test
     fun waitForInitialRemoteData_getInstanceAsync() = looperThread.runBlocking {
         // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)
@@ -212,7 +213,7 @@ class SyncedRealmIntegrationTests {
         })
     }
 
-    // Attempt to reproduce: https://github.com/realm/realm-java/issues/7517
+    // Try an scenario where a Sync and Async race to wait for the initial remote data.
     @Test
     fun waitForInitialRemoteData_getInstance_race_AsyncAndSync() = looperThread.runBlocking {
         // 1. Copy a valid Realm to the server (and pray it does it within 10 seconds)

--- a/tools/sync_test_server/Dockerfile
+++ b/tools/sync_test_server/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 
 # Copy webserver script and install dependencies
 WORKDIR "/tmp"
-COPY mongodb-realm-command-server.js /tmp
+COPY mongodb-realm-command-server.js /tmp/
 RUN npm install winston@2.4.0 temp httpdispatcher@1.0.0 fs-extra moment is-port-available@0.1.5
 
 # Run integration test server

--- a/tools/sync_test_server/start_server.sh
+++ b/tools/sync_test_server/start_server.sh
@@ -44,6 +44,6 @@ $SCRIPTPATH/app_config_generator.sh $APP_CONFIG_DIR $SCRIPTPATH/app_template tes
 docker network create mongodb-realm-network
 docker build $DOCKERFILE_DIR -t mongodb-realm-command-server || { echo "Failed to build Docker image." ; exit 1 ; }
 ID=$(docker run --rm -i -t -d -v$APP_CONFIG_DIR:/apps --network mongodb-realm-network -p9090:9090 -p8888:8888 -p26000:26000 --name mongodb-realm docker.pkg.github.com/realm/ci/mongodb-realm-test-server:$MONGODB_REALM_VERSION)
-docker run --rm -i -t -d --network container:$ID -v$APP_CONFIG_DIR:/apps -v$TMP_DIR:/tmp --name mongodb-realm-command-server mongodb-realm-command-server
+docker run --rm -i -t -d --network container:$ID -v$APP_CONFIG_DIR:/apps --name mongodb-realm-command-server mongodb-realm-command-server
 
 echo "Template apps are generated in/served from $APP_CONFIG_DIR"


### PR DESCRIPTION
An attempt at capturing #7517 

We have a lot of unit tests covering `Realm.getInstance()` so I suspect the bug is only for `Realm.getInstanceAsync()` but I haven't been able to reproduce it yet.

But both @hennasingh and @mohit-sharma-87 have reported seeing it.