### PR TITLE
Make User.remove() and User.removeAsync() public again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 10.8.0 (YYYY-MM-DD)
 
 ### Enhancements
-* None.
+* [RealmApp] Added `User.remove()` and `User.removeAsync()` that makes it possible to deletes a users Realm(s) from the device.
 
 ### Fixed
+* [RealmApp] Clarified Javadoc for `User.logOut()` and `User.logOutAsync()` as these methods do not delete a Users Realm(s).
 * Build error when having cross module model references (Issue [#7474](https://github.com/realm/realm-java/issues/7474), since v10.4.0)
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 10.8.0 (YYYY-MM-DD)
 
 ### Enhancements
-* [RealmApp] Added `User.remove()` and `User.removeAsync()` that makes it possible to deletes a users Realm(s) from the device.
+* [RealmApp] Added `User.remove()` and `User.removeAsync()` that makes it possible to delete a user's Realm(s) from the device.
 
 ### Fixed
-* [RealmApp] Clarified Javadoc for `User.logOut()` and `User.logOutAsync()` as these methods do not delete a Users Realm(s).
+* [RealmApp] Clarified Javadoc for `User.logOut()` and `User.logOutAsync()` as these methods do not delete a user's Realm(s).
 * Build error when having cross module model references (Issue [#7474](https://github.com/realm/realm-java/issues/7474), since v10.4.0)
 
 ### Compatibility

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
@@ -340,7 +340,17 @@ public class User {
         }.start();
     }
 
-    User remove() throws AppException {
+    /**
+     * Calling this will remove the user and any Realms the user has from the device. No data
+     * is removed from the server.
+     *
+     * If the user is logged in when calling this method, the user is logged out before any data
+     * is deleted.
+     *
+     * @throws AppException if an error occurred while trying to remove the user.
+     * @return the user that was removed.
+     */
+    public User remove() throws AppException {
         boolean loggedIn = isLoggedIn();
         AtomicReference<User> success = new AtomicReference<>(null);
         AtomicReference<AppException> error = new AtomicReference<>(null);
@@ -357,7 +367,18 @@ public class User {
         return this;
     }
 
-    RealmAsyncTask removeAsync(App.Callback<User> callback) {
+    /**
+     * Calling this will asynchronously remove the user and any Realms the user has from the device.
+     * No data is removed from the server.
+     *
+     * If the user is logged in when calling this method, the user is logged out before any data
+     * is deleted.
+     *
+     * @param callback callback when removing the user has completed or failed. The callback will
+     *                 always happen on the same thread as this method is called on.
+     * @throws IllegalStateException if called from a non-looper thread.
+     */
+    public RealmAsyncTask removeAsync(App.Callback<User> callback) {
         Util.checkLooperThread("Asynchronous removal of users is only possible from looper threads.");
         return new Request<User>(App.NETWORK_POOL_EXECUTOR, callback) {
             @Override
@@ -368,10 +389,8 @@ public class User {
     }
 
     /**
-     * Log the user out of the Realm App. This will unregister them on the device, stop any
-     * synchronization to and from the users' Realms, and those Realms will be deleted next time
-     * the app restarts. Therefor logging out should not be done until all changes to Realms have
-     * been uploaded to the server.
+     * Log the user out of the Realm App. This will unregister them on the device and stop any
+     * synchronization to and from the users' Realms.
      * <p>
      * Once the Realm App has confirmed the logout any registered {@link AuthenticationListener}
      * will be notified and user credentials will be deleted from this device.
@@ -379,7 +398,7 @@ public class User {
      * Logging out anonymous users will remove them immediately instead of marking them as
      * {@link User.State#LOGGED_OUT}. All other users will be marked as {@link User.State#LOGGED_OUT}
      * and will still be returned by {@link App#allUsers()}. They can be removed completely by calling
-     * {@link App#removeUser(User} ()}.
+     * {@link User#remove()}.
      *
      * @throws AppException if an error occurred while trying to log the user out of the Realm
      *                      App.
@@ -395,10 +414,8 @@ public class User {
     }
 
     /**
-     * Log the user out of the Realm App asynchronously. This will unregister them on the device, stop any
-     * synchronization to and from the users' Realms, and those Realms will be deleted next time
-     * the app restarts. Therefor logging out should not be done until all changes to Realms have
-     * been uploaded to the server.
+     * Log the user out of the Realm App asynchronously. This will unregister them on the device and
+     * stop any synchronization to and from the users' Realms.
      * <p>
      * Once the Realm App has confirmed the logout any registered {@link AuthenticationListener}
      * will be notified and user credentials will be deleted from this device.
@@ -406,7 +423,7 @@ public class User {
      * Logging out anonymous users will remove them immediately instead of marking them as
      * {@link User.State#LOGGED_OUT}. All other users will be marked as {@link User.State#LOGGED_OUT}
      * and will still be returned by {@link App#allUsers()}. They can be removed completely by calling
-     * {@link App#removeUser(User)} ()}.
+     * {@link User#remove()}.
      *
      * @param callback callback when logging out has completed or failed. The callback will always
      *                 happen on the same thread as this method is called on.

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
@@ -390,15 +390,19 @@ public class User {
 
     /**
      * Log the user out of the Realm App. This will unregister them on the device and stop any
-     * synchronization to and from the users' Realms.
+     * synchronization to and from the users' Realms. Any Realms owned by the user will
+     * not be deleted from the device before {@link User#remove()} is called.
+     *
      * <p>
      * Once the Realm App has confirmed the logout any registered {@link AuthenticationListener}
      * will be notified and user credentials will be deleted from this device.
      * <p>
      * Logging out anonymous users will remove them immediately instead of marking them as
-     * {@link User.State#LOGGED_OUT}. All other users will be marked as {@link User.State#LOGGED_OUT}
-     * and will still be returned by {@link App#allUsers()}. They can be removed completely by calling
-     * {@link User#remove()}.
+     * {@link User.State#LOGGED_OUT}.
+     * <p>
+     * All other users will be marked as {@link User.State#LOGGED_OUT}
+     * and will still be returned by {@link App#allUsers()}. They can be removed completely by
+     * calling {@link User#remove()}.
      *
      * @throws AppException if an error occurred while trying to log the user out of the Realm
      *                      App.
@@ -415,15 +419,17 @@ public class User {
 
     /**
      * Log the user out of the Realm App asynchronously. This will unregister them on the device and
-     * stop any synchronization to and from the users' Realms.
+     * stop any synchronization to and from the users' Realms. Any Realms owned by the user will
+     * not be deleted from the device before {@link User#remove()} is called.
      * <p>
      * Once the Realm App has confirmed the logout any registered {@link AuthenticationListener}
      * will be notified and user credentials will be deleted from this device.
      * <p>
      * Logging out anonymous users will remove them immediately instead of marking them as
-     * {@link User.State#LOGGED_OUT}. All other users will be marked as {@link User.State#LOGGED_OUT}
-     * and will still be returned by {@link App#allUsers()}. They can be removed completely by calling
-     * {@link User#remove()}.
+     * {@link User.State#LOGGED_OUT}.
+     * <p>
+     * All other users will be marked as {@link User.State#LOGGED_OUT} and will still be returned
+     * by {@link App#allUsers()}. They can be removed completely by calling {@link User#remove()}.
      *
      * @param callback callback when logging out has completed or failed. The callback will always
      *                 happen on the same thread as this method is called on.


### PR DESCRIPTION
Spinoff from https://github.com/realm/realm-java/issues/7501 where the discussion there revealed that we have the wrong documentation for logout. Also, .NET already has public methods for removing users, as this is also the only way to delete User Realms easily. So we should expose them in Java as well.

**TODO**
* [x] Tests (We already had them: https://github.com/realm/realm-java/blob/master/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/UserTests.kt#L283)