### PR TITLE
Allow executing instrumented and unit tests with the new transformer api release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ the main release [CHANGELOG.md](https://github.com/realm/realm-java/blob/release
 * None.
 
 ### Fixed
-* None.
+* Unit tests not being executed. (Issue [#7771](https://github.com/realm/realm-java/issues/7771))
+* Instrumented unit tests failed to execute because of the Realm dependencies being missing. (Issue [#7736](https://github.com/realm/realm-java/issues/7736))
 
 ### Compatibility
 * File format: Generates Realms with format v22. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -321,6 +321,7 @@ def runBuild(buildFlags, instrumentationTestTarget) {
           backgroundPid = startLogCatCollector()
           forwardAdbPorts()
           gradle('realm', "${instrumentationTestTarget} ${buildFlags}")
+          gradle('examples', ":unitTestExample:connectedDebugAndroidTest")
         } finally {
           stopLogCatCollector(backgroundPid)
           storeJunitResults 'realm/realm-library/build/outputs/androidTest-results/connected/**/TEST-*.xml'

--- a/gradle-plugin/src/main/kotlin/io/realm/gradle/Realm.kt
+++ b/gradle-plugin/src/main/kotlin/io/realm/gradle/Realm.kt
@@ -82,6 +82,7 @@ open class Realm : Plugin<Project> {
                 )
             }
         }
+    }
 
     companion object {
 

--- a/gradle-plugin/src/main/kotlin/io/realm/gradle/Realm.kt
+++ b/gradle-plugin/src/main/kotlin/io/realm/gradle/Realm.kt
@@ -69,10 +69,12 @@ open class Realm : Plugin<Project> {
             )
         }
 
-        project.afterEvaluate {
+        // FIXME When injected, dependencies are not propagating correctly from the main release to the 
+        // android test releases. We solve it by inject them into the instrumented tests manually.
+        project.afterEvaluate { 
             listOf(
                 dependencyConfigurationName,
-                ANDROID_TEST_IMPLEMENTATION // adds the dependencies to the instrumented tests configuration
+                ANDROID_TEST_IMPLEMENTATION // force adds the dependencies to the instrumented tests configuration
             ).forEach { dependencyConfigurationName: String ->
                 setDependencies(
                     project,

--- a/gradle-plugin/src/main/kotlin/io/realm/gradle/Realm.kt
+++ b/gradle-plugin/src/main/kotlin/io/realm/gradle/Realm.kt
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory
 
 val logger: Logger = LoggerFactory.getLogger("realm-logger")
 
+const val ANDROID_TEST_IMPLEMENTATION = "androidTestImplementation"
+
 // TODO Run a Task or Visitor to collect runtimeClassPath, then serialize it
 //      Run another task that depends on the output of the first task in order to deserialize the ClassPool and process each class apart
 open class Realm : Plugin<Project> {
@@ -32,7 +34,7 @@ open class Realm : Plugin<Project> {
         val isKotlinProject: Boolean =
             project.plugins.findPlugin("kotlin-android") != null || project.plugins.findPlugin("kotlin-multiplatform") != null
         val hasAnnotationProcessorConfiguration =
-            project.getConfigurations().findByName("annotationProcessor") != null
+            project.configurations.findByName("annotationProcessor") != null
         // TODO add a parameter in 'realm' block if this should be specified by users
         val dependencyConfigurationName: String = getDependencyConfigurationName(project)
         val extension = project.extensions.create("realm", RealmPluginExtension::class.java)
@@ -66,15 +68,20 @@ open class Realm : Plugin<Project> {
                 "io.realm:realm-annotations-processor:${Version.VERSION}"
             )
         }
+
         project.afterEvaluate {
-            setDependencies(
-                project,
+            listOf(
                 dependencyConfigurationName,
-                extension.isSyncEnabled,
-                extension.isKotlinExtensionsEnabled
-            )
+                ANDROID_TEST_IMPLEMENTATION // adds the dependencies to the instrumented tests configuration
+            ).forEach { dependencyConfigurationName: String ->
+                setDependencies(
+                    project,
+                    dependencyConfigurationName,
+                    extension.isSyncEnabled,
+                    extension.isKotlinExtensionsEnabled
+                )
+            }
         }
-    }
 
     companion object {
 

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -96,7 +96,14 @@ class RealmTransformer(private val metadata: ProjectMetaData,
                 project.extensions.getByType(AndroidComponentsExtension::class.java)
             androidComponents.onVariants { variant ->
                 variant.components
-                    .filterNot { it is UnitTest }
+                    .filterNot { 
+                        // FIXME With the new transformer API changes, processed classes from the Realm transformer aren't 
+                        // resolved correctly by the Unit tests gradle task causing the test runner not to execute tests.
+
+                        // This line disables the transformer on Unit test tasks. It is safe because Unit tests run
+                        // on JVM and Realm Java is not compatible with JVM.
+                        it is UnitTest 
+                    }
                     .forEach { component ->
                         val taskProvider =
                             project.tasks.register(


### PR DESCRIPTION
This PR fixes https://github.com/realm/realm-java/issues/7771 by disabling the transformer API on Unit Test components. 

There is some issue related in how the processed classes from the transformer are fed into the unit test task that does not allow the runner to resolve them.

Because Realm is not available in JVM and unit tests, disabling the Realm transformer has the same effect as applying the transformer on a Unit test, tests would only be able to use unmanaged versions of the objects.

Filed issue in google tracker: https://issuetracker.google.com/issues/270885482

The PR also fixes https://github.com/realm/realm-java/issues/7736 that prevented instrumented tests to run because of the Realm dependencies being not present in the configuration.