### PR TITLE
Add more error checking when creating User objects

### DIFF
--- a/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/mongodb/User.java
@@ -114,6 +114,9 @@ public class User {
     }
 
     User(OsSyncUser osUser, App app) {
+        if (osUser == null) {
+            throw new IllegalStateException("Non-null user required.");
+        }
         this.osUser = osUser;
         this.app = app;
         this.profile = new UserProfile(this);


### PR DESCRIPTION
An attempt at finding https://github.com/realm/realm-java/issues/7847

Observations:
- We are never setting the `osUser` reference to `null`, perhaps it is being passed in as such? But all the code paths we have for that look safe enough.
- We are only overriding the `osUser` ref when calling `linkCredentials`, but I don't see how that can nullify it either.