### PR TITLE
Unify sync error code mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* [RealmApp] Sync errors could return the error code UNKNOWN instead of the actual error code. (Issue [#7823](https://github.com/realm/realm-java/issues/7823))
 
 ### Compatibility
 * File format: Generates Realms with format v23. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SessionTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SessionTests.kt
@@ -20,6 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.*
 import io.realm.TestHelper.TestLogger
+import io.realm.admin.ServerAdmin
 import io.realm.entities.DefaultSyncSchema
 import io.realm.entities.SyncStringOnly
 import io.realm.entities.SyncStringOnlyModule
@@ -47,6 +48,7 @@ import kotlin.test.*
 class SessionTests {
     private lateinit var configuration: SyncConfiguration
     private lateinit var app: TestApp
+    private lateinit var admin: ServerAdmin
     private lateinit var user: User
 
     @get:Rule
@@ -58,6 +60,7 @@ class SessionTests {
     fun setUp() {
         Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
         app = TestApp()
+        admin = ServerAdmin(app)
         // TODO We could potentially work without a fully functioning user to speed up tests, but
         //  seems like the old  way of "faking" it, does now work for now, so using a real user.
         // user = SyncTestUtils.createTestUser(app)
@@ -265,10 +268,7 @@ class SessionTests {
                     assertEquals(filePathFromError, filePathFromConfig)
                     assertFalse(error.backupFile.exists())
                     assertTrue(error.originalFile.exists())
-                    // Note, this error message is just the one created by ObjectStore for testing
-                    // The server will send a different message. This just ensures that we don't
-                    // accidentially modify or remove the message.
-                    assertEquals("Simulate Client Reset", error.message)
+                    assertTrue(error.message!!.contains("Bad client file identifier"), error.message)
                     looperThread.testComplete()
                 }
                 .build()
@@ -277,7 +277,7 @@ class SessionTests {
         looperThread.closeAfterTest(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // Check that we can manually execute the Client Reset.
@@ -311,7 +311,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // Check that we can use the backup SyncConfiguration to open the Realm.
@@ -358,7 +358,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // Check that we can open the backup file without using the provided SyncConfiguration,
@@ -424,7 +424,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // make sure the backup file Realm is encrypted with the same key as the original synced Realm.
@@ -476,7 +476,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
 
@@ -491,10 +491,7 @@ class SessionTests {
                 assertEquals(filePathFromError, filePathFromConfig)
                 assertFalse(error.backupFile.exists())
                 assertTrue(error.originalFile.exists())
-                // Note, this error message is just the one created by ObjectStore for testing
-                // The server will send a different message. This just ensures that we don't
-                // accidentially modify or remove the message.
-                assertEquals("Simulate Client Reset", error.message)
+                assertTrue(error.message!!.contains("Bad client file identifier"), error.message)
                 looperThread.testComplete()
             }
             .build()
@@ -503,7 +500,7 @@ class SessionTests {
         looperThread.closeAfterTest(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // Check that we can manually execute the Client Reset.
@@ -536,7 +533,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // Check that we can use the backup SyncConfiguration to open the Realm.
@@ -585,7 +582,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // Check that we can open the backup file without using the provided SyncConfiguration,
@@ -651,7 +648,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     // make sure the backup file Realm is encrypted with the same key as the original synced Realm.
@@ -712,7 +709,7 @@ class SessionTests {
         resources.add(realm)
 
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     @Test

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -1002,32 +1002,6 @@ class SyncedRealmTests {
         }
     }
 
-    @Test
-    fun protocolErrorsAreMappedCorrectly() {
-        val user = createNewUser()
-        lateinit var syncError: AppException
-        val config = SyncConfiguration.Builder(user, 42L) // Wrong partition value type
-            .errorHandler { _, error ->
-                syncError = error
-            }
-            .waitForInitialRemoteData()
-            .schema(SyncColor::class.java)
-            .build()
-
-        val error = assertFailsWith<AppException> {
-            Realm.getInstance(config)
-        }
-        // Error is reported in the Sync Error Handler before throwing
-        assertNotNull(syncError)
-        assertEquals(ErrorCode.Type.SESSION, syncError.errorType)
-        assertEquals(ErrorCode.ILLEGAL_REALM_PATH, syncError.errorCode)
-
-        // But `Realm.getInstance()` also throws
-        assertEquals(ErrorCode.Type.SESSION, error.errorType)
-        assertEquals(ErrorCode.ILLEGAL_REALM_PATH, error.errorCode)
-        assertEquals(syncError.message, error.message)
-    }
-
     private fun createDefaultConfig(user: User, partitionValue: String = defaultPartitionValue): SyncConfiguration {
         return SyncConfiguration.Builder(user, partitionValue)
                 .modules(DefaultSyncSchema())

--- a/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_OsRealmConfig.cpp
@@ -271,8 +271,7 @@ JNIEXPORT jstring JNICALL Java_io_realm_internal_OsRealmConfig_nativeCreateAndSe
         auto error_handler = [sync_service_object = JavaGlobalRefByCopy(env, j_java_sync_service)](std::shared_ptr<SyncSession> session, SyncError error) {
 
             auto std_error_code = error.to_status().get_std_error_code();
-
-            int error_code = error.code();
+            int error_code = error.to_status().get_std_error_code().value();
             const std::error_category& error_category = std_error_code.category();
 
             jbyte category;

--- a/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsWatchStream.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_objectstore_OsWatchStream.cpp
@@ -101,8 +101,7 @@ Java_io_realm_internal_objectstore_OsWatchStream_nativeGetError(JNIEnv *env, jcl
         WatchStream *watch_stream = reinterpret_cast<WatchStream *>(j_watch_stream_ptr);
 
         auto app_error = watch_stream->error();
-        auto categories = ErrorCodes::error_categories(app_error.code());
-        jbyte category = categoryAsJByte(categories);
+        jbyte category = categoryAsJByte(app_error.to_status());
 
         jstring error_code_message = env->NewStringUTF(app_error.code_string().data());
         jstring app_error_message = env->NewStringUTF(app_error.what());

--- a/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_mongodb_sync_SyncSession.cpp
@@ -67,13 +67,10 @@ void handleCompletion(jint callback_id, JavaMethod &java_notify_result_method,
     JavaLocalRef<jstring> java_error_message;
 
     if (!status.is_ok()) {
-        realm::ErrorCategory categories = ErrorCodes::error_categories(status.code());
-        jbyte category = categoryAsJByte(categories);
-
-
+        jbyte category = categoryAsJByte(status);
         java_error_category = JavaLocalRef<jobject>(env, JavaClassGlobalDef::new_long(env,category));
         java_error_code = JavaLocalRef<jobject>(env, JavaClassGlobalDef::new_long(env,
-                                                                                  status.code()));
+                                                                                  status.get_std_error_code().value()));
         java_error_message = JavaLocalRef<jstring>(env, env->NewStringUTF(
                 status.reason().c_str()));
     }

--- a/realm/realm-library/src/main/cpp/java_network_transport.hpp
+++ b/realm/realm-library/src/main/cpp/java_network_transport.hpp
@@ -95,8 +95,7 @@ struct JavaNetworkTransport : public app::GenericNetworkTransport {
                             const JavaClass &java_callback_class) {
         static JavaMethod java_notify_onerror(env, java_callback_class, "onError", "(BILjava/lang/String;)V");
         auto err = error.value();
-        ErrorCategory categories = ErrorCodes::error_categories(err.code());
-        jbyte category = categoryAsJByte(categories);
+        jbyte category = categoryAsJByte(err.to_status());
         int error_code = err.is_custom_error() || err.is_http_error() ? err.additional_status_code.value() : err.code();
         env->CallVoidMethod(callback.get(),
                             java_notify_onerror,

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -149,7 +149,17 @@ inline jbyte categoryAsJByte(const realm::Status &status) {
     const std::error_category& error_category = std_error_code.category();
     realm::ErrorCategory categories = realm::ErrorCodes::error_categories(status.code());
     jbyte category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_UNKNOWN;
-    if (error_category == realm::sync::client_error_category()) {
+    if (categories.test(realm::ErrorCategory::client_error)) {
+        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_CLIENT;
+    } else if (categories.test(realm::ErrorCategory::json_error)) {
+        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_JSON;
+    } else if (categories.test(realm::ErrorCategory::service_error)) {
+        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_SERVICE;
+    } else if (categories.test(realm::ErrorCategory::http_error)) {
+        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_HTTP;
+    } else if (categories.test(realm::ErrorCategory::custom_error)) {
+        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_CUSTOM;
+    } else if (error_category == realm::sync::client_error_category()) {
         category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_CLIENT;
     } else if (error_category == realm::sync::protocol_error_category()) {
         if (realm::sync::is_session_level_error(realm::sync::ProtocolError(std_error_code.value()))) {
@@ -160,17 +170,8 @@ inline jbyte categoryAsJByte(const realm::Status &status) {
         }
     } else if (error_category == std::system_category() || error_category == realm::util::error::basic_system_error_category()) {
         category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_SYSTEM;
-    } else if (categories.test(realm::ErrorCategory::client_error)) {
-        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_CLIENT;
-    } else if (categories.test(realm::ErrorCategory::json_error)) {
-        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_JSON;
-    } else if (categories.test(realm::ErrorCategory::service_error)) {
-        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_SERVICE;
-    } else if (categories.test(realm::ErrorCategory::http_error)) {
-        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_HTTP;
-    } else if (categories.test(realm::ErrorCategory::custom_error)) {
-        category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_CUSTOM;
     }
+
     return category;
 }
 

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -41,10 +41,6 @@
 
 #if REALM_ENABLE_SYNC
 #include <realm/sync/client_base.hpp>
-//#include <realm/object-store/sync/app.hpp>
-//#include <realm/object-store/sync/sync_manager.hpp>
-//#include <realm/object-store/sync/sync_session.hpp>
-//#include <realm/util/misc_ext_errors.hpp>
 #endif
 
 #define CHECK_PARAMETERS 1 // Check all parameters in API and throw exceptions in java if invalid

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -28,14 +28,24 @@
 #include <inttypes.h>
 
 #include <realm.hpp>
+#include <realm/error_codes.hpp>
 #include <realm/timestamp.hpp>
 #include <realm/table.hpp>
+#include <realm/util/basic_system_errors.hpp>
 #include <realm/util/safe_int_ops.hpp>
 #include "io_realm_internal_Util.h"
 
 #include "java_exception_def.hpp"
 #include "jni_util/log.hpp"
 #include "jni_util/java_exception_thrower.hpp"
+
+#if REALM_ENABLE_SYNC
+#include <realm/sync/client_base.hpp>
+//#include <realm/object-store/sync/app.hpp>
+//#include <realm/object-store/sync/sync_manager.hpp>
+//#include <realm/object-store/sync/sync_session.hpp>
+//#include <realm/util/misc_ext_errors.hpp>
+#endif
 
 #define CHECK_PARAMETERS 1 // Check all parameters in API and throw exceptions in java if invalid
 
@@ -133,9 +143,24 @@ void ThrowNullValueException(JNIEnv* env, const realm::TableRef table, realm::Co
 #if REALM_ENABLE_SYNC
 #include "io_realm_internal_ErrorCategory.h"
 #include <realm/object-store/sync/sync_manager.hpp>
-inline jbyte categoryAsJByte(realm::ErrorCategory &categories) {// Map categories to something meaningful at SDK level
-    jbyte category = -1;
-    if (categories.test(realm::ErrorCategory::client_error)) {
+
+inline jbyte categoryAsJByte(const realm::Status &status) {
+    auto std_error_code = status.get_std_error_code();
+    const std::error_category& error_category = std_error_code.category();
+    realm::ErrorCategory categories = realm::ErrorCodes::error_categories(status.code());
+    jbyte category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_UNKNOWN;
+    if (error_category == realm::sync::client_error_category()) {
+        category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_CLIENT;
+    } else if (error_category == realm::sync::protocol_error_category()) {
+        if (realm::sync::is_session_level_error(realm::sync::ProtocolError(std_error_code.value()))) {
+            category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_SESSION;
+        }
+        else {
+            category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_CONNECTION;
+        }
+    } else if (error_category == std::system_category() || error_category == realm::util::error::basic_system_error_category()) {
+        category = io_realm_internal_ErrorCategory_RLM_SYNC_ERROR_CATEGORY_SYSTEM;
+    } else if (categories.test(realm::ErrorCategory::client_error)) {
         category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_CLIENT;
     } else if (categories.test(realm::ErrorCategory::json_error)) {
         category = io_realm_internal_ErrorCategory_RLM_APP_ERROR_CATEGORY_JSON;

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/ErrorCode.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/ErrorCode.java
@@ -80,42 +80,42 @@ public enum ErrorCode {
     BAD_CHANGESETS(Type.PROTOCOL, 113),                             // Bad changesets (UPLOAD)
 
     // Session level errors from the native Sync Client
-    SESSION_CLOSED(Type.PROTOCOL, 200, Category.RECOVERABLE),      // Session closed (no error)
-    OTHER_SESSION_ERROR(Type.PROTOCOL, 201, Category.RECOVERABLE), // Other session level error
-    TOKEN_EXPIRED(Type.PROTOCOL, 202, Category.RECOVERABLE),       // Access token expired
+    SESSION_CLOSED(Type.SESSION, 200, Category.RECOVERABLE),      // Session closed (no error)
+    OTHER_SESSION_ERROR(Type.SESSION, 201, Category.RECOVERABLE), // Other session level error
+    TOKEN_EXPIRED(Type.SESSION, 202, Category.RECOVERABLE),       // Access token expired
 
     // Session fatal: Auth wrong. Cannot be fixed without a new User/SyncConfiguration.
-    BAD_AUTHENTICATION(Type.PROTOCOL, 203),                        // Bad user authentication (BIND, REFRESH)
-    ILLEGAL_REALM_PATH(Type.PROTOCOL, 204),                        // Illegal Realm path (BIND)
-    NO_SUCH_PATH(Type.PROTOCOL, 205),                              // No such Realm (BIND)
-    PERMISSION_DENIED(Type.PROTOCOL, 206),                         // Permission denied (BIND, REFRESH)
+    BAD_AUTHENTICATION(Type.SESSION, 203),                        // Bad user authentication (BIND, REFRESH)
+    ILLEGAL_REALM_PATH(Type.SESSION, 204),                        // Illegal Realm path (BIND)
+    NO_SUCH_PATH(Type.SESSION, 205),                              // No such Realm (BIND)
+    PERMISSION_DENIED(Type.SESSION, 206),                         // Permission denied (BIND, REFRESH)
 
     // Fatal: Wrong server/client versions. Trying to sync incompatible files or the file was corrupted.
-    BAD_SERVER_FILE_IDENT(Type.PROTOCOL, 207),                     // Bad server file identifier (IDENT)
-    BAD_CLIENT_FILE_IDENT(Type.PROTOCOL, 208),                     // Bad client file identifier (IDENT)
-    BAD_SERVER_VERSION(Type.PROTOCOL, 209),                        // Bad server version (IDENT, UPLOAD)
-    BAD_CLIENT_VERSION(Type.PROTOCOL, 210),                        // Bad client version (IDENT, UPLOAD)
-    DIVERGING_HISTORIES(Type.PROTOCOL, 211),                       // Diverging histories (IDENT)
-    BAD_CHANGESET(Type.PROTOCOL, 212),                             // Bad changeset (UPLOAD)
-    DISABLED_SESSION(Type.PROTOCOL, 213),                          // Disabled session
-    PARTIAL_SYNC_DISABLED(Type.PROTOCOL, 214),                     // Partial sync disabled (BIND)
-    UNSUPPORTED_SESSION_FEATURE(Type.PROTOCOL, 215),               // Unsupported session-level feature
-    BAD_ORIGIN_FILE_IDENT(Type.PROTOCOL, 216),                     // Bad origin file identifier (UPLOAD)
-    BAD_CLIENT_FILE(Type.PROTOCOL, 217),                           // Synchronization no longer possible for client-side file
-    SERVER_FILE_DELETED(Type.PROTOCOL, 218),                       // Server file was deleted while session was bound to it
-    CLIENT_FILE_BLACKLISTED(Type.PROTOCOL, 219),                   // Client file has been blacklisted (IDENT)
-    USER_BLACKLISTED(Type.PROTOCOL, 220),                          // User has been blacklisted (BIND)
-    TRANSACT_BEFORE_UPLOAD(Type.PROTOCOL, 221),                    // Serialized transaction before upload completion
-    CLIENT_FILE_EXPIRED(Type.PROTOCOL, 222),                       // Client file has expired
-    USER_MISMATCH(Type.PROTOCOL, 223),                             // User mismatch for client file identifier (IDENT)
-    TOO_MANY_SESSIONS(Type.PROTOCOL, 224),                         // Too many sessions in connection (BIND)
-    INVALID_SCHEMA_CHANGE(Type.PROTOCOL, 225),                     // Invalid schema change (UPLOAD)
-    BAD_QUERY(Type.PROTOCOL, 226),                                 // Client query is invalid/malformed (IDENT, QUERY)
-    OBJECT_ALREADY_EXISTS(Type.PROTOCOL, 227),                     // Client tried to create an object that already exists outside their view (UPLOAD)
-    SERVER_PERMISSIONS_CHANGED(Type.PROTOCOL, 228),                // Server permissions for this file ident have changed since the last time it was used (IDENT)
-    INITIAL_SYNC_NOT_COMPLETE(Type.PROTOCOL, 229),                 // Client tried to open a session before initial sync is complete (BIND)
-    WRITE_NOT_ALLOWED(Type.PROTOCOL, 230),                         // Client attempted a write that is disallowed by permissions, or modifies an object outside the current query - requires client reset (UPLOAD)
-    COMPENSATING_WRITE(Type.PROTOCOL, 231),                        // Client attempted a write that is disallowed by permissions, or modifies an object outside the current query, and the server undid the change
+    BAD_SERVER_FILE_IDENT(Type.SESSION, 207),                     // Bad server file identifier (IDENT)
+    BAD_CLIENT_FILE_IDENT(Type.SESSION, 208),                     // Bad client file identifier (IDENT)
+    BAD_SERVER_VERSION(Type.SESSION, 209),                        // Bad server version (IDENT, UPLOAD)
+    BAD_CLIENT_VERSION(Type.SESSION, 210),                        // Bad client version (IDENT, UPLOAD)
+    DIVERGING_HISTORIES(Type.SESSION, 211),                       // Diverging histories (IDENT)
+    BAD_CHANGESET(Type.SESSION, 212),                             // Bad changeset (UPLOAD)
+    DISABLED_SESSION(Type.SESSION, 213),                          // Disabled session
+    PARTIAL_SYNC_DISABLED(Type.SESSION, 214),                     // Partial sync disabled (BIND)
+    UNSUPPORTED_SESSION_FEATURE(Type.SESSION, 215),               // Unsupported session-level feature
+    BAD_ORIGIN_FILE_IDENT(Type.SESSION, 216),                     // Bad origin file identifier (UPLOAD)
+    BAD_CLIENT_FILE(Type.SESSION, 217),                           // Synchronization no longer possible for client-side file
+    SERVER_FILE_DELETED(Type.SESSION, 218),                       // Server file was deleted while session was bound to it
+    CLIENT_FILE_BLACKLISTED(Type.SESSION, 219),                   // Client file has been blacklisted (IDENT)
+    USER_BLACKLISTED(Type.SESSION, 220),                          // User has been blacklisted (BIND)
+    TRANSACT_BEFORE_UPLOAD(Type.SESSION, 221),                    // Serialized transaction before upload completion
+    CLIENT_FILE_EXPIRED(Type.SESSION, 222),                       // Client file has expired
+    USER_MISMATCH(Type.SESSION, 223),                             // User mismatch for client file identifier (IDENT)
+    TOO_MANY_SESSIONS(Type.SESSION, 224),                         // Too many sessions in connection (BIND)
+    INVALID_SCHEMA_CHANGE(Type.SESSION, 225),                     // Invalid schema change (UPLOAD)
+    BAD_QUERY(Type.SESSION, 226),                                 // Client query is invalid/malformed (IDENT, QUERY)
+    OBJECT_ALREADY_EXISTS(Type.SESSION, 227),                     // Client tried to create an object that already exists outside their view (UPLOAD)
+    SERVER_PERMISSIONS_CHANGED(Type.SESSION, 228),                // Server permissions for this file ident have changed since the last time it was used (IDENT)
+    INITIAL_SYNC_NOT_COMPLETE(Type.SESSION, 229),                 // Client tried to open a session before initial sync is complete (BIND)
+    WRITE_NOT_ALLOWED(Type.SESSION, 230),                         // Client attempted a write that is disallowed by permissions, or modifies an object outside the current query - requires client reset (UPLOAD)
+    COMPENSATING_WRITE(Type.SESSION, 231),                        // Client attempted a write that is disallowed by permissions, or modifies an object outside the current query, and the server undid the change
 
     //
     // Type.Client
@@ -123,38 +123,38 @@ public enum ErrorCode {
     // Sync Network Client errors.
     // See https://github.com/realm/realm-core/blob/master/src/realm/sync/client_base.hpp#L75
     //
-    CLIENT_CONNECTION_CLOSED(Type.SESSION, 100),            // Connection closed (no error)
-    CLIENT_UNKNOWN_MESSAGE(Type.SESSION, 101),              // Unknown type of input message
-    CLIENT_LIMITS_EXCEEDED(Type.SESSION, 103),              // Limits exceeded in input message
-    CLIENT_BAD_SESSION_IDENT(Type.SESSION, 104),            // Bad session identifier in input message
-    CLIENT_BAD_MESSAGE_ORDER(Type.SESSION, 105),            // Bad input message order
-    CLIENT_BAD_CLIENT_FILE_IDENT(Type.SESSION, 106),        // Bad client file identifier (IDENT)
-    CLIENT_BAD_PROGRESS(Type.SESSION, 107),                 // Bad progress information (DOWNLOAD)
-    CLIENT_BAD_CHANGESET_HEADER_SYNTAX(Type.SESSION, 108),  // Bad syntax in changeset header (DOWNLOAD)
-    CLIENT_BAD_CHANGESET_SIZE(Type.SESSION, 109),           // Bad changeset size in changeset header (DOWNLOAD)
-    CLIENT_BAD_ORIGIN_FILE_IDENT(Type.SESSION, 110),        // Bad origin file identifier in changeset header (DOWNLOAD)
-    CLIENT_BAD_SERVER_VERSION(Type.SESSION, 111),           // Bad server version in changeset header (DOWNLOAD)
-    CLIENT_BAD_CHANGESET(Type.SESSION, 112),                // Bad changeset (DOWNLOAD)
-    CLIENT_BAD_REQUEST_IDENT(Type.SESSION, 113),            // Bad request identifier (MARK)
-    CLIENT_BAD_ERROR_CODE(Type.SESSION, 114),               // Bad error code (ERROR)
-    CLIENT_BAD_COMPRESSION(Type.SESSION, 115),              // Bad compression (DOWNLOAD)
-    CLIENT_BAD_CLIENT_VERSION_DOWNLOAD(Type.SESSION, 116),  // Bad last integrated client version in changeset header (DOWNLOAD)
-    CLIENT_SSL_SERVER_CERT_REJECTED(Type.SESSION, 117),     // SSL server certificate rejected
-    CLIENT_PONG_TIMEOUT(Type.SESSION, 118),                 // Timeout on reception of PONG respone message
-    CLIENT_BAD_CLIENT_FILE_IDENT_SALT(Type.SESSION, 119),   // Bad client file identifier salt (IDENT)
-    CLIENT_FILE_IDENT(Type.SESSION, 120),                   // Bad file identifier (ALLOC)
-    CLIENT_CONNECT_TIMEOUT(Type.SESSION, 121),              // Sync connection was not fully established in time
-    CLIENT_BAD_TIMESTAMP(Type.SESSION, 122),                // Bad timestamp (PONG)
-    CLIENT_BAD_PROTOCOL_FROM_SERVER(Type.SESSION, 123),     // Bad or missing protocol version information from server
-    CLIENT_TOO_OLD_FOR_SERVER(Type.SESSION, 124),           // Protocol version negotiation failed: Client is too old for server
-    CLIENT_TOO_NEW_FOR_SERVER(Type.SESSION, 125),           // Protocol version negotiation failed: Client is too new for server
-    CLIENT_PROTOCOL_MISMATCH(Type.SESSION, 126),            // Protocol version negotiation failed: No version supported by both client and server
-    CLIENT_BAD_STATE_MESSAGE(Type.SESSION, 127),            // Bad values in state message (STATE)
-    CLIENT_MISSING_PROTOCOL_FEATURE(Type.SESSION, 128),     // Requested feature missing in negotiated protocol version
-    CLIENT_BAD_SERIAL_TRANSACT_STATUS(Type.SESSION, 129),   // Bad status of serialized transaction (TRANSACT)
-    CLIENT_BAD_OBJECT_ID_SUBSTITUTIONS(Type.SESSION, 130),  // Bad encoded object identifier substitutions (TRANSACT)
-    CLIENT_HTTP_TUNNEL_FAILED(Type.SESSION, 131),           // Failed to establish HTTP tunnel with configured proxy
-    AUTO_CLIENT_RESET_FAILURE(Type.SESSION, 132),           // Automatic client reset failed
+    CLIENT_CONNECTION_CLOSED(Type.CLIENT, 100),            // Connection closed (no error)
+    CLIENT_UNKNOWN_MESSAGE(Type.CLIENT, 101),              // Unknown type of input message
+    CLIENT_LIMITS_EXCEEDED(Type.CLIENT, 103),              // Limits exceeded in input message
+    CLIENT_BAD_SESSION_IDENT(Type.CLIENT, 104),            // Bad session identifier in input message
+    CLIENT_BAD_MESSAGE_ORDER(Type.CLIENT, 105),            // Bad input message order
+    CLIENT_BAD_CLIENT_FILE_IDENT(Type.CLIENT, 106),        // Bad client file identifier (IDENT)
+    CLIENT_BAD_PROGRESS(Type.CLIENT, 107),                 // Bad progress information (DOWNLOAD)
+    CLIENT_BAD_CHANGESET_HEADER_SYNTAX(Type.CLIENT, 108),  // Bad syntax in changeset header (DOWNLOAD)
+    CLIENT_BAD_CHANGESET_SIZE(Type.CLIENT, 109),           // Bad changeset size in changeset header (DOWNLOAD)
+    CLIENT_BAD_ORIGIN_FILE_IDENT(Type.CLIENT, 110),        // Bad origin file identifier in changeset header (DOWNLOAD)
+    CLIENT_BAD_SERVER_VERSION(Type.CLIENT, 111),           // Bad server version in changeset header (DOWNLOAD)
+    CLIENT_BAD_CHANGESET(Type.CLIENT, 112),                // Bad changeset (DOWNLOAD)
+    CLIENT_BAD_REQUEST_IDENT(Type.CLIENT, 113),            // Bad request identifier (MARK)
+    CLIENT_BAD_ERROR_CODE(Type.CLIENT, 114),               // Bad error code (ERROR)
+    CLIENT_BAD_COMPRESSION(Type.CLIENT, 115),              // Bad compression (DOWNLOAD)
+    CLIENT_BAD_CLIENT_VERSION_DOWNLOAD(Type.CLIENT, 116),  // Bad last integrated client version in changeset header (DOWNLOAD)
+    CLIENT_SSL_SERVER_CERT_REJECTED(Type.CLIENT, 117),     // SSL server certificate rejected
+    CLIENT_PONG_TIMEOUT(Type.CLIENT, 118),                 // Timeout on reception of PONG respone message
+    CLIENT_BAD_CLIENT_FILE_IDENT_SALT(Type.CLIENT, 119),   // Bad client file identifier salt (IDENT)
+    CLIENT_FILE_IDENT(Type.CLIENT, 120),                   // Bad file identifier (ALLOC)
+    CLIENT_CONNECT_TIMEOUT(Type.CLIENT, 121),              // Sync connection was not fully established in time
+    CLIENT_BAD_TIMESTAMP(Type.CLIENT, 122),                // Bad timestamp (PONG)
+    CLIENT_BAD_PROTOCOL_FROM_SERVER(Type.CLIENT, 123),     // Bad or missing protocol version information from server
+    CLIENT_TOO_OLD_FOR_SERVER(Type.CLIENT, 124),           // Protocol version negotiation failed: Client is too old for server
+    CLIENT_TOO_NEW_FOR_SERVER(Type.CLIENT, 125),           // Protocol version negotiation failed: Client is too new for server
+    CLIENT_PROTOCOL_MISMATCH(Type.CLIENT, 126),            // Protocol version negotiation failed: No version supported by both client and server
+    CLIENT_BAD_STATE_MESSAGE(Type.CLIENT, 127),            // Bad values in state message (STATE)
+    CLIENT_MISSING_PROTOCOL_FEATURE(Type.CLIENT, 128),     // Requested feature missing in negotiated protocol version
+    CLIENT_BAD_SERIAL_TRANSACT_STATUS(Type.CLIENT, 129),   // Bad status of serialized transaction (TRANSACT)
+    CLIENT_BAD_OBJECT_ID_SUBSTITUTIONS(Type.CLIENT, 130),  // Bad encoded object identifier substitutions (TRANSACT)
+    CLIENT_HTTP_TUNNEL_FAILED(Type.CLIENT, 131),           // Failed to establish HTTP tunnel with configured proxy
+    AUTO_CLIENT_RESET_FAILURE(Type.CLIENT, 132),           // Automatic client reset failed
 
     //
     // Type.HTTP

--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/sync/Sync.java
@@ -336,6 +336,10 @@ public abstract class Sync {
      *
      * Only call this method when testing.
      *
+     * WARNING: This method will not prepare the metadata for an actual Client Reset, thus trying
+     * to call `ClientResetRequiredError.executeClientReset()` will not actually work, since the
+     * underlying metadata has not been correctly modified.
+     *
      * @param session Session to trigger Client Reset for.
      */
     void simulateClientReset(SyncSession session) {

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
@@ -658,12 +658,14 @@ class SyncSessionTests {
                     realm.createObject(SyncDog::class.java, ObjectId())
                 }
 
-                assertFailsWith<AppException> {
+                val error = assertFailsWith<AppException> {
                     // This throws as the server has NOT been configured to have long partitions!
                     realm.syncSession.uploadAllLocalChanges()
                 }.also {
                     looperThread.testComplete()
                 }
+                assertEquals(ErrorCode.Type.SESSION, error.errorType)
+                assertEquals(ErrorCode.ILLEGAL_REALM_PATH, error.errorCode)
             }
         }
     }

--- a/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
+++ b/realm/realm-library/src/syncIntegrationTest/kotlin/io/realm/SyncSessionTests.kt
@@ -1096,7 +1096,7 @@ class SyncSessionTests {
         val realm = Realm.getInstance(config)
         resources.add(realm)
         // Trigger error
-        user.app.sync.simulateClientReset(realm.syncSession)
+        admin.triggerClientReset(realm.syncSession) { /* Do nothing */ }
     }
 
     @Test

--- a/realm/realm-library/src/syncTestUtils/kotlin/io/realm/TestSyncConfigurationFactory.kt
+++ b/realm/realm-library/src/syncTestUtils/kotlin/io/realm/TestSyncConfigurationFactory.kt
@@ -36,7 +36,7 @@ class TestSyncConfigurationFactory : TestRealmConfigurationFactory() {
     }
 
     fun createSyncConfigurationBuilder(user: User): SyncConfiguration.Builder {
-        return SyncConfiguration.Builder(user, "default")
+        return SyncConfiguration.Builder(user, TestHelper.getRandomString(20))
                 .testSessionStopPolicy(OsRealmConfig.SyncSessionStopPolicy.IMMEDIATELY)
     }
 


### PR DESCRIPTION
Closes #7823 

This PR accomplishes three things:

- It fixes a few places where we send the wrong native error code to Java, resulting it being mapped to UNKNOWN.
- It unifies our mapping of the native category to the Java equivalent. We had multiple places this was happening, and they were slightly divergent resulting in unexpected behavior.
- Also, after the sync error refactors, most Protocol and session errors had ended up in the wrong category, resulting in them being reported as UNKNOWN.