### PR TITLE
Build core from source as default

### DIFF
--- a/realm/gradle.properties
+++ b/realm/gradle.properties
@@ -7,3 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=true
 #FIXME: enable when https://github.com/realm/realm-java/issues/7605 is resolved
 android.experimental.androidTest.useUnifiedTestPlatform=false
+
+# TODO Seems like using core binaries is currently broken and has been it for a while. Enabling
+#  explicit building of core so that builds don't fail. We should find out if we want to support
+#  using binaries or otherwise remove the logic around this and just always build core.
+buildCore=true


### PR DESCRIPTION
The project fails to build if we don't build core as part of the project. Has been like that for a while, just didn't hunt down why my local build was failing since my environment has been out of sync while working only on realm-kotlin. With realm-java brought up to JAVA11/Cmake 3.21.4 it was a bit easier to chase. 

Don't know if we should disable the logic completely, but at least a fresh clone in a raw environment will not fail to build ... due to this. 