### PR TITLE
Fix NetworkRequest being able to return invalid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Realm objects accessors behave as an unmanaged object after an incremental build. (Issue [#7844](https://github.com/realm/realm-java/pull/7844))
 * [RealmApp] Crash when opening a Realm with a proxy enabled. (Issue [#7828](https://github.com/realm/realm-java/issues/7828))
+* [RealmApp] It was possible to create a `User` object with invalid state that would throw a `NullPointerException` when accessed. (Issue [#7847](https://github.com/realm/realm-java/issues/7847))
 
 ### Compatibility
 * File format: Generates Realms with format v23. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/internal/network/NetworkRequestTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/internal/network/NetworkRequestTests.kt
@@ -1,0 +1,41 @@
+package io.realm.internal.network
+
+import androidx.test.platform.app.InstrumentationRegistry
+import io.realm.Realm
+import io.realm.mongodb.App
+import io.realm.mongodb.AppException
+import io.realm.mongodb.ErrorCode
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class NetworkRequestTests {
+
+	private lateinit var app: App
+
+	@Before
+	fun setUp() {
+		Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
+	}
+
+	// Test for https://github.com/realm/realm-java/issues/7847
+	@Test
+	fun interruptedRequestReturnsError() {
+		val request = object: NetworkRequest<Unit>() {
+			override fun mapSuccess(result: Any?): Unit {
+				Unit
+			}
+
+			override fun execute(callback: NetworkRequest<Unit>) {
+				Thread.currentThread().interrupt()
+			}
+		}
+		assertFailsWith<AppException> {
+			request.resultOrThrow()
+		}.also {
+			assertEquals(it.errorCode, ErrorCode.NETWORK_INTERRUPTED)
+			assertEquals(it.errorMessage, "Network request interrupted.")
+		}
+	}
+}

--- a/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/internal/network/NetworkRequestTests.kt
+++ b/realm/realm-library/src/androidTestObjectServer/kotlin/io/realm/internal/network/NetworkRequestTests.kt
@@ -12,30 +12,30 @@ import kotlin.test.assertFailsWith
 
 class NetworkRequestTests {
 
-	private lateinit var app: App
+    private lateinit var app: App
 
-	@Before
-	fun setUp() {
-		Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
-	}
+    @Before
+    fun setUp() {
+        Realm.init(InstrumentationRegistry.getInstrumentation().targetContext)
+    }
 
-	// Test for https://github.com/realm/realm-java/issues/7847
-	@Test
-	fun interruptedRequestReturnsError() {
-		val request = object: NetworkRequest<Unit>() {
-			override fun mapSuccess(result: Any?): Unit {
-				Unit
-			}
+    // Test for https://github.com/realm/realm-java/issues/7847
+    @Test
+    fun interruptedRequestReturnsError() {
+        val request = object: NetworkRequest<Unit>() {
+            override fun mapSuccess(result: Any?): Unit {
+                Unit
+            }
 
-			override fun execute(callback: NetworkRequest<Unit>) {
-				Thread.currentThread().interrupt()
-			}
-		}
-		assertFailsWith<AppException> {
-			request.resultOrThrow()
-		}.also {
-			assertEquals(it.errorCode, ErrorCode.NETWORK_INTERRUPTED)
-			assertEquals(it.errorMessage, "Network request interrupted.")
-		}
-	}
+            override fun execute(callback: NetworkRequest<Unit>) {
+                Thread.currentThread().interrupt()
+            }
+        }
+        assertFailsWith<AppException> {
+            request.resultOrThrow()
+        }.also {
+            assertEquals(it.errorCode, ErrorCode.NETWORK_INTERRUPTED)
+            assertEquals(it.errorMessage, "Network request interrupted.")
+        }
+    }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/NetworkRequest.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/NetworkRequest.java
@@ -48,9 +48,7 @@ public abstract class NetworkRequest<T> extends OsJavaNetworkTransport.NetworkTr
     @Override
     public void onSuccess(Object result) {
         T mappedResult = mapSuccess(result);
-        if (success != null) {
-            success.set(mappedResult);
-        }
+        success.set(mappedResult);
         latch.countDown();
     }
 
@@ -87,11 +85,11 @@ public abstract class NetworkRequest<T> extends OsJavaNetworkTransport.NetworkTr
 
         execute(this);
         try {
-            // Wait indefinitely. Timeouts should be handled by the Network layer,
-            // so will eventually bubble up as an exception.
+            // Wait indefinitely. Timeouts should be handled by the Network layer, otherwise
+            // it can be interrupted manually by calling `RealmAsyncTask.cancel()`
             latch.await();
         } catch (InterruptedException e) {
-            RealmLog.debug("Network request interrupted.");
+            error.set(new AppException(ErrorCode.NETWORK_INTERRUPTED, "Network request interrupted."));
         }
 
         // Result of request should be available. Throw if an error happened, otherwise return
@@ -99,11 +97,7 @@ public abstract class NetworkRequest<T> extends OsJavaNetworkTransport.NetworkTr
         if (error.get() != null) {
             throw error.get();
         } else {
-            if (success != null) {
-                return success.get();
-            } else {
-                return null;
-            }
+            return success.get();
         }
     }
 }

--- a/realm/realm-library/src/objectServer/java/io/realm/internal/network/VoidNetworkRequest.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/internal/network/VoidNetworkRequest.java
@@ -11,7 +11,7 @@ import io.realm.mongodb.ErrorCode;
 
 /**
  * Specialized case of {@link NetworkRequest} where we are not interested in the response value,
- * just wether or not the request succeeded.
+ * just whether or not the request succeeded.
  */
 public abstract class VoidNetworkRequest extends NetworkRequest<Void> {
 


### PR DESCRIPTION
Closes [#7848 ](https://github.com/realm/realm-java/issues/7847)

It turns out it was possible to get into a situation where a NetworkRequest would sometimes return `null` even though it shouldn't. This could happen if you cancel the `RealmAsyncTask` controlling the network request while the request was running.

It wasn't possible to add a unit test that would fail consistently in that case, so Instead I added something more low-level that ensured that we failed correctly if the request was interrupted.