### PR TITLE
Use Java 11 API's for checking embedded properties in the annotation processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 10.15.1 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* Building with Realm on Java 17 would fail with `java.lang.IllegalAccessError: class io.realm.processor.Utils (in unnamed module @0x5316ec7f) cannot access class com.sun.tools.javac.code.Symbol$ClassSymbol`. (Issue [#7799](https://github.com/realm/realm-java/issues/7799))
+
+### Compatibility
+* File format: Generates Realms with format v23. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* Gradle 7.5 and above.
+* Android Gradle Plugin 7.4.0 and above.
+
+### Internal
+* Updated to Google Compile Testing 0.21.0.
+* Updated Annotation Processor to use Java 11 reflection API's.
+
+
 ## 10.15.0 (2023-04-19)
 
 ### Breaking Changes

--- a/realm/realm-annotations-processor/build.gradle
+++ b/realm/realm-annotations-processor/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     implementation "org.mongodb:bson:${properties.getProperty('BSON_DEPENDENCY')}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation files('../realm-library/build/intermediates/aar_main_jar/baseRelease/classes.jar') // Java projects cannot depend on AAR files
-    testImplementation group:'junit', name:'junit', version:'4.12'
-    testImplementation group:'com.google.testing.compile', name:'compile-testing', version:'0.19'
+    testImplementation group:'junit', name:'junit', version:'4.13.1'
+    testImplementation group:'com.google.testing.compile', name:'compile-testing', version:'0.21.0'
     testImplementation files(file("${System.env.ANDROID_HOME}/platforms/android-29/android.jar"))
 }
 
@@ -81,15 +81,11 @@ tasks.withType(JavaCompile) {
 }
 tasks.withType(Test) {
     systemProperty "file.encoding", "UTF-8"
-}
+    // Work-around for https://github.com/google/compile-testing/issues/222
+    jvmArgs(
+        "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
 
-// Allow Java 17 to access internal compiler API's
-// See https://openjdk.org/jeps/261#Breaking-encapsulation for more information
-jar {
-    manifest {
-        attributes(
-            "Manifest-Version": "2.0",
-            "Add-Opens": "jdk.compiler/com.sun.tools.javac.code"
-        )
-    }
+    )
 }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.kt
@@ -649,18 +649,17 @@ object Utils {
         if (this.kind === TypeKind.DECLARED) {
             val declaredType: DeclaredType = this as DeclaredType
             val typeElement = declaredType.asElement() as TypeElement
-            val annotations: MutableList<out AnnotationMirror> = typeElement.annotationMirrors
-            for (annotation: AnnotationMirror in annotations) {
+            isEmbedded = typeElement.annotationMirrors.firstOrNull { annotation: AnnotationMirror ->
                 val annotationType = annotation.annotationType
                 if (annotationType.asElement().toString() == "io.realm.annotations.RealmClass") {
                     for (entry: Map.Entry<ExecutableElement?, AnnotationValue?> in annotation.elementValues) {
                         if (entry.key?.simpleName.toString() == "embedded") {
-                            isEmbedded = (entry.value?.value == true)
-                            break
+                            return (entry.value?.value == true)
                         }
                     }
                 }
-            }
+                return false
+            } != null
         }
         return isEmbedded
     }
@@ -682,17 +681,14 @@ object Utils {
             val declaredType = this as DeclaredType
             val typeElement = declaredType.asElement() as TypeElement
             val classElements: MutableList<out Element> = typeElement.enclosedElements
-            for (element: Element in classElements) {
-                if (element.kind === ElementKind.FIELD) {
-                    val annotations: MutableList<out AnnotationMirror> = element.annotationMirrors
-                    for (annotation: AnnotationMirror in annotations) {
+            return classElements
+                .filter { el: Element -> el.kind == ElementKind.FIELD}
+                .firstOrNull { el: Element ->
+                    return el.annotationMirrors.firstOrNull { annotation: AnnotationMirror ->
                         val annotationType: DeclaredType = annotation.annotationType
-                        if (annotationType.asElement().toString() == "io.realm.annotations.PrimaryKey") {
-                            return true
-                        }
-                    }
-                }
-            }
+                        annotationType.asElement().toString() == "io.realm.annotations.PrimaryKey"
+                    } != null
+                } != null
         }
         return false
     }

--- a/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.kt
+++ b/realm/realm-annotations-processor/src/main/java/io/realm/processor/Utils.kt
@@ -18,11 +18,6 @@
 
 package io.realm.processor
 
