### PR TITLE
Allow setting filename on partition and flexible sync Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 10.10.1 (YYYY-MM-DD)
 
 ### Enhancements
-* None.
+* [RealmApp] Add support for setting the filename on Flexible and Partition Sync configurations.
 
 ### Fixed
-* [RealmApp]  Creating multiple anonymous subscriptions for a Realm would throw an exception.
+* [RealmApp] Creating multiple anonymous subscriptions for a Realm would throw an exception.
 
 ### Compatibility
 * File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/FlexibleSyncConfigurationTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/FlexibleSyncConfigurationTests.kt
@@ -158,4 +158,13 @@ class FlexibleSyncConfigurationTests {
         val config: SyncConfiguration = SyncConfiguration.defaultConfig(user)
         assertTrue(config.syncClientResetStrategy is ManuallyRecoverUnsyncedChangesStrategy)
     }
+
+    @Test
+    fun overrideDefaultPath() {
+        val user: User = createTestUser(app)
+        val config: SyncConfiguration = SyncConfiguration.Builder(user)
+            .name("custom.realm")
+            .build()
+        assertTrue("Path is: ${config.path}", config.path.endsWith("${app.configuration.appId}/${user.id}/custom.realm"))
+    }
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncConfigurationTests.kt
@@ -711,4 +711,13 @@ class SyncConfigurationTests {
             .inMemory()
         assertFailsWith<IllegalStateException> { builder.assetFile("foo.bar") }
     }
+
+    @Test
+    fun overrideDefaultPath() {
+        val user: User = createTestUser(app)
+        val config: SyncConfiguration = SyncConfiguration.Builder(user, DEFAULT_PARTITION)
+            .name("custom.realm")
+            .build()
+        assertTrue("Path is: ${config.path}", config.path.endsWith("${app.configuration.appId}/${user.id}/custom.realm"))
+    }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncConfiguration.java
@@ -729,11 +729,11 @@ public class SyncConfiguration extends RealmConfiguration {
         }
 
         /**
-         * FIXME: Make public once https://github.com/realm/realm-object-store/pull/1049 is merged.
-         *
          * Sets the filename for the Realm file on this device.
+         *
+         * @param filename name for the Realm file.
          */
-        Builder name(String filename) {
+        public Builder name(String filename) {
             //noinspection ConstantConditions
             if (filename == null || filename.isEmpty()) {
                 throw new IllegalArgumentException("A non-empty filename must be provided");


### PR DESCRIPTION
This PR allows setting a custom filename on partition and flexible synced Realms.