### PR TITLE
Move UTP disabling flag into the correct gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
 org.gradle.jvmargs=-XX:MaxPermSize=512m
 org.gradle.caching=true
 android.enableD8=true
-#FIXME: enable when https://github.com/realm/realm-java/issues/7605 is resolved
-android.experimental.androidTest.useUnifiedTestPlatform=false

--- a/realm/gradle.properties
+++ b/realm/gradle.properties
@@ -5,3 +5,5 @@ org.gradle.parallel=false
 org.gradle.daemon=false
 android.useAndroidX=true
 android.enableJetifier=true
+#FIXME: enable when https://github.com/realm/realm-java/issues/7605 is resolved
+android.experimental.androidTest.useUnifiedTestPlatform=false


### PR DESCRIPTION
On PR #7606 we set the disabling unified testing pipeline flag into the root gradle project. This setting is not propagated into the directory Realm as they are separate projects.

This PR moves the flag into the Realm project gradle.properties.