### PR TITLE
Update to Core 13.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
 * Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
 
+### Internal
+* Updated to Realm Core 13.6.0, commit e5435e8e76b7e33f2d7ef6d5bb189cab47dc40db.
+
 
 ## 10.13.1 (2023-03-16)
 
@@ -33,7 +36,7 @@
 * Realm Studio 11.0.0-alpha.0 or above is required to open Realms created by this version.
 
 ### Internal
-* Updated to Realm Core 13.5.0, commit 37cc58865648f343f7d6e538d45980e7f2351211.
+* None.
 
 
 ## 10.13.0 (2022-12-05)

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,10 +89,10 @@ RUN chmod -R a+rwX ${ANDROID_HOME}
 
 # Ensure a new enough version of CMake is available.
 RUN cd /opt \
-    && wget -nv https://cmake.org/files/v3.21/cmake-3.21.4-linux-x86_64.tar.gz \
-    && tar zxf cmake-3.21.4-linux-x86_64.tar.gz
+    && wget -nv https://cmake.org/files/v3.22/cmake-3.22.1-linux-x86_64.tar.gz \
+    && tar zxf cmake-3.22.1-linux-x86_64.tar.gz
 
 # Workaround for https://issuetracker.google.com/issues/206099937
-RUN ln -s /usr/bin/ninja /opt/cmake-3.21.4-linux-x86_64/bin/ninja
+RUN ln -s /usr/bin/ninja /opt/cmake-3.22.1-linux-x86_64/bin/ninja
 
-ENV PATH "/opt/cmake-3.21.4-linux-x86_64/bin:$PATH"
+ENV PATH "/opt/cmake-3.22.1-linux-x86_64/bin:$PATH"

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,6 +1,6 @@
 # Realm Core release used by Realm Java
 # https://github.com/realm/realm-core/releases
-REALM_CORE=13.5.0
+REALM_CORE=13.6.0
 
 # Version of MongoDB Realm used by integration tests
 # See https://github.com/realm/ci/packages/147854 for available versions
@@ -25,7 +25,7 @@ gradle=7.3.3
 ndkVersion=23.1.7779620
 BUILD_INFO_EXTRACTOR_GRADLE=4.17.0
 GRADLE_NEXUS_PLUGIN=1.0.0
-CMAKE=3.21.4
+CMAKE=3.22.1
 
 # Bson dependency version
 BSON_DEPENDENCY=3.12.1


### PR DESCRIPTION
This updates Core to 13.6.0. I didn't update to 13.7.0, since that includes some breaking changes to logging that might end up being reverted. This will be discussed Thursday.

Also update to CMake 3.22.1, which is what gets shipped with Android Studio as the default.