### PR TITLE
Throw exception when initializing Realm on an Instant app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 10.10.2 (YYYY-MM-DD)
+
+### Enhancements
+* Throw a more comprehensive error when initializing Realm on an Instant App.
+
+### Fixed
+* None.
+
+### Compatibility
+* File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
+* Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
+
+### Internal
+* None
+
 ## 10.10.1 (2022-01-26)
 
 ### Enhancements

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -18,6 +18,7 @@ package io.realm;
 
 import android.app.IntentService;
 import android.content.Context;
+import android.os.Build;
 import android.os.SystemClock;
 import android.util.JsonReader;
 
@@ -48,6 +49,7 @@ import javax.annotation.Nullable;
 
 import io.reactivex.Flowable;
 import io.realm.annotations.RealmClass;
+import io.realm.exceptions.RealmError;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
 import io.realm.exceptions.RealmMigrationNeededException;
@@ -315,6 +317,11 @@ public class Realm extends BaseRealm {
                 throw new IllegalArgumentException("Non-null context required.");
             }
             checkFilesDirAvailable(context);
+
+            // https://github.com/realm/realm-java/issues/7640
+            if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) && context.getPackageManager().isInstantApp()) {
+                throw new RealmError("Could not initialize Realm: Instant apps are not supported");
+            }
 
             RealmCore.loadLibrary(context);
             setDefaultConfiguration(new RealmConfiguration.Builder(context).build());

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -338,7 +338,7 @@ public class Realm extends BaseRealm {
 
             // https://github.com/realm/realm-java/issues/7640
             if (isInstantApp(context)) {
-                throw new RealmError("Could not initialize Realm: Instant apps are not supported");
+                throw new RealmError("Could not initialize Realm: Instant apps are not currently supported.");
             }
 
             RealmCore.loadLibrary(context);


### PR DESCRIPTION
Currently Realm is not able to run on Instant apps, trying to run it would result on a `Permission denied` while trying to open a Realm, that is hard to reason about.

With this PR we check if Realm is being initialized on an Instant app and if so a `RealmError` is thrown stating that Instant apps are not currently supported.

Manually tested with an Instant App.