### PR TITLE
Add support for Gradle Configuration Cache

### DIFF
--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -21,15 +21,22 @@ import com.android.build.gradle.internal.publishing.AndroidArtifacts
 import io.realm.analytics.RealmAnalytics
 import io.realm.transformer.build.BuildTemplate
 import io.realm.transformer.build.FullBuild
+import io.realm.transformer.ext.getTargetSdk
+import io.realm.transformer.ext.getMinSdk
 import io.realm.transformer.ext.getBootClasspath
+import io.realm.transformer.ext.getAppId
+import io.realm.transformer.ext.getAgpVersion
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
@@ -49,38 +56,35 @@ val READ_TIMEOUT = 2000L;
 // Wrapper for storing data from org.gradle.api.Project as we cannot store a class variable to it
 // as that conflict with the Configuration Cache.
 data class ProjectMetaData(
-    val isOffline: Boolean,
-    val bootClassPath: List<File>)
+        val bootClassPath: Set<File>,
+        val usesKotlin: Boolean,
+        val targetType: String,
+        val targetSdk: String,
+        val minSdk: String,
+        val agpVersion: String,
+        val appId: String,
+        val gradleVersion: String,
+        val usesSync: Boolean,
+        val isGradleOffline: Boolean) {
+}
 
 /**
  * This class implements the Transform API provided by the Android Gradle plugin.
  */
