### PR TITLE
Test of nullability of private properties

### DIFF
--- a/realm/realm-library/src/androidTest/kotlin/io/realm/KotlinSchemaTests.kt
+++ b/realm/realm-library/src/androidTest/kotlin/io/realm/KotlinSchemaTests.kt
@@ -64,6 +64,8 @@ class KotlinSchemaTests {
         // We cannot enforce this constraint inside the schema right now.
         // If people maintain the variant themselves they need a custom getter
         // assertTrue(objSchema.isNullable(AllKotlinTypes::nonNullObject.name));
+
+        assertFalse(objSchema.isNullable("privateNonNullString"));
     }
 
     @Test
@@ -81,6 +83,7 @@ class KotlinSchemaTests {
         assertTrue(objSchema.isNullable(AllKotlinTypes::nullFloat.name));
         assertFalse(objSchema.isNullable(AllKotlinTypes::nullList.name)); // Managed realm objects do not allow null lists
         assertTrue(objSchema.isNullable(AllKotlinTypes::nullObject.name));
+        assertTrue(objSchema.isNullable("privateNullString"));
     }
 
 }

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/mongodb/sync/SyncedRealmTests.kt
@@ -788,8 +788,10 @@ class SyncedRealmTests {
                                 RealmFieldType.TYPED_LINK,          // Not an actual exposed type, it is used internally by RealmAny
                                 RealmFieldType.FLOAT,               // Float is not cloud compatible yet
                                 RealmFieldType.FLOAT_LIST,          // Float is not cloud compatible yet
+                                RealmFieldType.FLOAT_SET,
                                 RealmFieldType.STRING_TO_FLOAT_MAP  // Float is not cloud compatible yet
                                 -> {}
+
                             }
                         }
                     }

--- a/realm/realm-library/src/testUtils/kotlin/io/realm/entities/AllKotlinTypes.kt
+++ b/realm/realm-library/src/testUtils/kotlin/io/realm/entities/AllKotlinTypes.kt
@@ -84,6 +84,9 @@ open class AllKotlinTypes : RealmObject() {
 
     @LinkingObjects("nonNullList")
     val listParents: RealmResults<AllKotlinTypes>? = null;
+
+    private var privateNonNullString: String = "";
+    private var privateNullString: String? = "";
 }
 
 open class WithRealmAnyTestEntity(


### PR DESCRIPTION
Test showcasing #7810. Bumping to Kotlin 1.8.20 in `dependencies.txt` will make the test `kotlinTypeNonNull` pass, while it fails for lower versions.