### PR TITLE
Track kotlin usage without inspecting configurations in configuration phase

### DIFF
--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -148,18 +148,7 @@ class RealmTransformer(private val metadata: ProjectMetaData,
         }
 
         private fun Project.usesKotlin(): Boolean {
-            for (conf in project.configurations) {
-                try {
-                    for (artifact: ResolvedArtifact in conf.resolvedConfiguration.resolvedArtifacts) {
-                        if (artifact.name.startsWith("kotlin-stdlib")) {
-                            return true
-                        }
-                    }
-                } catch (ignore: Exception) {
-                    // Some artifacts might not be able to resolve, in this case, just ignore them.
-                }
-            }
-            return false
+            return project.pluginManager.hasPlugin("kotlin-kapt")
         }
     }
 


### PR DESCRIPTION
This PR reworks how we track kotlin usage at compile time. The previous approach triggered this warning with more recent Gradle/AGP versions:
```
Configuration '_agp_internal_javaPreCompileDebugAndroidTest_kaptClasspath' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
```
It also seemed like our old approach of tracking `kotlin-sdk` dependencies didn't report the correct result. This might be due to the Kotlin SDK being pulled as a transitive dependency of some of the other mandatory dependencies. 

I have tested the new approach against our `examples` and the detection across all the various projects yields:
```
USESKOTLIN: app false
USESKOTLIN: architectureComponentsExample false
USESKOTLIN: compatibilityExample true
USESKOTLIN: coroutinesExample true
USESKOTLIN: encryptionExample false
USESKOTLIN: gridViewExample false
USESKOTLIN: introExample false
USESKOTLIN: jsonExample false
USESKOTLIN: kotlinExample true
USESKOTLIN: library false
USESKOTLIN: migrationExample false
USESKOTLIN: mongoDbRealmExample true
USESKOTLIN: multiprocessExample false
USESKOTLIN: rxJavaExample false
USESKOTLIN: threadExample false
USESKOTLIN: unitTestExample false
```
which lists exactly the projects that have kotlin code. 