-class RealmTransformer(project: Project,
+class RealmTransformer(private val metadata: ProjectMetaData,
                        private val inputs: ListProperty<Directory>,
                        private val allJars: ListProperty<RegularFile>,
                        private val referencedInputs: ConfigurableFileCollection,
                        private val output: RegularFileProperty) {
-    private lateinit var metadata: ProjectMetaData
-    private var analytics: RealmAnalytics? = null
 
-    init {
-        // Fetch project metadata when registering the transformer, but as some of the properties
-        // we need to read might not be initialized yet (e.g. the Android extension), we need
-        // to wait until after the build files have been evaluated.
-        metadata = ProjectMetaData(
-            // Plugin requirements
-            project.gradle.startParameter.isOffline,
-            project.getBootClasspath()
-        )
-
-        try {
-            this.analytics = RealmAnalytics()
-            this.analytics!!.calculateAnalyticsData(project)
-
-        } catch (e: Exception) {
-            // Analytics should never crash the build.
-            logger.debug("Could not calculate Realm analytics data:\n$e")
-        }
+    private val analytics: RealmAnalytics? = try {
+        val analytics = RealmAnalytics()
+        analytics.calculateAnalyticsData(metadata)
+        analytics
+    } catch (e: Exception) {
+        // Analytics should never crash the build.
+        logger.debug("Could not calculate Realm analytics data:\n$e")
+        null
     }
 
     companion object {
@@ -90,7 +94,7 @@ class RealmTransformer(project: Project,
             androidComponents.onVariants { variant ->
                 variant.components.forEach { component ->
                     val taskProvider =
-                        project.tasks.register<ModifyClassesTask>(
+                        project.tasks.register(
                             "${component.name}RealmAccessorsTransformer",
                             ModifyClassesTask::class.java
                         ) {
@@ -100,6 +104,16 @@ class RealmTransformer(project: Project,
                                     AndroidArtifacts.ArtifactType.CLASSES_JAR.type
                                 )
                             }.files)
+                            it.bootClasspath.setFrom(project.getBootClasspath())
+                            it.offline.set(project.gradle.startParameter.isOffline)
+                            it.targetType.set(project.targetType())
+                            it.usesKotlin.set(project.usesKotlin())
+                            it.minSdk.set(project.getMinSdk())
+                            it.targetSdk.set(project.getTargetSdk())
+                            it.agpVersion.set(project.getAgpVersion())
+                            it.usesSync.set(Utils.isSyncEnabled(project))
+                            it.gradleVersion.set(project.gradle.gradleVersion)
+                            it.appId.set(project.getAppId())
                         }
                     component.artifacts.forScope(com.android.build.api.variant.ScopedArtifacts.Scope.PROJECT)
                         .use<ModifyClassesTask>(taskProvider)
@@ -111,6 +125,29 @@ class RealmTransformer(project: Project,
                         )
                 }
             }
+        }
+
+        private fun Project.targetType(): String = with(project.plugins) {
+            when {
+                findPlugin("com.android.application") != null -> "app"
+                findPlugin("com.android.library") != null -> "library"
+                else -> "unknown"
+            }
+        }
+
+        private fun Project.usesKotlin(): Boolean {
+            for (conf in project.configurations) {
+                try {
+                    for (artifact: ResolvedArtifact in conf.resolvedConfiguration.resolvedArtifacts) {
+                        if (artifact.name.startsWith("kotlin-stdlib")) {
+                            return true
+                        }
+                    }
+                } catch (ignore: Exception) {
+                    // Some artifacts might not be able to resolve, in this case, just ignore them.
+                }
+            }
+            return false
         }
     }
 
@@ -167,6 +204,7 @@ class RealmTransformer(project: Project,
 }
 
 abstract class ModifyClassesTask: DefaultTask() {
+
     @get:Classpath
     abstract val fullRuntimeClasspath : ConfigurableFileCollection
 
@@ -176,13 +214,60 @@ abstract class ModifyClassesTask: DefaultTask() {
     @get:InputFiles
     abstract val allDirectories: ListProperty<Directory>
 
+    @get:InputFiles
+    abstract val bootClasspath: ConfigurableFileCollection
+
+    @get:Input
+    abstract val targetType: Property<String>
+
+    @get:Input
+    abstract val offline: Property<Boolean>
+
+    @get:Input
+    abstract val usesKotlin: Property<Boolean>
+
+    @get:Input
+    abstract val targetSdk: Property<String>
+
+    @get:Input
+    abstract val minSdk: Property<String>
+
+    @get:Input
+    abstract val agpVersion: Property<String>
+
+    @get:Input
+    abstract val appId: Property<String>
+
+    @get:Input
+    abstract val gradleVersion: Property<String>
+
+    @get:Input
+    abstract val usesSync: Property<Boolean>
+
     @get:OutputFiles
     abstract val output: RegularFileProperty
 
     @TaskAction
     fun taskAction() {
-        RealmTransformer(project, allDirectories, allJars, fullRuntimeClasspath, output)
-            .transform()
+        val metadata = ProjectMetaData(
+                bootClassPath = bootClasspath.files,
+                usesKotlin = usesKotlin.get(),
+                targetType = targetType.get(),
+                targetSdk = targetSdk.get(),
+                minSdk = minSdk.get(),
+                agpVersion = agpVersion.get(),
+                appId = appId.get(),
+                gradleVersion = gradleVersion.get(),
+                usesSync = usesSync.get(),
+                isGradleOffline = offline.get(),
+        )
+        RealmTransformer(
+                metadata = metadata,
+                inputs = allDirectories,
+                allJars = allJars,
+                referencedInputs = fullRuntimeClasspath,
+                output = output,
+        ).transform()
     }
 }
 


### PR DESCRIPTION
## Description
This PR fixes Gradle Configuration Cache support of Realm Gradle Plugin. Related to this issue: https://github.com/realm/realm-java/issues/7299

### Problem
Currently, the `-transform-api` versions of Realm do not support Gradle Configuration Cache. The reason is that `ModifyClassesTask` class in Realm Gradle Plugin uses a reference to `Project` object which is something that is now allowed by Config Cache. The build fails with the error below:
```
4 problems were found storing the configuration cache.
- Task `:app:debugRealmAccessorsTransformer` of type `io.realm.transformer.ModifyClassesTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
...
```
### Solution
The solution is to move all of the usages of `Project` object out of the Gradle task at the registration step. This way, Configuration cache works as expected.
Tested with AGP 8.0