### PR TITLE
Fix null pointer exception when proxy is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* [RealmApp] Crash when opening a Realm when a proxy is enabled. (Issue [#7828](https://github.com/realm/realm-java/issues/7828))
+* [RealmApp] Crash when opening a Realm with a proxy enabled. (Issue [#7828](https://github.com/realm/realm-java/issues/7828))
 
 ### Compatibility
 * File format: Generates Realms with format v23. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 10.16.2 (YYYY-MM-DD)
+
+### Breaking Changes
+* None.
+
+### Enhancements
+* None.
+
+### Fixed
+* [RealmApp] Crash when opening a Realm when a proxy is enabled. (Issue [#7828](https://github.com/realm/realm-java/issues/7828))
+
+### Compatibility
+* File format: Generates Realms with format v23. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.
+* APIs are backwards compatible with all previous release of realm-java in the 10.6.y series.
+* Realm Studio 13.0.0 or above is required to open Realms created by this version.
+* Gradle 7.5 and above.
+* Android Gradle Plugin 7.4.0 and above.
+
+### Internal
+* None.
+
+
 ## 10.16.1 (2023-06-26)
 
 ### Breaking Changes

--- a/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
@@ -233,8 +233,8 @@ public class OsRealmConfig implements NativeObject {
         String syncAccessToken = (String) syncConfigurationOptions[j++];
         String deviceId = (String) syncConfigurationOptions[j++];
         Byte sessionStopPolicy = (Byte) syncConfigurationOptions[j++];
-        String urlPrefix = (String) (syncConfigurationOptions[j++]);
-        String customAuthorizationHeaderName = (String) (syncConfigurationOptions[j++]);
+        String urlPrefix = (String)(syncConfigurationOptions[j++]);
+        String customAuthorizationHeaderName = (String)(syncConfigurationOptions[j++]);
         //noinspection unchecked
         Map<String, String> customHeadersMap = (Map<String, String>) (syncConfigurationOptions[j++]);
         Byte clientResyncMode = (Byte) syncConfigurationOptions[j++];
@@ -298,7 +298,7 @@ public class OsRealmConfig implements NativeObject {
             nativeSetInitializationCallback(nativePtr, initializationCallback);
         }
 
-        URI resolvedRealmURI = null;
+        URI resolvedRealmURI  = null;
         // Set sync config
         if (syncRealmUrl != null) {
             String resolvedSyncRealmUrl = nativeCreateAndSetSyncConfig(
@@ -443,12 +443,12 @@ public class OsRealmConfig implements NativeObject {
     private static native void nativeEnableChangeNotification(long nativePtr, boolean enableNotification);
 
     private native String nativeCreateAndSetSyncConfig(long appPtr, long configPtr, String syncRealmUrl,
-                                                       String userId, String userProvider, String refreshToken, String accessToken,
-                                                       String deviceId, byte sessionStopPolicy, String urlPrefix,
-                                                       String customAuthorizationHeaderName,
-                                                       String[] customHeaders, byte clientResetMode,
-                                                       Object beforeClientResetHandler, Object afterClientResetHandler,
-                                                       String partionKeyValue, Object syncService);
+                                                           String userId, String userProvider, String refreshToken, String accessToken,
+                                                           String deviceId, byte sessionStopPolicy, String urlPrefix,
+                                                           String customAuthorizationHeaderName,
+                                                           String[] customHeaders, byte clientResetMode,
+                                                           Object beforeClientResetHandler, Object afterClientResetHandler,
+                                                           String partionKeyValue, Object syncService);
 
     private static native void nativeSetSyncConfigSslSettings(long nativePtr,
                                                               boolean validateSsl, String trustCertificatePath);

--- a/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsRealmConfig.java
@@ -443,12 +443,12 @@ public class OsRealmConfig implements NativeObject {
     private static native void nativeEnableChangeNotification(long nativePtr, boolean enableNotification);
 
     private native String nativeCreateAndSetSyncConfig(long appPtr, long configPtr, String syncRealmUrl,
-                                                           String userId, String userProvider, String refreshToken, String accessToken,
-                                                           String deviceId, byte sessionStopPolicy, String urlPrefix,
-                                                           String customAuthorizationHeaderName,
-                                                           String[] customHeaders, byte clientResetMode,
-                                                           Object beforeClientResetHandler, Object afterClientResetHandler,
-                                                           String partionKeyValue, Object syncService);
+                                                              String userId, String userProvider, String refreshToken, String accessToken,
+                                                              String deviceId, byte sessionStopPolicy, String urlPrefix,
+                                                              String customAuthorizationHeaderName,
+                                                              String[] customHeaders, byte clientResetMode,
+                                                              Object beforeClientResetHandler, Object afterClientResetHandler,
+                                                              String partionKeyValue, Object syncService);
 
     private static native void nativeSetSyncConfigSslSettings(long nativePtr,
                                                               boolean validateSsl, String trustCertificatePath);


### PR DESCRIPTION
A null pointer exception is thrown when a proxy is configured. It is reproducible in the emulator by enabling it in the WIFI settings. 

The issue is caused by the backported logic from getHostString, it was wrong. Fixed by porting the actual expected logic.

Tested on an emulator and physical devices.

Closes #7828 