### PR TITLE
Update to Core v13.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 * None.
 
 ### Fixed
+* Set<Mixed> consider string and binary data equivalent. This could cause the client to be inconsistent with the server if a string and some binary data with equivalent content was inserted from Atlas. ([#4860](https://github.com/realm/realm-core/issues/4860), since v11.0.0)
+* Fixed wrong assertion on query error that could result in a crash. ([#6038](https://github.com/realm/realm-core/issues/6038), since v11.7.0)
 * Fixed a bug that would result in `RealmDictionary` not being able to find `double` values due not taking the precision of the input parameter into consideration when using `RealmDictionary.contains`.
+* Not possible to open an encrypted file on a device with a page size bigger than the one on which the file was produced. ([#8030](https://github.com/realm/realm-swift/issues/8030), since v12.11.0)
+* Fix no notification for write transaction that contains only change to backlink property. ([#4994](https://github.com/realm/realm-core/issues/4994), since v11.4.1)
 
 ### Compatibility
-* File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* File format: Generates Realms with format v23. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
 * APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
 * Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Fixed
-* None.
+* Fixed a bug that would result in `RealmDictionary` not being able to find `double` values due not taking the precision of the input parameter into consideration when using `RealmDictionary.contains`.
 
 ### Compatibility
 * File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
 * Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
 
+### Internal
+* Updated to Realm Core 13.1.1, commit e26863394f415ff1e0693ca9155db071255c7fa6.
+
 
 ## 10.13.0 (2022-12-05)
 

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/internal/network/LoggingInterceptorTest.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/internal/network/LoggingInterceptorTest.kt
@@ -259,19 +259,21 @@ class LoggingInterceptorTest {
                 RealmLog.setLevel(LogLevel.ALL)
             }
 
-    // Check whether the expected logcat entries are present in the test logger, either as the
-    // latest or previous entry
+    // Check whether the expected logcat entries are present in the test logger buffer
     private fun assertMessageExists(vararg entries: String) {
         var patternExists = false
         for (entry in entries) {
-            patternExists = patternExists
-                    || testLogger.message.contains(entry)
-                    || testLogger.previousMessage.contains(entry)
+            val iterator = testLogger.messageBuffer.iterator()
+            while (iterator.hasNext()) {
+                val bufferEntry = iterator.next()
+                if (bufferEntry != null && bufferEntry.contains(entry)) {
+                    patternExists = true
+                    continue
+                }
+            }
+            // Skip to assertion if found
+            if (patternExists) continue
         }
-        assertTrue(
-            patternExists,
-            "Pattern expected: ${entries}, was: (${testLogger.message}, ${testLogger.previousMessage}"
-
-        )
+        assertTrue(patternExists)
     }
 }

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsMap.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsMap.cpp
@@ -587,6 +587,21 @@ Java_io_realm_internal_OsMap_nativeContainsLong(JNIEnv* env, jclass, jlong wrapp
 }
 
 JNIEXPORT jboolean JNICALL
+Java_io_realm_internal_OsMap_nativeContainsDouble(JNIEnv* env, jclass, jlong wrapper_ptr,
+                                                  jdouble j_value) {
+    try {
+        auto& wrapper = *reinterpret_cast<ObservableDictionaryWrapper*>(wrapper_ptr);
+        auto& dictionary = wrapper.collection();
+        size_t find_result = dictionary.find_any(Mixed(j_value));
+        if (find_result != realm::not_found) {
+            return true;
+        }
+    }
+    CATCH_STD()
+    return false;
+}
+
+JNIEXPORT jboolean JNICALL
 Java_io_realm_internal_OsMap_nativeContainsBoolean(JNIEnv* env, jclass, jlong wrapper_ptr,
                                                    jboolean j_value) {
     try {

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsApp.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsApp.cpp
@@ -96,7 +96,13 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsApp_nativeCreate(JN
                                                                jstring j_user_agent_application_info,
                                                                jstring j_platform,
                                                                jstring j_platform_version,
-                                                               jstring j_sdk_version)
+                                                               jstring j_sdk_version,
+                                                               jstring j_cpu_arch,
+                                                               jstring j_device_name,
+                                                               jstring j_device_version,
+                                                               jstring j_framework_name,
+                                                               jstring j_framework_version
+                                                               )
 {
     try {
 
@@ -119,6 +125,11 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsApp_nativeCreate(JN
         JStringAccessor platform_version(env, j_platform_version);
         JStringAccessor sdk_version(env, j_sdk_version);
         JByteArrayAccessor encryption_key(env, j_encryption_key);
+        JStringAccessor cpu_arch(env, j_cpu_arch);
+        JStringAccessor device_name(env, j_device_name);
+        JStringAccessor device_version(env, j_device_version);
+        JStringAccessor framework_name(env, j_framework_name);
+        JStringAccessor framework_version(env, j_framework_version);
 
         // Create Network Transport
         static JavaMethod get_network_transport_method(env, obj, "getNetworkTransport", "()Lio/realm/internal/objectstore/OsJavaNetworkTransport;");
@@ -132,9 +143,17 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsApp_nativeCreate(JN
                 util::Optional<std::string>(app_name),
                 util::Optional<std::string>(app_version),
                 util::Optional<std::uint64_t>(j_request_timeout_ms),
-                platform,
-                platform_version,
-                sdk_version
+                {
+                        platform,
+                        platform_version,
+                        sdk_version,
+                        "Java",
+                        cpu_arch,
+                        device_name,
+                        device_version,
+                        framework_name,
+                        framework_version
+                }
         };
 
         // Sync Config

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsApp.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsApp.cpp
@@ -21,7 +21,7 @@
 #include "jni_util/java_method.hpp"
 #include "jni_util/jni_utils.hpp"
 
-#include <realm/object-store/binding_callback_thread_observer.hpp>
+#include <realm/sync/binding_callback_thread_observer.hpp>
 #include <realm/object-store/sync/app.hpp>
 #include <realm/object-store/sync/sync_manager.hpp>
 

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
@@ -22,7 +22,7 @@
 #include "jni_util/jni_utils.hpp"
 
 #include <realm/object-store/shared_realm.hpp>
-#include <realm/object-store/binding_callback_thread_observer.hpp>
+#include <realm/sync/binding_callback_thread_observer.hpp>
 #include <realm/object-store/sync/app.hpp>
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/sync/subscriptions.hpp>

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsMutableSubscriptionSet.cpp
@@ -80,7 +80,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_objectstore_OsMutableSubscript
         auto subscriptions = reinterpret_cast<sync::MutableSubscriptionSet*>(j_subscriptions_set_ptr);
         JStringAccessor name(env, j_name);
         for (auto it = subscriptions->begin(); it != subscriptions->end(); ++it) {
-            if (it->name() == name) {
+            if (it->name == name) {
                 subscriptions->erase(it);
                 return true;
             }
@@ -99,7 +99,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_objectstore_OsMutableSubscript
         auto subscriptions = reinterpret_cast<sync::MutableSubscriptionSet*>(j_subscriptions_set_ptr);
         auto sub = reinterpret_cast<sync::Subscription*>(j_subscription_ptr);
         for (auto it = subscriptions->begin(); it != subscriptions->end(); ++it) {
-            if (it->id() == sub->id()) {
+            if (it->id == sub->id) {
                 subscriptions->erase(it);
                 return true;
             }
@@ -133,7 +133,7 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_objectstore_OsMutableSubscript
         JStringAccessor type(env, j_clazz_type);
         bool remove = false;
         for (auto it = subscriptions->begin(); it != subscriptions->end(); ++it) {
-            if (it->object_class_name() == type) {
+            if (it->object_class_name == type) {
                 it = subscriptions->erase(it);
                 remove = true;
                 if (it == subscriptions->end()) {

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscription.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscription.cpp
@@ -22,7 +22,7 @@
 #include "jni_util/jni_utils.hpp"
 
 #include <realm/object-store/shared_realm.hpp>
-#include <realm/object-store/binding_callback_thread_observer.hpp>
+#include <realm/sync/binding_callback_thread_observer.hpp>
 #include <realm/object-store/sync/app.hpp>
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/sync/subscriptions.hpp>

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscription.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscription.cpp
@@ -49,7 +49,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_objectstore_OsSubscription_nati
 {
     try {
         auto sub = reinterpret_cast<sync::Subscription*>(j_subscription_ptr);
-        return to_jstring(env, sub->name());
+        return to_jstring(env, sub->name);
     }
     CATCH_STD()
     return nullptr;
@@ -61,7 +61,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_objectstore_OsSubscription_nati
 {
     try {
         auto sub = reinterpret_cast<sync::Subscription*>(j_subscription_ptr);
-        return to_jstring(env, sub->object_class_name());
+        return to_jstring(env, sub->object_class_name);
     }
     CATCH_STD()
     return nullptr;
@@ -73,7 +73,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_objectstore_OsSubscription_nati
 {
     try {
         auto sub = reinterpret_cast<sync::Subscription*>(j_subscription_ptr);
-        return to_jstring(env, sub->query_string());
+        return to_jstring(env, sub->query_string);
     }
     CATCH_STD()
     return nullptr;
@@ -85,7 +85,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsSubscription_native
 {
     try {
         auto sub = reinterpret_cast<sync::Subscription*>(j_subscription_ptr);
-        return to_milliseconds(sub->created_at());
+        return to_milliseconds(sub->created_at);
     }
     CATCH_STD()
     return 0;
@@ -97,7 +97,7 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsSubscription_native
 {
     try {
         auto sub = reinterpret_cast<sync::Subscription*>(j_subscription_ptr);
-        return to_milliseconds(sub->updated_at());
+        return to_milliseconds(sub->updated_at);
     }
     CATCH_STD()
     return 0;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscriptionSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscriptionSet.cpp
@@ -23,7 +23,7 @@
 #include "jni_util/jni_utils.hpp"
 
 #include <realm/object-store/shared_realm.hpp>
-#include <realm/object-store/binding_callback_thread_observer.hpp>
+#include <realm/sync/binding_callback_thread_observer.hpp>
 #include <realm/object-store/sync/app.hpp>
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/sync/subscriptions.hpp>

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscriptionSet.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsSubscriptionSet.cpp
@@ -141,9 +141,9 @@ Java_io_realm_internal_objectstore_OsSubscriptionSet_nativeFindByName(JNIEnv *en
     try {
         auto subscriptions = reinterpret_cast<sync::SubscriptionSet*>(j_subscription_set_ptr);
         JStringAccessor name(env, j_name);
-        sync::SubscriptionSet::const_iterator iter = subscriptions->find(name);
-        if (iter != subscriptions->end()) {
-            return reinterpret_cast<jlong>(new sync::Subscription(std::move(*iter)));
+        const sync::Subscription* subscription = subscriptions->find(name);
+        if (subscription != nullptr) {
+            return reinterpret_cast<jlong>(new sync::Subscription(std::move(*subscription)));
         } else {
             return -1;
         }
@@ -159,9 +159,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_internal_objectstore_OsSubscriptionSet_nat
     try {
         auto subscriptions = reinterpret_cast<sync::SubscriptionSet*>(j_subscription_set_ptr);
         auto query = reinterpret_cast<Query*>(j_query_ptr);
-        sync::SubscriptionSet::const_iterator iter = subscriptions->find(*query);
-        if (iter != subscriptions->end()) {
-            return reinterpret_cast<jlong>(new sync::Subscription(std::move(*iter)));
+        const sync::Subscription* subscription = subscriptions->find(*query);
+        if (subscription != nullptr) {
+            return reinterpret_cast<jlong>(new sync::Subscription(std::move(*subscription)));
         } else {
             return -1;
         }

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_Sync.cpp
@@ -21,7 +21,7 @@
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/object-store/sync/sync_session.hpp>
 #include <realm/sync/protocol.hpp>
-#include <realm/object-store/binding_callback_thread_observer.hpp>
+#include <realm/sync/binding_callback_thread_observer.hpp>
 
 #include "util.hpp"
 #include <jni_util/bson_util.hpp>

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
@@ -212,6 +212,8 @@ JNIEXPORT jbyte JNICALL Java_io_realm_mongodb_sync_SyncSession_nativeGetState(JN
                     return io_realm_mongodb_sync_SyncSession_STATE_VALUE_DYING;
                 case SyncSession::State::Inactive:
                     return io_realm_mongodb_sync_SyncSession_STATE_VALUE_INACTIVE;
+                case SyncSession::State::Paused:
+                    return io_realm_mongodb_sync_SyncSession_STATE_VALUE_PAUSED;
                 case SyncSession::State::WaitingForAccessToken:
                     return io_realm_mongodb_sync_SyncSession_STATE_VALUE_WAITING_FOR_ACCESS_TOKEN;
             }
@@ -335,7 +337,7 @@ JNIEXPORT void JNICALL Java_io_realm_mongodb_sync_SyncSession_nativeStop(JNIEnv*
         JStringAccessor local_realm_path(env, j_local_realm_path);
         auto session = app->sync_manager()->get_existing_session(local_realm_path);
         if (session) {
-            session->log_out();
+            session->close();
         }
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/cpp/jni_util/log.cpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.cpp
@@ -180,25 +180,25 @@ void Log::log(Level level, const char* tag, jthrowable throwable, const char* me
     }
 }
 
-realm::util::RootLogger::Level Log::convert_to_core_log_level(Level level)
+realm::util::Logger::Level Log::convert_to_core_log_level(Level level)
 {
         switch (level) {
             case Log::trace:
-                return RootLogger::Level::trace;
+                return Logger::Level::trace;
             case Log::debug:
-                return RootLogger::Level::debug;
+                return Logger::Level::debug;
             case Log::info:
-                return RootLogger::Level::info;
+                return Logger::Level::info;
             case Log::warn:
-                return RootLogger::Level::warn;
+                return Logger::Level::warn;
             case Log::error:
-                return RootLogger::Level::error;
+                return Logger::Level::error;
             case Log::fatal:
-                return RootLogger::Level::fatal;
+                return Logger::Level::fatal;
             case Log::all:
-                return RootLogger::Level::all;
+                return Logger::Level::all;
             case Log::off:
-                return RootLogger::Level::off;
+                return Logger::Level::off;
             default:
                 break;
         }

--- a/realm/realm-library/src/main/cpp/jni_util/log.hpp
+++ b/realm/realm-library/src/main/cpp/jni_util/log.hpp
@@ -132,7 +132,7 @@ public:
         shared().log(fatal, REALM_JNI_TAG, nullptr, util::format(fmt, {util::Printable(args)...}).c_str());
     }
 
-    static realm::util::RootLogger::Level convert_to_core_log_level(Level level);
+    static realm::util::Logger::Level convert_to_core_log_level(Level level);
 
     // Get the shared Log instance.
     static Log& shared();
@@ -173,7 +173,7 @@ extern std::shared_ptr<JniLogger> get_default_logger();
 
 // Do NOT call set_level_threshold on the bridge to set the log level. Instead, call the Log::set_level which will
 // set all logger levels.
-class CoreLoggerBridge : public realm::util::RootLogger {
+class CoreLoggerBridge : public realm::util::Logger {
 public:
     CoreLoggerBridge(std::string tag);
     ~CoreLoggerBridge();

--- a/realm/realm-library/src/main/java/io/realm/internal/OsMap.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsMap.java
@@ -96,7 +96,7 @@ public class OsMap implements NativeObject {
         } else if (value instanceof Long) {
             return nativeContainsLong(nativePtr, (long) value);
         } else if (value instanceof Double) {
-            return nativeContainsLong(nativePtr, ((Double) value).longValue());
+            return nativeContainsDouble(nativePtr, (double) value);
         } else if (value instanceof Short) {
             return nativeContainsLong(nativePtr, ((Short) value).longValue());
         } else if (value instanceof Byte) {
@@ -328,6 +328,8 @@ public class OsMap implements NativeObject {
     private static native Object[] nativeGetEntryForPrimitive(long nativePtr, int position);
 
     private static native boolean nativeContainsNull(long nativePtr);
+
+    private static native boolean nativeContainsDouble(long nativePtr, double value);
 
     private static native boolean nativeContainsLong(long nativePtr, long value);
 

--- a/realm/realm-library/src/main/java/io/realm/mongodb/sync/Subscription.java
+++ b/realm/realm-library/src/main/java/io/realm/mongodb/sync/Subscription.java
@@ -97,5 +97,5 @@ public interface Subscription {
      *
      * @return the query covered by this subscription.
      */
-    public String getQuery();
+     String getQuery();
 }

--- a/realm/realm-library/src/main/java/io/realm/mongodb/sync/SubscriptionSet.java
+++ b/realm/realm-library/src/main/java/io/realm/mongodb/sync/SubscriptionSet.java
@@ -41,7 +41,7 @@ public interface SubscriptionSet extends Iterable<Subscription> {
     /**
      * The possible states a subscription set can be in.
      */
-    public enum State {
+    enum State {
         /**
          * The initial state of subscriptions when opening a new Realm or when entering a
          * {@link #update(UpdateCallback)}. This state is only valid for

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsApp.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/objectstore/OsApp.java
@@ -10,6 +10,7 @@ import io.realm.internal.network.MockableNetworkTransport;
 import io.realm.internal.network.NetworkRequest;
 import io.realm.internal.network.OkHttpNetworkTransport;
 import io.realm.mongodb.AppConfiguration;
+import kotlin.Suppress;
 
 public class OsApp implements NativeObject {
     private static final long nativeFinalizerPtr = nativeGetFinalizerMethodPtr();
@@ -36,6 +37,13 @@ public class OsApp implements NativeObject {
             for (Map.Entry<String, String> entry : config.getCustomRequestHeaders().entrySet()) {
                 networkTransport.addCustomRequestHeader(entry.getKey(), entry.getValue());
             }
+            String cpuArch;
+             if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
+                cpuArch = android.os.Build.CPU_ABI;
+            } else {
+                 cpuArch = android.os.Build.SUPPORTED_ABIS[0];
+            }
+
             nativePtr = nativeCreate(
                     config.getAppId(),
                     config.getBaseUrl().toString(),
@@ -48,7 +56,13 @@ public class OsApp implements NativeObject {
                     appDefinedUserAgent,
                     "android",
                     android.os.Build.VERSION.RELEASE,
-                    io.realm.BuildConfig.VERSION_NAME);
+                    io.realm.BuildConfig.VERSION_NAME,
+                    cpuArch,
+                    android.os.Build.MANUFACTURER,
+                    android.os.Build.MODEL,
+                    "Android",
+                    String.valueOf(android.os.Build.VERSION.SDK_INT)
+            );
         }
     }
 
@@ -126,7 +140,13 @@ public class OsApp implements NativeObject {
                                      String appUserInfo,
                                      String platform,
                                      String platformVersion,
-                                     String sdkVersion);
+                                     String sdkVersion,
+                                     String cpuArch,
+                                     String deviceName,
+                                     String deviceVersion,
+                                     String frameworkName,
+                                     String frameworkVersion
+    );
 
     private static native void nativeLogin(long nativeAppPtr, long nativeCredentialsPtr, NetworkRequest callback);
 

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -387,7 +387,7 @@ public abstract class Sync {
     // In this implementation we use the second method, since it's more suitable for
     // the underlying Java API we need to call to validate the certificate chain.
     @SuppressWarnings("unused")
-    synchronized static boolean sslVerifyCallback(String serverAddress, String pemData, int depth) {
+    static synchronized boolean sslVerifyCallback(String serverAddress, String pemData, int depth) {
         try {
             if (ATLAS_CERTIFICATES_CHAIN == null) {
                 ATLAS_CERTIFICATES_CHAIN = new HashMap<>();

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/SyncSession.java
@@ -95,7 +95,8 @@ public class SyncSession {
     private static final byte STATE_VALUE_DYING = 1;
     private static final byte STATE_VALUE_INACTIVE = 2;
     private static final byte STATE_VALUE_WAITING_FOR_ACCESS_TOKEN = 3;
-    
+    private static final byte STATE_VALUE_PAUSED = 4;
+
 
     // List of Java connection change listeners
     private final CopyOnWriteArrayList<ConnectionListener> connectionListeners = new CopyOnWriteArrayList<>();
@@ -149,8 +150,14 @@ public class SyncSession {
          * <p>
          * Once a valid token is acquired, the session will transition to {@link #ACTIVE}.
          */
-        WAITING_FOR_ACCESS_TOKEN(STATE_VALUE_WAITING_FOR_ACCESS_TOKEN);
+        WAITING_FOR_ACCESS_TOKEN(STATE_VALUE_WAITING_FOR_ACCESS_TOKEN),
 
+        /**
+         * The Realm is open and has a connection to the server, but no data is allowed to be
+         * transferred between the device and the server. Call {@link SyncSession#start()} to start
+         * transferring data again. The state will then become {@link #ACTIVE}.
+         */
+        PAUSED(STATE_VALUE_PAUSED);
 
         final byte value;
 

--- a/realm/realm-library/src/testUtils/java/io/realm/TestHelper.java
+++ b/realm/realm-library/src/testUtils/java/io/realm/TestHelper.java
@@ -40,7 +40,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.Locale;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -399,6 +401,66 @@ public class TestHelper {
         return sb.toString();
     }
 
+    public static class MessageBuffer {
+
+        private final int size;
+
+        private int writeIndex = 0;
+        private int availablePos = 0;
+
+        public String[] entries;
+
+        public MessageBuffer(int size) {
+            this.size = size;
+            this.entries = new String[size];
+        }
+
+        public void put(String entry) {
+            if (availablePos < size) {
+                if (writeIndex >= size) {
+                    writeIndex = 0;
+                }
+                entries[writeIndex] = entry;
+                writeIndex++;
+                availablePos++;
+            }
+        }
+
+        public String take() {
+            if (availablePos == 0) {
+                return null;
+            }
+            int nextAvailable = writeIndex - availablePos;
+            if (nextAvailable < 0) {
+                nextAvailable += size;
+            }
+            String nextObj = entries[nextAvailable];
+            availablePos--;
+            return nextObj;
+        }
+
+        public Iterator<String> iterator() {
+            return new Iterator<String>() {
+
+                private int pos = -1;
+
+                @Override
+                public boolean hasNext() {
+                    return pos + 1 < size;
+                }
+
+                @Override
+                public String next() {
+                    pos = pos + 1;
+                    if (pos > size) {
+                        throw new NoSuchElementException("Went beyond message buffer capacity.");
+                    }
+                    return entries[pos];
+                }
+            };
+        }
+    }
+
     /**
      * Returns a naive logger that can be used to test the values that are sent to the logger.
      */
@@ -406,8 +468,10 @@ public class TestHelper {
 
         private final int minimumLevel;
         public String message;
-        public String previousMessage;
         public Throwable throwable;
+
+        // Store just a few log entries
+        public MessageBuffer messageBuffer = new MessageBuffer(5);
 
         public TestLogger() {
             this(LogLevel.DEBUG);
@@ -420,7 +484,7 @@ public class TestHelper {
         @Override
         public void log(int level, String tag, Throwable throwable, String message) {
             if (minimumLevel <= level) {
-                this.previousMessage = this.message;
+                messageBuffer.put(message);
                 this.message = message;
                 this.throwable = throwable;
             }


### PR DESCRIPTION
- Updated to Core v13.1.1.
- Fixed a bug that would result in `RealmDictionary` not being able to find `double` values due not taking the precision of the input parameter into consideration when using `RealmDictionary.contains`.
- Added a message buffer for our test logger since Core now logs more messages than before when logging. This broke our obfuscator tests.