-import com.sun.tools.javac.code.Attribute
-import com.sun.tools.javac.code.Scope
-import com.sun.tools.javac.code.Symbol
-import com.sun.tools.javac.code.Type
-import com.sun.tools.javac.util.Pair
 import io.realm.annotations.RealmNamingPolicy
 import io.realm.processor.nameconverter.*
 import javax.annotation.processing.Messager
@@ -39,17 +34,6 @@ import javax.tools.Diagnostic
  * Utility methods working with the Realm processor.
  */
 object Utils {
-
-    // API for retrieving symbols differs between JDK 8 and 9, so retrieve symbol information by
-    // reflection
-    private val classSymbolMembersMethod = Symbol.ClassSymbol::class.java.getMethod("members")
-    private val scopeElementsMethod = try {
-        // JDK 8
-        Scope::class.java.getMethod("getElements")
-    } catch (e: NoSuchMethodException) {
-        // JDK 9+
-        Scope::class.java.getMethod("getSymbols")
-    }
 
     private lateinit var typeUtils: Types
     private lateinit var messager: Messager
@@ -662,23 +646,22 @@ object Utils {
 
     private fun TypeMirror.isEmbedded() : Boolean {
         var isEmbedded = false
-
-        if (this is Type.ClassType) {
-            val declarationAttributes: com.sun.tools.javac.util.List<Attribute.Compound>? = tsym.metadata?.declarationAttributes
-            if (declarationAttributes != null) {
-                loop@for (attribute: Attribute.Compound in declarationAttributes) {
-                    if (attribute.type.tsym.qualifiedName.toString() == "io.realm.annotations.RealmClass") {
-                        for (pair: Pair<Symbol.MethodSymbol, Attribute> in attribute.values) {
-                            if (pair.fst.name.toString() == "embedded") {
-                                isEmbedded = pair.snd.value as Boolean
-                                break@loop
-                            }
+        if (this.kind === TypeKind.DECLARED) {
+            val declaredType: DeclaredType = this as DeclaredType
+            val typeElement = declaredType.asElement() as TypeElement
+            val annotations: MutableList<out AnnotationMirror> = typeElement.annotationMirrors
+            for (annotation: AnnotationMirror in annotations) {
+                val annotationType = annotation.annotationType
+                if (annotationType.asElement().toString() == "io.realm.annotations.RealmClass") {
+                    for (entry: Map.Entry<ExecutableElement?, AnnotationValue?> in annotation.elementValues) {
+                        if (entry.key?.simpleName.toString() == "embedded") {
+                            isEmbedded = (entry.value?.value == true)
+                            break
                         }
                     }
                 }
             }
         }
-
         return isEmbedded
     }
 
@@ -695,13 +678,19 @@ object Utils {
     }
 
     private fun TypeMirror.hasPrimaryKey(): Boolean {
-        if (this is Type.ClassType) {
-            val scope = classSymbolMembersMethod.invoke(tsym)
-            val elements: Iterable<Symbol> = scopeElementsMethod.invoke(scope) as Iterable<Symbol>
-            val symbols = elements.filter { it is Symbol.VarSymbol }
-            return symbols.any {
-                it.declarationAttributes.any { attribute ->
-                    attribute.type.tsym.qualifiedName.toString() == "io.realm.annotations.PrimaryKey"
+        if (this.kind === TypeKind.DECLARED) {
+            val declaredType = this as DeclaredType
+            val typeElement = declaredType.asElement() as TypeElement
+            val classElements: MutableList<out Element> = typeElement.enclosedElements
+            for (element: Element in classElements) {
+                if (element.kind === ElementKind.FIELD) {
+                    val annotations: MutableList<out AnnotationMirror> = element.annotationMirrors
+                    for (annotation: AnnotationMirror in annotations) {
+                        val annotationType: DeclaredType = annotation.annotationType
+                        if (annotationType.asElement().toString() == "io.realm.annotations.PrimaryKey") {
+                            return true
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The fix introduced in https://github.com/realm/realm-java/pull/7807 turned out to not be enough.

I was testing the previous approach by manually unzipping the jar, and modifying the MANIFEST.MF file and then re-zipping the jar. I'm not 100% sure what is going on, but doing that seemed to cause issues with the build so some variants would compile successfully. However, recreating the SNAPSHOT artifact using the `publishToMavenLocal` would always reproduce the error.

It looks like the problem might be the presence of `Manifest-Version`, but there doesn't appear to be a way to remove this using the Gradle API.

So I decided to instead refactor our annotation processor to APIs available in Java 11. This unfortunately broke Google's Compile Testing framework which still has not been updated, but that could luckily be worked around using the same approach that people have to use with Realm Java 10.15.0 right now.