### PR TITLE
Fixed some typos

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -163,8 +163,8 @@ abstract class BaseRealm implements Closeable {
      * <p>
      * Auto-refresh is a feature that enables automatic update of the current Realm instance and all its derived objects
      * (RealmResults and RealmObject instances) when a commit is performed on a Realm acting on the same file in
-     * another thread. This feature is only available if the Realm instance lives on a {@link android.os.Looper} enabled
-     * thread.
+     * another thread. This feature is only available if the Realm instance lives on an {@link android.os.Looper}
+     * enabled thread.
      *
      * @param autoRefresh {@code true} will turn auto-refresh on, {@code false} will turn it off.
      * @throws IllegalStateException if called from a non-Looper thread.

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -159,7 +159,7 @@ public class DynamicRealm extends BaseRealm {
      * @return the new object. All fields will have default values for their type, except for the
      * primary key field which will have the provided value.
      * @throws RealmException if object could not be created due to the primary key being invalid.
-     * @throws IllegalStateException if the model clazz does not have an primary key defined.
+     * @throws IllegalStateException if the model clazz does not have a primary key defined.
      * @throws IllegalArgumentException if the {@code primaryKeyValue} doesn't have a value that can be converted to the
      * expected value.
      */

--- a/realm/realm-library/src/main/java/io/realm/ImportFlag.java
+++ b/realm/realm-library/src/main/java/io/realm/ImportFlag.java
@@ -30,12 +30,12 @@ public enum ImportFlag {
      * value as the value already present in the Realm.
      * <p>
      * For local Realms this only has an impact on change listeners which will not report changes to
-     * those fields that was not written.
+     * those fields that were not written.
      * <p>
      * For synchronized Realms this also impacts the server, which will see improved performance as
-     * there is less changes to upload and merge into the server Realm.
+     * there are fewer changes to upload and merge into the server Realm.
      * <p>
-     * It also impact how the server merges changes from different devices. Realm uses a
+     * It also impacts how the server merges changes from different devices. Realm uses a
      * last-write-wins approach when merging individual fields in an object, so if a field is not
      * written it will be considered "older" than other fields modified.
      * <p>
@@ -57,7 +57,7 @@ public enum ImportFlag {
      *         becomes (Field A = 3, Field B = 2).
      *     </li>
      * </ol>
-     * This is normally the desired behaviour as the final object is the merged result of the latest
+     * This is normally the desired behavior as the final object is the merged result of the latest
      * changes from both devices, however if all the fields in an object are considered an atomic
      * unit, then this flag should not be set as it will ensure that all fields are set and thus have
      * the same "age" when data are sent to the server.

--- a/realm/realm-library/src/main/java/io/realm/ManagedListOperator.java
+++ b/realm/realm-library/src/main/java/io/realm/ManagedListOperator.java
@@ -37,7 +37,7 @@ import static io.realm.CollectionUtils.LIST_TYPE;
  * This class provides facade for against {@link OsList}. {@link OsList} is used for both {@link RealmModel}s
  * and values, but there are some subtle differences in actual operation.
  * <p>
- * This class provides common interface for them.
+ * This class provides a common interface for them.
  * <p>
  * You need to use appropriate sub-class for underlying field type.
  *

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -90,7 +90,7 @@ import io.realm.log.RealmLog;
  * onStart/onStop.
  * <p>
  * Realm instances coordinate their state across threads using the {@link android.os.Handler} mechanism. This also means
- * that Realm instances on threads without a {@link android.os.Looper} cannot receive updates unless {@link #refresh()}
+ * that Realm instances on threads without an {@link android.os.Looper} cannot receive updates unless {@link #refresh()}
  * is manually called.
  * <p>
  * A standard pattern for working with Realm in Android activities can be seen below:

--- a/realm/realm-library/src/main/java/io/realm/RealmAny.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmAny.java
@@ -298,7 +298,7 @@ public class RealmAny {
      * If the value is not null the type will be {@link RealmAny.Type#UUID}, {@link RealmAny.Type#NULL} otherwise.
      *
      * @param value the RealmAny value.
-     * @return a new RealmAny of an UUID.
+     * @return a new RealmAny of a UUID.
      */
     public static RealmAny valueOf(@Nullable UUID value) {
         return new RealmAny((value == null) ? new NullRealmAnyOperator() : new UUIDRealmAnyOperator(value));

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -258,7 +258,7 @@ public abstract class RealmObject implements RealmModel, ManageableObject {
     /**
      * Checks if the query used to find this RealmObject has completed.
      * <p>
-     * Async methods like {@link RealmQuery#findFirstAsync()} return an {@link RealmObject} that represents the future
+     * Async methods like {@link RealmQuery#findFirstAsync()} return a {@link RealmObject} that represents the future
      * result of the {@link RealmQuery}. It can be considered similar to a {@link java.util.concurrent.Future} in this
      * regard.
      * <p>

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -2782,7 +2782,7 @@ public class RealmQuery<E> {
     }
 
     /**
-     * Similar to {@link #findFirst()} but runs asynchronously on a worker thread. An listener should be registered to
+     * Similar to {@link #findFirst()} but runs asynchronously on a worker thread. A listener should be registered to
      * the returned {@link RealmObject} to get the notification when query completes. The registered listener will also
      * be triggered if there are changes made to the queried {@link RealmObject}. If the {@link RealmObject} is deleted,
      * the listener will be called one last time and then stop. The query will not be re-run.

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -66,7 +66,7 @@ public abstract class RealmSchema {
 
     /**
      * Returns the {@link RealmObjectSchema} for a given class. If this {@link RealmSchema} is immutable, an immutable
-     * {@link RealmObjectSchema} will be returned. Otherwise, it returns an mutable {@link RealmObjectSchema}.
+     * {@link RealmObjectSchema} will be returned. Otherwise, it returns a mutable {@link RealmObjectSchema}.
      *
      * @param className name of the class
      * @return schema object for that class or {@code null} if the class doesn't exists.

--- a/realm/realm-library/src/main/java/io/realm/RealmSet.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSet.java
@@ -42,7 +42,7 @@ import io.realm.internal.OsSet;
  * managed mode a RealmSet persists all its contents inside a Realm whereas in unmanaged mode
  * it functions like a {@link HashSet}.
  * <p>
- * Managed RealmSets can only be created by Realm and will automatically update its content
+ * Managed RealmSets can only be created by Realm and will automatically update their content
  * whenever the underlying Realm is updated. Managed RealmSet can only be accessed using the getter
  * that points to a RealmSet field of a {@link RealmObject}.
  * <p>

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmError.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmError.java
@@ -20,7 +20,7 @@ import io.realm.internal.Keep;
 
 
 /**
- * RealmError is Realm specific Error used when unrecoverable problems happen in the underlying storage engine. An
+ * RealmError is a Realm specific Error used when unrecoverable problems happen in the underlying storage engine. A
  * RealmError should never be caught or ignored. By doing so, the Realm could possibly get corrupted.
  */
 @Keep

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmException.java
@@ -20,7 +20,7 @@ import io.realm.internal.Keep;
 
 
 /**
- * RealmException is Realm specific exceptions.
+ * RealmException is for Realm specific exceptions.
  */
 @Keep
 public final class RealmException extends RuntimeException {


### PR DESCRIPTION
This PR contains fixes of some minor typos in the documentation.

The case `a {@link android.os.Looper}` vs. `an {@link android.os.Looper}` is a bit ambiguous, depending on how it might be displayed by an IDE, but I think it should at least be handled consistently within the project.