### PR TITLE
Disable AGP7 unified testing pipeline

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.jvmargs=-XX:MaxPermSize=512m
 org.gradle.caching=true
 android.enableD8=true
+#FIXME: enable when https://github.com/realm/realm-java/issues/7605 is resolved
+android.experimental.androidTest.useUnifiedTestPlatform=false


### PR DESCRIPTION
The new unified testing pipeline introduced in AGP7 fails to run our test suite.

This PR disables it until the issue gets resolved.

https://developer.android.com/studio/preview/features#disable-utp
https://issuetracker.google.com/issues/208583140
