### PR TITLE
Fix notification exceptions not getting correctly detected in JNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * None.
 
 ### Fixed
+* [RealmApp] Failing to refresh the access token due to a 401/403 error will now correctly emit an error with `ErrorCode.BAD_AUTHENTICATION` rather than `ErrorCode.PERMISSION_DENIED`. (Realm Core [#4881](https://github.com/realm/realm-core/issues/4881), since 10.6.1)
+* [RealmApp] If an object with a null primary key was deleted by another sync client, the exception `KeyNotFound: No such object` could be triggered. ([Realm Core #4885](https://github.com/realm/realm-core/issues/4885), since 10.0.0)
 * Exceptions inside change listeners running on background looper threads would crash the Looper with a native `JNI DETECTED ERROR IN APPLICATION: JNI NewLocalRef called with pending exception` instead of the original Java exception. This could also happen when canceling a corutine using a background looper as a Dispatcher.
 
 ### Compatibility
@@ -12,7 +14,7 @@
 * Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
 
 ### Internal
-* Updated to Realm Core 11.3.1, commit: 15219f3b4b31b565c6a312cfa52f98821cafe798.
+* Updated to Realm Core 11.4.0, commit: 9b2f67c24581503486d8e1d2066fd7e8c5fd1491.
 
 
 ## 10.8.0 (2021-08-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Fixed
-* None.
+* Exceptions inside change listeners running on background looper threads would crash the Looper with a native `JNI DETECTED ERROR IN APPLICATION: JNI NewLocalRef called with pending exception` instead of the original Java exception. This could also happen when canceling a corutine using a background looper as a Dispatcher.
 
 ### Compatibility
 * File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
 
 ### Internal
-* None.
+* Updated to Realm Core 11.3.1, commit: 15219f3b4b31b565c6a312cfa52f98821cafe798.
 
 
 ## 10.8.0 (2021-08-27)

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/RealmNotifierTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/RealmNotifierTests.java
@@ -16,6 +16,11 @@
 package io.realm.internal;
 
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertTrue;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -24,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -31,21 +37,18 @@ import javax.annotation.Nullable;
 
 import io.realm.RealmChangeListener;
 import io.realm.RealmConfiguration;
-import io.realm.internal.android.AndroidRealmNotifier;
-import io.realm.rule.RunInLooperThread;
-import io.realm.rule.RunTestInLooperThread;
 import io.realm.TestRealmConfigurationFactory;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.fail;
+import io.realm.internal.android.AndroidRealmNotifier;
+import io.realm.rule.BlockingLooperThread;
 
 @RunWith(AndroidJUnit4.class)
 public class RealmNotifierTests {
     @Rule
     public final TestRealmConfigurationFactory configFactory = new TestRealmConfigurationFactory();
-    @Rule
-    public final RunInLooperThread looperThread = new RunInLooperThread();
+
+    private final BlockingLooperThread looperThread = new BlockingLooperThread();
+
+    private RealmConfiguration realmConfig;
 
     private Capabilities capabilitiesCanDeliver = new Capabilities() {
         @Override
@@ -65,6 +68,7 @@ public class RealmNotifierTests {
 
     @Before
     public void setUp() throws Exception {
+        realmConfig = configFactory.createConfiguration(UUID.randomUUID().toString());
     }
 
     @After
@@ -78,35 +82,37 @@ public class RealmNotifierTests {
     }
 
     @Test
-    @RunTestInLooperThread
     public void post() {
-        RealmNotifier notifier = new AndroidRealmNotifier(null, capabilitiesCanDeliver);
-        notifier.post(new Runnable() {
-            @Override
-            public void run() {
-                looperThread.testComplete();
-            }
+        looperThread.runBlocking(() -> {
+            RealmNotifier notifier = new AndroidRealmNotifier(null, capabilitiesCanDeliver);
+            notifier.post(new Runnable() {
+                @Override
+                public void run() {
+                    looperThread.testComplete();
+                }
+            });
         });
     }
 
     // Callback is immediately called when commitTransaction for local changes.
     @Test
-    @RunTestInLooperThread
     public void addChangeListener_byLocalChanges() {
-        final AtomicBoolean commitReturns = new AtomicBoolean(false);
-        OsSharedRealm sharedRealm = getSharedRealm(looperThread.getConfiguration());
-        sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<OsSharedRealm>() {
-            @Override
-            public void onChange(OsSharedRealm sharedRealm) {
-                // Transaction has been committed in core, but commitTransaction hasn't returned in java.
-                assertFalse(commitReturns.get());
-                sharedRealm.close();
-                looperThread.testComplete();
-            }
+        looperThread.runBlocking(() -> {
+            final AtomicBoolean commitReturns = new AtomicBoolean(false);
+            OsSharedRealm sharedRealm = getSharedRealm(realmConfig);
+            sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<OsSharedRealm>() {
+                @Override
+                public void onChange(OsSharedRealm sharedRealm) {
+                    // Transaction has been committed in core, but commitTransaction hasn't returned in java.
+                    assertFalse(commitReturns.get());
+                    sharedRealm.close();
+                    looperThread.testComplete();
+                }
+            });
+            sharedRealm.beginTransaction();
+            sharedRealm.commitTransaction();
+            commitReturns.set(true);
         });
-        sharedRealm.beginTransaction();
-        sharedRealm.commitTransaction();
-        commitReturns.set(true);
     }
 
     private void makeRemoteChanges(final RealmConfiguration config) {
@@ -118,61 +124,83 @@ public class RealmNotifierTests {
     }
 
     @Test
-    @RunTestInLooperThread
     public void addChangeListener_byRemoteChanges() {
-        // To catch https://github.com/realm/realm-java/pull/4037 CI failure.
-        // In this case, object store should not send more than 100 notifications.
-        final int TIMES = 100;
-        final AtomicInteger commitCounter = new AtomicInteger(0);
-        final AtomicInteger listenerCounter = new AtomicInteger(0);
+        looperThread.runBlocking(() -> {
+            // To catch https://github.com/realm/realm-java/pull/4037 CI failure.
+            // In this case, object store should not send more than 100 notifications.
+            final int TIMES = 100;
+            final AtomicInteger commitCounter = new AtomicInteger(0);
+            final AtomicInteger listenerCounter = new AtomicInteger(0);
 
-        looperThread.getRealm().close();
-
-        OsSharedRealm sharedRealm = getSharedRealm(looperThread.getConfiguration());
-        looperThread.keepStrongReference(sharedRealm);
-        sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<OsSharedRealm>() {
-            @Override
-            public void onChange(OsSharedRealm sharedRealm) {
-                int commits = commitCounter.get();
-                int listenerCount = listenerCounter.addAndGet(1);
-                assertEquals(commits, listenerCount);
-                if (commits == TIMES) {
-                    sharedRealm.close();
-                    looperThread.testComplete();
-                } else {
-                    makeRemoteChanges(looperThread.getConfiguration());
-                    commitCounter.getAndIncrement();
+            OsSharedRealm sharedRealm = getSharedRealm(realmConfig);
+            looperThread.keepStrongReference(sharedRealm);
+            sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<OsSharedRealm>() {
+                @Override
+                public void onChange(OsSharedRealm sharedRealm) {
+                    int commits = commitCounter.get();
+                    int listenerCount = listenerCounter.addAndGet(1);
+                    assertEquals(commits, listenerCount);
+                    if (commits == TIMES) {
+                        sharedRealm.close();
+                        looperThread.testComplete();
+                    } else {
+                        makeRemoteChanges(realmConfig);
+                        commitCounter.getAndIncrement();
+                    }
                 }
-            }
+            });
+            makeRemoteChanges(realmConfig);
+            commitCounter.getAndIncrement();
         });
-        makeRemoteChanges(looperThread.getConfiguration());
-        commitCounter.getAndIncrement();
+    }
+
+    // Ensure that exceptions in changelisteners do not cause native crashes, but instead
+    // propagate correctly to end users
+    @Test
+    public void addChangeListener_exceptionsPropagateCorrectly() {
+        try {
+            looperThread.runBlocking(() -> {
+                OsSharedRealm sharedRealm = getSharedRealm(realmConfig);
+                looperThread.closeAfterTest(sharedRealm);
+                sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<OsSharedRealm>() {
+                    @Override
+                    public void onChange(OsSharedRealm sharedRealm) {
+                        throw new RuntimeException("BOOM");
+                    }
+                });
+                makeRemoteChanges(realmConfig);
+            });
+            fail();
+        } catch (RuntimeException ex) {
+            assertTrue(ex.getMessage().contains("BOOM"));
+        }
     }
 
     @Test
-    @RunTestInLooperThread
     public void removeChangeListeners() {
-        OsSharedRealm sharedRealm = getSharedRealm(looperThread.getConfiguration());
-        Integer dummyObserver = 1;
-        looperThread.keepStrongReference(dummyObserver);
-        looperThread.keepStrongReference(sharedRealm);
-        sharedRealm.realmNotifier.addChangeListener(dummyObserver, new RealmChangeListener<Integer>() {
-            @Override
-            public void onChange(Integer dummy) {
-                fail();
-            }
-        });
-        sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<OsSharedRealm>() {
-            @Override
-            public void onChange(OsSharedRealm sharedRealm) {
-                sharedRealm.close();
-                looperThread.testComplete();
-            }
-        });
+        looperThread.runBlocking(() -> {
+            OsSharedRealm sharedRealm = getSharedRealm(realmConfig);
+            Integer dummyObserver = 1;
+            looperThread.keepStrongReference(dummyObserver);
+            looperThread.keepStrongReference(sharedRealm);
+            sharedRealm.realmNotifier.addChangeListener(dummyObserver, new RealmChangeListener<Integer>() {
+                @Override
+                public void onChange(Integer dummy) {
+                    fail();
+                }
+            });
+            sharedRealm.realmNotifier.addChangeListener(sharedRealm, new RealmChangeListener<OsSharedRealm>() {
+                @Override
+                public void onChange(OsSharedRealm sharedRealm) {
+                    sharedRealm.close();
+                    looperThread.testComplete();
+                }
+            });
 
-        // This should only remove the listeners related with dummyObserver
-        sharedRealm.realmNotifier.removeChangeListeners(dummyObserver);
+            // This should only remove the listeners related with dummyObserver
+            sharedRealm.realmNotifier.removeChangeListeners(dummyObserver);
 
-        makeRemoteChanges(looperThread.getConfiguration());
+            makeRemoteChanges(realmConfig);
+        });
     }
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -228,6 +228,7 @@ class SyncedRealmTests {
     }
 
     @Test
+    @Ignore // FIXME: Seems to be a problem with Synced Realm lifecycles for logged out users
     fun compactOnLaunch_shouldCompact() {
         val user = createTestUser(app)
 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -228,7 +228,6 @@ class SyncedRealmTests {
     }
 
     @Test
-    @Ignore // FIXME: Seems to be a problem with Synced Realm lifecycles for logged out users
     fun compactOnLaunch_shouldCompact() {
         val user = createTestUser(app)
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -310,7 +310,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSe
             jstring jerror_category = to_jstring(env, error_category);
             jstring jerror_message = to_jstring(env, error_message);
             jstring jclient_reset_path_info = to_jstring(env, client_reset_path_info);
-            jstring jsession_path = to_jstring(env, session.get()->path());
+            jstring jsession_path = to_jstring(env, session->path());
             env->CallVoidMethod(sync_service_object.get(),
                                 java_error_callback_method,
                                 jerror_category,

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -373,11 +373,6 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSe
             }
         }
 
-        if (!config.encryption_key.empty()) {
-            config.sync_config->realm_encryption_key = std::array<char, 64>();
-            std::copy_n(config.encryption_key.begin(), 64, config.sync_config->realm_encryption_key->begin());
-        }
-
         // return to_jstring(env, config.sync_config->realm_url.c_str());
         // FIXME: We must return the realm url here for proxy support to work
         return to_jstring(env, "");

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
@@ -73,15 +73,6 @@ JNIEXPORT void JNICALL Java_io_realm_mongodb_sync_Sync_nativeReconnect(JNIEnv* e
     CATCH_STD()
 }
 
-JNIEXPORT void JNICALL Java_io_realm_mongodb_sync_Sync_nativeCreateSession(JNIEnv* env, jclass, jlong j_native_config_ptr)
-{
-    try {
-        auto& config = *reinterpret_cast<Realm::Config*>(j_native_config_ptr);
-        _impl::RealmCoordinator::get_coordinator(config)->create_session(config);
-    }
-    CATCH_STD()
-}
-
 JNIEXPORT jstring JNICALL Java_io_realm_mongodb_sync_Sync_nativeGetPathForRealm(JNIEnv* env,
                                                                                 jclass,
                                                                                 jlong j_app_ptr,

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
@@ -37,6 +37,7 @@ JNIEXPORT void JNICALL Java_io_realm_mongodb_sync_Sync_nativeReset(JNIEnv* env, 
 {
     try {
         auto app = *reinterpret_cast<std::shared_ptr<app::App>*>(j_app_ptr);
+        app->sync_manager()->wait_for_sessions_to_terminate();
         app->sync_manager()->reset_for_testing();
         app::App::clear_cached_apps();
     }

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
@@ -37,7 +37,6 @@ JNIEXPORT void JNICALL Java_io_realm_mongodb_sync_Sync_nativeReset(JNIEnv* env, 
 {
     try {
         auto app = *reinterpret_cast<std::shared_ptr<app::App>*>(j_app_ptr);
-        app->sync_manager()->wait_for_sessions_to_terminate();
         app->sync_manager()->reset_for_testing();
         app::App::clear_cached_apps();
     }

--- a/realm/realm-library/src/main/cpp/java_binding_context.cpp
+++ b/realm/realm-library/src/main/cpp/java_binding_context.cpp
@@ -43,8 +43,7 @@ void JavaBindingContext::did_change(std::vector<BindingContext::ObserverState> c
                                     bool version_changed)
 {
     auto env = JniUtils::get_env();
-
-    if (JniUtils::get_env()->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
         return;
     }
     if (version_changed) {
@@ -62,6 +61,9 @@ void JavaBindingContext::schema_did_change(Schema const&)
         return;
     }
     auto env = JniUtils::get_env(false);
+    if (env->ExceptionCheck()) {
+        return;
+    }
     static JavaMethod on_schema_changed_method(env, JavaClassGlobalDef::shared_realm_schema_change_callback(),
                                                "onSchemaChanged", "()V");
     m_schema_changed_callback.call_with_local_ref(
@@ -75,6 +77,9 @@ void JavaBindingContext::set_schema_changed_callback(JNIEnv* env, jobject schema
 
 void JavaBindingContext::will_send_notifications() {
     auto env = JniUtils::get_env();
+    if (env->ExceptionCheck()) {
+        return;
+    }
     m_java_notifier.call_with_local_ref(env, [&](JNIEnv*, jobject notifier_obj) {
         static JavaMethod realm_notifier_will_send_notifications(env, JavaClassGlobalDef::realm_notifier(),
                                                            "willSendNotifications", "()V");
@@ -84,6 +89,9 @@ void JavaBindingContext::will_send_notifications() {
 
 void JavaBindingContext::did_send_notifications() {
     auto env = JniUtils::get_env();
+    if (env->ExceptionCheck()) {
+        return;
+    }
     m_java_notifier.call_with_local_ref(env, [&](JNIEnv*, jobject notifier_obj) {
         static JavaMethod realm_notifier_did_send_notifications(env, JavaClassGlobalDef::realm_notifier(),
                                                                  "didSendNotifications", "()V");

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -175,12 +175,6 @@ public abstract class Sync {
                 RealmLog.debug("First session created. Adding network listener.");
                 NetworkStateReceiver.addListener(networkListener);
             }
-            // The underlying session will be created as part of opening the Realm, but this approach
-            // does not work when using `Realm.getInstanceAsync()` in combination with AsyncOpen.
-            //
-            // So instead we manually create the underlying native session.
-//            OsRealmConfig config = new OsRealmConfig.Builder(syncConfiguration).build();
-//            nativeCreateSession(config.getNativePtr());
         }
 
         return session;
@@ -218,11 +212,6 @@ public abstract class Sync {
         RealmLog.debug("Removing session for: %s", syncConfiguration.getPath());
         SyncSession syncSession = sessions.remove(syncConfiguration.getPath());
         if (syncSession != null) {
-            if (syncConfiguration.getSessionStopPolicy() == OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY) {
-                // Attempt to work around IMMEDIATELY being slightly delayed on the native side,
-                // so instead we manually stop the session before closing the Realm.
-                syncSession.stop();
-            }
             syncSession.close();
         }
         if (sessions.isEmpty()) {
@@ -319,6 +308,5 @@ public abstract class Sync {
     private static native void nativeReset(long appNativePointer);
     private static native void nativeSimulateSyncError(long appNativePointer, String realmPath, int errorCode, String errorMessage, boolean isFatal);
     private static native void nativeReconnect(long appNativePointer);
-    private static native void nativeCreateSession(long nativeConfigPtr);
     private static native String nativeGetPathForRealm(long appNativePointer, String userId, String partitionValue, @Nullable String overrideFileName);
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -218,6 +218,11 @@ public abstract class Sync {
         RealmLog.debug("Removing session for: %s", syncConfiguration.getPath());
         SyncSession syncSession = sessions.remove(syncConfiguration.getPath());
         if (syncSession != null) {
+            if (syncConfiguration.getSessionStopPolicy() == OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY) {
+                // Attempt to work around IMMEDIATELY being slightly delayed on the native side,
+                // so instead we manually stop the session before closing the Realm.
+                syncSession.stop();
+            }
             syncSession.close();
         }
         if (sessions.isEmpty()) {

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -179,8 +179,8 @@ public abstract class Sync {
             // does not work when using `Realm.getInstanceAsync()` in combination with AsyncOpen.
             //
             // So instead we manually create the underlying native session.
-            OsRealmConfig config = new OsRealmConfig.Builder(syncConfiguration).build();
-            nativeCreateSession(config.getNativePtr());
+//            OsRealmConfig config = new OsRealmConfig.Builder(syncConfiguration).build();
+//            nativeCreateSession(config.getNativePtr());
         }
 
         return session;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
@@ -428,6 +428,17 @@ public class SyncSession {
     }
 
     synchronized void close() {
+        // Clear any running listeners as they might prevent the underlying session
+        // from correctly closing.
+        if (!connectionListeners.isEmpty()) {
+            connectionListeners.clear();
+            nativeRemoveConnectionListener(appNativePointer, nativeConnectionListenerToken, configuration.getPath());
+        }
+        for (Long token : progressListenerToOsTokenMap.values()) {
+            nativeRemoveProgressListener(appNativePointer, configuration.getPath(), token);
+        }
+        listenerIdToProgressListenerMap.clear();
+        progressListenerToOsTokenMap.clear();
         isClosed = true;
     }
 

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
@@ -625,7 +625,7 @@ class SyncSessionTests {
                 }
             }
             if (session.connectionState == ConnectionState.CONNECTED) {
-                // Failsafe in case, the connection is actually established before
+                // Failsafe in case the connection is actually established before
                 // we can attach the connection listener. Manual testing shows
                 // that this is highly unlikely.
                 looperThread.testComplete()


### PR DESCRIPTION
This PR fixes an issue where crashes inside background change listeners would not get correctly detected, thus crashing the JavaBindingContext in unrelated ways when accessing the JNIEnv. 

Sending notifications on background looper threads involves a number of callbacks from and to JNI and each of these steps needs a guard against this. It isn't possible to test for each specific callback, so I just added a test for the most important one: Exceptions inside the actual callback.

This case was detected when using coroutines with a custom looper Dispatcher. Canceling the scope would result in a `CoroutineException` inside the callback, but instead of the "real" exception people would see `JNI DETECTED ERROR IN APPLICATION: JNI NewLocalRef called with pending exception kotlinx.coroutines.JobCancellationException: Job was cancelled` in unrelated code.
