### PR TITLE
Use 16 KB ELF alignment for shared native libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Fixed
-* None.
+* Use 16 KB ELF packaging for native artifacts produced by `realm-library`, allowing them to be loaded on devices with 16 KB memory page sizes. (Issue [#7894](https://github.com/realm/realm-java/issues/7894))
 
 ### Compatibility
 * File format: Generates Realms with format v23. Unsynced Realms will be upgraded from Realm Java 2.0 and later. Synced Realms can only be read and upgraded if created with Realm Java v10.0.0-BETA.1.

--- a/realm/realm-library/build.gradle
+++ b/realm/realm-library/build.gradle
@@ -121,6 +121,11 @@ android {
         // We did strip with cmake for release build.
         // Please, Gradle, you are not that smart! Pleas DO NOT strip debug symbols for debug build!
         doNotStrip "*/*/*.so"
+
+        // Use compressed shared libraries to support 16 KB ELF alignment
+        jniLibs {
+            useLegacyPackaging = true
+        }
     }
 
     lintOptions {

--- a/realm/realm-library/src/main/cpp/CMakeLists.txt
+++ b/realm/realm-library/src/main/cpp/CMakeLists.txt
@@ -214,6 +214,9 @@ endif()
 add_library(realm-jni SHARED ${jni_SRC})
 target_link_libraries(realm-jni log android Realm::ObjectStore)
 
+# Use 16 KB ELF alignment to support devices with page size greater than 4 KB
+target_link_options(realm-jni PRIVATE "-Wl,-z,max-page-size=16384")
+
 # Strip the release so files and backup the unstripped versions
 if (buildTypeCap STREQUAL "Release")
     set(unstripped_SO_DIR


### PR DESCRIPTION
Starting from the upcoming Android 15, the possibility for devices configured with a memory page size of 16 KB (rather than the default 4 KB) becomes available to OEMs. This has an impact on how native code must be packed into Android applications in order to prevent crashes at runtime when unaligned code is being loaded on these devices (ref https://github.com/realm/realm-java/issues/7894).

This PR applies [the suggested migration steps](https://developer.android.com/guide/practices/page-sizes) for 16 KB ELF packaging to the output of `realm-library`. As I did not want to upgrade the entire stack to AGP 8.3+ and NDK 27+, it follows the "legacy path" that yields the same results: After building the native libraries with these flags, calls to `Realm.init()` no longer cause an immediate crash on devices/emulators configured with 16 KB page size.

Full disclaimer: This change also applies to the `objectServer` binaries, which we aren't using for our use case. I don't know if there are any ramifications of 16 KB page size for those binaries.
