### PR TITLE
Fix broken links in Realm.Transaction doc

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -577,9 +577,9 @@ public class DynamicRealm extends BaseRealm {
     /**
      * Encapsulates a Realm transaction.
      * <p>
-     * Using this class will automatically handle {@link #beginTransaction()} and {@link #commitTransaction()}
-     * If any exception is thrown during the transaction {@link #cancelTransaction()} will be called
-     * instead of {@link #commitTransaction()}.
+     * Using this class will automatically handle {@link io.realm.DynamicRealm#beginTransaction()} and {@link io.realm.DynamicRealm#commitTransaction()}
+     * If any exception is thrown during the transaction {@link io.realm.DynamicRealm#cancelTransaction()} will be called
+     * instead of {@link io.realm.DynamicRealm#commitTransaction()}.
      */
     public interface Transaction {
         void execute(DynamicRealm realm);

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -1999,9 +1999,9 @@ public class Realm extends BaseRealm {
     /**
      * Encapsulates a Realm transaction.
      * <p>
-     * Using this class will automatically handle {@link #beginTransaction()} and {@link #commitTransaction()}
-     * If any exception is thrown during the transaction {@link #cancelTransaction()} will be called instead of
-     * {@link #commitTransaction()}.
+     * Using this class will automatically handle {@link io.realm.Realm#beginTransaction()} and {@link io.realm.Realm#commitTransaction()}
+     * If any exception is thrown during the transaction {@link io.realm.Realm#cancelTransaction()} will be called instead of
+     * {@link io.realm.Realm#commitTransaction()}.
      */
     public interface Transaction {
         void execute(Realm realm);


### PR DESCRIPTION
Seems to be a javadoc issue, not your fault.

Note that the links don't work in the description: https://docs.mongodb.com/realm-sdks/java/latest/io/realm/Realm.Transaction.html
Because they try to relatively link... within Realm.Transaction, rather than resolving the containing class methods. Fix seems to be fully qualified links.