### PR TITLE
Flexible Sync bug fix on multiple anonymous subscriptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 10.10.1 (YYYY-MM-DD)
+
+### Enhancements
+* None.
+
+### Fixed
+* [RealmApp] Allow defining multiple anonymous subscriptions on a Realm Object.
+
+### Compatibility
+* File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
+* Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
+
+### Internal
+* None.
+
+
 ## 10.10.0 (2022-01-18)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Fixed
-* [RealmApp] Allow defining multiple anonymous subscriptions on a Realm Object.
+* [RealmApp]  Creating multiple anonymous subscriptions for a Realm would throw an exception.
 
 ### Compatibility
 * File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/MutableSubscriptionSetTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/MutableSubscriptionSetTests.kt
@@ -118,6 +118,16 @@ class MutableSubscriptionSetTests {
     }
 
     @Test
+    fun add_multiple_anonymous() {
+        realm.subscriptions.update { mutableSubs ->
+            mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>()))
+            mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>().equalTo("section", 10L)))
+            mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>().equalTo("section", 5L)))
+            mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>().equalTo("section", 1L)))
+        }
+    }
+
+    @Test
     fun addExistingAnonymous_throws() {
         realm.subscriptions.update { mutableSubs ->
             mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>()))

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/MutableSubscriptionSetTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/MutableSubscriptionSetTests.kt
@@ -124,6 +124,8 @@ class MutableSubscriptionSetTests {
             mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>().equalTo("section", 10L)))
             mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>().equalTo("section", 5L)))
             mutableSubs.add(Subscription.create(realm.where<FlexSyncColor>().equalTo("section", 1L)))
+        }.also { subscriptionSet ->
+            assertEquals(4, subscriptionSet.count())
         }
     }
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
@@ -43,9 +43,16 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsMutableSubscription
 {
     try {
         auto subscriptions = reinterpret_cast<sync::MutableSubscriptionSet*>(j_subscription_set_ptr);
-        JStringAccessor name(env, j_name);
         auto query = reinterpret_cast<Query*>(j_query);
-        std::pair<sync::SubscriptionSet::iterator, bool> result = subscriptions->insert_or_assign(name, *query);
+        std::pair<sync::SubscriptionSet::iterator, bool> result;
+
+        if(j_name == nullptr) {
+            result = subscriptions->insert_or_assign(*query);
+        } else {
+            JStringAccessor name(env, j_name);
+            result = subscriptions->insert_or_assign(name, *query);
+        }
+
         if (j_throw_on_update && !result.second) {
             ThrowException(env, ExceptionKind::IllegalArgument, "Subscription could not be added because it already existed");
             return -1;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
@@ -43,15 +43,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsMutableSubscription
 {
     try {
         auto subscriptions = reinterpret_cast<sync::MutableSubscriptionSet*>(j_subscription_set_ptr);
+        JStringAccessor name(env, j_name);
         auto query = reinterpret_cast<Query*>(j_query);
-        std::pair<sync::SubscriptionSet::iterator, bool> result;
-
-        if(j_name == nullptr) {
-            result = subscriptions->insert_or_assign(*query);
-        } else {
-            JStringAccessor name(env, j_name);
-            result = subscriptions->insert_or_assign(name, *query);
-        }
+        std::pair<sync::SubscriptionSet::iterator, bool> result = name.is_null() ? subscriptions->insert_or_assign(*query) : subscriptions->insert_or_assign(name, *query);
 
         if (j_throw_on_update && !result.second) {
             ThrowException(env, ExceptionKind::IllegalArgument, "Subscription could not be added because it already existed");


### PR DESCRIPTION
This PR fixes a bug in Flexible Sync that prevented declaring multiple anonymous subscriptions on a Realm Object.