### PR TITLE
Add automatic handling of orphan embedded objects during migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None.
 
 ### Fixed
-* None.
+* Added support for automatic handling of orphan embedded objects after migrating regular object properties to become embedded objects. (Issue [#7769](https://github.com/realm/realm-java/issues/7769)).
 
 ### Compatibility
 * File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -65,6 +65,10 @@ import io.realm.entities.StringOnlyRequired;
 import io.realm.entities.Thread;
 import io.realm.entities.embedded.EmbeddedSimpleChild;
 import io.realm.entities.embedded.EmbeddedSimpleParent;
+import io.realm.entities.migration.HandleBackLinksChild1;
+import io.realm.entities.migration.HandleBackLinksChild2;
+import io.realm.entities.migration.HandleBackLinksParent1;
+import io.realm.entities.migration.HandleBackLinksParent2;
 import io.realm.entities.migration.MigrationClassRenamed;
 import io.realm.entities.migration.MigrationCore6PKStringIndexedByDefault;
 import io.realm.entities.migration.MigrationFieldRenameAndAdd;
@@ -1716,7 +1720,7 @@ public class RealmMigrationTests {
     }
 
     @Test
-    public void migrate_embeddedObject_handleBackLinks() {
+    public void migrate_embeddedObject_deleteOrphans() {
         RealmConfiguration config1 = configFactory.createConfigurationBuilder()
                 .schema(HandleBackLinksParent1.class, HandleBackLinksChild1.class)
                 .schemaVersion(1)
@@ -1728,8 +1732,8 @@ public class RealmMigrationTests {
             HandleBackLinksParent1 parent = new HandleBackLinksParent1();
             parent.child = child;
             HandleBackLinksChild1 orphan = new HandleBackLinksChild1();
-            realm.insert(parent);
-            realm.insert(orphan);
+            realm.insertOrUpdate(parent);
+            realm.insertOrUpdate(orphan);
         });
         long parentCountV1 = realm1.where(HandleBackLinksParent1.class)
                 .count();
@@ -1778,49 +1782,72 @@ public class RealmMigrationTests {
         realm2.close();
     }
 
+    @Test
+    public void migrate_embeddedObject_clonesChildWhenReferencedMoreThanOnce() {
+        RealmConfiguration config1 = configFactory.createConfigurationBuilder()
+                .schema(HandleBackLinksParent1.class, HandleBackLinksChild1.class)
+                .schemaVersion(1)
+                .build();
+
+        Realm realm1 = Realm.getInstance(config1);
+        HandleBackLinksChild1 child = new HandleBackLinksChild1();
+        HandleBackLinksParent1 parent1 = new HandleBackLinksParent1();
+        HandleBackLinksParent1 parent2 = new HandleBackLinksParent1();
+        realm1.executeTransaction(realm -> {
+            // Copy child and set it as children for both parents.
+            // Now the managed child has two parents. This will not be allowed after converting it
+            // to an embedded object and will result into the child object being duplicated so that
+            // both parents can have a reference to a separate and different embedded object.
+            HandleBackLinksChild1 managedChild = realm.copyToRealm(child);
+            parent1.id = 1L;
+            parent1.child = managedChild;
+            realm.insert(parent1);
+            parent2.id = 2L;
+            parent2.child = managedChild;
+            realm.insert(parent2);
+        });
+        long parentCountV1 = realm1.where(HandleBackLinksParent1.class)
+                .count();
+        assertEquals(2L, parentCountV1);
+        long childCountV1 = realm1.where(HandleBackLinksChild1.class)
+                .count();
+        assertEquals(1L, childCountV1);
+        realm1.close();
+
+        RealmMigration migration = (realm, oldVersion, newVersion) -> {
+            RealmSchema schema = realm.getSchema();
+            if (oldVersion == 1L) {
+                RealmObjectSchema parentSchema = schema.get("HandleBackLinksParent1");
+                assertNotNull(parentSchema);
+                RealmObjectSchema childSchema = schema.get("HandleBackLinksChild1");
+                assertNotNull(childSchema);
+                childSchema.setEmbedded(true, true);
+
+                // Rename classes to avoid conflicts with all other tests
+                parentSchema.setClassName("HandleBackLinksParent2");
+                childSchema.setClassName("HandleBackLinksChild2");
+            }
+        };
+
+        // Create schema v2
+        RealmConfiguration config2 = configFactory.createConfigurationBuilder()
+                .schema(HandleBackLinksParent2.class, HandleBackLinksChild2.class)
+                .schemaVersion(2)
+                .migration(migration)
+                .build();
+
+        // After the migration the only child class is embedded and will not be allowed to have two parents
+        // so the child object will be duplicated
+        Realm realm2 = Realm.getInstance(config2);
+        long parentCountV2 = realm2.where(HandleBackLinksParent2.class)
+                .count();
+        assertEquals(2L, parentCountV2);
+        long childCountV2 = realm2.where(HandleBackLinksChild2.class)
+                .count();
+        assertEquals(2L, childCountV2);
+        realm2.close();
+    }
+
     // TODO Add unit tests for default nullability
     // TODO Add unit tests for default Indexing for Primary keys
-}
-
-// Original parent with a regular object as a child
-//@RealmClass(name = "HandleBackLinksParent1")
-class HandleBackLinksParent1 extends RealmObject {
-    @PrimaryKey
-    public long id;
-
-    public HandleBackLinksChild1 child;
-
-    public HandleBackLinksParent1() {}
-}
-
-// Original child as a regular object
-//@RealmClass(name = "HandleBackLinksChild1")
-class HandleBackLinksChild1 extends RealmObject {
-
-    public String name;
-
-    public HandleBackLinksChild1() {}
-
-}
-
-// Parent, now having an embedded object as a child, respecting table names
-//@RealmClass(name = "HandleBackLinksParent2")
-class HandleBackLinksParent2 extends RealmObject {
-    @PrimaryKey
-    public long id;
-
-    public HandleBackLinksChild2 child;
-
-    public HandleBackLinksParent2() {}
-}
-
-// Child, now as an embedded object, respecting table names
-//@RealmClass(embedded = true, name = "HandleBackLinksChild2")
-@RealmClass(embedded = true)
-class HandleBackLinksChild2 extends RealmObject {
-
-    public String name;
-
-    public HandleBackLinksChild2() {}
-
 }

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -1777,7 +1777,7 @@ public class RealmMigrationTests {
 }
 
 // Original parent with a regular object as a child
-@RealmClass(name = "Parent")
+@RealmClass(name = "HandleBackLinksParent")
 class BackLinkParent1 extends RealmObject {
     @PrimaryKey
     public long id;
@@ -1788,7 +1788,7 @@ class BackLinkParent1 extends RealmObject {
 }
 
 // Original child as a regular object
-@RealmClass(name = "Child")
+@RealmClass(name = "HandleBackLinksChild")
 class BackLinkChild1 extends RealmObject {
 
     public String name;
@@ -1798,7 +1798,7 @@ class BackLinkChild1 extends RealmObject {
 }
 
 // Parent, now having an embedded object as a child, respecting table names
-@RealmClass(name = "Parent")
+@RealmClass(name = "HandleBackLinksParent")
 class BackLinkParent2 extends RealmObject {
     @PrimaryKey
     public long id;
@@ -1809,7 +1809,7 @@ class BackLinkParent2 extends RealmObject {
 }
 
 // Child, now as an embedded object, respecting table names
-@RealmClass(embedded = true, name = "Child")
+@RealmClass(embedded = true, name = "HandleBackLinksChild")
 class BackLinkChild2 extends RealmObject {
 
     public String name;

--- a/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/RealmMigrationTests.java
@@ -1776,6 +1776,7 @@ public class RealmMigrationTests {
     // TODO Add unit tests for default Indexing for Primary keys
 }
 
+// Original parent with a regular object as a child
 @RealmClass(name = "Parent")
 class BackLinkParent1 extends RealmObject {
     @PrimaryKey
@@ -1786,6 +1787,7 @@ class BackLinkParent1 extends RealmObject {
     public BackLinkParent1() {}
 }
 
+// Original child as a regular object
 @RealmClass(name = "Child")
 class BackLinkChild1 extends RealmObject {
 
@@ -1795,6 +1797,7 @@ class BackLinkChild1 extends RealmObject {
 
 }
 
+// Parent, now having an embedded object as a child, respecting table names
 @RealmClass(name = "Parent")
 class BackLinkParent2 extends RealmObject {
     @PrimaryKey
@@ -1805,6 +1808,7 @@ class BackLinkParent2 extends RealmObject {
     public BackLinkParent2() {}
 }
 
+// Child, now as an embedded object, respecting table names
 @RealmClass(embedded = true, name = "Child")
 class BackLinkChild2 extends RealmObject {
 

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksChild1.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksChild1.java
@@ -1,0 +1,12 @@
+package io.realm.entities.migration;
+
+import io.realm.RealmObject;
+
+// Original child as a regular object
+public class HandleBackLinksChild1 extends RealmObject {
+
+    public String name;
+
+    public HandleBackLinksChild1() {}
+
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksChild2.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksChild2.java
@@ -1,0 +1,14 @@
+package io.realm.entities.migration;
+
+import io.realm.RealmObject;
+import io.realm.annotations.RealmClass;
+
+// Child, now as an embedded object, respecting table names
+@RealmClass(embedded = true)
+public class HandleBackLinksChild2 extends RealmObject {
+
+    public String name;
+
+    public HandleBackLinksChild2() {}
+
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksParent1.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksParent1.java
@@ -1,0 +1,14 @@
+package io.realm.entities.migration;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+// Original parent with a regular object as a child
+public class HandleBackLinksParent1 extends RealmObject {
+    @PrimaryKey
+    public long id;
+
+    public HandleBackLinksChild1 child;
+
+    public HandleBackLinksParent1() {}
+}

--- a/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksParent2.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/entities/migration/HandleBackLinksParent2.java
@@ -1,0 +1,14 @@
+package io.realm.entities.migration;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+// Parent, now having an embedded object as a child, respecting table names
+public class HandleBackLinksParent2 extends RealmObject {
+    @PrimaryKey
+    public long id;
+
+    public HandleBackLinksChild2 child;
+
+    public HandleBackLinksParent2() {}
+}

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -1120,11 +1120,11 @@ JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeIsEmbedded(JNIEnv*
     return false;
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeSetEmbedded(JNIEnv* env, jclass, jlong j_table_ptr, jboolean j_embedded)
+JNIEXPORT jboolean JNICALL Java_io_realm_internal_Table_nativeSetEmbedded(JNIEnv* env, jclass, jlong j_table_ptr, jboolean j_embedded, jboolean j_handle_backlinks)
 {
     try {
         TableRef table = TableRef(TBL_REF(j_table_ptr));
-        table->set_table_type(to_bool(j_embedded) ? Table::Type::Embedded : Table::Type::TopLevel);
+        table->set_table_type(to_bool(j_embedded) ? Table::Type::Embedded : Table::Type::TopLevel, to_bool(j_handle_backlinks));
         return true;
     }
     CATCH_STD()

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -588,11 +588,36 @@ public abstract class RealmObjectSchema {
      * @see RealmClass#embedded()
      */
     public void setEmbedded(boolean embedded) {
+        setEmbedded(embedded, false);
+    }
+
+    /**
+     * Converts the class to be embedded or not.
+     * <p>
+     * A class can only be marked as embedded if the following invariants are satisfied:
+     * <ul>
+     *     <li>
+     *         The class is not allowed to have a primary key defined.
+     *     </li>
+     *     <li>
+     *         All existing objects of this type, must have one and exactly one parent object
+     *         already pointing to it. If 0 or more than 1 object has a reference to an object
+     *         about to be marked embedded an {@link IllegalStateException} will be thrown.
+     *     </li>
+     * </ul>
+     *
+     * This variant adds on {@link RealmObjectSchema#setEmbedded(boolean)} to add support for automatic deletion of orphan objects
+     * after converting the property into a embedded object class.
+     *
+     * @throws IllegalStateException if the class could not be converted because it broke some of the Embedded Objects invariants.
+     * @see RealmClass#embedded()
+     */
+    public void setEmbedded(boolean embedded, boolean deleteOrphanChildren) {
         if (hasPrimaryKey()) {
             throw new IllegalStateException("Embedded classes cannot have primary keys. This class " +
                     "has a primary key defined so cannot be marked as embedded: " + getClassName());
         }
-        boolean setEmbedded = table.setEmbedded(embedded);
+        boolean setEmbedded = table.setEmbedded(embedded, deleteOrphanChildren);
         if (!setEmbedded && embedded) {
             throw new IllegalStateException("The class could not be marked as embedded as some " +
                     "objects of this type break some of the Embedded Objects invariants. In order to convert " +

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -606,18 +606,18 @@ public abstract class RealmObjectSchema {
      *     </li>
      * </ul>
      *
-     * This variant adds on {@link RealmObjectSchema#setEmbedded(boolean)} to add support for automatic deletion of orphan objects
-     * after converting the property into a embedded object class.
+     * This variant adds on {@link RealmObjectSchema#setEmbedded(boolean)} to add support for automatic handling of unsatisfied
+     * invariants after converting the property into an embedded object property.
      *
      * @throws IllegalStateException if the class could not be converted because it broke some of the Embedded Objects invariants.
      * @see RealmClass#embedded()
      */
-    public void setEmbedded(boolean embedded, boolean deleteOrphanChildren) {
+    public void setEmbedded(boolean embedded, boolean handleBackLinks) {
         if (hasPrimaryKey()) {
             throw new IllegalStateException("Embedded classes cannot have primary keys. This class " +
                     "has a primary key defined so cannot be marked as embedded: " + getClassName());
         }
-        boolean setEmbedded = table.setEmbedded(embedded, deleteOrphanChildren);
+        boolean setEmbedded = table.setEmbedded(embedded, handleBackLinks);
         if (!setEmbedded && embedded) {
             throw new IllegalStateException("The class could not be marked as embedded as some " +
                     "objects of this type break some of the Embedded Objects invariants. In order to convert " +

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -592,7 +592,8 @@ public abstract class RealmObjectSchema {
     }
 
     /**
-     * Converts the class to be embedded or not.
+     * Converts the class to be embedded or not allowing automatic handling of backlinks, including cloning of children objects
+     * with multiple parents.
      * <p>
      * A class can only be marked as embedded if the following invariants are satisfied:
      * <ul>
@@ -607,7 +608,8 @@ public abstract class RealmObjectSchema {
      * </ul>
      *
      * This variant adds on {@link RealmObjectSchema#setEmbedded(boolean)} to add support for automatic handling of unsatisfied
-     * invariants after converting the property into an embedded object property.
+     * invariants after converting the property into an embedded object property. In addition, children objects with multiple
+     * parents that are converted to embedded objects will be cloned to keep the link between parent and child.
      *
      * @throws IllegalStateException if the class could not be converted because it broke some of the Embedded Objects invariants.
      * @see RealmClass#embedded()

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -967,7 +967,5 @@ public class Table implements NativeObject {
 
     private static native boolean nativeIsEmbedded(long nativeTableRefPtr);
 
-//    private static native boolean nativeSetEmbedded(long nativeTableRefPtr, boolean isEmbedded);
-
     private static native boolean nativeSetEmbedded(long nativeTableRefPtr, boolean isEmbedded, boolean handleBackLinks);
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -793,7 +793,17 @@ public class Table implements NativeObject {
      * some invariant was broken when trying to change the state
      */
     public boolean setEmbedded(boolean embedded) {
-        return nativeSetEmbedded(nativeTableRefPtr, embedded);
+        return setEmbedded(embedded, false);
+    }
+
+    /**
+     * Returns true if the state was changed, false if not. If false was returned, it meant
+     * some invariant was broken when trying to change the state. The {@code deleteOrphanChildren}
+     * parameter tells Core to automatically delete objects that become orphan children during
+     * migrations.
+     */
+    public boolean setEmbedded(boolean embedded, boolean deleteOrphanChildren) {
+        return nativeSetEmbedded(nativeTableRefPtr, embedded, deleteOrphanChildren);
     }
 
     @Nullable
@@ -957,5 +967,7 @@ public class Table implements NativeObject {
 
     private static native boolean nativeIsEmbedded(long nativeTableRefPtr);
 
-    private static native boolean nativeSetEmbedded(long nativeTableRefPtr, boolean isEmbedded);
+//    private static native boolean nativeSetEmbedded(long nativeTableRefPtr, boolean isEmbedded);
+
+    private static native boolean nativeSetEmbedded(long nativeTableRefPtr, boolean isEmbedded, boolean handleBackLinks);
 }

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -798,12 +798,13 @@ public class Table implements NativeObject {
 
     /**
      * Returns true if the state was changed, false if not. If false was returned, it meant
-     * some invariant was broken when trying to change the state. The {@code deleteOrphanChildren}
-     * parameter tells Core to automatically delete objects that become orphan children during
-     * migrations.
+     * some invariant was broken when trying to change the state. The {@code handleBackLinks}
+     * parameter tells Core to automatically handle all unsatisfied invariants for backlinks, e.g.
+     * children becoming orphan or cloning objects with multiple references during migrations from
+     * a regular object to an embedded object.
      */
-    public boolean setEmbedded(boolean embedded, boolean deleteOrphanChildren) {
-        return nativeSetEmbedded(nativeTableRefPtr, embedded, deleteOrphanChildren);
+    public boolean setEmbedded(boolean embedded, boolean handleBackLinks) {
+        return nativeSetEmbedded(nativeTableRefPtr, embedded, handleBackLinks);
     }
 
     @Nullable


### PR DESCRIPTION
Closes #7769

Added support for automatic handling of back links during migrations.