### PR TITLE
Add support for UUID's as partition values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 10.9.0 (YYYY-MM-DD)
 
 ### Enhancements
-* [RealmApp] Add support for UUID's as partition values.
+* [RealmApp] Add support for UUID's as partition values. (Issue [#7598](https://github.com/realm/realm-java/issues/7598))
 * [RealmApp] Reduced native memory usage when working with synchronized Realms.
 * [RealmApp] Make it possible to bundle synchronized Realms in apps using `Realm.writeCopyTo()` and `SyncConfiguration.Builder.assetFile()`.
 * The Realm Transformer and Realm Gradle Plugin now supports the Gradle Configuration Cache. (Issue [#7299](https://github.com/realm/realm-java/issues/7299)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 10.9.0 (YYYY-MM-DD)
 
 ### Enhancements
+* [RealmApp] Add support for UUID's as partition values.
 * [RealmApp] Reduced native memory usage when working with synchronized Realms.
 * [RealmApp] Make it possible to bundle synchronized Realms in apps using `Realm.writeCopyTo()` and `SyncConfiguration.Builder.assetFile()`.
 * The Realm Transformer and Realm Gradle Plugin now supports the Gradle Configuration Cache. (Issue [#7299](https://github.com/realm/realm-java/issues/7299)) 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
@@ -44,6 +44,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertFailsWith
 import java.lang.IllegalStateException
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class SyncConfigurationTests {
@@ -366,10 +367,12 @@ class SyncConfigurationTests {
                 SyncConfiguration.defaultConfig(user, null as Int?),
                 SyncConfiguration.defaultConfig(user, null as Long?),
                 SyncConfiguration.defaultConfig(user, null as ObjectId?),
+                SyncConfiguration.defaultConfig(user, null as UUID?),
                 SyncConfiguration.Builder(user, null as String?).build(),
                 SyncConfiguration.Builder(user, null as Int?).build(),
                 SyncConfiguration.Builder(user, null as Long?).build(),
-                SyncConfiguration.Builder(user, null as ObjectId?).build()
+                SyncConfiguration.Builder(user, null as ObjectId?).build(),
+                SyncConfiguration.Builder(user, null as UUID?).build()
         )
 
         configs.forEach { config ->

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -689,7 +689,7 @@ class SyncedRealmTests {
                                 RealmFieldType.STRING -> assertEquals(expectedString, syncAllTypes.columnString)
                                 RealmFieldType.BINARY -> assertTrue(expectedBinary.contentEquals(syncAllTypes.columnBinary))
                                 RealmFieldType.DATE -> assertEquals(expectedDate, syncAllTypes.columnDate)
-                                RealmFieldType.DOUBLE -> assertEquals(expectedDouble, syncAllTypes.columnDouble)
+                                RealmFieldType.DOUBLE -> assertEquals(expectedDouble, syncAllTypes.columnDouble, 0.0)
                                 RealmFieldType.OBJECT -> assertEquals(expectedObjectId, syncAllTypes.columnRealmObject!!.id)
                                 RealmFieldType.DECIMAL128 -> assertEquals(expectedDecimal128, syncAllTypes.columnDecimal128)
                                 RealmFieldType.OBJECT_ID -> assertEquals(expectedObjectId, syncAllTypes.columnObjectId)

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/SyncObjectServerFacade.java
@@ -122,6 +122,7 @@ public class SyncObjectServerFacade extends ObjectServerFacade {
                 case OBJECT_ID:
                 case INT32:
                 case INT64:
+                case BINARY:
                 case NULL:
                     encodedPartitionValue = JniBsonProtocol.encode(partitionValue, AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY);
                     break;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -16,6 +16,7 @@
 
 package io.realm.mongodb.sync;
 
+import org.bson.BsonBinary;
 import org.bson.BsonValue;
 
 import java.io.File;
@@ -190,9 +191,13 @@ public abstract class Sync {
             case OBJECT_ID:
             case INT32:
             case INT64:
+            // Only way to here is though Realm API's which only only UUID's. So no chance of
+            // normal byte arrays to reach here.
+            case BINARY:
             case NULL:
                 encodedPartitionValue = JniBsonProtocol.encode(partitionValue, AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY);
                 break;
+
             default:
                 throw new IllegalArgumentException("Unsupported type: " + partitionValue);
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -191,8 +191,8 @@ public abstract class Sync {
             case OBJECT_ID:
             case INT32:
             case INT64:
-            // Only way to here is though Realm API's which only only UUID's. So no chance of
-            // normal byte arrays to reach here.
+            // Only way to here is through Realm API's which only allow UUID's. So we can safely
+            // just convert it to a Bson binary which will give it its correct UUID subtype.
             case BINARY:
             case NULL:
                 encodedPartitionValue = JniBsonProtocol.encode(partitionValue, AppConfiguration.DEFAULT_BSON_CODEC_REGISTRY);

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
@@ -18,6 +18,7 @@ package io.realm.mongodb.sync;
 
 import android.content.Context;
 
+import org.bson.BsonBinary;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonNull;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
@@ -96,7 +98,6 @@ import io.realm.rx.RxObservableFactory;
  * @see <a href="https://docs.mongodb.com/realm/sync/">The docs</a> for
  * more information about synchronization.
  */
-@Beta
 public class SyncConfiguration extends RealmConfiguration {
 
     private final URI serverUrl;
@@ -210,7 +211,6 @@ public class SyncConfiguration extends RealmConfiguration {
      * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
      * @return the default configuration for the given user and partition value.
      */
-    @Beta
     public static SyncConfiguration defaultConfig(User user, @Nullable String partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
@@ -222,7 +222,6 @@ public class SyncConfiguration extends RealmConfiguration {
      * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
      * @return the default configuration for the given user and partition value.
      */
-    @Beta
     public static SyncConfiguration defaultConfig(User user, @Nullable Long partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
@@ -234,7 +233,6 @@ public class SyncConfiguration extends RealmConfiguration {
      * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
      * @return the default configuration for the given user and partition value.
      */
-    @Beta
     public static SyncConfiguration defaultConfig(User user, @Nullable Integer partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
@@ -246,8 +244,18 @@ public class SyncConfiguration extends RealmConfiguration {
      * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
      * @return the default configuration for the given user and partition value.
      */
-    @Beta
     public static SyncConfiguration defaultConfig(User user, @Nullable ObjectId partitionValue) {
+        return new SyncConfiguration.Builder(user, partitionValue).build();
+    }
+
+    /**
+     * Returns a default configuration for the given user and partition value.
+     *
+     * @param user The user that will be used for accessing the Realm App.
+     * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
+     * @return the default configuration for the given user and partition value.
+     */
+    public static SyncConfiguration defaultConfig(User user, @Nullable UUID partitionValue) {
         return new SyncConfiguration.Builder(user, partitionValue).build();
     }
 
@@ -540,6 +548,17 @@ public class SyncConfiguration extends RealmConfiguration {
          */
         public Builder(User user, @Nullable Long partitionValue) {
             this(user, (partitionValue == null? new BsonNull() : new BsonInt64(partitionValue)));
+        }
+
+        /**
+         * Creates an instance of the builder for a <i>SyncConfiguration</i> with the given user
+         * and partition value.
+         *
+         * @param user The user that will be used for accessing the Realm App.
+         * @param partitionValue The partition value identifying the remote Realm that will be synchronized.
+         */
+        public Builder(User user, @Nullable UUID partitionValue) {
+            this(user, (partitionValue == null? new BsonNull() : new BsonBinary(partitionValue)));
         }
 
         /**


### PR DESCRIPTION
Closes #7598.

It isn't possible to add an integration test for this as our integration tests uses a String partition key, but I verified a server roundtrip using a manual test where I modified the server.