### PR TITLE
Fix incremental builds missing accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * None.
 
 ### Fixed
+* Realm objects accessors behave as an unmanaged object after an incremental build. (Issue [#7844](https://github.com/realm/realm-java/pull/7844))
 * [RealmApp] Crash when opening a Realm with a proxy enabled. (Issue [#7828](https://github.com/realm/realm-java/issues/7828))
 
 ### Compatibility

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/ByteCodeModifier.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/ByteCodeModifier.kt
@@ -189,7 +189,7 @@ class BytecodeModifier {
                     // javassist.CannotCompileException: [source error] realmGet$id() not found in 'foo.Model'
                     addRealmAccessors(fieldAccessCtClass)
 
-                    val fieldName: String = fieldAccess . fieldName
+                    val fieldName: String = fieldAccess.fieldName
                     if (fieldAccess.isReader) {
                         fieldAccess.replace("\$_ = \$0.realmGet\$$fieldName();")
                     } else if (fieldAccess.isWriter) {
@@ -202,6 +202,6 @@ class BytecodeModifier {
         fun CtClass.isRealmModelClass(): Boolean =
             name != "io.realm.RealmObject" &&
                     (hasAnnotation(RealmClass::class.java) || hasRealmClassAnnotation(superclass)) &&
-                    safeSubtypeOf(realmObjectProxyInterface)
+                    !safeSubtypeOf(realmObjectProxyInterface)
     }
 }


### PR DESCRIPTION
Closes #7840.

Incremental builds would not modify the accessors correctly. The issue is caused because the function `isRealmModelClass` fails to detect valid Realm models in incremental builds.

The issue was introduced when this function was refactored and failed to add a negation. [Original function](https://github.com/realm/realm-java/blob/7219b6a9bc114775a876ef2f92cf920816cc89b2/realm-transformer/src/main/kotlin/io/realm/transformer/ByteCodeModifier.kt#L184).

Tested manually and reviewed the generated bytecode.