### PR TITLE
Fix unit tests not running for base library.

### DIFF
--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -48,7 +48,6 @@ import io.realm.internal.Util;
 import io.realm.internal.annotations.ObjectServer;
 import io.realm.internal.async.RealmThreadPoolExecutor;
 import io.realm.log.RealmLog;
-import io.realm.mongodb.sync.SubscriptionSet;
 
 /**
  * Base class for all Realm instances.
@@ -717,7 +716,7 @@ abstract class BaseRealm implements Closeable {
      * synchronized realm.
      */
     @ObjectServer
-    public SubscriptionSet getSubscriptions() {
+    public io.realm.mongodb.sync.SubscriptionSet getSubscriptions() {
         checkIfValid();
         return sharedRealm.getSubscriptions(configuration.getSchemaMediator(), asyncTaskExecutor, WRITE_EXECUTOR);
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsSharedRealm.java
@@ -31,8 +31,6 @@ import io.realm.internal.android.AndroidCapabilities;
 import io.realm.internal.android.AndroidRealmNotifier;
 import io.realm.internal.annotations.ObjectServer;
 import io.realm.internal.async.RealmThreadPoolExecutor;
-import io.realm.internal.objectstore.OsSubscriptionSet;
-import io.realm.mongodb.sync.SubscriptionSet;
 
 @Keep
 public final class OsSharedRealm implements Closeable, NativeObject {
@@ -381,13 +379,13 @@ public final class OsSharedRealm implements Closeable, NativeObject {
     }
 
     @ObjectServer
-    public SubscriptionSet getSubscriptions(RealmProxyMediator schema,
+    public io.realm.mongodb.sync.SubscriptionSet getSubscriptions(RealmProxyMediator schema,
                                             RealmThreadPoolExecutor listenerExecutor,
                                             RealmThreadPoolExecutor writeExecutor) {
         ObjectServerFacade facade = ObjectServerFacade.getSyncFacadeIfPossible();
         facade.checkFlexibleSyncEnabled(getConfiguration());
         long ptr = nativeGetLatestSubscriptionSet(nativePtr);
-        return new OsSubscriptionSet(ptr, schema, listenerExecutor, writeExecutor);
+        return new io.realm.internal.objectstore.OsSubscriptionSet(ptr, schema, listenerExecutor, writeExecutor);
     }
 
     public boolean isClosed() {

--- a/realm/realm-library/src/main/java/io/realm/mongodb/sync/SubscriptionSet.java
+++ b/realm/realm-library/src/main/java/io/realm/mongodb/sync/SubscriptionSet.java
@@ -34,7 +34,6 @@ import io.realm.internal.objectstore.OsSubscriptionSet;
  * {@link #waitForSynchronization()} and its variants.
  *
  */
-@ObjectServer
 @Beta
 @Keep
 public interface SubscriptionSet extends Iterable<Subscription> {


### PR DESCRIPTION
Note, this is just a work-around that has the downside that `SubscriptionSet` now leaks into the public API for the base library.

I tried to find the root cause, but after running a bit in circles, it is probably going to take longer than what we have time for right now. So I created https://github.com/realm/realm-java/issues/7681 to track it.
