### PR TITLE
Fix AppConfiguration.syncRootDirectory() not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * The Realm Transformer and Realm Gradle Plugin now supports the Gradle Configuration Cache. (Issue [#7299](https://github.com/realm/realm-java/issues/7299)) 
 
 ### Fixed
+* [RealmApp] Setting `AppConfiguration.syncRootDirectory()` didn't have any effect beside creating the new folder. Realms were still placed in the default location. 
 * [RealmApp] Bug where progress notifiers continue to be called after the download of a synced realm is complete. (Issue [Realm Core #4919](https://github.com/realm/realm-core/issues/4919)) 
 * [RealmApp] User being left in the logged in state when the user's refresh token expires. (Issue [Realm Core #4882](https://github.com/realm/realm-core/issues/4882), since v10)
 * Using "sort", "distinct", or "limit" as field name in query expression would cause an "Invalid predicate" error. (Issue [#7545](), since v10.X.X)

--- a/dependencies.list
+++ b/dependencies.list
@@ -4,7 +4,7 @@ REALM_CORE=11.6.0
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
-MONGODB_REALM_SERVER=2021-04-22
+MONGODB_REALM_SERVER=2021-12-01
 
 # Common Android settings across projects
 GRADLE_BUILD_TOOLS=7.1.0-beta03

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/App.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/App.java
@@ -184,12 +184,12 @@ public class App {
     private OsApp init(AppConfiguration config) {
         String userAgentBindingInfo = getBindingInfo();
         String appDefinedUserAgent = getAppInfo(config);
-        String syncDir = getSyncBaseDirectory();
+        String syncDir = getSyncBaseDirectory(config);
 
         return new OsApp(config, userAgentBindingInfo, appDefinedUserAgent, syncDir);
     }
 
-    private String getSyncBaseDirectory() {
+    private String getSyncBaseDirectory(AppConfiguration config) {
         Context context = Realm.getApplicationContext();
         if (context == null) {
             throw new IllegalStateException("Call Realm.init() first.");
@@ -213,7 +213,7 @@ public class App {
                 throw new IllegalStateException(e);
             }
         } else {
-            syncDir = context.getFilesDir().getPath();
+            syncDir = config.getSyncRootDirectory().getPath();
         }
         return syncDir;
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/AppConfiguration.java
@@ -415,11 +415,6 @@ public class AppConfiguration {
             if (context == null) {
                 throw new IllegalStateException("Call `Realm.init(Context)` before calling this method.");
             }
-            File rootDir = new File(context.getFilesDir(), "mongodb-realm");
-            if (!rootDir.exists() && !rootDir.mkdir()) {
-                throw new IllegalStateException("Could not create Sync root dir: " + rootDir.getAbsolutePath());
-            }
-            syncRootDir = rootDir;
         }
 
         /**
@@ -638,6 +633,18 @@ public class AppConfiguration {
          * @return the AppConfiguration that can be used to create a {@link App}.
          */
         public AppConfiguration build() {
+            // Initialize default sync root if none has been defined.
+            // Ideally this should just have been `context.getFilesDir()` since ObjectStore also
+            // creates a mongodb-realm folder, but changing it now would be a massive breaking change.
+            if (syncRootDir == null) {
+                syncRootDir = new File(Realm.getApplicationContext().getFilesDir(), "mongodb-realm");
+                if (!syncRootDir.exists()) {
+                    if (!syncRootDir.mkdirs()) {
+                        throw new IllegalStateException("Could not create root folder for synchronized Realms: " + syncRootDir.getAbsolutePath());
+                    }
+                }
+            }
+
             return new AppConfiguration(appId,
                     appName,
                     appVersion,


### PR DESCRIPTION
Depends on https://github.com/realm/realm-java/pull/7601 being merged first.