### PR TITLE
Fix Javadoc generation on JDK11

### DIFF
--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -252,9 +252,8 @@ task javadoc(type: Javadoc) {
 
         links "https://docs.oracle.com/javase/7/docs/api/"
         links "http://reactivex.io/RxJava/javadoc/"
-        // TODO We probably need to add the bson.jar to the classpath for these to work
+        links "https://developer.android.com/reference"
         links "https://www.javadoc.io/doc/org.mongodb/bson/${properties.getProperty('BSON_DEPENDENCY')}/"
-        linksOffline "https://developer.android.com/reference/", "${project.android.sdkDirectory}/docs/reference"
 
         tags = [betaTag]
     }
@@ -410,6 +409,15 @@ project.afterEvaluate {
         // as of android gradle plugin 3.0.0-alpha5, generateJsonModel* triggers native build. Java files must be compiled before them.
         android.buildTypes.all { buildType ->
             tasks["generateJsonModel${variant.name.capitalize()}"].dependsOn "compile${variant.flavorName.capitalize()}${buildType.name.capitalize()}JavaWithJavac"
+        }
+
+        // Set javaDoc task's classpath with the project compiled classes and its dependencies
+        if(variant.name == "objectServerRelease") {
+            def javaCompile = variant.javaCompileProvider.get()
+            javadoc.classpath += files(
+                    javaCompile.destinationDir, // All intermediate Realm compiled classes
+                    javaCompile.classpath.files // Dependencies
+            )
         }
     }
 }


### PR DESCRIPTION
CI won't be able to build this PR as it is a part of #7539.

Fixes the Javadoc generation by pointing the classpath to the project compiled classes and dependencies.

It is no longer required to point to the Android Sdk's local reference as google [has published a `package-list` with their developer documentation.](https://stackoverflow.com/a/63547141) 